### PR TITLE
fix(timeline): address review findings for 3-row clip layout

### DIFF
--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -20,8 +20,9 @@ interface ClipContentProps {
 
 /**
  * Renders the visual content of a timeline clip based on its type.
- * - Video: Filmstrip with overlayed label + waveform
- * - Audio: Label + waveform
+ * - Video: 3-row layout — label | filmstrip | waveform
+ * - Audio: Label row + waveform
+ * - Composition (with video): Same 3-row layout as video
  * - Text: Text content preview
  * - Adjustment: Effects summary
  * - Image/Shape: Simple label
@@ -150,8 +151,8 @@ export const ClipContent = memo(function ClipContent({
           {item.label}
         </div>
         {/* Row 2: Waveform - fills remaining space */}
-        <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
-          {showWaveforms && (
+        {showWaveforms && (
+          <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
             <ClipWaveform
               mediaId={item.mediaId}
               clipWidth={clipWidth}
@@ -163,8 +164,8 @@ export const ClipContent = memo(function ClipContent({
               isVisible={isClipVisible}
               pixelsPerSecond={pixelsPerSecond}
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/features/timeline/components/timeline-item/clip-indicators.tsx
+++ b/src/features/timeline/components/timeline-item/clip-indicators.tsx
@@ -43,34 +43,33 @@ export const ClipIndicators = memo(function ClipIndicators({
 
   return (
     <>
-      {/* Keyframe indicator - constrained to label row */}
-      {hasKeyframes && (
+      {/* Label-row badges — single container to prevent overlap */}
+      {(hasKeyframes || (isShape && isMask) || showSpeedBadge) && (
         <div
-          className="absolute right-1 z-10 pointer-events-none flex items-center"
-          style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
-          title="Has keyframe animations"
-        >
-          <Diamond className="w-3 h-3 text-amber-500 fill-amber-500/50" />
-        </div>
-      )}
-
-      {/* Mask indicator for shape items - constrained to label row */}
-      {isShape && isMask && (
-        <div
-          className="absolute right-1 px-1 text-[10px] leading-none font-bold bg-cyan-500/80 text-white rounded flex items-center"
+          className="absolute right-1 z-10 pointer-events-none flex items-center gap-1"
           style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
         >
-          M
-        </div>
-      )}
-
-      {/* Speed badge - constrained to label row */}
-      {showSpeedBadge && (
-        <div
-          className="absolute right-1 px-1 text-[10px] leading-none font-bold bg-black/60 text-white rounded font-mono flex items-center"
-          style={{ top: 0, height: CLIP_LABEL_ROW_HEIGHT }}
-        >
-          {currentSpeed.toFixed(2)}x
+          {hasKeyframes && (
+            <span title="Has keyframe animations">
+              <Diamond className="w-3 h-3 text-amber-500 fill-amber-500/50" />
+            </span>
+          )}
+          {isShape && isMask && (
+            <span
+              className="px-1 py-0.5 text-[10px] font-bold bg-cyan-500/80 text-white rounded"
+              title="Mask"
+            >
+              M
+            </span>
+          )}
+          {showSpeedBadge && (
+            <span
+              className="px-1 py-0.5 text-[10px] font-bold bg-black/60 text-white rounded font-mono"
+              title={`Speed: ${currentSpeed.toFixed(2)}x`}
+            >
+              {currentSpeed.toFixed(2)}x
+            </span>
+          )}
         </div>
       )}
 

--- a/src/features/timeline/theme.css
+++ b/src/features/timeline/theme.css
@@ -132,12 +132,12 @@ body.timeline-item-drag-cursor-not-allowed * {
  */
 .timeline-item {
   content-visibility: auto;
-  contain-intrinsic-size: auto 48px; /* width auto, estimated height 48px */
+  contain-intrinsic-size: auto 80px; /* width auto, estimated height matches DEFAULT_TRACK_HEIGHT */
 }
 
 .track-header-item {
   content-visibility: auto;
-  contain-intrinsic-size: 192px 48px; /* sidebar width, estimated height */
+  contain-intrinsic-size: 192px 80px; /* sidebar width, estimated height matches DEFAULT_TRACK_HEIGHT */
 }
 
 /* Filmstrip loading shimmer animation */

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -97,7 +97,7 @@ const migrations: Record<number, Migration> = {
 
       const updatedTracks = project.timeline.tracks.map((track) => {
         if (track.height === 64) {
-          return { ...track, height: DEFAULT_TRACK_HEIGHT };
+          return { ...track, height: 80 };
         }
         return track;
       });


### PR DESCRIPTION
## Summary
- Wrap audio waveform container in `showWaveforms` conditional so `bg-waveform-gradient` doesn't render when waveforms are disabled
- Consolidate label-row badges (keyframe, mask, speed) into a single flex container with `gap-1` to prevent overlap
- Add `title` attributes to mask and speed badges for accessibility
- Update `contain-intrinsic-size` from 48px to 80px to match `DEFAULT_TRACK_HEIGHT`
- Hardcode migration 4 target height to `80` for determinism
- Update outdated JSDoc to describe current 3-row layout

## Test plan
- [ ] Toggle waveforms off — audio clips should show no gradient background below the label
- [ ] Rate-stretch a video clip with keyframes — both speed badge and keyframe diamond should appear side by side without overlapping
- [ ] Hover over speed/mask/keyframe badges to verify tooltip text
- [ ] Scroll a long timeline — no layout jump as items enter the viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Timeline item heights increased to provide enhanced visual spacing and better content readability
  * Indicator badges consolidated into a unified layout for a cleaner interface
  * Waveform sections now render conditionally based on visibility preferences, improving display flexibility
* **Automatic Updates**
  * Existing projects automatically migrated with new track height dimensions to maintain consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->