### PR TITLE
fix(timeline): prevent image/gif clips from trimming across adjacent clips

### DIFF
--- a/src/features/timeline/hooks/use-timeline-trim.ts
+++ b/src/features/timeline/hooks/use-timeline-trim.ts
@@ -5,7 +5,7 @@ import { useTimelineStore } from '../stores/timeline-store';
 import { useSelectionStore } from '@/features/editor/stores/selection-store';
 import { useTimelineZoom } from './use-timeline-zoom';
 import { useSnapCalculator } from './use-snap-calculator';
-import { clampTrimAmount, type TrimHandle } from '../utils/trim-utils';
+import { clampTrimAmount, clampToAdjacentItems, type TrimHandle } from '../utils/trim-utils';
 
 interface TrimState {
   isTrimming: boolean;
@@ -128,6 +128,10 @@ export function useTimelineTrim(item: TimelineItem, timelineDuration: number, tr
       const currentItem = getItemFromStore();
       const { clampedAmount } = clampTrimAmount(currentItem, handle!, deltaFrames, fps);
       deltaFrames = clampedAmount;
+
+      // Clamp to adjacent items on the same track
+      const allItems = useTimelineStore.getState().items;
+      deltaFrames = clampToAdjacentItems(currentItem, handle!, deltaFrames, allItems);
 
       // Update local state for visual feedback
       if (deltaFrames !== trimStateRef.current.currentDelta) {

--- a/src/features/timeline/stores/items-store.ts
+++ b/src/features/timeline/stores/items-store.ts
@@ -3,7 +3,7 @@ import { createLogger } from '@/lib/logger';
 import type { TimelineItem, TimelineTrack } from '@/types/timeline';
 import type { TransformProperties } from '@/types/transform';
 import type { VisualEffect, ItemEffect } from '@/types/effects';
-import { clampTrimAmount, calculateTrimSourceUpdate } from '../utils/trim-utils';
+import { clampTrimAmount, clampToAdjacentItems, calculateTrimSourceUpdate } from '../utils/trim-utils';
 import { getSourceProperties, isMediaItem, calculateSplitSourceBoundaries, timelineToSourceFrames, calculateSpeed, clampSpeed } from '../utils/source-calculations';
 import { useCompositionNavigationStore } from './composition-navigation-store';
 import { useTimelineSettingsStore } from './timeline-settings-store';
@@ -279,7 +279,9 @@ export const useItemsStore = create<ItemsState & ItemsActions>()(
 
         // Clamp trim amount to source boundaries and minimum duration
         const timelineFps = useTimelineSettingsStore.getState().fps;
-        const { clampedAmount } = clampTrimAmount(item, 'start', trimAmount, timelineFps);
+        let { clampedAmount } = clampTrimAmount(item, 'start', trimAmount, timelineFps);
+        // Clamp to adjacent items on the same track
+        clampedAmount = clampToAdjacentItems(item, 'start', clampedAmount, state.items);
 
         const newFrom = item.from + clampedAmount;
         const newDuration = item.durationInFrames - clampedAmount;
@@ -305,7 +307,9 @@ export const useItemsStore = create<ItemsState & ItemsActions>()(
 
         // Clamp trim amount to source boundaries and minimum duration
         const timelineFps = useTimelineSettingsStore.getState().fps;
-        const { clampedAmount } = clampTrimAmount(item, 'end', trimAmount, timelineFps);
+        let { clampedAmount } = clampTrimAmount(item, 'end', trimAmount, timelineFps);
+        // Clamp to adjacent items on the same track
+        clampedAmount = clampToAdjacentItems(item, 'end', clampedAmount, state.items);
 
         const newDuration = item.durationInFrames + clampedAmount;
         if (newDuration <= 0) return item;

--- a/src/features/timeline/utils/trim-utils.test.ts
+++ b/src/features/timeline/utils/trim-utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { clampToAdjacentItems } from './trim-utils';
+import type { TimelineItem } from '@/types/timeline';
+
+function makeItem(overrides: Partial<TimelineItem> & { id: string; trackId: string; from: number; durationInFrames: number }): TimelineItem {
+  return {
+    type: 'image',
+    label: 'test',
+    src: '',
+    ...overrides,
+  } as TimelineItem;
+}
+
+describe('clampToAdjacentItems', () => {
+  const trackId = 'track-1';
+
+  describe('end handle (extending right)', () => {
+    it('passes through when no neighbors exist', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const result = clampToAdjacentItems(item, 'end', 50, [item]);
+      expect(result).toBe(50);
+    });
+
+    it('clamps to gap before next item', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 120, durationInFrames: 50 });
+      // Gap is 20 frames, requesting 50
+      const result = clampToAdjacentItems(item, 'end', 50, [item, neighbor]);
+      expect(result).toBe(20);
+    });
+
+    it('returns 0 when neighbor is exactly touching', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 100, durationInFrames: 50 });
+      const result = clampToAdjacentItems(item, 'end', 10, [item, neighbor]);
+      expect(result).toBe(0);
+    });
+
+    it('passes through when trimAmount fits within gap', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 150, durationInFrames: 50 });
+      // Gap is 50, requesting 30
+      const result = clampToAdjacentItems(item, 'end', 30, [item, neighbor]);
+      expect(result).toBe(30);
+    });
+
+    it('picks the nearest neighbor when multiple exist', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const far = makeItem({ id: 'b', trackId, from: 200, durationInFrames: 50 });
+      const near = makeItem({ id: 'c', trackId, from: 110, durationInFrames: 50 });
+      // Nearest gap is 10
+      const result = clampToAdjacentItems(item, 'end', 50, [item, far, near]);
+      expect(result).toBe(10);
+    });
+
+    it('ignores items on different tracks', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const otherTrack = makeItem({ id: 'b', trackId: 'track-2', from: 100, durationInFrames: 50 });
+      const result = clampToAdjacentItems(item, 'end', 50, [item, otherTrack]);
+      expect(result).toBe(50);
+    });
+  });
+
+  describe('start handle (extending left)', () => {
+    it('passes through when no neighbors exist to the left', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const result = clampToAdjacentItems(item, 'start', -50, [item]);
+      expect(result).toBe(-50);
+    });
+
+    it('clamps to gap after previous item', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 0, durationInFrames: 80 });
+      // Gap is 20 frames, requesting -50
+      const result = clampToAdjacentItems(item, 'start', -50, [item, neighbor]);
+      expect(result).toBe(-20);
+    });
+
+    it('returns 0 when neighbor is exactly touching', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 0, durationInFrames: 100 });
+      const result = clampToAdjacentItems(item, 'start', -10, [item, neighbor]);
+      expect(result).toBe(0);
+    });
+
+    it('passes through when trimAmount fits within gap', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 0, durationInFrames: 50 });
+      // Gap is 50, requesting -30
+      const result = clampToAdjacentItems(item, 'start', -30, [item, neighbor]);
+      expect(result).toBe(-30);
+    });
+
+    it('ignores items on different tracks', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const otherTrack = makeItem({ id: 'b', trackId: 'track-2', from: 50, durationInFrames: 100 });
+      const result = clampToAdjacentItems(item, 'start', -80, [item, otherTrack]);
+      expect(result).toBe(-80);
+    });
+  });
+
+  describe('shrinking (no clamping needed)', () => {
+    it('passes through end handle shrinking (negative trimAmount)', () => {
+      const item = makeItem({ id: 'a', trackId, from: 0, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 100, durationInFrames: 50 });
+      const result = clampToAdjacentItems(item, 'end', -20, [item, neighbor]);
+      expect(result).toBe(-20);
+    });
+
+    it('passes through start handle shrinking (positive trimAmount)', () => {
+      const item = makeItem({ id: 'a', trackId, from: 100, durationInFrames: 100 });
+      const neighbor = makeItem({ id: 'b', trackId, from: 0, durationInFrames: 100 });
+      const result = clampToAdjacentItems(item, 'start', 20, [item, neighbor]);
+      expect(result).toBe(20);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Image/GIF clips had no trim extension constraints (unlike video/audio bounded by `sourceDuration`), allowing them to extend through neighboring clips on the same track
- Added `clampToAdjacentItems()` in `trim-utils.ts` that finds the nearest same-track neighbor and prevents overlap during trim
- Applied in both the store commit path (`items-store.ts`) and visual feedback path (`use-timeline-trim.ts`) so the handle stops at the correct position during drag

## Test plan
- [x] 13 unit tests added for `clampToAdjacentItems` covering: extend right/left with gap, no gap, no neighbors, multiple neighbors, cross-track isolation, and shrink pass-through
- [x] All 183 tests pass
- [ ] Manual: place two image clips adjacent on same track, verify trim handles stop at neighbor boundary
- [ ] Manual: verify video/audio trim still works as before (source duration + adjacency)
- [ ] Manual: verify clips on different tracks are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trim operations on timeline items to respect neighboring items on the same track, improving precision when trimming near adjacent content.

* **Tests**
  * Added comprehensive test suite covering trim clamping across multiple scenarios including various neighbor configurations, gap calculations, and track-based filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->