### PR TITLE
feat(timeline): add Shift+Z shortcut to zoom to 100% at cursor/playhead

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -104,7 +104,7 @@ export const HOTKEY_DESCRIPTIONS: Record<HotkeyKey, string> = {
 
   // Zoom
   ZOOM_TO_FIT: 'Zoom to fit all content',
-  ZOOM_TO_100: 'Zoom to 100% at playhead',
+  ZOOM_TO_100: 'Zoom to 100% at cursor or playhead',
 
   // Clipboard
   COPY: 'Copy selected items',

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 // Stores and selectors
 import { useTimelineStore } from '../stores/timeline-store';
 import { useTimelineZoom } from '../hooks/use-timeline-zoom';
-import { useZoomStore } from '../stores/zoom-store';
+import { registerZoomTo100 } from '../stores/zoom-store';
 import { usePlaybackStore } from '@/features/preview/stores/playback-store';
 import { useSelectionStore } from '@/features/editor/stores/selection-store';
 
@@ -655,7 +655,8 @@ export const TimelineContent = memo(function TimelineContent({ duration, scrollR
 
   // Register zoom-to-100 handler globally so keyboard shortcuts can use it
   useEffect(() => {
-    useZoomStore.getState().registerZoomTo100(handleZoomTo100);
+    registerZoomTo100(handleZoomTo100);
+    return () => registerZoomTo100(null);
   }, [handleZoomTo100]);
 
   // Expose zoom handlers to parent component (only once on mount)

--- a/src/features/timeline/hooks/shortcuts/use-ui-shortcuts.ts
+++ b/src/features/timeline/hooks/shortcuts/use-ui-shortcuts.ts
@@ -4,7 +4,7 @@
 
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTimelineStore } from '../../stores/timeline-store';
-import { useZoomStore } from '../../stores/zoom-store';
+import { useZoomStore, getZoomTo100Handler } from '../../stores/zoom-store';
 import { usePlaybackStore } from '@/features/preview/stores/playback-store';
 import { HOTKEYS, HOTKEY_OPTIONS } from '@/config/hotkeys';
 import type { TimelineShortcutCallbacks } from '../use-timeline-shortcuts';
@@ -94,7 +94,7 @@ export function useUIShortcuts(callbacks: TimelineShortcutCallbacks) {
       const { currentFrame, previewFrame } = usePlaybackStore.getState();
       const targetFrame = previewFrame ?? currentFrame;
 
-      const handler = useZoomStore.getState()._zoomTo100Handler;
+      const handler = getZoomTo100Handler();
       if (handler) {
         handler(targetFrame);
       }

--- a/src/features/timeline/stores/zoom-store.ts
+++ b/src/features/timeline/stores/zoom-store.ts
@@ -11,9 +11,6 @@ interface ZoomActions {
   zoomIn: () => void;
   zoomOut: () => void;
   zoomToFit: (containerWidth: number, contentDurationSeconds: number) => void;
-  /** Registered by TimelineContent — zooms to 100% centered on a frame */
-  _zoomTo100Handler: ((centerFrame: number) => void) | null;
-  registerZoomTo100: (handler: (centerFrame: number) => void) => void;
 }
 
 // Throttle zoom updates to reduce re-render frequency during rapid zoom
@@ -85,6 +82,15 @@ export const useZoomStore = create<ZoomState & ZoomActions>((set) => ({
     const newLevel = Math.max(0.01, Math.min(2, targetWidth / (duration * 100)));
     set({ level: newLevel, pixelsPerSecond: newLevel * 100 });
   },
-  _zoomTo100Handler: null,
-  registerZoomTo100: (handler) => set({ _zoomTo100Handler: handler }),
 }));
+
+// Non-reactive handler registration — avoids unnecessary subscriber notifications
+let _zoomTo100Handler: ((centerFrame: number) => void) | null = null;
+
+export function registerZoomTo100(handler: ((centerFrame: number) => void) | null) {
+  _zoomTo100Handler = handler;
+}
+
+export function getZoomTo100Handler() {
+  return _zoomTo100Handler;
+}


### PR DESCRIPTION
## Summary
- Adds `Shift+Z` keyboard shortcut that resets timeline zoom to 100% (1x) centered on the current cursor position (skimmer) or playhead
- Registers a `handleZoomTo100` handler from `TimelineContent` via the zoom store, using `pendingScrollRef` to correctly apply scroll after the DOM re-renders with the new zoom width
- Adds `ZOOM_TO_100` hotkey config and description

## Test plan
- [ ] Hover over a position on the timeline and press `Shift+Z` — verify zoom resets to 100% centered on the hovered frame
- [ ] Without hovering the timeline, press `Shift+Z` — verify zoom resets to 100% centered on the playhead
- [ ] Verify `Z` (zoom to fit) still works as before
- [ ] Verify `Ctrl+Shift+Z` (redo) is not affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shift+Z keyboard shortcut to reset timeline zoom to 100% and center the view on the cursor or playhead.
  * Zoom-to-100 now recenters the timeline for a clearer, immediate view when returning to 1x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->