### PR TITLE
fix: resolve TypeScript strict mode errors

### DIFF
--- a/src/features/preview/utils/media-resolver.test.ts
+++ b/src/features/preview/utils/media-resolver.test.ts
@@ -3,7 +3,7 @@ import { resolveMediaUrl, resolveMediaUrls, cleanupBlobUrls } from './media-reso
 import { blobUrlManager } from '@/lib/blob-url-manager';
 import { mediaLibraryService, FileAccessError } from '@/features/media-library/services/media-library-service';
 import { useMediaLibraryStore } from '@/features/media-library/stores/media-library-store';
-import type { TimelineTrack } from '@/types/timeline';
+import type { TimelineTrack, VideoItem } from '@/types/timeline';
 
 // Mock dependencies
 vi.mock('@/features/media-library/services/media-library-service', () => ({
@@ -178,6 +178,12 @@ describe('resolveMediaUrls', () => {
     const tracks: TimelineTrack[] = [
       {
         id: 'track-1',
+        name: 'Track 1',
+        height: 40,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
         order: 0,
         items: [
           {
@@ -187,6 +193,7 @@ describe('resolveMediaUrls', () => {
             from: 0,
             durationInFrames: 30,
             mediaId: 'media-1',
+            src: '',
             label: 'clip',
           },
           {
@@ -195,6 +202,8 @@ describe('resolveMediaUrls', () => {
             trackId: 'track-1',
             from: 0,
             durationInFrames: 30,
+            text: 'test',
+            color: '#ffffff',
             label: 'text',
           },
         ],
@@ -204,9 +213,9 @@ describe('resolveMediaUrls', () => {
     const resolved = await resolveMediaUrls(tracks, { useProxy: false });
 
     // Video item should have src resolved
-    expect(resolved[0]!.items[0]!.src).toMatch(/^blob:test-/);
+    expect((resolved[0]!.items[0]! as VideoItem).src).toMatch(/^blob:test-/);
     // Text item should be unchanged (no mediaId)
-    expect(resolved[0]!.items[1]!.src).toBeUndefined();
+    expect((resolved[0]!.items[1]! as any).src).toBeUndefined();
   });
 
   it('does not mutate original tracks', async () => {
@@ -221,6 +230,12 @@ describe('resolveMediaUrls', () => {
     const tracks: TimelineTrack[] = [
       {
         id: 'track-1',
+        name: 'Track 1',
+        height: 40,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
         order: 0,
         items: [
           {
@@ -230,6 +245,7 @@ describe('resolveMediaUrls', () => {
             from: 0,
             durationInFrames: 30,
             mediaId: 'media-1',
+            src: '',
             label: 'clip',
           },
         ],
@@ -239,7 +255,7 @@ describe('resolveMediaUrls', () => {
     await resolveMediaUrls(tracks, { useProxy: false });
 
     // Original should not be mutated
-    expect(tracks[0]!.items[0]!.src).toBeUndefined();
+    expect((tracks[0]!.items[0]! as VideoItem).src).toBe('');
   });
 });
 

--- a/src/features/project-bundle/services/bundle-export-service.ts
+++ b/src/features/project-bundle/services/bundle-export-service.ts
@@ -294,7 +294,7 @@ export async function exportProjectBundleStreaming(
       if (err) { zipError = err; return; }
       if (chunk) {
         totalSize += chunk.length;
-        writePromises.push(writable.write(chunk));
+        writePromises.push(writable.write(chunk as Uint8Array<ArrayBuffer>));
       }
     });
 

--- a/src/features/projects/utils/project-helpers.ts
+++ b/src/features/projects/utils/project-helpers.ts
@@ -203,7 +203,7 @@ export function generateTemplateName(
   for (const name of existingNames) {
     const match = name.match(pattern);
     if (match) {
-      const suffix = parseInt(match[1], 10);
+      const suffix = parseInt(match[1]!, 10);
       maxSuffix = Math.max(maxSuffix, suffix);
     }
   }

--- a/src/features/timeline/services/waveform-cache.ts
+++ b/src/features/timeline/services/waveform-cache.ts
@@ -467,7 +467,7 @@ class WaveformCacheService {
                 mediaId,
                 kind: 'bin',
                 binIndex,
-                peaks: chunkPeaks.buffer,
+                peaks: chunkPeaks.buffer as ArrayBuffer,
                 samples: chunkPeaks.length,
                 createdAt: Date.now(),
               };

--- a/src/lib/composition-runtime/utils/audio-decode-cache.ts
+++ b/src/lib/composition-runtime/utils/audio-decode-cache.ts
@@ -431,8 +431,8 @@ async function persistBin(
     mediaId,
     kind: 'bin',
     binIndex: binIdx,
-    left: leftInt16.buffer,
-    right: rightInt16.buffer,
+    left: leftInt16.buffer as ArrayBuffer,
+    right: rightInt16.buffer as ArrayBuffer,
     frames: downsampled.length,
     createdAt: Date.now(),
   });


### PR DESCRIPTION
## Summary
- Fix `ArrayBufferLike` not assignable to `ArrayBuffer` errors in waveform-cache, audio-decode-cache, and bundle-export-service by adding explicit casts
- Add missing required properties (`src`, `text`, `color`, track fields) to test fixtures in media-resolver tests
- Fix `noUncheckedIndexedAccess` error in project-helpers with non-null assertion on regex capture group
- Fix union type property access in test assertions with proper type casts

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `vitest run media-resolver.test.ts` — all 11 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type consistency and safety across media processing, project management, and audio caching services.

* **Tests**
  * Updated test fixtures and assertions to align with enhanced type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->