### PR TITLE
fix(timeline): scope marquee querySelector to timeline container

### DIFF
--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -306,7 +306,9 @@ export const TimelineContent = memo(function TimelineContent({ duration, scrollR
       itemIds.map((id) => ({
         id,
         getBoundingRect: () => {
-          const element = document.querySelector(`[data-item-id="${id}"]`);
+          // Scope query to timeline container to avoid matching preview player elements
+          // (video-content.tsx also uses data-item-id for the composition runtime)
+          const element = containerRef.current?.querySelector(`[data-item-id="${id}"]`);
           if (!element) {
             return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
           }


### PR DESCRIPTION
## Summary
- Fix marquee selection failing to select clips that are currently visible in the preview player
- `document.querySelector('[data-item-id]')` was matching preview player elements (from `video-content.tsx`) instead of timeline elements, since both use the same `data-item-id` attribute
- Scoped the query to the timeline scroll container to ensure correct bounding rects

## Test plan
- [ ] Open a project with multiple clips on the timeline
- [ ] Try marquee-selecting clips that are visible at the current playhead position — they should now be selectable
- [ ] Try marquee-selecting clips from different starting positions — all covered clips should be selected regardless of drag origin