### PR TITLE
fix(preview): use offsetWidth/Height for GIF canvas to prevent rotation distortion

### DIFF
--- a/src/lib/composition-runtime/components/gif-player/gif-canvas.tsx
+++ b/src/lib/composition-runtime/components/gif-player/gif-canvas.tsx
@@ -31,8 +31,11 @@ export const GifCanvas = memo(function GifCanvas({ frame, fit, style }: GifCanva
     // CSS transforms (rotation/scale).  getBoundingClientRect() returns the
     // axis-aligned bounding box AFTER transforms, which distorts the canvas
     // pixel buffer when the item is rotated via the gizmo.
-    const containerWidth = container.offsetWidth || 1920;
-    const containerHeight = container.offsetHeight || 1080;
+    const containerWidth = container.offsetWidth;
+    const containerHeight = container.offsetHeight;
+
+    // Skip drawing when container is hidden or detached (zero dimensions)
+    if (containerWidth === 0 || containerHeight === 0) return;
 
     // Set canvas size to match container
     if (canvas.width !== containerWidth || canvas.height !== containerHeight) {


### PR DESCRIPTION
## Summary
- GIF/WebP clips in the preview canvas were getting squashed/distorted when rotated via the transform gizmo
- Root cause: `getBoundingClientRect()` returns the axis-aligned bounding box **after** CSS transforms, so the canvas pixel buffer was sized to the rotated bounding rect instead of the actual element dimensions
- Switched to `offsetWidth`/`offsetHeight` which return layout dimensions **before** transforms, matching how native `<img>` elements behave

## Test plan
- [ ] Add a GIF or WebP clip to the timeline
- [ ] Rotate it using the transform gizmo to various angles (45°, 90°, etc.)
- [ ] Verify the image stays proportionally correct at all rotation angles
- [ ] Verify 0° rotation still renders correctly
- [ ] Verify cover/contain fit modes still work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented GIF canvas distortion during rotations by improving how canvas dimensions are determined, ensuring proper rendering during transforms.
  * Added a guard to skip rendering when container size is zero to avoid visual glitches or wasted drawing attempts when the element is not sized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->