### PR TITLE
fix(editor): resolve stale properties panel on clip selection

### DIFF
--- a/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
@@ -66,10 +66,12 @@ export const ClipPanel = memo(function ClipPanel() {
   // NOTE: Do NOT use useShallow(useCallback(..., [selectedItemIds])) as a combined
   // selector here. React 19's useSyncExternalStore does not re-evaluate a changed
   // selector function when the re-render was triggered by a different store
-  // (selection store), causing stale items to be returned.
+  // (selection store), causing stale items to be returned. Wrapping cross-store
+  // deps like selectedItemIds in the selector reintroduces this stale-selector bug.
   // Trade-off: subscribing to s.items means ClipPanel re-renders on any item
-  // mutation. If this becomes a hot path, replace with a custom equality selector:
-  //   useTimelineStore(useCallback((s) => s.items.filter(...), [selectedItemIds]), isShallowEqual)
+  // mutation. useTimelineStore (the facade in timeline-store-facade.ts) only accepts
+  // a single selector — no custom equality comparator. If perf becomes a problem,
+  // consider subscribeWithSelector or restructuring to avoid deriving here.
   const items = useTimelineStore((s: TimelineState & TimelineActions) => s.items);
   const selectedItemIdSet = useMemo(() => new Set(selectedItemIds), [selectedItemIds]);
   const selectedItems = useMemo(


### PR DESCRIPTION
## Summary
- Fix properties panel not updating when switching selected clips in the timeline
- Root cause: React 19's `useSyncExternalStore` does not re-evaluate a changed selector function when the re-render was triggered by a different store (selection store triggers re-render, but timeline store's `useShallow(useCallback(...))` selector returns stale cached result)
- Replace cross-store `useShallow(useCallback(..., [selectedItemIds]))` pattern with direct `items` subscription + `useMemo` derivation

## Test plan
- [ ] Select a clip in the timeline — properties panel shows its properties
- [ ] Click a different clip — properties panel updates to the new clip
- [ ] Rapidly switch between video, image, text, and shape clips — panel always reflects current selection
- [ ] Multi-select clips — panel shows shared/mixed properties
- [ ] Deselect all clips — panel falls back to canvas properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where selected items in the clip panel could display stale data under certain React conditions, ensuring selections update reliably in real time when viewing or editing clips.
  * No visible UI or API changes; behavior adjusted to improve selection consistency (may affect internal update frequency to ensure correctness).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->