### PR TITLE
fix(timeline): normalize track heights in sub-compositions on project load

### DIFF
--- a/src/lib/migrations/normalize.ts
+++ b/src/lib/migrations/normalize.ts
@@ -19,8 +19,6 @@
 import type { Project, ProjectTimeline } from '@/types/project';
 import {
   DEFAULT_TRACK_HEIGHT,
-  MIN_TRACK_HEIGHT,
-  MAX_TRACK_HEIGHT,
   DEFAULT_FPS,
 } from '@/features/timeline/constants';
 
@@ -33,11 +31,8 @@ function normalizeTrack(
 ): ProjectTimeline['tracks'][number] {
   return {
     ...track,
-    // Ensure height is within valid bounds
-    height: Math.max(
-      MIN_TRACK_HEIGHT,
-      Math.min(MAX_TRACK_HEIGHT, track.height ?? DEFAULT_TRACK_HEIGHT)
-    ),
+    // Always use current default — no user-facing track resize exists yet
+    height: DEFAULT_TRACK_HEIGHT,
     // Ensure boolean fields have defaults
     locked: track.locked ?? false,
     visible: track.visible ?? true,
@@ -149,6 +144,13 @@ function normalizeTimeline(timeline: ProjectTimeline): ProjectTimeline {
     items: timeline.items.map(normalizeItem),
     // Normalize transitions if present
     transitions: timeline.transitions?.map(normalizeTransition),
+    // Normalize sub-composition tracks and items
+    compositions: timeline.compositions?.map((comp) => ({
+      ...comp,
+      tracks: comp.tracks.map((track, index) => normalizeTrack(track, index)),
+      items: comp.items.map(normalizeItem),
+      transitions: comp.transitions?.map(normalizeTransition),
+    })),
     // Ensure frame values are non-negative integers
     currentFrame: Math.max(0, Math.floor(timeline.currentFrame ?? 0)),
     // Ensure zoom is positive


### PR DESCRIPTION
## Summary
- Extend `normalizeTimeline` to also normalize sub-composition tracks, items, and transitions — previously only main timeline data was processed
- Always reset track `height` to `DEFAULT_TRACK_HEIGHT` since no user-facing track resize exists yet, removing stale serialized values
- Remove unused `MIN_TRACK_HEIGHT` / `MAX_TRACK_HEIGHT` imports from normalize.ts

## Test plan
- [ ] Open a project that has pre-compositions created before this change
- [ ] Enter a pre-composition and verify track heights match the default (80px)
- [ ] Verify main timeline track heights are also correct after load
- [ ] Create a new pre-composition and re-enter it — heights should be consistent