### PR TITLE
fix(preview): update video preview for gizmo transform changes

### DIFF
--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -819,7 +819,6 @@ export const VideoPreview = memo(function VideoPreview({
     scrubVideoSourceSpans,
     fastScrubBoundaryFrames,
     fastScrubBoundarySources,
-    resolvedTracksFingerprint,
     fastScrubTracksFingerprint,
   } = useMemo(() => {
     const resolvedTrackList: CompositionInputProps['tracks'] = [];
@@ -910,7 +909,6 @@ export const VideoPreview = memo(function VideoPreview({
       scrubVideoSourceSpans: scrubSpans,
       fastScrubBoundaryFrames: sortedBoundaryFrames,
       fastScrubBoundarySources: sortedBoundarySources,
-      resolvedTracksFingerprint: toTrackFingerprint(resolvedTrackList),
       fastScrubTracksFingerprint: toTrackFingerprint(fastScrubTrackList),
     };
   }, [combinedTracks, resolvedUrls, useProxy, proxyReadyCount]);
@@ -1311,7 +1309,7 @@ export const VideoPreview = memo(function VideoPreview({
     tracks: resolvedTracks as CompositionInputProps['tracks'],
     transitions,
     backgroundColor: project.backgroundColor,
-  }), [fps, project.width, project.height, resolvedTracksFingerprint, transitions, project.backgroundColor]);
+  }), [fps, project.width, project.height, resolvedTracks, transitions, project.backgroundColor]);
 
   // Compute scaled render resolution for preview quality.
   // Keep dimensions even for decoder compatibility.


### PR DESCRIPTION
Fixes the preview desync reported in #85 where gizmo translate/resize changes were not visible until another state change occurred.

VideoPreview memoized inputProps using esolvedTracksFingerprint, but that fingerprint did not include transform fields, so transform-only edits could keep stale props. This change makes inputProps depend on esolvedTracks directly and removes the now-unused esolvedTracksFingerprint plumbing.

Validation:
- 
pm run lint
- 
pm run test:run -- src/features/preview/components/edit-panels.smoke.test.tsx

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized video preview component's internal dependency tracking mechanism for improved code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->