### PR TITLE
perf(preview): strict-decode video frames in edit 2-up overlay with legacy fallback

### DIFF
--- a/src/features/preview/components/edit-2up-panels.tsx
+++ b/src/features/preview/components/edit-2up-panels.tsx
@@ -44,9 +44,9 @@ function useResolvedVideoBlobUrl(mediaId: string | undefined, useProxy: boolean)
 
   useEffect(() => {
     let cancelled = false;
+    setBlobUrl(null);
 
     if (!mediaId) {
-      setBlobUrl(null);
       return () => {
         cancelled = true;
       };
@@ -62,10 +62,15 @@ function useResolvedVideoBlobUrl(mediaId: string | undefined, useProxy: boolean)
       }
     }
 
-    resolveMediaUrl(mediaId).then((url) => {
-      if (cancelled) return;
-      setBlobUrl(url || null);
-    });
+    resolveMediaUrl(mediaId)
+      .then((url) => {
+        if (cancelled) return;
+        setBlobUrl(url || null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBlobUrl(null);
+      });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- Replace seek-based video frame rendering in edit 2-up panels with a strict WebCodecs decoder path using `SharedVideoExtractorPool` for more accurate frame extraction
- Add automatic fallback to legacy `HTMLVideoElement` seek approach after consecutive decode failures
- Extract shared `useResolvedVideoBlobUrl` hook to deduplicate blob URL resolution logic

## Test plan
- [ ] Open a project with video clips and enter rolling/ripple edit mode to verify the 2-up overlay renders frames correctly
- [ ] Verify frame accuracy is improved compared to the seek-based approach
- [ ] Test with a codec/file that triggers decode failures and confirm graceful fallback to legacy rendering
- [ ] Confirm no memory leaks by checking decoder pool cleanup on component unmount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, more responsive video frame rendering in edit panels and optional precise source-time support for previews.
* **Bug Fixes**
  * Improved reliability with automatic fallback when strict decoding fails, reducing preview glitches and failures.
* **Refactor**
  * Streamlined decoding pipeline for better performance and stability during video editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->