### PR TITLE
fix(timeline): robust OPFS filmstrip frame discovery and writable error handling

### DIFF
--- a/src/features/timeline/utils/opfs-safe-write.ts
+++ b/src/features/timeline/utils/opfs-safe-write.ts
@@ -1,0 +1,21 @@
+export async function safeWrite(
+  writable: FileSystemWritableFileStream,
+  data: FileSystemWriteChunkType
+): Promise<void> {
+  let error: unknown;
+  try {
+    await writable.write(data);
+    await writable.close();
+  } catch (writeError) {
+    error = writeError;
+    throw writeError;
+  } finally {
+    if (error) {
+      try {
+        await writable.abort(error);
+      } catch {
+        // Ignore abort failures from already-closed handles.
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace synthetic contiguous-offset frame tracking with disk-based discovery so incremental loads correctly find frames written by parallel workers
- Abort OPFS writables on error to prevent locked file handles
- Fix completion detection to account for skipped (already-extracted) frames
- Preserve existing object URLs on incremental loads to prevent stale references

## Test plan
- [ ] Import a video and verify filmstrip thumbnails render correctly on the timeline
- [ ] Verify filmstrip extraction completes without errors in the console
- [ ] Test with multiple videos to confirm parallel worker extraction works
- [ ] Reload the project and verify cached filmstrips load from OPFS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable frame storage and write operations to reduce data corruption and recovery issues.
  * Improved discovery and incremental loading of filmstrip frames for more accurate playback progress.
  * More precise detection of extraction completion to avoid premature or incomplete processing.
  * Safer resource and URL cleanup to prevent rendering glitches and leaks.

* **Enhancements**
  * Serialized, de-duplicated range loading to reduce redundant work and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->