### PR TITLE
fix: recover media loading after stale blob URL invalidation

### DIFF
--- a/src/features/preview/components/edit-2up-panels.tsx
+++ b/src/features/preview/components/edit-2up-panels.tsx
@@ -12,6 +12,7 @@ import {
   getItemAspectRatio,
   renderPanelMedia,
 } from './edit-panel-media-utils';
+import { useBlobUrlVersion } from '@/infrastructure/browser/blob-url-manager';
 
 const TYPE_PLACEHOLDER_COLORS: Record<string, string> = {
   image: '#22c55e',
@@ -41,10 +42,16 @@ function getEditOverlayDecoderPool(): SharedVideoExtractorPool {
 
 function useResolvedVideoBlobUrl(mediaId: string | undefined, useProxy: boolean): string | null {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const blobUrlVersion = useBlobUrlVersion();
+  const requestKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setBlobUrl(null);
+    const requestKey = `${mediaId ?? 'none'}:${useProxy ? 'proxy' : 'source'}`;
+    if (requestKeyRef.current !== requestKey) {
+      requestKeyRef.current = requestKey;
+      setBlobUrl(null);
+    }
 
     if (!mediaId) {
       return () => {
@@ -75,7 +82,7 @@ function useResolvedVideoBlobUrl(mediaId: string | undefined, useProxy: boolean)
     return () => {
       cancelled = true;
     };
-  }, [mediaId, useProxy]);
+  }, [mediaId, useProxy, blobUrlVersion]);
 
   return blobUrl;
 }


### PR DESCRIPTION
## Summary
- stop preview from reusing stale resolved media URLs after blob URL invalidation
- restart pending filmstrip extraction when a mediaId gets a refreshed blob URL
- make edit 2-up overlay blob URL resolution react to blob URL manager version updates
- keep editor open path resilient by clearing stale preview scrub frame and avoiding editor unmount blob cleanup revocation
- add regression coverage for blob URL invalidation/re-resolution in video-preview.sync.test.tsx

## Root Cause
Project-open navigation could retain or race against revoked blob: URLs. Components and worker-backed extraction paths could keep stale URL references, causing Failed to fetch and ERR_FILE_NOT_FOUND until a full refresh rebuilt URLs.

## Validation
- npm run test:preview-sync
- npx eslint src/features/preview/components/video-preview.tsx src/features/timeline/services/filmstrip-cache.ts src/features/preview/components/edit-2up-panels.tsx src/features/preview/components/video-preview.sync.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale media URLs to prevent outdated content from displaying in previews.
  * Enhanced cleanup process when closing the editor to properly reset playback state.
  * Fixed robustness of video extraction when media sources are updated during processing.

* **Tests**
  * Expanded test coverage for media URL invalidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->