### PR TITLE
fix(preview): lighter video preview background

### DIFF
--- a/src/features/preview/components/source-monitor.tsx
+++ b/src/features/preview/components/source-monitor.tsx
@@ -251,7 +251,7 @@ function SourceMonitorInner({
       {/* Video area - same gradient bg as composition panel */}
       <div
         ref={containerRef}
-        className="flex-1 min-h-0 relative overflow-hidden bg-linear-to-br from-background to-secondary/20"
+        className="flex-1 min-h-0 relative overflow-hidden bg-video-preview-background"
       >
         {src ? (
           <div

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -643,7 +643,7 @@ export const VideoPreview = memo(function VideoPreview({
   return (
     <div
       ref={backgroundRef}
-      className="w-full h-full bg-gradient-to-br from-background to-secondary/20 relative"
+      className="w-full h-full bg-video-preview-background relative"
       style={{ overflow: needsOverflow ? 'auto' : 'visible' }}
       onClick={handleBackgroundClick}
     >

--- a/src/features/timeline/theme.css
+++ b/src/features/timeline/theme.css
@@ -36,6 +36,9 @@
   /* Snap/Join indicator colors */
   --color-timeline-snap: #f97316;                    /* orange-500 - snap indicator */
   --color-timeline-join: #fb923c;                    /* orange-400 - join indicator */
+
+
+  --color-video-preview-background: oklch(0.1914 0 58);
 }
 
 /* Scissors cursor for razor/cut tool - uses Lucide scissors icon */


### PR DESCRIPTION
## Summary
- Replaced the dark gradient background (`from-background to-secondary/20`) in the video preview and source monitor with a dedicated CSS variable (`--color-video-preview-background`)
- The new background is lighter to improve contrast between the preview area and actual video content

## Test plan
- [ ] Open the editor and verify the preview panel background is visibly lighter than before
- [ ] Confirm video content does not blend into the background
- [ ] Check the source monitor panel has the same updated background