### PR TITLE
fix: prevent infinite retry storm on failed video source init

### DIFF
--- a/src/features/export/utils/shared-video-extractor.ts
+++ b/src/features/export/utils/shared-video-extractor.ts
@@ -117,13 +117,8 @@ export class SharedVideoExtractorPool {
 
     state.sourceInitPromise = (async () => {
       const ready = await this.ensureLaneInitialized(state, 0);
-      if (ready) {
-        state.sourceInitAttempted = true;
-        state.sourceReady = true;
-      } else {
-        state.sourceInitAttempted = false;
-        state.sourceReady = false;
-      }
+      state.sourceInitAttempted = true;
+      state.sourceReady = ready;
       return ready;
     })().finally(() => {
       state.sourceInitPromise = null;


### PR DESCRIPTION
## Summary

- `sourceInitAttempted` was reset to `false` on init failure in `SharedVideoExtractorPool.initSource()`, allowing every frame render to re-attempt fetch on dead blob URLs (e.g. after HMR revokes them)
- Now permanently marks init as attempted so failed sources are not retried, letting the render engine's existing `MEDIABUNNY_DISABLE_THRESHOLD` work as designed

## Test plan
- [ ] Verify no fetch retry spam in console when blob URLs are revoked (HMR or navigation)
- [ ] Confirm video playback still works normally after a clean page load