### PR TITLE
fix(timeline): clear stale join indicators on neighbor delete/move

### DIFF
--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -650,14 +650,14 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   // The selector is O(n) but only triggers re-render when neighbor IDs change.
   const neighborKey = useTimelineStore(
     useCallback((s) => {
-      let left = '';
-      let right = '';
+      let leftId = '';
+      let rightId = '';
       for (const other of s.items) {
         if (other.id === item.id || other.trackId !== item.trackId) continue;
-        if (other.from + other.durationInFrames === item.from) left = other.id;
-        else if (other.from === item.from + item.durationInFrames) right = other.id;
+        if (other.from + other.durationInFrames === item.from) leftId = other.id;
+        else if (other.from === item.from + item.durationInFrames) rightId = other.id;
       }
-      return left + '|' + right;
+      return leftId + '|' + rightId;
     }, [item.id, item.trackId, item.from, item.durationInFrames])
   );
 


### PR DESCRIPTION
## Summary

- Join indicators were stale after deleting or moving an adjacent split-sibling (e.g., split a-b-c → delete b → a and c still showed join glow)
- Root cause: neighbor joinability was computed in a `useMemo` dependent only on the current item's props — neighbor changes (deletion, track moves) never triggered recomputation
- Added a reactive Zustand selector (`neighborKey`) that tracks adjacent item IDs, triggering recomputation only when the neighbor set actually changes

## Test plan

- [ ] Split a clip into 3 segments (a-b-c), delete the middle (b) — verify join indicators on a and c disappear
- [ ] Split a clip into 3 segments (a-b-c), move the middle (b) to another track — verify join indicators on a and c disappear
- [ ] Split a clip into 2 segments (a-b), verify join indicator still shows between them
- [ ] Drag a split segment away then back — verify join indicator reappears when adjacent again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved join indicator behavior in timeline items to correctly update when adjacent items change, ensuring more accurate visual connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->