### PR TITLE
feat(timeline): 3-row clip layout with dedicated label row

### DIFF
--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -3,7 +3,7 @@ import type { TimelineItem } from '@/types/timeline';
 import { ClipFilmstrip } from '../clip-filmstrip';
 import { ClipWaveform } from '../clip-waveform';
 import {
-  CLIP_LABEL_HEIGHT,
+  CLIP_LABEL_ROW_HEIGHT,
   VIDEO_WAVEFORM_HEIGHT,
 } from '@/features/timeline/constants';
 import { useSettingsStore } from '@/features/settings/stores/settings-store';
@@ -91,11 +91,18 @@ export const ClipContent = memo(function ClipContent({
   const trimStart = (item.trimStart ?? 0) / fps;
   const speed = item.speed ?? 1;
 
-  // Video clip 2-row layout: filmstrip (with overlayed label) | waveform
+  // Video clip 3-row layout: label | filmstrip | waveform
   if (item.type === 'video' && item.mediaId) {
     return (
       <div className="absolute inset-0 flex flex-col">
-        {/* Row 1: Filmstrip with overlayed label - flex-1 to fill remaining space */}
+        {/* Row 1: Label - fixed height */}
+        <div
+          className="px-2 text-[11px] font-medium truncate shrink-0"
+          style={{ height: CLIP_LABEL_ROW_HEIGHT, lineHeight: `${CLIP_LABEL_ROW_HEIGHT}px` }}
+        >
+          {item.label}
+        </div>
+        {/* Row 2: Filmstrip - flex-1 to fill remaining space */}
         <div className="relative overflow-hidden flex-1 min-h-0">
           {showFilmstrips && (
             <ClipFilmstrip
@@ -110,15 +117,8 @@ export const ClipContent = memo(function ClipContent({
               pixelsPerSecond={pixelsPerSecond}
             />
           )}
-          {/* Overlayed label */}
-          <div
-            className="absolute top-0 left-0 max-w-full px-2 text-[11px] font-medium truncate"
-            style={{ lineHeight: `${CLIP_LABEL_HEIGHT}px` }}
-          >
-            {item.label}
-          </div>
         </div>
-        {/* Row 2: Waveform - fixed height with gradient bg */}
+        {/* Row 3: Waveform - fixed height with gradient bg */}
         {showWaveforms && (
           <div className="relative overflow-hidden bg-waveform-gradient" style={{ height: VIDEO_WAVEFORM_HEIGHT }}>
             <ClipWaveform
@@ -138,29 +138,32 @@ export const ClipContent = memo(function ClipContent({
     );
   }
 
-  // Audio clip - waveform fills entire clip with overlayed label
+  // Audio clip - label row + waveform fills remaining space
   if (item.type === 'audio' && item.mediaId) {
     return (
-      <div className="absolute inset-0 bg-waveform-gradient">
-        {showWaveforms && (
-          <ClipWaveform
-            mediaId={item.mediaId}
-            clipWidth={clipWidth}
-            sourceStart={sourceStart}
-            sourceDuration={sourceDuration}
-            trimStart={trimStart}
-            speed={speed}
-            fps={fps}
-            isVisible={isClipVisible}
-            pixelsPerSecond={pixelsPerSecond}
-          />
-        )}
-        {/* Overlayed label */}
+      <div className="absolute inset-0 flex flex-col">
+        {/* Row 1: Label - fixed height */}
         <div
-          className="absolute top-0 left-0 max-w-full px-2 text-[11px] font-medium truncate"
-          style={{ lineHeight: `${CLIP_LABEL_HEIGHT}px` }}
+          className="px-2 text-[11px] font-medium truncate shrink-0"
+          style={{ height: CLIP_LABEL_ROW_HEIGHT, lineHeight: `${CLIP_LABEL_ROW_HEIGHT}px` }}
         >
           {item.label}
+        </div>
+        {/* Row 2: Waveform - fills remaining space */}
+        <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
+          {showWaveforms && (
+            <ClipWaveform
+              mediaId={item.mediaId}
+              clipWidth={clipWidth}
+              sourceStart={sourceStart}
+              sourceDuration={sourceDuration}
+              trimStart={trimStart}
+              speed={speed}
+              fps={fps}
+              isVisible={isClipVisible}
+              pixelsPerSecond={pixelsPerSecond}
+            />
+          )}
         </div>
       </div>
     );
@@ -183,6 +186,14 @@ export const ClipContent = memo(function ClipContent({
     if (compTopVideoMediaId) {
       return (
         <div className="absolute inset-0 flex flex-col">
+          {/* Row 1: Label - fixed height */}
+          <div
+            className="px-2 text-[11px] font-medium truncate shrink-0"
+            style={{ height: CLIP_LABEL_ROW_HEIGHT, lineHeight: `${CLIP_LABEL_ROW_HEIGHT}px` }}
+          >
+            {item.label || 'Composition'}
+          </div>
+          {/* Row 2: Filmstrip - flex-1 */}
           <div className="relative overflow-hidden flex-1 min-h-0">
             {showFilmstrips && (
               <ClipFilmstrip
@@ -197,13 +208,8 @@ export const ClipContent = memo(function ClipContent({
                 pixelsPerSecond={pixelsPerSecond}
               />
             )}
-            <div
-              className="absolute top-0 left-0 max-w-full px-2 text-[11px] font-medium truncate"
-              style={{ lineHeight: `${CLIP_LABEL_HEIGHT}px` }}
-            >
-              {item.label || 'Composition'}
-            </div>
           </div>
+          {/* Row 3: Waveform */}
           {showWaveforms && (
             <div className="relative overflow-hidden bg-waveform-gradient" style={{ height: VIDEO_WAVEFORM_HEIGHT }}>
               <ClipWaveform

--- a/src/features/timeline/components/timeline-item/clip-indicators.tsx
+++ b/src/features/timeline/components/timeline-item/clip-indicators.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { Link2Off, Diamond } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { CLIP_LABEL_ROW_HEIGHT } from '@/features/timeline/constants';
 
 interface ClipIndicatorsProps {
   /** Whether the item has keyframe animations */
@@ -42,26 +43,33 @@ export const ClipIndicators = memo(function ClipIndicators({
 
   return (
     <>
-      {/* Keyframe indicator */}
+      {/* Keyframe indicator - constrained to label row */}
       {hasKeyframes && (
         <div
-          className="absolute top-1 right-1 z-10 pointer-events-none"
+          className="absolute right-1 z-10 pointer-events-none flex items-center"
+          style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
           title="Has keyframe animations"
         >
           <Diamond className="w-3 h-3 text-amber-500 fill-amber-500/50" />
         </div>
       )}
 
-      {/* Mask indicator for shape items */}
+      {/* Mask indicator for shape items - constrained to label row */}
       {isShape && isMask && (
-        <div className="absolute top-1 right-1 px-1 py-0.5 text-[10px] font-bold bg-cyan-500/80 text-white rounded">
+        <div
+          className="absolute right-1 px-1 text-[10px] leading-none font-bold bg-cyan-500/80 text-white rounded flex items-center"
+          style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
+        >
           M
         </div>
       )}
 
-      {/* Speed badge - show when speed is not 1x */}
+      {/* Speed badge - constrained to label row */}
       {showSpeedBadge && (
-        <div className="absolute top-1 right-1 px-1 py-0.5 text-[10px] font-bold bg-black/60 text-white rounded font-mono">
+        <div
+          className="absolute right-1 px-1 text-[10px] leading-none font-bold bg-black/60 text-white rounded font-mono flex items-center"
+          style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
+        >
           {currentSpeed.toFixed(2)}x
         </div>
       )}

--- a/src/features/timeline/constants.ts
+++ b/src/features/timeline/constants.ts
@@ -7,19 +7,19 @@
 // TRACK & CLIP DIMENSIONS
 // =============================================================================
 
-export const DEFAULT_TRACK_HEIGHT = 64;
-export const MIN_TRACK_HEIGHT = 40;
+export const DEFAULT_TRACK_HEIGHT = 80;
+export const MIN_TRACK_HEIGHT = 48;
 export const MAX_TRACK_HEIGHT = 200;
 
 // Clip fills entire track height (selection ring is inset)
 const CLIP_HEIGHT = DEFAULT_TRACK_HEIGHT;
 
 // Shared clip layout
-export const CLIP_LABEL_HEIGHT = 16;
+export const CLIP_LABEL_ROW_HEIGHT = 18;
 
-// Video clip layout (2 rows: filmstrip with overlayed label | waveform)
+// Video clip layout (3 rows: label | filmstrip | waveform)
 export const VIDEO_WAVEFORM_HEIGHT = 30;
-const VIDEO_FILMSTRIP_HEIGHT = CLIP_HEIGHT - VIDEO_WAVEFORM_HEIGHT;
+const VIDEO_FILMSTRIP_HEIGHT = CLIP_HEIGHT - CLIP_LABEL_ROW_HEIGHT - VIDEO_WAVEFORM_HEIGHT;
 
 // =============================================================================
 // FILMSTRIP / THUMBNAILS

--- a/src/features/timeline/theme.css
+++ b/src/features/timeline/theme.css
@@ -13,7 +13,7 @@
 @theme {
   /* Timeline item type colors - OKLCH format (dark, muted for dark theme) */
   --color-timeline-baseclip: oklch(0.42 0 0);
-  --color-timeline-video: oklch(0.62 0.17 250);
+  --color-timeline-video: oklch(0.3991 0.0401 250);
   --color-timeline-audio: oklch(0.22 0.02 302);
   --color-timeline-image: oklch(0.62 0.17 250);
   --color-timeline-text: oklch(0.671 0 290);

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -80,6 +80,37 @@ const migrations: Record<number, Migration> = {
       };
     },
   },
+  /**
+   * Version 4: Increase default track height for 3-row clip layout
+   *
+   * The clip layout changed from 2-row (filmstrip with overlaid label + waveform)
+   * to 3-row (label | filmstrip | waveform). Increase track height from 64 to 80
+   * to accommodate the dedicated label row.
+   */
+  4: {
+    version: 4,
+    description: 'Increase track height from 64px to 80px for 3-row clip layout',
+    migrate: (project: Project): Project => {
+      if (!project.timeline?.tracks) {
+        return project;
+      }
+
+      const updatedTracks = project.timeline.tracks.map((track) => {
+        if (track.height === 64) {
+          return { ...track, height: DEFAULT_TRACK_HEIGHT };
+        }
+        return track;
+      });
+
+      return {
+        ...project,
+        timeline: {
+          ...project.timeline,
+          tracks: updatedTracks,
+        },
+      };
+    },
+  },
 };
 
 /**

--- a/src/lib/migrations/types.ts
+++ b/src/lib/migrations/types.ts
@@ -10,7 +10,7 @@ import type { Project } from '@/types/project';
  * Current schema version.
  * Increment this when adding a new migration.
  */
-export const CURRENT_SCHEMA_VERSION = 3;
+export const CURRENT_SCHEMA_VERSION = 4;
 
 /**
  * A migration function transforms a project from version N to N+1.


### PR DESCRIPTION
## Summary
- Switch clip segments from 2-row (filmstrip with overlaid label + waveform) to 3-row layout (label | filmstrip | waveform) so the filename has its own dedicated row
- Increase default track height from 64px to 80px to accommodate the new label row
- Constrain indicator badges (speed, keyframe, mask) to the label row so they don't bleed into the filmstrip

## Test plan
- [ ] Open an existing project — tracks should auto-migrate from 64px to 80px
- [ ] Video clips show filename row, filmstrip row, and waveform row as separate sections
- [ ] Audio clips show filename row above the waveform
- [ ] Composition clips with filmstrip show the 3-row layout
- [ ] Speed badge and keyframe diamond stay within the label row, not overlapping the filmstrip
- [ ] All drag, trim, rate-stretch, and selection behaviors work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured timeline clip display layouts to enhance visual organization and readability across video, audio, and composition items.
  * Increased track and row heights to provide improved spacing and content visibility in the timeline interface.
  * Optimized positioning of clip indicators and badges for clearer alignment within timeline clips.
  * Updated color styling for video timeline elements to improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->