### PR TITLE
revert(timeline): revert OPFS filmstrip storage and stale async load fix

### DIFF
--- a/src/features/timeline/components/clip-filmstrip/filmstrip-skeleton.tsx
+++ b/src/features/timeline/components/clip-filmstrip/filmstrip-skeleton.tsx
@@ -23,16 +23,16 @@ export const FilmstripSkeleton = memo(function FilmstripSkeleton({
 }: FilmstripSkeletonProps) {
   return (
     <div
-      className={`absolute left-0 right-0 overflow-hidden bg-zinc-900 pointer-events-none ${className}`}
+      className={`absolute left-0 right-0 overflow-hidden bg-zinc-900/30 ${className}`}
       style={{
         height,
         width: clipWidth,
         // Subtle shimmer effect using CSS animation
         backgroundImage: `linear-gradient(
           90deg,
-          rgba(255,255,255,0.02) 0%,
-          rgba(255,255,255,0.06) 50%,
-          rgba(255,255,255,0.02) 100%
+          transparent 0%,
+          rgba(255,255,255,0.03) 50%,
+          transparent 100%
         )`,
         backgroundSize: `${THUMBNAIL_WIDTH * 2}px 100%`,
         animation: 'filmstrip-shimmer 1.5s ease-in-out infinite',

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState, useMemo, useCallback, useRef, type SyntheticEvent } from 'react';
+import { memo, useEffect, useState, useMemo, useDeferredValue, useCallback, useRef } from 'react';
 import { FilmstripSkeleton } from './filmstrip-skeleton';
 import { useFilmstrip, type FilmstripFrame } from '../../hooks/use-filmstrip';
 import { mediaLibraryService } from '@/features/media-library/services/media-library-service';
@@ -71,76 +71,31 @@ const FilmstripTile = memo(function FilmstripTile({
   height: number;
   width: number;
 }) {
-  const [displayedSrc, setDisplayedSrc] = useState(src);
-  const [pendingSrc, setPendingSrc] = useState<string | null>(null);
-  const [displayError, setDisplayError] = useState(false);
+  const [errorSrc, setErrorSrc] = useState<string | null>(null);
 
-  // Queue incoming src for atomic swap once it has loaded.
-  useEffect(() => {
-    if (src === displayedSrc) return;
-    setPendingSrc(src);
-  }, [src, displayedSrc]);
+  const handleError = useCallback(() => {
+    setErrorSrc(src);
+  }, [src]);
 
-  const handleDisplayedError = useCallback(() => {
-    setDisplayError(true);
-  }, []);
-
-  const handlePendingLoad = useCallback((e: SyntheticEvent<HTMLImageElement>) => {
-    const loadedSrc = e.currentTarget.currentSrc || pendingSrc;
-    if (!loadedSrc) return;
-    setDisplayedSrc(loadedSrc);
-    setDisplayError(false);
-    setPendingSrc(null);
-  }, [pendingSrc]);
-
-  const handlePendingError = useCallback(() => {
-    // Keep showing current frame if next src fails.
-    setPendingSrc(null);
-  }, []);
+  // Hide if this specific src failed, but allow new src to try again
+  if (errorSrc === src) {
+    return null;
+  }
 
   return (
-    <div
+    <img
+      src={src}
+      alt=""
+      decoding="async"
       className="absolute top-0"
+      onError={handleError}
       style={{
         left: x,
         width,
         height,
-        overflow: 'hidden',
+        objectFit: 'cover',
       }}
-    >
-      {!displayError && (
-        <img
-          src={displayedSrc}
-          alt=""
-          decoding="async"
-          className="absolute inset-0"
-          onError={handleDisplayedError}
-          style={{
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-          }}
-        />
-      )}
-      {pendingSrc && pendingSrc !== displayedSrc && (
-        <img
-          src={pendingSrc}
-          alt=""
-          decoding="async"
-          className="absolute inset-0 opacity-0 pointer-events-none"
-          onLoad={handlePendingLoad}
-          onError={handlePendingError}
-          style={{
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-          }}
-        />
-      )}
-      {displayError && (
-        <div className="absolute inset-0 bg-zinc-900" />
-      )}
-    </div>
+    />
   );
 });
 
@@ -148,7 +103,7 @@ const FilmstripTile = memo(function FilmstripTile({
  * Clip Filmstrip Component
  *
  * Renders video frame thumbnails as a tiled filmstrip.
- * Updates immediately with zoom so thumbnails stay visually in sync with clip width.
+ * Uses useDeferredValue to keep zoom interactions responsive.
  * Auto-fills container height.
  */
 export const ClipFilmstrip = memo(function ClipFilmstrip({
@@ -190,6 +145,10 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
   // Calculate thumbnail width based on height (16:9 aspect ratio)
   const thumbnailWidth = Math.round(height * (16 / 9)) || THUMBNAIL_WIDTH;
 
+  // Defer zoom values to keep zoom slider responsive
+  const deferredPixelsPerSecond = useDeferredValue(pixelsPerSecond);
+  const deferredClipWidth = useDeferredValue(clipWidth);
+
   // Load blob URL for the media
   useEffect(() => {
     let mounted = true;
@@ -218,12 +177,12 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
   }, [mediaId, isVisible]);
 
   // Use filmstrip hook
-  const { frames, isComplete, error } = useFilmstrip({
+  const { frames, isLoading, isComplete, error } = useFilmstrip({
     mediaId,
     blobUrl,
     duration: sourceDuration,
     isVisible,
-    enabled: isVisible && sourceDuration > 0,
+    enabled: isVisible && !!blobUrl && sourceDuration > 0,
   });
 
   // Calculate tiles - maps each tile position to the best frame
@@ -232,13 +191,12 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     if (!frames || frames.length === 0 || thumbnailWidth === 0) return [];
 
     const effectiveStart = sourceStart + trimStart;
-    // Overscan one tile on the right so we never expose clip background during fast resizes.
-    const tileCount = Math.ceil(clipWidth / thumbnailWidth) + 1;
+    const tileCount = Math.ceil(deferredClipWidth / thumbnailWidth);
     const result: { tileIndex: number; frame: FilmstripFrame; x: number }[] = [];
 
     for (let tile = 0; tile < tileCount; tile++) {
       const tileX = tile * thumbnailWidth;
-      const tileTime = effectiveStart + (tileX / pixelsPerSecond) * speed;
+      const tileTime = effectiveStart + (tileX / deferredPixelsPerSecond) * speed;
       const frame = findClosestFrame(frames, tileTime);
 
       if (frame) {
@@ -247,7 +205,7 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     }
 
     return result;
-  }, [frames, clipWidth, pixelsPerSecond, sourceStart, trimStart, speed, thumbnailWidth]);
+  }, [frames, deferredClipWidth, deferredPixelsPerSecond, sourceStart, trimStart, speed, thumbnailWidth]);
 
   if (error) {
     return null;
@@ -255,16 +213,18 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
 
   // Show skeleton while actively loading.
   if (!frames || frames.length === 0 || height === 0) {
+    if (!isLoading && height > 0) {
+      return <div ref={containerRef} className="absolute inset-0" />;
+    }
     return (
       <div ref={containerRef} className="absolute inset-0">
-        <div className="absolute inset-0 bg-zinc-900" />
         <FilmstripSkeleton clipWidth={clipWidth} height={height || 40} />
       </div>
     );
   }
 
   return (
-    <div ref={containerRef} className="absolute inset-0 bg-zinc-900">
+    <div ref={containerRef} className="absolute inset-0">
       {/* Show shimmer skeleton behind while loading */}
       {!isComplete && (
         <FilmstripSkeleton clipWidth={clipWidth} height={height} />
@@ -272,8 +232,10 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
       <div
         className="absolute left-0 top-0 overflow-hidden pointer-events-none"
         style={{
-          width: clipWidth,
+          width: deferredClipWidth,
           height,
+          contentVisibility: 'auto',
+          containIntrinsicSize: `${deferredClipWidth}px ${height}px`,
         }}
       >
         {tiles.map(({ tileIndex, frame, x }) => (

--- a/src/features/timeline/hooks/use-filmstrip.ts
+++ b/src/features/timeline/hooks/use-filmstrip.ts
@@ -77,7 +77,7 @@ export function useFilmstrip({
 
   // Subscribe to progressive updates
   useEffect(() => {
-    if (!enabled || !duration || duration <= 0) {
+    if (!enabled || !blobUrl || !duration || duration <= 0) {
       return;
     }
 
@@ -88,11 +88,11 @@ export function useFilmstrip({
     });
 
     return unsubscribe;
-  }, [mediaId, enabled, duration]);
+  }, [mediaId, enabled, blobUrl, duration]);
 
   // Load filmstrip when visible
   useEffect(() => {
-    if (!enabled || !duration || duration <= 0) {
+    if (!enabled || !blobUrl || !duration || duration <= 0) {
       return;
     }
 

--- a/src/features/timeline/services/filmstrip-opfs-storage.ts
+++ b/src/features/timeline/services/filmstrip-opfs-storage.ts
@@ -1,18 +1,13 @@
 /**
  * OPFS Filmstrip Storage
  *
- * Progressive extraction writes per-frame webp files for fast incremental updates.
- * Completed filmstrips are compacted into binary bins plus an index manifest to:
- * - reduce OPFS file count
- * - avoid directory scans on load
- * - speed up existing-index lookup for resume/load paths
+ * Simple storage for filmstrip frames. Worker handles saving,
+ * this service handles loading and providing object URLs.
  *
  * Storage structure:
  *   filmstrips/{mediaId}/
- *     meta.json
- *     index.json               (optional, binned complete storage)
- *     bin-0.bin, bin-1.bin... (optional, binned complete storage)
- *     0.webp, 1.webp...       (legacy / in-progress extraction)
+ *     meta.json - { width, height, isComplete, frameCount }
+ *     0.webp, 1.webp, 2.webp, ...
  */
 
 import { createLogger } from '@/lib/logger';
@@ -22,36 +17,12 @@ const logger = createLogger('FilmstripOPFS');
 
 const FILMSTRIP_DIR = 'filmstrips';
 const FRAME_RATE = 1; // Must match worker - 1fps for filmstrip thumbnails
-const BIN_INDEX_FILE = 'index.json';
-const BIN_VERSION = 1;
-const FRAMES_PER_BIN = 16;
-const BIN_HEADER_BYTES = 4; // uint32 entry count
-const BIN_ENTRY_BYTES = 12; // uint32 index, uint32 offset, uint32 size
 
 interface FilmstripMetadata {
   width: number;
   height: number;
   isComplete: boolean;
   frameCount: number;
-}
-
-interface FilmstripBinDescriptor {
-  binIndex: number;
-  fileName: string;
-  frameIndices: number[];
-}
-
-interface FilmstripBinIndex {
-  version: number;
-  framesPerBin: number;
-  frameCount: number;
-  bins: FilmstripBinDescriptor[];
-}
-
-interface ParsedBinEntry {
-  index: number;
-  offset: number;
-  size: number;
 }
 
 export interface FilmstripFrame {
@@ -73,9 +44,6 @@ class FilmstripOPFSStorage {
   private dirHandle: FileSystemDirectoryHandle | null = null;
   private initPromise: Promise<FileSystemDirectoryHandle> | null = null;
   private objectUrls = new Map<string, string[]>(); // mediaId -> urls for cleanup
-  private binIndexCache = new Map<string, FilmstripBinIndex>();
-  private binBufferCache = new Map<string, Map<number, ArrayBuffer>>();
-  private compactionPromises = new Map<string, Promise<void>>();
 
   /**
    * Initialize OPFS directory
@@ -115,20 +83,6 @@ class FilmstripOPFSStorage {
     }
   }
 
-  private clearMediaCaches(mediaId: string): void {
-    this.binIndexCache.delete(mediaId);
-    this.binBufferCache.delete(mediaId);
-  }
-
-  private getBinBufferMap(mediaId: string): Map<number, ArrayBuffer> {
-    let map = this.binBufferCache.get(mediaId);
-    if (!map) {
-      map = new Map<number, ArrayBuffer>();
-      this.binBufferCache.set(mediaId, map);
-    }
-    return map;
-  }
-
   /**
    * Get media directory handle
    */
@@ -149,252 +103,6 @@ class FilmstripOPFSStorage {
     return dir.getDirectoryHandle(mediaId, { create: true });
   }
 
-  private async readMetadata(mediaDir: FileSystemDirectoryHandle): Promise<FilmstripMetadata | null> {
-    try {
-      const metaHandle = await mediaDir.getFileHandle('meta.json');
-      const metaFile = await metaHandle.getFile();
-      return JSON.parse(await metaFile.text()) as FilmstripMetadata;
-    } catch {
-      return null;
-    }
-  }
-
-  private async writeJsonFile(
-    mediaDir: FileSystemDirectoryHandle,
-    fileName: string,
-    data: unknown
-  ): Promise<void> {
-    const fileHandle = await mediaDir.getFileHandle(fileName, { create: true });
-    const writable = await fileHandle.createWritable();
-    await writable.write(JSON.stringify(data));
-    await writable.close();
-  }
-
-  private async readLegacyFrameFiles(
-    mediaDir: FileSystemDirectoryHandle
-  ): Promise<{ index: number; file: File }[]> {
-    const frameFiles: { index: number; file: File }[] = [];
-    for await (const entry of mediaDir.values()) {
-      if (entry.kind === 'file' && entry.name.endsWith('.webp')) {
-        const index = parseInt(entry.name.replace('.webp', ''), 10);
-        if (!Number.isFinite(index)) continue;
-        try {
-          const fileHandle = await mediaDir.getFileHandle(entry.name);
-          const file = await fileHandle.getFile();
-          if (file.size > 0) {
-            frameFiles.push({ index, file });
-          }
-        } catch {
-          // Skip unreadable files.
-        }
-      }
-    }
-    frameFiles.sort((a, b) => a.index - b.index);
-    return frameFiles;
-  }
-
-  private trackUrl(mediaId: string, url: string): void {
-    const urls = this.objectUrls.get(mediaId) || [];
-    urls.push(url);
-    this.objectUrls.set(mediaId, urls);
-  }
-
-  /**
-   * Create and track an object URL for a frame blob.
-   * Useful when frames are streamed from workers (without immediate OPFS read-back).
-   */
-  createFrameUrl(mediaId: string, blob: Blob): string {
-    const url = URL.createObjectURL(blob);
-    this.trackUrl(mediaId, url);
-    return url;
-  }
-
-  private isValidBinIndex(value: unknown): value is FilmstripBinIndex {
-    if (!value || typeof value !== 'object') return false;
-    const candidate = value as Partial<FilmstripBinIndex>;
-    if (candidate.version !== BIN_VERSION) return false;
-    if (!Number.isFinite(candidate.framesPerBin) || (candidate.framesPerBin ?? 0) <= 0) return false;
-    if (!Number.isFinite(candidate.frameCount) || (candidate.frameCount ?? 0) < 0) return false;
-    if (!Array.isArray(candidate.bins)) return false;
-
-    for (const bin of candidate.bins) {
-      if (!bin || typeof bin !== 'object') return false;
-      const desc = bin as Partial<FilmstripBinDescriptor>;
-      if (!Number.isFinite(desc.binIndex)) return false;
-      if (typeof desc.fileName !== 'string' || desc.fileName.length === 0) return false;
-      if (!Array.isArray(desc.frameIndices)) return false;
-      for (const frameIndex of desc.frameIndices) {
-        if (!Number.isFinite(frameIndex)) return false;
-      }
-    }
-
-    return true;
-  }
-
-  private async getBinIndex(
-    mediaId: string,
-    mediaDir: FileSystemDirectoryHandle
-  ): Promise<FilmstripBinIndex | null> {
-    const cached = this.binIndexCache.get(mediaId);
-    if (cached) return cached;
-
-    try {
-      const handle = await mediaDir.getFileHandle(BIN_INDEX_FILE);
-      const file = await handle.getFile();
-      const parsed = JSON.parse(await file.text()) as unknown;
-      if (!this.isValidBinIndex(parsed)) {
-        logger.warn(`Invalid bin index for filmstrip ${mediaId}`);
-        return null;
-      }
-      const sortedBins = [...parsed.bins].sort((a, b) => a.binIndex - b.binIndex);
-      const normalized: FilmstripBinIndex = {
-        version: parsed.version,
-        framesPerBin: parsed.framesPerBin,
-        frameCount: parsed.frameCount,
-        bins: sortedBins,
-      };
-      this.binIndexCache.set(mediaId, normalized);
-      return normalized;
-    } catch {
-      return null;
-    }
-  }
-
-  private getFrameIndicesFromBinIndex(index: FilmstripBinIndex): number[] {
-    const out: number[] = [];
-    for (const bin of index.bins) {
-      out.push(...bin.frameIndices);
-    }
-    return out.sort((a, b) => a - b);
-  }
-
-  private parseBinEntries(buffer: ArrayBuffer): ParsedBinEntry[] | null {
-    if (buffer.byteLength < BIN_HEADER_BYTES) return null;
-
-    const view = new DataView(buffer);
-    const entryCount = view.getUint32(0, true);
-    const tableBytes = entryCount * BIN_ENTRY_BYTES;
-    const payloadStart = BIN_HEADER_BYTES + tableBytes;
-    if (payloadStart > buffer.byteLength) return null;
-
-    const entries: ParsedBinEntry[] = [];
-    for (let i = 0; i < entryCount; i++) {
-      const offset = BIN_HEADER_BYTES + i * BIN_ENTRY_BYTES;
-      const index = view.getUint32(offset, true);
-      const payloadOffset = view.getUint32(offset + 4, true);
-      const size = view.getUint32(offset + 8, true);
-      if (size <= 0) return null;
-
-      const start = payloadStart + payloadOffset;
-      const end = start + size;
-      if (start < payloadStart || end > buffer.byteLength) return null;
-
-      entries.push({
-        index,
-        offset: payloadOffset,
-        size,
-      });
-    }
-
-    return entries;
-  }
-
-  private async getBinBuffer(
-    mediaId: string,
-    mediaDir: FileSystemDirectoryHandle,
-    descriptor: FilmstripBinDescriptor
-  ): Promise<ArrayBuffer | null> {
-    const cache = this.getBinBufferMap(mediaId);
-    const cached = cache.get(descriptor.binIndex);
-    if (cached) return cached;
-
-    try {
-      const handle = await mediaDir.getFileHandle(descriptor.fileName);
-      const file = await handle.getFile();
-      if (file.size === 0) return null;
-      const buffer = await file.arrayBuffer();
-      cache.set(descriptor.binIndex, buffer);
-      return buffer;
-    } catch {
-      return null;
-    }
-  }
-
-  private async loadFramesFromBins(
-    mediaId: string,
-    mediaDir: FileSystemDirectoryHandle,
-    binIndex: FilmstripBinIndex
-  ): Promise<{ frames: FilmstripFrame[]; existingIndices: number[] } | null> {
-    const frameRecords: { index: number; blob: Blob }[] = [];
-
-    for (const descriptor of binIndex.bins) {
-      const buffer = await this.getBinBuffer(mediaId, mediaDir, descriptor);
-      if (!buffer) return null;
-
-      const entries = this.parseBinEntries(buffer);
-      if (!entries) return null;
-
-      const payloadStart = BIN_HEADER_BYTES + entries.length * BIN_ENTRY_BYTES;
-      for (const entry of entries) {
-        const start = payloadStart + entry.offset;
-        const end = start + entry.size;
-        const blob = new Blob([buffer.slice(start, end)], { type: 'image/webp' });
-        frameRecords.push({ index: entry.index, blob });
-      }
-    }
-
-    frameRecords.sort((a, b) => a.index - b.index);
-
-    const urls: string[] = [];
-    const frames: FilmstripFrame[] = frameRecords.map(({ index, blob }) => {
-      const url = URL.createObjectURL(blob);
-      urls.push(url);
-      return {
-        index,
-        timestamp: index / FRAME_RATE,
-        url,
-      };
-    });
-    this.objectUrls.set(mediaId, urls);
-
-    return {
-      frames,
-      existingIndices: frameRecords.map((r) => r.index),
-    };
-  }
-
-  private async loadSingleFrameFromBins(
-    mediaId: string,
-    index: number,
-    mediaDir: FileSystemDirectoryHandle,
-    binIndex: FilmstripBinIndex
-  ): Promise<FilmstripFrame | null> {
-    const descriptor = binIndex.bins.find((bin) => bin.frameIndices.includes(index));
-    if (!descriptor) return null;
-
-    const buffer = await this.getBinBuffer(mediaId, mediaDir, descriptor);
-    if (!buffer) return null;
-
-    const entries = this.parseBinEntries(buffer);
-    if (!entries) return null;
-
-    const target = entries.find((entry) => entry.index === index);
-    if (!target) return null;
-
-    const payloadStart = BIN_HEADER_BYTES + entries.length * BIN_ENTRY_BYTES;
-    const start = payloadStart + target.offset;
-    const end = start + target.size;
-    const blob = new Blob([buffer.slice(start, end)], { type: 'image/webp' });
-    const url = URL.createObjectURL(blob);
-    this.trackUrl(mediaId, url);
-
-    return {
-      index,
-      timestamp: index / FRAME_RATE,
-      url,
-    };
-  }
-
   /**
    * Save metadata file (used by worker and fallback extraction)
    */
@@ -403,7 +111,10 @@ class FilmstripOPFSStorage {
     metadata: { width: number; height: number; isComplete: boolean; frameCount: number }
   ): Promise<void> {
     const mediaDir = await this.getOrCreateMediaDir(mediaId);
-    await this.writeJsonFile(mediaDir, 'meta.json', metadata);
+    const fileHandle = await mediaDir.getFileHandle('meta.json', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify(metadata));
+    await writable.close();
   }
 
   /**
@@ -418,115 +129,6 @@ class FilmstripOPFSStorage {
   }
 
   /**
-   * Compact a completed legacy filmstrip into binned storage.
-   * Safe to call repeatedly; no-op if already compacted or incomplete.
-   */
-  async compactToBins(mediaId: string): Promise<void> {
-    const pending = this.compactionPromises.get(mediaId);
-    if (pending) {
-      return pending;
-    }
-
-    const promise = this.runCompaction(mediaId).finally(() => {
-      this.compactionPromises.delete(mediaId);
-    });
-    this.compactionPromises.set(mediaId, promise);
-    return promise;
-  }
-
-  private async runCompaction(mediaId: string): Promise<void> {
-    const mediaDir = await this.getMediaDir(mediaId);
-    if (!mediaDir) return;
-
-    const metadata = await this.readMetadata(mediaDir);
-    if (!metadata || !metadata.isComplete) return;
-
-    const existingBinIndex = await this.getBinIndex(mediaId, mediaDir);
-    if (existingBinIndex) return;
-
-    const legacyFrames = await this.readLegacyFrameFiles(mediaDir);
-    if (legacyFrames.length === 0) return;
-
-    type RawFrame = { index: number; bytes: ArrayBuffer };
-    const byBin = new Map<number, RawFrame[]>();
-    for (const frame of legacyFrames) {
-      const bytes = await frame.file.arrayBuffer();
-      if (bytes.byteLength === 0) continue;
-      const binIndex = Math.floor(frame.index / FRAMES_PER_BIN);
-      const group = byBin.get(binIndex) ?? [];
-      group.push({ index: frame.index, bytes });
-      byBin.set(binIndex, group);
-    }
-
-    const sortedBinIndexes = Array.from(byBin.keys()).sort((a, b) => a - b);
-    const descriptors: FilmstripBinDescriptor[] = [];
-
-    for (const binIndex of sortedBinIndexes) {
-      const frames = byBin.get(binIndex);
-      if (!frames || frames.length === 0) continue;
-      frames.sort((a, b) => a.index - b.index);
-
-      const entryCount = frames.length;
-      const tableBytes = entryCount * BIN_ENTRY_BYTES;
-      const payloadStart = BIN_HEADER_BYTES + tableBytes;
-      const payloadBytes = frames.reduce((sum, frame) => sum + frame.bytes.byteLength, 0);
-      const totalBytes = payloadStart + payloadBytes;
-
-      const out = new ArrayBuffer(totalBytes);
-      const view = new DataView(out);
-      const outBytes = new Uint8Array(out);
-
-      view.setUint32(0, entryCount, true);
-
-      let payloadOffset = 0;
-      for (let i = 0; i < frames.length; i++) {
-        const frame = frames[i]!;
-        const tableOffset = BIN_HEADER_BYTES + i * BIN_ENTRY_BYTES;
-        view.setUint32(tableOffset, frame.index, true);
-        view.setUint32(tableOffset + 4, payloadOffset, true);
-        view.setUint32(tableOffset + 8, frame.bytes.byteLength, true);
-
-        outBytes.set(new Uint8Array(frame.bytes), payloadStart + payloadOffset);
-        payloadOffset += frame.bytes.byteLength;
-      }
-
-      const fileName = `bin-${binIndex}.bin`;
-      const handle = await mediaDir.getFileHandle(fileName, { create: true });
-      const writable = await handle.createWritable();
-      await writable.write(out);
-      await writable.close();
-
-      descriptors.push({
-        binIndex,
-        fileName,
-        frameIndices: frames.map((frame) => frame.index),
-      });
-    }
-
-    const compactedFrameCount = descriptors.reduce((sum, descriptor) => sum + descriptor.frameIndices.length, 0);
-    if (compactedFrameCount === 0) return;
-
-    const index: FilmstripBinIndex = {
-      version: BIN_VERSION,
-      framesPerBin: FRAMES_PER_BIN,
-      frameCount: compactedFrameCount,
-      bins: descriptors,
-    };
-    await this.writeJsonFile(mediaDir, BIN_INDEX_FILE, index);
-    this.binIndexCache.set(mediaId, index);
-    this.binBufferCache.delete(mediaId);
-
-    // Remove legacy per-frame files once the bin index is durable.
-    for (const frame of legacyFrames) {
-      await mediaDir.removeEntry(`${frame.index}.webp`).catch(() => {});
-    }
-
-    logger.info(
-      `Compacted filmstrip ${mediaId}: ${compactedFrameCount} frames -> ${descriptors.length} bins`
-    );
-  }
-
-  /**
    * Load filmstrip - returns object URLs for img src
    */
   async load(mediaId: string): Promise<LoadedFilmstrip | null> {
@@ -534,42 +136,57 @@ class FilmstripOPFSStorage {
       const mediaDir = await this.getMediaDir(mediaId);
       if (!mediaDir) return null;
 
-      const metadata = await this.readMetadata(mediaDir);
-      if (!metadata) return null;
+      // Load metadata
+      let metadata: FilmstripMetadata;
+      try {
+        const metaHandle = await mediaDir.getFileHandle('meta.json');
+        const metaFile = await metaHandle.getFile();
+        metadata = JSON.parse(await metaFile.text());
+      } catch {
+        return null;
+      }
 
-      let frames: FilmstripFrame[] = [];
-      let existingIndices: number[] = [];
-
-      const binIndex = await this.getBinIndex(mediaId, mediaDir);
-      if (binIndex) {
-        const binned = await this.loadFramesFromBins(mediaId, mediaDir, binIndex);
-        if (binned) {
-          frames = binned.frames;
-          existingIndices = binned.existingIndices;
-        } else {
-          // Index is unusable; clear cache and fall back to legacy files.
-          this.clearMediaCaches(mediaId);
+      // Collect frame files
+      const frameFiles: { index: number; file: File }[] = [];
+      for await (const entry of mediaDir.values()) {
+        if (entry.kind === 'file' && entry.name.endsWith('.webp')) {
+          const index = parseInt(entry.name.replace('.webp', ''), 10);
+          if (!isNaN(index)) {
+            try {
+              const fileHandle = await mediaDir.getFileHandle(entry.name);
+              const file = await fileHandle.getFile();
+              if (file.size > 0) {
+                frameFiles.push({ index, file });
+              }
+            } catch {
+              // Skip unreadable files
+            }
+          }
         }
       }
 
-      if (frames.length === 0) {
-        const frameFiles = await this.readLegacyFrameFiles(mediaDir);
+      // Sort by index
+      frameFiles.sort((a, b) => a.index - b.index);
 
-        // Don't revoke URLs here - they may still be in use by displayed components.
-        // URLs are only cleaned up when filmstrip is explicitly deleted or cleared.
-        const urls: string[] = [];
-        frames = frameFiles.map(({ index, file }) => {
-          const url = URL.createObjectURL(file);
-          urls.push(url);
-          return {
-            index,
-            timestamp: index / FRAME_RATE,
-            url,
-          };
-        });
-        this.objectUrls.set(mediaId, urls);
-        existingIndices = frameFiles.map((f) => f.index);
-      }
+      // Don't revoke URLs here - they may still be in use by displayed components.
+      // URLs are only cleaned up when filmstrip is explicitly deleted or cleared.
+
+      // Create object URLs
+      const urls: string[] = [];
+      const frames: FilmstripFrame[] = frameFiles.map(({ index, file }) => {
+        const url = URL.createObjectURL(file);
+        urls.push(url);
+        return {
+          index,
+          timestamp: index / FRAME_RATE,
+          url,
+        };
+      });
+
+      // Store URLs for cleanup
+      this.objectUrls.set(mediaId, urls);
+
+      const existingIndices = frameFiles.map(f => f.index);
 
       // Sanity check: if marked complete but no frames, treat as incomplete
       if (metadata.isComplete && frames.length === 0) {
@@ -579,6 +196,7 @@ class FilmstripOPFSStorage {
       }
 
       logger.debug(`Loaded filmstrip ${mediaId}: ${frames.length} frames, complete: ${metadata.isComplete}`);
+
       return { metadata, frames, existingIndices };
     } catch (error) {
       logger.warn('Failed to load filmstrip:', error);
@@ -594,13 +212,25 @@ class FilmstripOPFSStorage {
       const mediaDir = await this.getMediaDir(mediaId);
       if (!mediaDir) return [];
 
-      const binIndex = await this.getBinIndex(mediaId, mediaDir);
-      if (binIndex) {
-        return this.getFrameIndicesFromBinIndex(binIndex);
+      const indices: number[] = [];
+      for await (const entry of mediaDir.values()) {
+        if (entry.kind === 'file' && entry.name.endsWith('.webp')) {
+          const index = parseInt(entry.name.replace('.webp', ''), 10);
+          if (!isNaN(index)) {
+            try {
+              const fileHandle = await mediaDir.getFileHandle(entry.name);
+              const file = await fileHandle.getFile();
+              if (file.size > 0) {
+                indices.push(index);
+              }
+            } catch {
+              // Skip
+            }
+          }
+        }
       }
 
-      const legacy = await this.readLegacyFrameFiles(mediaDir);
-      return legacy.map((frame) => frame.index);
+      return indices.sort((a, b) => a - b);
     } catch {
       return [];
     }
@@ -614,19 +244,16 @@ class FilmstripOPFSStorage {
       const mediaDir = await this.getMediaDir(mediaId);
       if (!mediaDir) return null;
 
-      const binIndex = await this.getBinIndex(mediaId, mediaDir);
-      if (binIndex) {
-        const binnedFrame = await this.loadSingleFrameFromBins(mediaId, index, mediaDir, binIndex);
-        if (binnedFrame) return binnedFrame;
-      }
-
-      // Fallback for legacy/in-progress extraction.
       const fileHandle = await mediaDir.getFileHandle(`${index}.webp`);
       const file = await fileHandle.getFile();
       if (file.size === 0) return null;
 
       const url = URL.createObjectURL(file);
-      this.trackUrl(mediaId, url);
+
+      // Track this URL for cleanup
+      const urls = this.objectUrls.get(mediaId) || [];
+      urls.push(url);
+      this.objectUrls.set(mediaId, urls);
 
       return {
         index,
@@ -646,8 +273,10 @@ class FilmstripOPFSStorage {
       const mediaDir = await this.getMediaDir(mediaId);
       if (!mediaDir) return false;
 
-      const metadata = await this.readMetadata(mediaDir);
-      return metadata?.isComplete ?? false;
+      const metaHandle = await mediaDir.getFileHandle('meta.json');
+      const metaFile = await metaHandle.getFile();
+      const metadata: FilmstripMetadata = JSON.parse(await metaFile.text());
+      return metadata.isComplete;
     } catch {
       return false;
     }
@@ -658,14 +287,12 @@ class FilmstripOPFSStorage {
    */
   async delete(mediaId: string): Promise<void> {
     this.revokeUrls(mediaId);
-    this.clearMediaCaches(mediaId);
-    this.compactionPromises.delete(mediaId);
     try {
       const dir = await this.ensureDirectory();
       await dir.removeEntry(mediaId, { recursive: true });
       logger.debug(`Deleted filmstrip ${mediaId}`);
     } catch {
-      // May not exist.
+      // May not exist
     }
   }
 
@@ -690,9 +317,6 @@ class FilmstripOPFSStorage {
     for (const mediaId of this.objectUrls.keys()) {
       this.revokeUrls(mediaId);
     }
-    this.binIndexCache.clear();
-    this.binBufferCache.clear();
-    this.compactionPromises.clear();
 
     try {
       const dir = await this.ensureDirectory();

--- a/src/features/timeline/workers/filmstrip-extraction-worker.ts
+++ b/src/features/timeline/workers/filmstrip-extraction-worker.ts
@@ -43,8 +43,6 @@ export interface ProgressResponse {
   frameIndex: number;
   frameCount: number;
   progress: number;
-  frameIndices?: number[]; // Newly saved frame indices since last progress report
-  frames?: Array<{ index: number; blob: Blob }>; // Newly saved frame payloads
 }
 
 export interface CompleteResponse {
@@ -92,6 +90,19 @@ async function saveFrame(
 }
 
 /**
+ * Save metadata to OPFS
+ */
+async function saveMetadata(
+  dir: FileSystemDirectoryHandle,
+  metadata: { width: number; height: number; isComplete: boolean; frameCount: number }
+): Promise<void> {
+  const fileHandle = await dir.getFileHandle('meta.json', { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(JSON.stringify(metadata));
+  await writable.close();
+}
+
+/**
  * Extract frames and save directly to OPFS
  */
 async function extractAndSave(
@@ -131,6 +142,9 @@ async function extractAndSave(
   // Get OPFS directory
   const dir = await getFilmstripDir(mediaId);
 
+  // Save initial metadata
+  await saveMetadata(dir, { width, height, isComplete: false, frameCount: skipSet.size });
+
   // Load mediabunny
   const { Input, UrlSource, CanvasSink, ALL_FORMATS } = await loadMediabunny();
 
@@ -162,8 +176,6 @@ async function extractAndSave(
     // Track extracted frames
     let extractedCount = skipSet.size;
     let frameListIndex = 0;
-    const newlySavedFrameIndices: number[] = [];
-    const newlySavedFrames: Array<{ index: number; blob: Blob }> = [];
 
     // Generator for timestamps
     async function* timestampGenerator(): AsyncGenerator<number> {
@@ -199,8 +211,6 @@ async function extractAndSave(
       // Save to OPFS in parallel (don't await)
       const frameIndex = frame.index;
       const savePromise = saveFrame(dir, frameIndex, blob).then(() => {
-        newlySavedFrameIndices.push(frameIndex);
-        newlySavedFrames.push({ index: frameIndex, blob });
         // Remove from pending when done
         const idx = pendingSaves.indexOf(savePromise);
         if (idx > -1) pendingSaves.splice(idx, 1);
@@ -219,8 +229,6 @@ async function extractAndSave(
       const shouldReport = extractedCount <= 3 || extractedCount % 10 === 0;
       if (shouldReport) {
         const progress = Math.round((extractedCount / totalFrames) * 100);
-        const frameIndices = newlySavedFrameIndices.splice(0, newlySavedFrameIndices.length);
-        const frames = newlySavedFrames.splice(0, newlySavedFrames.length);
 
         self.postMessage({
           type: 'progress',
@@ -228,8 +236,6 @@ async function extractAndSave(
           frameIndex,
           frameCount: extractedCount,
           progress: Math.min(progress, 99),
-          frameIndices,
-          frames,
         } as ProgressResponse);
       }
     }
@@ -239,20 +245,16 @@ async function extractAndSave(
       await Promise.all(pendingSaves);
     }
 
+    // Save final metadata - only mark complete if we actually have frames
     if (!state.aborted) {
-      // Flush any newly saved frame indices that have not been reported yet.
-      if (newlySavedFrameIndices.length > 0) {
-        const progress = Math.round((extractedCount / totalFrames) * 100);
-        self.postMessage({
-          type: 'progress',
-          requestId,
-          frameIndex: Math.max(0, rangeStart),
-          frameCount: extractedCount,
-          progress: Math.min(progress, 99),
-          frameIndices: newlySavedFrameIndices.splice(0, newlySavedFrameIndices.length),
-          frames: newlySavedFrames.splice(0, newlySavedFrames.length),
-        } as ProgressResponse);
-      }
+      const actuallyComplete = extractedCount > 0;
+
+      await saveMetadata(dir, {
+        width,
+        height,
+        isComplete: actuallyComplete,
+        frameCount: extractedCount,
+      });
 
       self.postMessage({
         type: 'complete',


### PR DESCRIPTION
## Summary

- Revert "feat(timeline): binned OPFS filmstrip storage, streamed frame delivery, and flicker-free tiles"
- Revert "fix(timeline): prevent stale async loads from swapping filmstrip tiles"

## Test plan
- [ ] Verify filmstrip rendering still works after reverts
- [ ] Confirm no stale tile flicker regressions