### PR TITLE
feat(text): add italic and underline controls across preview and export

### DIFF
--- a/src/features/composition-runtime/components/text-content.tsx
+++ b/src/features/composition-runtime/components/text-content.tsx
@@ -89,6 +89,7 @@ export const TextContent: React.FC<{ item: TextItem }> = ({ item }) => {
           fontFamily: fontFamily,
           fontWeight,
           fontStyle: item.fontStyle ?? 'normal',
+          textDecoration: item.underline ? 'underline' : 'none',
           color,
           textAlign: item.textAlign ?? 'center',
           lineHeight,

--- a/src/features/editor/components/media-sidebar.tsx
+++ b/src/features/editor/components/media-sidebar.tsx
@@ -147,6 +147,8 @@ export const MediaSidebar = memo(function MediaSidebar() {
       fontSize: 60,
       fontFamily: 'Inter',
       fontWeight: 'normal',
+      fontStyle: 'normal',
+      underline: false,
       color: '#ffffff',
       textAlign: 'center',
       lineHeight: 1.2,
@@ -720,4 +722,3 @@ export const MediaSidebar = memo(function MediaSidebar() {
     </div>
   );
 });
-

--- a/src/features/editor/components/properties-sidebar/clip-panel/text-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/text-section.tsx
@@ -1,5 +1,5 @@
 ﻿import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Type, AlignLeft, AlignCenter, AlignRight, AlignStartHorizontal, AlignCenterHorizontal, AlignEndHorizontal } from 'lucide-react';
+import { Type, Bold, Italic, Underline, AlignLeft, AlignCenter, AlignRight, AlignStartHorizontal, AlignCenterHorizontal, AlignEndHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -64,6 +64,8 @@ export function TextSection({ items }: TextSectionProps) {
       fontSize: textItems.every(i => (i.fontSize ?? 60) === (first.fontSize ?? 60)) ? (first.fontSize ?? 60) : 'mixed' as const,
       fontFamily: textItems.every(i => (i.fontFamily ?? 'Inter') === (first.fontFamily ?? 'Inter')) ? (first.fontFamily ?? 'Inter') : undefined,
       fontWeight: textItems.every(i => (i.fontWeight ?? 'normal') === (first.fontWeight ?? 'normal')) ? (first.fontWeight ?? 'normal') : undefined,
+      fontStyle: textItems.every(i => (i.fontStyle ?? 'normal') === (first.fontStyle ?? 'normal')) ? (first.fontStyle ?? 'normal') : undefined,
+      underline: textItems.every(i => (i.underline ?? false) === (first.underline ?? false)) ? (first.underline ?? false) : undefined,
       color: textItems.every(i => i.color === first.color) ? first.color : undefined,
       textAlign: textItems.every(i => (i.textAlign ?? 'center') === (first.textAlign ?? 'center')) ? (first.textAlign ?? 'center') : undefined,
       verticalAlign: textItems.every(i => (i.verticalAlign ?? 'middle') === (first.verticalAlign ?? 'middle')) ? (first.verticalAlign ?? 'middle') : undefined,
@@ -154,6 +156,23 @@ export function TextSection({ items }: TextSectionProps) {
     },
     [supportedFontWeightOptions, updateTextItems]
   );
+
+  const handleBoldToggle = useCallback(() => {
+    if (!supportedFontWeightOptions.some((weight) => weight.value === 'bold')) {
+      return;
+    }
+    const nextWeight: TextItem['fontWeight'] = sharedValues?.fontWeight === 'bold' ? 'normal' : 'bold';
+    updateTextItems({ fontWeight: nextWeight });
+  }, [sharedValues?.fontWeight, supportedFontWeightOptions, updateTextItems]);
+
+  const handleItalicToggle = useCallback(() => {
+    const nextStyle: TextItem['fontStyle'] = sharedValues?.fontStyle === 'italic' ? 'normal' : 'italic';
+    updateTextItems({ fontStyle: nextStyle });
+  }, [sharedValues?.fontStyle, updateTextItems]);
+
+  const handleUnderlineToggle = useCallback(() => {
+    updateTextItems({ underline: !(sharedValues?.underline ?? false) });
+  }, [sharedValues?.underline, updateTextItems]);
 
   useEffect(() => {
     const currentFontFamily = sharedValues?.fontFamily;
@@ -262,6 +281,10 @@ export function TextSection({ items }: TextSectionProps) {
   }
 
   const fontPreviewText = sharedValues.text ?? textItems[0]?.text ?? '';
+  const isBoldActive = sharedValues.fontWeight === 'bold';
+  const canUseBold = supportedFontWeightOptions.some((weight) => weight.value === 'bold');
+  const isItalicActive = sharedValues.fontStyle === 'italic';
+  const isUnderlineActive = sharedValues.underline === true;
 
   return (
     <PropertySection title="Text" icon={Type} defaultOpen={true}>
@@ -317,6 +340,40 @@ export function TextSection({ items }: TextSectionProps) {
             ))}
           </SelectContent>
         </Select>
+      </PropertyRow>
+
+      {/* Font Style */}
+      <PropertyRow label="Style">
+        <div className="flex gap-1">
+          <Button
+            variant={isBoldActive ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleBoldToggle}
+            title={canUseBold ? 'Bold' : 'Bold is not available for this font'}
+            disabled={!canUseBold}
+          >
+            <Bold className="w-3.5 h-3.5" />
+          </Button>
+          <Button
+            variant={isItalicActive ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleItalicToggle}
+            title="Italic"
+          >
+            <Italic className="w-3.5 h-3.5" />
+          </Button>
+          <Button
+            variant={isUnderlineActive ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleUnderlineToggle}
+            title="Underline"
+          >
+            <Underline className="w-3.5 h-3.5" />
+          </Button>
+        </div>
       </PropertyRow>
 
       {/* Text Align */}
@@ -419,5 +476,4 @@ export function TextSection({ items }: TextSectionProps) {
     </PropertySection>
   );
 }
-
 

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -487,8 +487,10 @@ function renderTextItem(
 
   const fontSize = item.fontSize ?? 60;
   const fontFamily = item.fontFamily ?? 'Inter';
+  const fontStyle = item.fontStyle ?? 'normal';
   const fontWeightName = item.fontWeight ?? 'normal';
   const fontWeight = FONT_WEIGHT_MAP[fontWeightName] ?? 400;
+  const underline = item.underline ?? false;
   const lineHeight = item.lineHeight ?? 1.2;
   const letterSpacing = item.letterSpacing ?? 0;
   const textAlign = item.textAlign ?? 'center';
@@ -503,7 +505,7 @@ function renderTextItem(
   ctx.rect(itemLeft, itemTop, transform.width, transform.height);
   ctx.clip();
 
-  ctx.font = `${fontWeight} ${fontSize}px "${fontFamily}", sans-serif`;
+  ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px "${fontFamily}", sans-serif`;
   ctx.fillStyle = item.color ?? '#ffffff';
 
   const availableWidth = transform.width - padding * 2;
@@ -576,6 +578,19 @@ function renderTextItem(
     }
 
     drawTextWithLetterSpacing(ctx, line, lineX, lineY, letterSpacing, false, textMeasureCache);
+
+    if (underline) {
+      drawUnderline(
+        ctx,
+        line,
+        lineX,
+        lineY,
+        textAlign,
+        letterSpacing,
+        fontSize,
+        textMeasureCache,
+      );
+    }
   }
 
   ctx.restore();
@@ -708,6 +723,42 @@ function drawTextWithLetterSpacing(
   }
 
   ctx.textAlign = currentAlign;
+}
+
+function drawUnderline(
+  ctx: OffscreenCanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  textAlign: 'left' | 'center' | 'right',
+  letterSpacing: number,
+  fontSize: number,
+  textMeasureCache: TextMeasurementCache,
+): void {
+  const lineWidth = textMeasureCache.measure(ctx, text, letterSpacing);
+  if (lineWidth <= 0) return;
+
+  let startX = x;
+  if (textAlign === 'center') {
+    startX = x - lineWidth / 2;
+  } else if (textAlign === 'right') {
+    startX = x - lineWidth;
+  }
+
+  const underlineY = y + Math.max(1, fontSize * 0.08);
+  const underlineThickness = Math.max(1, fontSize * 0.05);
+  const previousLineWidth = ctx.lineWidth;
+  const previousStrokeStyle = ctx.strokeStyle;
+
+  ctx.beginPath();
+  ctx.lineWidth = underlineThickness;
+  ctx.strokeStyle = ctx.fillStyle;
+  ctx.moveTo(startX, underlineY);
+  ctx.lineTo(startX + lineWidth, underlineY);
+  ctx.stroke();
+
+  ctx.lineWidth = previousLineWidth;
+  ctx.strokeStyle = previousStrokeStyle;
 }
 
 // ---------------------------------------------------------------------------
@@ -942,4 +993,3 @@ export function calculateMediaDrawDimensions(
     height: drawHeight,
   };
 }
-

--- a/src/features/project-bundle/schemas/project-schema.ts
+++ b/src/features/project-bundle/schemas/project-schema.ts
@@ -203,6 +203,7 @@ const timelineItemSchema = z.object({
   fontFamily: z.string().optional(),
   fontWeight: fontWeightSchema.optional(),
   fontStyle: fontStyleSchema.optional(),
+  underline: z.boolean().optional(),
   color: z.string().optional(),
   backgroundColor: z.string().optional(),
   textAlign: textAlignSchema.optional(),

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -57,6 +57,7 @@ export type TextItem = BaseTimelineItem & {
   fontFamily?: string; // Font family name (default: 'Inter')
   fontWeight?: 'normal' | 'medium' | 'semibold' | 'bold'; // Font weight (default: 'normal')
   fontStyle?: 'normal' | 'italic'; // Font style (default: 'normal')
+  underline?: boolean; // Underline text decoration (default: false)
   // Colors
   color: string; // Text color (hex or oklch)
   backgroundColor?: string; // Background color behind text (optional)


### PR DESCRIPTION
## Summary
Adds text style controls for italic and underline and wires them through preview, export, and project schema/type definitions.

Changes:
- Add `fontStyle`/`underline` defaults for newly created text items.
- Add style buttons (Bold/Italic/Underline) in text properties panel.
- Apply underline rendering in runtime text preview.
- Apply `fontStyle` and custom underline drawing in canvas export text renderer.
- Extend timeline and bundle schema types to persist `underline`.

## Validation
- `npm run check:boundaries`
