### PR TITLE
fix(projects): preserve aspect ratio in resolution template silhouettes

### DIFF
--- a/src/features/projects/components/project-template-picker.tsx
+++ b/src/features/projects/components/project-template-picker.tsx
@@ -34,7 +34,7 @@ export function ProjectTemplatePicker({
              }`}
            >
              {/* Silhouette Container */}
-             <div className="relative h-24 bg-secondary/30 rounded overflow-hidden flex items-center justify-center">
+             <div className="relative h-24 bg-secondary/30 rounded overflow-hidden flex items-center justify-center" style={{ containerType: 'size' }}>
                {/* Aspect Ratio Silhouette */}
                <div
                  className={`bg-primary/20 border-2 border-dashed rounded-sm ${
@@ -42,8 +42,8 @@ export function ProjectTemplatePicker({
                  }`}
                  style={{
                    aspectRatio: `${template.width} / ${template.height}`,
-                   height: '100%',
-                   maxWidth: '100%',
+                   width: `min(100cqw, ${(template.width / template.height) * 100}cqh)`,
+                   height: `min(100cqh, ${(template.height / template.width) * 100}cqw)`,
                  }}
                />
              </div>


### PR DESCRIPTION
## Summary
- Fix resolution preset silhouettes in the project creation form rendering at incorrect aspect ratios (e.g. 16:9 appearing nearly square)
- Replace `height: 100%` / `maxWidth: 100%` sizing with CSS container query units (`cqw`/`cqh`) that properly contain-fit the silhouette within its container at any viewport width

## Test plan
- [ ] Open the "Create New Project" page
- [ ] Verify the YouTube 1080p (16:9) silhouette is visibly wider than tall
- [ ] Verify the Vertical/9:16 silhouette is visibly taller than wide
- [ ] Verify the Instagram Square (1:1) silhouette is square
- [ ] Verify the Instagram Portrait (4:5) silhouette is slightly taller than wide
- [ ] Resize the browser window and confirm all silhouettes maintain correct proportions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced responsive layout handling in the project template picker component through updated sizing approach, enabling better adaptation to different container dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->