### PR TITLE
feat: track groups, codebase reorg, and export fixes

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -58,6 +58,10 @@ export const HOTKEYS = {
   CLEAR_KEYFRAMES: 'shift+k',
   TOGGLE_KEYFRAME_EDITOR: 'mod+k',
 
+  // Track Groups
+  GROUP_TRACKS: 'mod+g',
+  UNGROUP_TRACKS: 'mod+shift+g',
+
   // Source Monitor
   MARK_IN: 'i',
   MARK_OUT: 'o',
@@ -124,6 +128,10 @@ export const HOTKEY_DESCRIPTIONS: Record<HotkeyKey, string> = {
   ADD_KEYFRAME: 'Add keyframe at playhead',
   CLEAR_KEYFRAMES: 'Clear all keyframes from selected items',
   TOGGLE_KEYFRAME_EDITOR: 'Toggle keyframe editor panel',
+
+  // Track Groups
+  GROUP_TRACKS: 'Group selected tracks',
+  UNGROUP_TRACKS: 'Ungroup selected tracks',
 
   // Source Monitor
   MARK_IN: 'Mark In point',

--- a/src/features/export/utils/timeline-to-composition.ts
+++ b/src/features/export/utils/timeline-to-composition.ts
@@ -3,6 +3,7 @@ import type { Transition } from '@/types/transition';
 import type { CompositionInputProps } from '@/types/export';
 import type { ItemKeyframes, Keyframe, PropertyKeyframes } from '@/types/keyframe';
 import { interpolatePropertyValue } from '@/features/keyframes/utils/interpolation';
+import { resolveEffectiveTrackStates } from '@/features/timeline/utils/group-utils';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('TimelineToComposition');
@@ -33,6 +34,10 @@ export function convertTimelineToComposition(
   keyframes?: ItemKeyframes[],
   backgroundColor?: string
 ): CompositionInputProps {
+  // Resolve group gate behavior: parent group mute/hide propagates to children.
+  // Also filters out group container tracks (which hold no items).
+  tracks = resolveEffectiveTrackStates(tracks);
+
   // Determine if we're exporting a specific in/out range
   const hasInOutRange = inPoint !== null && inPoint !== undefined &&
                         outPoint !== null && outPoint !== undefined &&

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -5,6 +5,7 @@ import { useTimelineStore } from '@/features/timeline/stores/timeline-store';
 import { useSelectionStore } from '@/features/editor/stores/selection-store';
 import { MainComposition } from '@/lib/composition-runtime/compositions/main-composition';
 import { resolveMediaUrl } from '../utils/media-resolver';
+import { resolveEffectiveTrackStates } from '@/features/timeline/utils/group-utils';
 import { GizmoOverlay } from './gizmo-overlay';
 import type { CompositionInputProps } from '@/types/export';
 import { isMarqueeJustFinished } from '@/hooks/use-marquee-selection';
@@ -250,8 +251,11 @@ export const VideoPreview = memo(function VideoPreview({
   const [isResolving, setIsResolving] = useState(false);
 
   // Combine tracks and items into TimelineTrack format
+  // resolveEffectiveTrackStates applies parent group gate behavior (mute/hide/lock)
+  // and filters out group container tracks (which hold no items)
   const combinedTracks = useMemo(() => {
-    return tracks
+    const effectiveTracks = resolveEffectiveTrackStates(tracks);
+    return effectiveTracks
       .map((track) => ({
         ...track,
         items: items.filter((item) => item.trackId === track.id),

--- a/src/features/project-bundle/schemas/project-schema.ts
+++ b/src/features/project-bundle/schemas/project-schema.ts
@@ -257,6 +257,9 @@ const trackSchema = z.object({
   solo: z.boolean(),
   color: z.string().optional(),
   order: z.number().int().min(0),
+  parentTrackId: z.string().optional(),
+  isGroup: z.boolean().optional(),
+  isCollapsed: z.boolean().optional(),
 });
 
 // ============================================================================

--- a/src/features/timeline/components/group-summary-track.tsx
+++ b/src/features/timeline/components/group-summary-track.tsx
@@ -1,0 +1,71 @@
+import { memo, useMemo } from 'react';
+import type { TimelineTrack } from '@/types/timeline';
+import { useTimelineStore } from '../stores/timeline-store';
+import { useTimelineZoomContext } from '../contexts/timeline-zoom-context';
+import { getChildTrackIds, getGroupItemCoverage } from '../utils/group-utils';
+
+/** Color mapping for item types in the summary bar */
+const TYPE_COLORS: Record<string, string> = {
+  video: 'rgba(59, 130, 246, 0.6)',   // blue
+  audio: 'rgba(168, 85, 247, 0.6)',   // purple
+  text: 'rgba(34, 197, 94, 0.6)',     // green
+  image: 'rgba(249, 115, 22, 0.6)',   // orange
+  shape: 'rgba(236, 72, 153, 0.6)',   // pink
+  adjustment: 'rgba(156, 163, 175, 0.5)', // gray
+};
+
+interface GroupSummaryTrackProps {
+  track: TimelineTrack;
+}
+
+function arePropsEqual(prev: GroupSummaryTrackProps, next: GroupSummaryTrackProps) {
+  return prev.track === next.track;
+}
+
+/**
+ * Renders a summary bar for a collapsed group track.
+ * Shows colored coverage rectangles representing items in child tracks.
+ */
+export const GroupSummaryTrack = memo(function GroupSummaryTrack({ track }: GroupSummaryTrackProps) {
+  const { frameToPixels } = useTimelineZoomContext();
+
+  // Get all tracks to find children
+  const allTracks = useTimelineStore((s) => s.tracks);
+  const childTrackIds = useMemo(
+    () => new Set(getChildTrackIds(allTracks, track.id)),
+    [allTracks, track.id]
+  );
+
+  // Get items in child tracks (use shallow comparison on the derived coverage array)
+  const items = useTimelineStore((s) => s.items);
+  const coverage = useMemo(
+    () => getGroupItemCoverage(items, childTrackIds),
+    [items, childTrackIds]
+  );
+
+  return (
+    <div
+      className="relative border-b border-border bg-secondary/20"
+      style={{ height: `${track.height}px` }}
+      data-track-id={track.id}
+    >
+      {/* Coverage bars */}
+      {coverage.map((item, i) => {
+        const left = frameToPixels(item.from);
+        const width = frameToPixels(item.to) - left;
+        return (
+          <div
+            key={i}
+            className="absolute top-1 rounded-sm"
+            style={{
+              left: `${left}px`,
+              width: `${Math.max(width, 2)}px`,
+              height: `${track.height - 8}px`,
+              backgroundColor: TYPE_COLORS[item.type] ?? 'rgba(156, 163, 175, 0.4)',
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}, arePropsEqual);

--- a/src/features/timeline/hooks/use-timeline-tracks.ts
+++ b/src/features/timeline/hooks/use-timeline-tracks.ts
@@ -200,6 +200,12 @@ export function useTimelineTracks() {
     [setTracks]
   );
 
+  // Group actions (delegating to store actions via facade)
+  const createGroup = useTimelineStore((s) => s.createGroup);
+  const ungroupAction = useTimelineStore((s) => s.ungroup);
+  const toggleGroupCollapse = useTimelineStore((s) => s.toggleGroupCollapse);
+  const removeFromGroup = useTimelineStore((s) => s.removeFromGroup);
+
   return {
     tracks,
     addTrack,
@@ -212,5 +218,9 @@ export function useTimelineTracks() {
     toggleTrackVisibility,
     toggleTrackMute,
     toggleTrackSolo,
+    createGroup,
+    ungroup: ungroupAction,
+    toggleGroupCollapse,
+    removeFromGroup,
   };
 }

--- a/src/features/timeline/stores/actions/track-actions.ts
+++ b/src/features/timeline/stores/actions/track-actions.ts
@@ -6,10 +6,163 @@ import type { TimelineTrack } from '@/types/timeline';
 import { useItemsStore } from '../items-store';
 import { useTimelineSettingsStore } from '../timeline-settings-store';
 import { execute } from './shared';
+import { DEFAULT_TRACK_HEIGHT } from '../../constants';
 
 export function setTracks(tracks: TimelineTrack[]): void {
   execute('SET_TRACKS', () => {
     useItemsStore.getState().setTracks(tracks);
     useTimelineSettingsStore.getState().markDirty();
   }, { count: tracks.length });
+}
+
+/**
+ * Create a group track from selected tracks.
+ * Inserts a new group track at the position of the first selected track,
+ * and parents all selected tracks under it.
+ */
+export function createGroup(trackIds: string[]): void {
+  if (trackIds.length === 0) return;
+
+  execute('CREATE_GROUP', () => {
+    const tracks = useItemsStore.getState().tracks;
+
+    // Don't allow grouping tracks that are already group containers
+    const selectedTracks = tracks.filter((t) => trackIds.includes(t.id));
+    if (selectedTracks.some((t) => t.isGroup)) return;
+
+    // Don't allow grouping tracks from different parent groups
+    const parentIds = new Set(selectedTracks.map((t) => t.parentTrackId ?? null));
+    if (parentIds.size > 1) return;
+
+    // Find the index of the first selected track (by order)
+    const sortedSelected = [...selectedTracks].sort((a, b) => a.order - b.order);
+    const firstSelected = sortedSelected[0];
+    if (!firstSelected) return;
+
+    // Find the insertion position — just before the first selected track
+    const firstIndex = tracks.findIndex((t) => t.id === firstSelected.id);
+    const orderBefore = firstIndex > 0 ? (tracks[firstIndex - 1]?.order ?? firstSelected.order - 2) : firstSelected.order - 2;
+    const groupOrder = (orderBefore + firstSelected.order) / 2;
+
+    // Create the group track
+    const groupTrack: TimelineTrack = {
+      id: `group-${Date.now()}`,
+      name: `Group`,
+      height: DEFAULT_TRACK_HEIGHT,
+      locked: false,
+      visible: true,
+      muted: false,
+      solo: false,
+      order: groupOrder,
+      items: [],
+      isGroup: true,
+      isCollapsed: false,
+      parentTrackId: firstSelected.parentTrackId, // inherit parent if grouping within a group
+    };
+
+    // Reparent selected tracks under the new group
+    const selectedIds = new Set(trackIds);
+    const updatedTracks = tracks.map((t) => {
+      if (selectedIds.has(t.id)) {
+        return { ...t, parentTrackId: groupTrack.id };
+      }
+      return t;
+    });
+
+    // Insert group track and re-sort
+    const newTracks = [groupTrack, ...updatedTracks].sort((a, b) => a.order - b.order);
+
+    useItemsStore.getState().setTracks(newTracks);
+    useTimelineSettingsStore.getState().markDirty();
+  }, { trackIds });
+}
+
+/**
+ * Dissolve a group, promoting its children to top-level (or parent group).
+ */
+export function ungroup(groupTrackId: string): void {
+  execute('UNGROUP', () => {
+    const tracks = useItemsStore.getState().tracks;
+    const groupTrack = tracks.find((t) => t.id === groupTrackId);
+    if (!groupTrack?.isGroup) return;
+
+    // Promote children to the group's parent (or top-level)
+    const updatedTracks = tracks
+      .filter((t) => t.id !== groupTrackId) // Remove the group track
+      .map((t) => {
+        if (t.parentTrackId === groupTrackId) {
+          return { ...t, parentTrackId: groupTrack.parentTrackId };
+        }
+        return t;
+      });
+
+    useItemsStore.getState().setTracks(updatedTracks);
+    useTimelineSettingsStore.getState().markDirty();
+  }, { groupTrackId });
+}
+
+/**
+ * Toggle the collapsed state of a group track.
+ */
+export function toggleGroupCollapse(groupTrackId: string): void {
+  execute('TOGGLE_GROUP_COLLAPSE', () => {
+    const tracks = useItemsStore.getState().tracks;
+    const updatedTracks = tracks.map((t) => {
+      if (t.id === groupTrackId && t.isGroup) {
+        return { ...t, isCollapsed: !t.isCollapsed };
+      }
+      return t;
+    });
+
+    useItemsStore.getState().setTracks(updatedTracks);
+    useTimelineSettingsStore.getState().markDirty();
+  }, { groupTrackId });
+}
+
+/**
+ * Move tracks into an existing group.
+ */
+export function addToGroup(trackIds: string[], groupTrackId: string): void {
+  if (trackIds.length === 0) return;
+
+  execute('ADD_TO_GROUP', () => {
+    const tracks = useItemsStore.getState().tracks;
+    const groupTrack = tracks.find((t) => t.id === groupTrackId);
+    if (!groupTrack?.isGroup) return;
+
+    const selectedIds = new Set(trackIds);
+    const updatedTracks = tracks.map((t) => {
+      if (selectedIds.has(t.id) && !t.isGroup) {
+        return { ...t, parentTrackId: groupTrackId };
+      }
+      return t;
+    });
+
+    useItemsStore.getState().setTracks(updatedTracks);
+    useTimelineSettingsStore.getState().markDirty();
+  }, { trackIds, groupTrackId });
+}
+
+/**
+ * Remove tracks from their group (detach to top-level or parent's parent).
+ */
+export function removeFromGroup(trackIds: string[]): void {
+  if (trackIds.length === 0) return;
+
+  execute('REMOVE_FROM_GROUP', () => {
+    const tracks = useItemsStore.getState().tracks;
+    const selectedIds = new Set(trackIds);
+
+    const updatedTracks = tracks.map((t) => {
+      if (selectedIds.has(t.id) && t.parentTrackId) {
+        // Find the group's parent to promote to
+        const group = tracks.find((g) => g.id === t.parentTrackId);
+        return { ...t, parentTrackId: group?.parentTrackId };
+      }
+      return t;
+    });
+
+    useItemsStore.getState().setTracks(updatedTracks);
+    useTimelineSettingsStore.getState().markDirty();
+  }, { trackIds });
 }

--- a/src/features/timeline/stores/timeline-store-facade.ts
+++ b/src/features/timeline/stores/timeline-store-facade.ts
@@ -427,6 +427,11 @@ function getSnapshot(): TimelineState & TimelineActions {
 
       // Actions (static references, never change)
       setTracks: timelineActions.setTracks,
+      createGroup: timelineActions.createGroup,
+      ungroup: timelineActions.ungroup,
+      toggleGroupCollapse: timelineActions.toggleGroupCollapse,
+      addToGroup: timelineActions.addToGroup,
+      removeFromGroup: timelineActions.removeFromGroup,
       addItem: timelineActions.addItem,
       updateItem: timelineActions.updateItem,
       removeItems: timelineActions.removeItems,

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -22,6 +22,12 @@ export interface TimelineState {
 
 export interface TimelineActions {
   setTracks: (tracks: TimelineTrack[]) => void;
+  // Track group actions
+  createGroup: (trackIds: string[]) => void;
+  ungroup: (groupTrackId: string) => void;
+  toggleGroupCollapse: (groupTrackId: string) => void;
+  addToGroup: (trackIds: string[], groupTrackId: string) => void;
+  removeFromGroup: (trackIds: string[]) => void;
   addItem: (item: TimelineItem) => void;
   updateItem: (id: string, updates: Partial<TimelineItem>) => void;
   removeItems: (ids: string[]) => void;

--- a/src/features/timeline/utils/group-utils.ts
+++ b/src/features/timeline/utils/group-utils.ts
@@ -1,0 +1,151 @@
+/**
+ * Track Group Utilities
+ *
+ * Pure functions for querying and manipulating track group hierarchy.
+ * Groups are container tracks that organize children. Group-level mute/visible/locked
+ * gates propagate to child tracks via resolveEffectiveTrackStates().
+ */
+
+import type { TimelineTrack, TimelineItem } from '@/types/timeline';
+
+/**
+ * Get ordered child tracks of a group track.
+ * Returns children sorted by their `order` property.
+ */
+export function getChildTracks(tracks: TimelineTrack[], parentId: string): TimelineTrack[] {
+  return tracks
+    .filter((t) => t.parentTrackId === parentId)
+    .sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Get the parent group track for a given track.
+ * Returns undefined if the track is top-level (not in any group).
+ */
+export function getGroupTrack(tracks: TimelineTrack[], trackId: string): TimelineTrack | undefined {
+  const track = tracks.find((t) => t.id === trackId);
+  if (!track?.parentTrackId) return undefined;
+  return tracks.find((t) => t.id === track.parentTrackId);
+}
+
+/**
+ * Check if a track belongs to a group.
+ */
+export function isTrackInGroup(track: TimelineTrack): boolean {
+  return !!track.parentTrackId;
+}
+
+/**
+ * Check if a track is a group container.
+ */
+export function isGroupTrack(track: TimelineTrack): boolean {
+  return !!track.isGroup;
+}
+
+/**
+ * Get all tracks that should be visible in the timeline UI.
+ * Filters out children of collapsed group tracks.
+ */
+export function getVisibleTracks(tracks: TimelineTrack[]): TimelineTrack[] {
+  // Collect IDs of all collapsed groups
+  const collapsedGroupIds = new Set(
+    tracks.filter((t) => t.isGroup && t.isCollapsed).map((t) => t.id)
+  );
+
+  if (collapsedGroupIds.size === 0) return tracks;
+
+  return tracks.filter((t) => {
+    // Show the track if it has no parent, or its parent is not collapsed
+    return !t.parentTrackId || !collapsedGroupIds.has(t.parentTrackId);
+  });
+}
+
+/**
+ * Get the nesting depth of a track (0 = top-level, 1 = inside a group).
+ * Currently capped at 1 level of nesting.
+ */
+export function getGroupDepth(tracks: TimelineTrack[], trackId: string): number {
+  const track = tracks.find((t) => t.id === trackId);
+  if (!track?.parentTrackId) return 0;
+  return 1; // Capped at 1 level for now
+}
+
+/**
+ * Get frame coverage ranges for a collapsed group's summary bar.
+ * Returns an array of { from, to, type } for each item in the child tracks.
+ */
+export function getGroupItemCoverage(
+  items: TimelineItem[],
+  childTrackIds: Set<string>
+): Array<{ from: number; to: number; type: TimelineItem['type'] }> {
+  return items
+    .filter((item) => childTrackIds.has(item.trackId))
+    .map((item) => ({
+      from: item.from,
+      to: item.from + item.durationInFrames,
+      type: item.type,
+    }));
+}
+
+/**
+ * Get all child track IDs for a group (non-recursive — direct children only).
+ */
+export function getChildTrackIds(tracks: TimelineTrack[], groupId: string): string[] {
+  return tracks.filter((t) => t.parentTrackId === groupId).map((t) => t.id);
+}
+
+/**
+ * Check if all provided track IDs share the same parent group (or are all top-level).
+ */
+export function tracksShareSameParent(tracks: TimelineTrack[], trackIds: string[]): boolean {
+  const targetTracks = tracks.filter((t) => trackIds.includes(t.id));
+  if (targetTracks.length === 0) return true;
+  const firstParent = targetTracks[0]?.parentTrackId ?? null;
+  return targetTracks.every((t) => (t.parentTrackId ?? null) === firstParent);
+}
+
+/**
+ * Resolve effective track states by applying parent group gate behavior.
+ *
+ * When a group track has `visible: false`, all children are effectively hidden.
+ * When a group track has `muted: true`, all children are effectively muted.
+ * When a group track has `locked: true`, all children are effectively locked.
+ *
+ * Returns a new array with overridden values — original tracks are not mutated.
+ * Group container tracks (isGroup: true) are excluded from the result since they
+ * hold no items and should not be rendered.
+ */
+export function resolveEffectiveTrackStates(tracks: TimelineTrack[]): TimelineTrack[] {
+  // Build a lookup of group tracks by ID
+  const groupById = new Map<string, TimelineTrack>();
+  for (const t of tracks) {
+    if (t.isGroup) {
+      groupById.set(t.id, t);
+    }
+  }
+
+  // No groups → return non-group tracks unchanged
+  if (groupById.size === 0) return tracks;
+
+  return tracks
+    .filter((t) => !t.isGroup) // Exclude group containers (they have no items)
+    .map((t) => {
+      if (!t.parentTrackId) return t; // Top-level track, no gating
+
+      const parent = groupById.get(t.parentTrackId);
+      if (!parent) return t; // Orphaned reference, no gating
+
+      const needsMuteGate = parent.muted && !t.muted;
+      const needsHideGate = !parent.visible && t.visible !== false;
+      const needsLockGate = parent.locked && !t.locked;
+
+      if (!needsMuteGate && !needsHideGate && !needsLockGate) return t;
+
+      return {
+        ...t,
+        ...(needsMuteGate && { muted: true }),
+        ...(needsHideGate && { visible: false }),
+        ...(needsLockGate && { locked: true }),
+      };
+    });
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -41,6 +41,9 @@ export interface ProjectTimeline {
     solo: boolean;
     color?: string;
     order: number;
+    parentTrackId?: string;
+    isGroup?: boolean;
+    isCollapsed?: boolean;
   }>;
   items: Array<{
     id: string;

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -132,6 +132,10 @@ export interface TimelineTrack {
   color?: string; // Optional - tracks are generic containers, items have colors
   order: number;
   items: TimelineItem[];
+  // Track grouping (subsequences)
+  parentTrackId?: string; // ID of the group track this track belongs to
+  isGroup?: boolean; // true = container track (no items, only children)
+  isCollapsed?: boolean; // Whether the group's children are collapsed
 }
 
 // Project markers (user-created timeline markers)


### PR DESCRIPTION
## Summary
- **Track groups**: Add track grouping with collapse/expand, group-aware drag-and-drop with blue drop indicators, gate behavior (parent mute/hide/lock propagates to children), shift+click range selection, 1-level nesting guard, and keyboard shortcuts (Ctrl+G / Ctrl+Shift+G)
- **Codebase reorg**: Rename and co-locate files, add barrel files (index.ts) for feature modules
- **Export fixes**: Apply cornerRadius in preview and export, improve export player UX

## Test plan
- [ ] Create a group from 2+ tracks via Ctrl+G or right-click context menu
- [ ] Collapse/expand group, verify children hide/show and summary bar appears
- [ ] Drag tracks in/out of groups, verify blue indicators and correct reparenting
- [ ] Mute/hide/lock a group, verify gate behavior propagates to children in preview and export
- [ ] Shift+click to range-select tracks, Ctrl+click to toggle individual selection
- [ ] Drag selected tracks and verify selection is retained after drop
- [ ] Verify tracks already in a group cannot be grouped again (1-level nesting)
- [ ] Undo/redo group operations
- [ ] Save and reload project with groups, verify persistence
- [ ] Export project with groups, verify output matches ungrouped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added track grouping capabilities with keyboard shortcuts (Ctrl+G to group; Ctrl+Shift+G to ungroup)
  * Groups can be collapsed/expanded to organize and streamline the timeline view
  * Collapsed groups now display a visual summary of contained items
  * Added context menu for group management operations
  * Grouped tracks are properly handled in preview and export workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->