### PR TITLE
feat: rolling edit, ripple edit, and NLE-style waveforms

### DIFF
--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -43,6 +43,7 @@ export const HOTKEYS = {
   SPLIT_AT_CURSOR: 'shift+c',
   RATE_STRETCH_TOOL: 'r',
   ROLLING_EDIT_TOOL: 'n',
+  RIPPLE_EDIT_TOOL: 'b',
 
   // Project
   SAVE: 'mod+s',
@@ -118,6 +119,7 @@ export const HOTKEY_DESCRIPTIONS: Record<HotkeyKey, string> = {
   SPLIT_AT_CURSOR: 'Split at cursor',
   RATE_STRETCH_TOOL: 'Rate stretch tool',
   ROLLING_EDIT_TOOL: 'Rolling edit tool',
+  RIPPLE_EDIT_TOOL: 'Ripple edit tool',
 
   // Project
   SAVE: 'Save project',

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -30,7 +30,7 @@ export interface SelectionState {
   selectedTrackIds: string[]; // Multi-track selection
   activeTrackId: string | null; // Single active track
   selectionType: 'item' | 'track' | 'marker' | 'transition' | null;
-  activeTool: 'select' | 'razor' | 'rate-stretch' | 'rolling-edit'; // Active timeline tool
+  activeTool: 'select' | 'razor' | 'rate-stretch' | 'rolling-edit' | 'ripple-edit'; // Active timeline tool
   // Drag state for visual feedback
   dragState: {
     isDragging: boolean;

--- a/src/features/timeline/components/timeline-header.tsx
+++ b/src/features/timeline/components/timeline-header.tsx
@@ -10,6 +10,7 @@ import {
   Scissors,
   Gauge,
   SplitSquareHorizontal,
+  MoveHorizontal,
   X,
   MousePointer2,
   Undo2,
@@ -248,6 +249,18 @@ export const TimelineHeader = memo(function TimelineHeader({
             data-tooltip="Rolling Edit Tool (N)"
           >
             <SplitSquareHorizontal className="w-3.5 h-3.5" />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`h-7 w-7 ${
+              activeTool === 'ripple-edit' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : ''
+            }`}
+            onClick={() => setActiveTool(activeTool === 'ripple-edit' ? 'select' : 'ripple-edit')}
+            data-tooltip="Ripple Edit Tool (B)"
+          >
+            <MoveHorizontal className="w-3.5 h-3.5" />
           </Button>
         </div>
 

--- a/src/features/timeline/components/timeline-item/trim-handles.tsx
+++ b/src/features/timeline/components/timeline-item/trim-handles.tsx
@@ -41,12 +41,12 @@ export const TrimHandles = memo(function TrimHandles({
 }: TrimHandlesProps) {
   const showLeftHandle = !trackLocked &&
     (!isAnyDragActive || isTrimming) &&
-    (activeTool === 'select' || activeTool === 'rolling-edit') &&
+    (activeTool === 'select' || activeTool === 'rolling-edit' || activeTool === 'ripple-edit') &&
     (hoveredEdge === 'start' || (isTrimming && trimHandle === 'start'));
 
   const showRightHandle = !trackLocked &&
     (!isAnyDragActive || isTrimming) &&
-    (activeTool === 'select' || activeTool === 'rolling-edit') &&
+    (activeTool === 'select' || activeTool === 'rolling-edit' || activeTool === 'ripple-edit') &&
     (hoveredEdge === 'end' || (isTrimming && trimHandle === 'end'));
 
   return (

--- a/src/features/timeline/hooks/shortcuts/use-tool-shortcuts.ts
+++ b/src/features/timeline/hooks/shortcuts/use-tool-shortcuts.ts
@@ -80,4 +80,15 @@ export function useToolShortcuts(callbacks: TimelineShortcutCallbacks) {
     HOTKEY_OPTIONS,
     [activeTool, setActiveTool]
   );
+
+  // Tool: B - Toggle Ripple Edit Tool
+  useHotkeys(
+    HOTKEYS.RIPPLE_EDIT_TOOL,
+    (event) => {
+      event.preventDefault();
+      setActiveTool(activeTool === 'ripple-edit' ? 'select' : 'ripple-edit');
+    },
+    HOTKEY_OPTIONS,
+    [activeTool, setActiveTool]
+  );
 }

--- a/src/features/timeline/stores/ripple-edit-preview-store.ts
+++ b/src/features/timeline/stores/ripple-edit-preview-store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+
+interface RippleEditPreviewState {
+  /** The item being trimmed */
+  trimmedItemId: string | null;
+  /** Which handle on the trimmed item: 'start' or 'end' */
+  handle: 'start' | 'end' | null;
+  /** Track ID of the trimmed item (for filtering downstream items) */
+  trackId: string | null;
+  /** Original end frame of the trimmed item (items at or after this position are downstream) */
+  trimmedItemEnd: number;
+  /** Shift delta in frames for downstream items (positive = shift right, negative = shift left) */
+  delta: number;
+}
+
+interface RippleEditPreviewActions {
+  setPreview: (params: {
+    trimmedItemId: string;
+    handle: 'start' | 'end';
+    trackId: string;
+    trimmedItemEnd: number;
+    delta: number;
+  }) => void;
+  setDelta: (delta: number) => void;
+  clearPreview: () => void;
+}
+
+export const useRippleEditPreviewStore = create<
+  RippleEditPreviewState & RippleEditPreviewActions
+>()((set) => ({
+  trimmedItemId: null,
+  handle: null,
+  trackId: null,
+  trimmedItemEnd: 0,
+  delta: 0,
+  setPreview: (params) => set(params),
+  setDelta: (delta) => set({ delta }),
+  clearPreview: () =>
+    set({
+      trimmedItemId: null,
+      handle: null,
+      trackId: null,
+      trimmedItemEnd: 0,
+      delta: 0,
+    }),
+}));

--- a/src/features/timeline/stores/timeline-store-facade.ts
+++ b/src/features/timeline/stores/timeline-store-facade.ts
@@ -514,6 +514,7 @@ function getSnapshot(): TimelineState & TimelineActions {
       trimItemStart: timelineActions.trimItemStart,
       trimItemEnd: timelineActions.trimItemEnd,
       rollingTrimItems: timelineActions.rollingTrimItems,
+      rippleTrimItem: timelineActions.rippleTrimItem,
       splitItem: timelineActions.splitItem,
       joinItems: timelineActions.joinItems,
       rateStretchItem: timelineActions.rateStretchItem,

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -42,6 +42,7 @@ export interface TimelineActions {
   trimItemStart: (id: string, trimAmount: number) => void;
   trimItemEnd: (id: string, trimAmount: number) => void;
   rollingTrimItems: (leftId: string, rightId: string, editPointDelta: number) => void;
+  rippleTrimItem: (id: string, handle: 'start' | 'end', trimDelta: number) => void;
   splitItem: (id: string, splitFrame: number) => void;
   joinItems: (itemIds: string[]) => void;
   rateStretchItem: (id: string, newFrom: number, newDuration: number, newSpeed: number) => void;


### PR DESCRIPTION
## Major Features

- **Rolling Edit Tool** (N): Trim both ends of adjacent clips simultaneously with 2-up frame comparison overlay
- **Ripple Edit Tool** (B): Move clips with automatic downstream shifting to maintain timeline continuity
- **NLE-Style Waveforms**: Continuous filled-path audio waveform rendering matching professional editors
- **Zoom to 100%** (Shift+Z): Zoom to 100% at cursor position or playhead

## Timeline & Editing Improvements

- Tool-aware playhead colors (visual feedback for active tool)
- Razor mode restoration with interactive cutting
- Shift+Snap in razor mode for precision cuts
- Block split/razor cuts inside transition overlap zones
- Clear stale join indicators on neighbor delete/move
- Eliminate 1px gaps from independent rounding of clip edges
- FCP-style bridge transitions with live ripple preview

## Export & Media Handling

- Fixed stale blob URLs after tab inactivity with `refreshAllBlobUrls()`
- Improved transition audio crossfade during overlap regions
- VideoFrame caching for repeated draws (critical for transitions)
- Canvas state reset between pool reuses
- Better fallback video element preloading

## UI/UX

- Lift media library drop zone to panel level for full-height coverage
- Drag/drop counter to prevent overlay flicker
- Media library drag/drop improvements
- Normalize track heights in sub-compositions on project load

## Infrastructure

- New stores: `rolling-edit-preview-store`, `ripple-edit-preview-store`, `transition-resize-preview-store`
- Improved transition auto-repair logic
- Enhanced snap calculator and trim utilities
- New migration system for project data normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Ripple Edit Tool**: New timeline editing capability accessible via the 'B' hotkey or the toolbar button in the timeline header. Trim clips at the start or end while automatically adjusting and shifting downstream items on the same track to maintain seamless editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->