### PR TITLE
Add Brave browser support and landing page improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Open [http://localhost:5173](http://localhost:5173) in Chrome.
 
 Chrome 102+ required. FreeCut uses WebCodecs, OPFS, and the File System Access API which are not yet available in all browsers.
 
+### Brave
+
+Brave disables the File System Access API by default. To enable it:
+
+1. Navigate to `brave://flags/#file-system-access-api`
+2. Change the setting from **Disabled** to **Enabled**
+3. Click **Relaunch** to restart the browser
+
 ## Keyboard Shortcuts
 
 | Action | Shortcut |

--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react';
-import { Search, Filter, SortAsc, Video, FileAudio, Image as ImageIcon, Trash2, Grid3x3, List, AlertTriangle, Info, X, FolderOpen, Link2Off, ChevronRight, Film, ArrowLeft, Zap, Loader2 } from 'lucide-react';
+import { Search, Filter, SortAsc, Video, FileAudio, Image as ImageIcon, Trash2, Grid3x3, List, AlertTriangle, Info, X, FolderOpen, Link2Off, ChevronRight, Film, ArrowLeft, Zap, Loader2, Copy, Check } from 'lucide-react';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('MediaLibrary');
@@ -41,6 +41,24 @@ import { useProjectStore } from '@/features/projects/stores/project-store';
 import { proxyService } from '../services/proxy-service';
 import { mediaLibraryService } from '../services/media-library-service';
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center justify-center h-5 w-5 rounded hover:bg-muted transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3 text-muted-foreground" />}
+    </button>
+  );
+}
+
 interface MediaLibraryProps {
   onMediaSelect?: (mediaId: string) => void;
 }
@@ -77,6 +95,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
   const mediaItems = useMediaLibraryStore((s) => s.mediaItems);
   const clearSelection = useMediaLibraryStore((s) => s.clearSelection);
   const error = useMediaLibraryStore((s) => s.error);
+  const errorLink = useMediaLibraryStore((s) => s.errorLink);
   const clearError = useMediaLibraryStore((s) => s.clearError);
   const notification = useMediaLibraryStore((s) => s.notification);
   const clearNotification = useMediaLibraryStore((s) => s.clearNotification);
@@ -388,7 +407,17 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
       {error && (
         <div className="mx-4 mt-3 p-3 bg-destructive/10 border border-destructive/50 rounded text-xs animate-in slide-in-from-top-2 duration-200">
           <div className="flex items-start justify-between gap-2">
-            <p className="text-destructive leading-relaxed flex-1">{error}</p>
+            <div className="text-destructive leading-relaxed flex-1">
+              <p>{error}</p>
+              {errorLink && (
+                <div className="mt-2 flex items-center gap-1.5">
+                  <code className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-foreground select-text">
+                    {errorLink}
+                  </code>
+                  <CopyButton text={errorLink} />
+                </div>
+              )}
+            </div>
             <Button
               variant="ghost"
               size="sm"

--- a/src/features/media-library/stores/media-import-actions.ts
+++ b/src/features/media-library/stores/media-import-actions.ts
@@ -30,7 +30,13 @@ export function createImportActions(
 
       // Check if File System Access API is supported
       if (!('showOpenFilePicker' in window)) {
-        set({ error: 'File picker not supported. Please use Google Chrome.' });
+        const isBrave = 'brave' in navigator;
+        set({
+          error: isBrave
+            ? 'File System Access API is disabled in Brave. Copy the URL below, paste it in your address bar, set the flag to Enabled, and relaunch.'
+            : 'File picker not supported. Please use Google Chrome.',
+          errorLink: isBrave ? 'brave://flags/#file-system-access-api' : null,
+        });
         return [];
       }
 

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -24,6 +24,7 @@ export const useMediaLibraryStore = create<
       isLoading: false, // Only load once a project context is available
       importingIds: [],
       error: null,
+      errorLink: null,
       notification: null,
       selectedMediaIds: [],
       searchQuery: '',
@@ -125,7 +126,7 @@ export const useMediaLibraryStore = create<
       setViewMode: (viewMode) => set({ viewMode }),
 
       // Utility actions
-      clearError: () => set({ error: null }),
+      clearError: () => set({ error: null, errorLink: null }),
 
       showNotification: (notification: MediaLibraryNotification) => {
         set({ notification });

--- a/src/features/media-library/types.ts
+++ b/src/features/media-library/types.ts
@@ -48,6 +48,7 @@ export interface MediaLibraryState {
   isLoading: boolean;
   importingIds: string[]; // IDs of media items currently being imported
   error: string | null;
+  errorLink: string | null;
   notification: MediaLibraryNotification | null;
   selectedMediaIds: string[];
   searchQuery: string;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,8 +27,25 @@ const faqItems = [
     answer: 'Your videos and projects are stored locally in your browser or referenced to your local files using modern storage APIs.',
   },
   {
+    id: 'browser-support',
     question: 'What browsers are supported?',
-    answer: 'FreeCut currently supports Google Chrome version 102+. We use modern browser APIs like WebCodecs and File System Access which have limited cross-browser support.',
+    answer: (
+      <>
+        <p className="mb-3">
+          FreeCut currently supports Google Chrome version 102+. We use modern
+          browser APIs like WebCodecs and File System Access which have limited
+          cross-browser support.
+        </p>
+        <p>
+          <strong>Brave users:</strong> The File System Access API is disabled by
+          default. To enable it, navigate to{' '}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            brave://flags/#file-system-access-api
+          </code>
+          , set it to <strong>Enabled</strong>, and relaunch the browser.
+        </p>
+      </>
+    ),
   },
   {
     question: 'What export formats are supported?',
@@ -102,7 +119,7 @@ const showcaseItems = [
 
 function LandingPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-background text-foreground select-text">
       {/* Hero Section */}
       <section className="relative flex min-h-[60vh] flex-col items-center justify-center px-6 py-12">
         {/* Subtle gradient background */}
@@ -259,7 +276,7 @@ function LandingPage() {
 
           <Accordion type="single" collapsible className="w-full">
             {faqItems.map((item, index) => (
-              <AccordionItem key={index} value={`item-${index}`}>
+              <AccordionItem key={index} value={`item-${index}`} id={item.id}>
                 <AccordionTrigger className="text-left">
                   {item.question}
                 </AccordionTrigger>


### PR DESCRIPTION
## Summary
- Detect Brave browser when the File System Access API is unavailable and show a targeted error with the `brave://flags` URL and a copy-to-clipboard button
- Add Brave setup instructions to the landing page FAQ and README
- Enable text selection on the landing page

## Test plan
- [ ] Open FreeCut in Brave with File System Access API disabled and verify the import error shows the flags URL with a copy button
- [ ] Verify the copy button copies the URL to clipboard
- [ ] Verify the landing page FAQ "What browsers are supported?" section displays the Brave instructions
- [ ] Verify text is selectable on the landing page
- [ ] Verify the README includes the new Brave section under Browser Support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages now display with copyable links for accessing support resources and additional context.
  * Added Brave browser support with detailed setup instructions in the FAQ.

* **Documentation**
  * Updated README with step-by-step Brave File System Access API configuration guide.

* **Style**
  * Improved text selectability on the main page for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->