### PR TITLE
fix: lazy-init root logger to avoid production chunk ordering crash

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -90,8 +90,13 @@ class Logger {
   }
 }
 
-// Root logger instance
-const logger = new Logger();
+// Lazy root logger — avoids "Cannot access before initialization" in production
+// builds where Vite/Rollup may reorder module-level code across chunks.
+let _logger: Logger | undefined;
+function getLogger(): Logger {
+  if (!_logger) _logger = new Logger();
+  return _logger;
+}
 
 /**
  * Factory for creating module-specific loggers
@@ -101,5 +106,5 @@ const logger = new Logger();
  * log.debug('Socket connected');
  */
 export function createLogger(module: string): Logger {
-  return logger.child(module);
+  return getLogger().child(module);
 }


### PR DESCRIPTION
## Summary
- Vite/Rollup production builds can reorder module-level initialization across chunks, causing `connection.ts` to call `createLogger()` before the root `Logger` instance was constructed
- Switches from a module-level `const logger = new Logger()` to lazy initialization via `getLogger()`, so the root logger is created on first use

## Test plan
- [ ] Verify production build (`npm run build`) no longer throws `Cannot access 'cn' before initialization`
- [ ] Verify logging still works correctly in dev mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced logger initialization with lazy loading to improve reliability across different build environments. Logging functionality and API remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->