### PR TITLE
Fix gizmo/keyframe desync while skimming (issue #93)

### DIFF
--- a/src/features/keyframes/hooks/use-animated-transform.test.tsx
+++ b/src/features/keyframes/hooks/use-animated-transform.test.tsx
@@ -1,0 +1,160 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePlaybackStore } from '@/shared/state/playback';
+import { useTimelineStore } from '@/features/keyframes/deps/timeline';
+import { useAnimatedTransform, useAnimatedTransforms } from './use-animated-transform';
+import type { TimelineItem } from '@/types/timeline';
+
+const PROJECT_SIZE = { width: 1920, height: 1080 } as const;
+
+const ITEM = {
+  id: 'item-1',
+  type: 'text',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 200,
+  label: 'Test Item',
+  text: 'Hello',
+  color: '#ffffff',
+  transform: {
+    x: 0,
+    y: 0,
+    width: 320,
+    height: 120,
+    rotation: 0,
+    opacity: 1,
+  },
+} as unknown as TimelineItem;
+
+function SingleAnimatedTransformProbe() {
+  const { transform, relativeFrame } = useAnimatedTransform(ITEM, PROJECT_SIZE);
+  return (
+    <div
+      data-testid="single-probe"
+      data-x={String(transform.x)}
+      data-relative-frame={String(relativeFrame)}
+    />
+  );
+}
+
+function MultiAnimatedTransformsProbe() {
+  const transforms = useAnimatedTransforms([ITEM], PROJECT_SIZE);
+  const resolved = transforms.get(ITEM.id);
+  return (
+    <div
+      data-testid="multi-probe"
+      data-x={String(resolved?.x ?? Number.NaN)}
+    />
+  );
+}
+
+function resetStores() {
+  localStorage.clear();
+
+  usePlaybackStore.setState({
+    currentFrame: 10,
+    currentFrameEpoch: 0,
+    isPlaying: false,
+    playbackRate: 1,
+    loop: false,
+    volume: 1,
+    muted: false,
+    zoom: -1,
+    previewFrame: null,
+    previewFrameEpoch: 0,
+    frameUpdateEpoch: 0,
+    previewItemId: null,
+    captureFrame: null,
+    useProxy: true,
+    previewQuality: 1,
+  });
+
+  useTimelineStore.setState({
+    keyframes: [
+      {
+        itemId: ITEM.id,
+        properties: [
+          {
+            property: 'x',
+            keyframes: [
+              { id: 'kf-10', frame: 10, value: 110, easing: 'linear' },
+              { id: 'kf-20', frame: 20, value: 220, easing: 'linear' },
+              { id: 'kf-30', frame: 30, value: 330, easing: 'linear' },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+describe('useAnimatedTransform skimming frame resolution', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('uses previewFrame while paused (single-item hook)', async () => {
+    render(<SingleAnimatedTransformProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-x', '110');
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-relative-frame', '10');
+    });
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(20);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-x', '220');
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-relative-frame', '20');
+    });
+  });
+
+  it('uses previewFrame while paused (multi-item hook)', async () => {
+    render(<MultiAnimatedTransformsProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('multi-probe')).toHaveAttribute('data-x', '110');
+    });
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(20);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('multi-probe')).toHaveAttribute('data-x', '220');
+    });
+  });
+
+  it('ignores previewFrame while playing', async () => {
+    render(<SingleAnimatedTransformProbe />);
+
+    act(() => {
+      const playback = usePlaybackStore.getState();
+      playback.setPreviewFrame(20);
+      playback.play();
+    });
+
+    await waitFor(() => {
+      // Playing mode follows currentFrame, not previewFrame.
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-x', '110');
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-relative-frame', '10');
+    });
+  });
+
+  it('falls back to currentFrame when previewFrame is stale', async () => {
+    render(<SingleAnimatedTransformProbe />);
+
+    act(() => {
+      const playback = usePlaybackStore.getState();
+      playback.setPreviewFrame(20);
+      playback.setCurrentFrame(30);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-x', '330');
+      expect(screen.getByTestId('single-probe')).toHaveAttribute('data-relative-frame', '30');
+    });
+  });
+});

--- a/src/features/keyframes/hooks/use-animated-transform.ts
+++ b/src/features/keyframes/hooks/use-animated-transform.ts
@@ -3,6 +3,7 @@ import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransform } from '@/types/transform';
 import { useTimelineStore } from '@/features/keyframes/deps/timeline';
 import { usePlaybackStore } from '@/shared/state/playback';
+import { getResolvedPlaybackFrame } from '@/shared/state/playback/frame-resolution';
 import {
   resolveTransform,
   getSourceDimensions,
@@ -42,9 +43,20 @@ export function useAnimatedTransform(
 
   // Get current frame from playback store
   const currentFrame = usePlaybackStore((s) => s.currentFrame);
+  const previewFrame = usePlaybackStore((s) => s.previewFrame);
+  const isPlaying = usePlaybackStore((s) => s.isPlaying);
+  const currentFrameEpoch = usePlaybackStore((s) => s.currentFrameEpoch);
+  const previewFrameEpoch = usePlaybackStore((s) => s.previewFrameEpoch);
+  const animationFrame = getResolvedPlaybackFrame({
+    currentFrame,
+    previewFrame,
+    isPlaying,
+    currentFrameEpoch,
+    previewFrameEpoch,
+  });
 
   // Calculate relative frame
-  const relativeFrame = currentFrame - item.from;
+  const relativeFrame = animationFrame - item.from;
 
   // Resolve the animated transform
   const transform = useMemo(() => {
@@ -84,6 +96,17 @@ export function useAnimatedTransforms(
 
   // Get current frame from playback store
   const currentFrame = usePlaybackStore((s) => s.currentFrame);
+  const previewFrame = usePlaybackStore((s) => s.previewFrame);
+  const isPlaying = usePlaybackStore((s) => s.isPlaying);
+  const currentFrameEpoch = usePlaybackStore((s) => s.currentFrameEpoch);
+  const previewFrameEpoch = usePlaybackStore((s) => s.previewFrameEpoch);
+  const animationFrame = getResolvedPlaybackFrame({
+    currentFrame,
+    previewFrame,
+    isPlaying,
+    currentFrameEpoch,
+    previewFrameEpoch,
+  });
 
   // Resolve transforms for all items
   return useMemo(() => {
@@ -100,7 +123,7 @@ export function useAnimatedTransforms(
       // Apply keyframe animation if item has keyframes
       const itemKeyframes = allKeyframes.find((k) => k.itemId === item.id);
       if (itemKeyframes) {
-        const relativeFrame = currentFrame - item.from;
+        const relativeFrame = animationFrame - item.from;
         transforms.set(
           item.id,
           resolveAnimatedTransform(baseResolved, itemKeyframes, relativeFrame)
@@ -111,5 +134,5 @@ export function useAnimatedTransforms(
     }
 
     return transforms;
-  }, [items, projectSize, allKeyframes, currentFrame]);
+  }, [items, projectSize, allKeyframes, animationFrame]);
 }

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -129,6 +129,7 @@ import { VideoPreview } from './video-preview';
 function resetStores() {
   usePlaybackStore.setState({
     currentFrame: 0,
+    currentFrameEpoch: 0,
     isPlaying: false,
     playbackRate: 1,
     loop: false,
@@ -136,6 +137,8 @@ function resetStores() {
     muted: false,
     zoom: -1,
     previewFrame: null,
+    previewFrameEpoch: 0,
+    frameUpdateEpoch: 0,
     previewItemId: null,
     captureFrame: null,
     useProxy: true,

--- a/src/features/preview/hooks/use-visual-transform.test.tsx
+++ b/src/features/preview/hooks/use-visual-transform.test.tsx
@@ -1,0 +1,137 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePlaybackStore } from '@/shared/state/playback';
+import { useTimelineStore } from '@/features/preview/deps/timeline-store';
+import { useGizmoStore } from '@/features/preview/stores/gizmo-store';
+import { useVisualTransforms } from './use-visual-transform';
+import type { TimelineItem } from '@/types/timeline';
+
+const PROJECT_SIZE = { width: 1920, height: 1080 } as const;
+
+const ITEM = {
+  id: 'item-1',
+  type: 'text',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 200,
+  label: 'Test Item',
+  text: 'Hello',
+  color: '#ffffff',
+  transform: {
+    x: 0,
+    y: 0,
+    width: 320,
+    height: 120,
+    rotation: 0,
+    opacity: 1,
+  },
+} as unknown as TimelineItem;
+
+function VisualTransformsProbe() {
+  const transforms = useVisualTransforms([ITEM], PROJECT_SIZE);
+  const resolved = transforms.get(ITEM.id);
+  return (
+    <div
+      data-testid="visual-probe"
+      data-x={String(resolved?.x ?? Number.NaN)}
+    />
+  );
+}
+
+function resetStores() {
+  localStorage.clear();
+
+  usePlaybackStore.setState({
+    currentFrame: 10,
+    currentFrameEpoch: 0,
+    isPlaying: false,
+    playbackRate: 1,
+    loop: false,
+    volume: 1,
+    muted: false,
+    zoom: -1,
+    previewFrame: null,
+    previewFrameEpoch: 0,
+    frameUpdateEpoch: 0,
+    previewItemId: null,
+    captureFrame: null,
+    useProxy: true,
+    previewQuality: 1,
+  });
+
+  useTimelineStore.setState({
+    keyframes: [
+      {
+        itemId: ITEM.id,
+        properties: [
+          {
+            property: 'x',
+            keyframes: [
+              { id: 'kf-10', frame: 10, value: 110, easing: 'linear' },
+              { id: 'kf-20', frame: 20, value: 220, easing: 'linear' },
+              { id: 'kf-30', frame: 30, value: 330, easing: 'linear' },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  useGizmoStore.setState({
+    activeGizmo: null,
+    previewTransform: null,
+    preview: null,
+    snapLines: [],
+    canvasBackgroundPreview: null,
+  });
+}
+
+describe('useVisualTransforms skimming frame resolution', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('uses previewFrame while paused', async () => {
+    render(<VisualTransformsProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('visual-probe')).toHaveAttribute('data-x', '110');
+    });
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(20);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('visual-probe')).toHaveAttribute('data-x', '220');
+    });
+  });
+
+  it('ignores previewFrame while playing', async () => {
+    render(<VisualTransformsProbe />);
+
+    act(() => {
+      const playback = usePlaybackStore.getState();
+      playback.setPreviewFrame(20);
+      playback.play();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('visual-probe')).toHaveAttribute('data-x', '110');
+    });
+  });
+
+  it('falls back to currentFrame when previewFrame is stale', async () => {
+    render(<VisualTransformsProbe />);
+
+    act(() => {
+      const playback = usePlaybackStore.getState();
+      playback.setPreviewFrame(20);
+      playback.setCurrentFrame(30);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('visual-probe')).toHaveAttribute('data-x', '330');
+    });
+  });
+});

--- a/src/features/preview/stores/playback-store.test.ts
+++ b/src/features/preview/stores/playback-store.test.ts
@@ -5,6 +5,7 @@ describe('playback-store', () => {
   beforeEach(() => {
     usePlaybackStore.setState({
       currentFrame: 0,
+      currentFrameEpoch: 0,
       isPlaying: false,
       playbackRate: 1,
       loop: false,
@@ -12,6 +13,8 @@ describe('playback-store', () => {
       muted: false,
       zoom: -1,
       previewFrame: null,
+      previewFrameEpoch: 0,
+      frameUpdateEpoch: 0,
       captureFrame: null,
       previewQuality: 1,
     });

--- a/src/shared/state/playback/frame-resolution.ts
+++ b/src/shared/state/playback/frame-resolution.ts
@@ -1,0 +1,23 @@
+import type { PlaybackState } from './types';
+
+type FrameResolutionInput = Pick<
+  PlaybackState,
+  'currentFrame' | 'previewFrame' | 'isPlaying' | 'currentFrameEpoch' | 'previewFrameEpoch'
+>;
+
+/**
+ * Resolve the frame that should drive preview-adjacent UI (gizmos, overlays, keyframe probes).
+ *
+ * Rules:
+ * - Playing always follows currentFrame.
+ * - If previewFrame is null, follow currentFrame.
+ * - While paused, follow whichever source was updated most recently.
+ */
+export function getResolvedPlaybackFrame(input: FrameResolutionInput): number {
+  if (input.isPlaying) return input.currentFrame;
+  if (input.previewFrame === null) return input.currentFrame;
+  return input.previewFrameEpoch >= input.currentFrameEpoch
+    ? input.previewFrame
+    : input.currentFrame;
+}
+

--- a/src/shared/state/playback/index.ts
+++ b/src/shared/state/playback/index.ts
@@ -1,4 +1,5 @@
 export { usePlaybackStore } from './store';
+export { getResolvedPlaybackFrame } from './frame-resolution';
 export type {
   CaptureOptions,
   PreviewQuality,

--- a/src/shared/state/playback/types.ts
+++ b/src/shared/state/playback/types.ts
@@ -11,6 +11,8 @@ export type PreviewQuality = 1 | 0.5 | 0.25;
 
 export interface PlaybackState {
   currentFrame: number;
+  /** Internal epoch for last currentFrame mutation (monotonic per store session) */
+  currentFrameEpoch: number;
   isPlaying: boolean;
   playbackRate: number;
   loop: boolean;
@@ -19,6 +21,10 @@ export interface PlaybackState {
   zoom: number;
   /** Frame to preview on hover (null when not hovering) */
   previewFrame: number | null;
+  /** Internal epoch for last previewFrame mutation (monotonic per store session) */
+  previewFrameEpoch: number;
+  /** Internal shared mutation counter used to order frame updates */
+  frameUpdateEpoch: number;
   /** Item ID under the cursor when previewing (null when not over an item) */
   previewItemId: string | null;
   /** Function to capture the current Player frame as a data URL (set by VideoPreview) */


### PR DESCRIPTION
## Summary
- fix gizmo/keyframe transform resolution to handle stale previewFrame by tracking frame update epochs
- centralize paused frame selection via getResolvedPlaybackFrame
- update gizmo overlay frozen-frame updates to follow the resolved frame source
- add regression tests for animated transform hooks and stale-preview fallback behavior

## Validation
- itest:
  - src/features/keyframes/hooks/use-animated-transform.test.tsx
  - src/features/preview/hooks/use-visual-transform.test.tsx
  - src/features/preview/components/video-preview.sync.test.tsx
  - src/features/preview/stores/playback-store.test.ts
- eslint on changed files
- ite build

Closes #93