### PR TITLE
hotfix(preview): prevent stale scrub overlay from blocking live gizmo updates

### DIFF
--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -1658,6 +1658,20 @@ export const VideoPreview = memo(function VideoPreview({
           if (!scrubMountedRef.current) break;
 
           if (isPriorityFrame) {
+            const playbackState = usePlaybackStore.getState();
+            // Guard against stale in-flight renders that finish after scrub has ended.
+            // Without this, a completed old render can re-show the overlay and hide
+            // live Player updates (e.g. ruler click + gizmo interaction).
+            if (
+              playbackState.isPlaying ||
+              playbackState.previewFrame === null ||
+              playbackState.previewFrame !== frameToRender
+            ) {
+              setShowFastScrubOverlay(false);
+              bypassPreviewSeekRef.current = false;
+              continue;
+            }
+
             drawToDisplay();
             setShowFastScrubOverlay(true);
             bypassPreviewSeekRef.current = true;
@@ -2168,4 +2182,3 @@ export const VideoPreview = memo(function VideoPreview({
     </div>
   );
 });
-


### PR DESCRIPTION
Fixes a fast-scrub race that could keep a stale scrub frame overlay visible after scrub state changed.

When an in-flight priority scrub render completed late, it could re-show the fast-scrub canvas even after scrub had ended or frame target moved. That stale overlay sat above the Player and made gizmo transforms look non-realtime.

This hotfix adds a state guard before displaying the rendered scrub frame. We now only show the overlay if scrub is still active and the rendered frame still matches the current previewFrame; otherwise we hide overlay and fall back to live Player output.

Validation:
- npm run lint
- npm run test:run -- src/features/preview/components/edit-panels.smoke.test.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where video preview scrubbing could display stale visual overlays or interfere with live playback. The video preview now correctly suppresses overlays and maintains proper playback state when scrubbing completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->