### PR TITLE
feat(keyframes): make volume/gain animatable with keyframes

### DIFF
--- a/src/features/keyframes/components/value-graph-editor/types.ts
+++ b/src/features/keyframes/components/value-graph-editor/types.ts
@@ -113,6 +113,7 @@ export const PROPERTY_VALUE_RANGES: Record<AnimatableProperty, PropertyValueRang
   rotation: { property: 'rotation', min: -360, max: 360, unit: '°', decimals: 1 },
   opacity: { property: 'opacity', min: 0, max: 1, unit: '', decimals: 2 },
   cornerRadius: { property: 'cornerRadius', min: 0, max: 1000, unit: 'px', decimals: 0 },
+  volume: { property: 'volume', min: -60, max: 20, unit: 'dB', decimals: 1 },
 };
 
 /**

--- a/src/types/keyframe.ts
+++ b/src/types/keyframe.ts
@@ -4,7 +4,7 @@
  */
 
 /** Properties that can be animated via keyframes */
-export type AnimatableProperty = 'x' | 'y' | 'width' | 'height' | 'rotation' | 'opacity' | 'cornerRadius';
+export type AnimatableProperty = 'x' | 'y' | 'width' | 'height' | 'rotation' | 'opacity' | 'cornerRadius' | 'volume';
 
 /** Basic easing functions for interpolation between keyframes */
 export type BasicEasingType = 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out';
@@ -138,6 +138,7 @@ export const PROPERTY_LABELS: Record<AnimatableProperty, string> = {
   rotation: 'Rotation',
   opacity: 'Opacity',
   cornerRadius: 'Corner Radius',
+  volume: 'Volume (dB)',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `volume` to `AnimatableProperty` so users can animate audio gain over time using the existing keyframe system
- Wires keyframe interpolation into both video and audio preview paths (context-first, store-fallback pattern)
- Adds per-sample animated volume envelope to the export audio pipeline
- Adds `KeyframeToggle` diamond button and auto-keyframe support to the Audio section in the properties sidebar
- Prevents continuous-boundary segment merging when volume keyframes exist to preserve keyframe context during export

## Test plan
- [ ] Select a video/audio clip, verify KeyframeToggle diamond appears next to the Gain input
- [ ] Add keyframes at different frames with different dB values, scrub timeline to verify interpolated volume in preview
- [ ] Verify auto-keyframing: once volume has keyframes, changing Gain value auto-adds/updates keyframe at current frame
- [ ] Export a clip with animated volume keyframes, verify volume changes are audible in the exported file
- [ ] Verify existing behavior: clips without volume keyframes still use static volume as before
- [ ] Run `npm run build` — passes with no errors
- [ ] Run `npm run lint` — no new errors
- [ ] Run `npm run test:run` — all 71 tests pass