### PR TITLE
Add option to delete local files when deleting a project

### DIFF
--- a/src/features/projects/hooks/use-project-actions.ts
+++ b/src/features/projects/hooks/use-project-actions.ts
@@ -78,9 +78,9 @@ export const useDeleteProject = () => {
   const deleteProject = useProjectStore((s) => s.deleteProject);
 
   return useCallback(
-    async (id: string) => {
+    async (id: string, clearLocalFiles?: boolean) => {
       try {
-        await deleteProject(id);
+        await deleteProject(id, clearLocalFiles);
         return { success: true, error: null };
       } catch (error) {
         return {


### PR DESCRIPTION
## Summary
- Adds a checkbox to the project delete confirmation dialog that lets users optionally delete the linked local folder on disk
- Checkbox only appears when the project has a linked root folder (`rootFolderHandle`)
- Uses Chromium's `FileSystemDirectoryHandle.remove({ recursive: true })` to delete the folder itself, with a fallback to clearing contents on unsupported browsers
- File system errors are logged but never block the project deletion

## Test plan
- [ ] Create a project and link a local folder to it
- [ ] Open delete dialog — verify checkbox appears with folder name
- [ ] Delete without checking — verify local files remain on disk
- [ ] Delete with checkbox checked — verify local folder is removed from disk
- [ ] Delete a project without a linked folder — verify no checkbox is shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an option to delete local files from disk when deleting a project. Users can now check a box in the delete confirmation dialog to remove local project files alongside the project deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->