### PR TITLE
fix(player): freeze clock tick while tab is hidden to prevent reseek stutter

### DIFF
--- a/src/features/player/clock/Clock.ts
+++ b/src/features/player/clock/Clock.ts
@@ -449,6 +449,17 @@ export class Clock {
       }
 
       const now = performance.now();
+
+      // While the tab is hidden, browsers throttle RAF to ~1fps.
+      // Don't advance the frame — just keep the loop alive and reset
+      // the timing reference so the first visible tick starts fresh.
+      if (document.hidden) {
+        this._playbackStartTime = now;
+        this._playbackStartFrame = this._currentFrame;
+        this._animationFrameId = requestAnimationFrame(tick);
+        return;
+      }
+
       const elapsedMs = now - this._playbackStartTime;
       const elapsedSeconds = elapsedMs / 1000;
 


### PR DESCRIPTION
## Summary
- Freezes the playback clock's animation frame tick while `document.hidden` is true, preventing frame advancement in background tabs
- Continuously resets the timing reference so the first visible tick resumes seamlessly from the last visible position
- Eliminates the reseek/stutter that occurred when switching tabs during video playback

## Root cause
Browsers throttle `requestAnimationFrame` to ~1fps in background tabs while `performance.now()` keeps advancing. This caused the clock to compute a large frame jump on tab return, triggering video element reseeks and visible playback stutter.

## Test plan
- [ ] Play a video in the editor, switch to another browser tab, switch back — playback should resume smoothly without any visible jump or stutter
- [ ] Verify playback still loops correctly when loop is enabled
- [ ] Verify playback rate changes still work during active playback
- [ ] Run `npm run test:run` — all 170 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Animation timing now correctly pauses when the application tab is hidden, resuming properly upon return to the active tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->