### PR TITLE
fix: prevent gizmo transform leak when switching selected layers in precomp

### DIFF
--- a/src/features/keyframes/hooks/use-animated-transform.test.tsx
+++ b/src/features/keyframes/hooks/use-animated-transform.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useTimelineStore } from '@/features/keyframes/deps/timeline';
@@ -7,7 +8,7 @@ import type { TimelineItem } from '@/types/timeline';
 
 const PROJECT_SIZE = { width: 1920, height: 1080 } as const;
 
-const ITEM = {
+const ANIMATED_ITEM = {
   id: 'item-1',
   type: 'text',
   trackId: 'track-1',
@@ -26,8 +27,27 @@ const ITEM = {
   },
 } as unknown as TimelineItem;
 
+const STATIC_ITEM = {
+  id: 'item-2',
+  type: 'text',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 200,
+  label: 'Static Item',
+  text: 'World',
+  color: '#ffffff',
+  transform: {
+    x: 480,
+    y: 0,
+    width: 320,
+    height: 120,
+    rotation: 0,
+    opacity: 1,
+  },
+} as unknown as TimelineItem;
+
 function SingleAnimatedTransformProbe() {
-  const { transform, relativeFrame } = useAnimatedTransform(ITEM, PROJECT_SIZE);
+  const { transform, relativeFrame } = useAnimatedTransform(ANIMATED_ITEM, PROJECT_SIZE);
   return (
     <div
       data-testid="single-probe"
@@ -38,13 +58,31 @@ function SingleAnimatedTransformProbe() {
 }
 
 function MultiAnimatedTransformsProbe() {
-  const transforms = useAnimatedTransforms([ITEM], PROJECT_SIZE);
-  const resolved = transforms.get(ITEM.id);
+  const transforms = useAnimatedTransforms([ANIMATED_ITEM], PROJECT_SIZE);
+  const resolved = transforms.get(ANIMATED_ITEM.id);
   return (
     <div
       data-testid="multi-probe"
       data-x={String(resolved?.x ?? Number.NaN)}
     />
+  );
+}
+
+function SwitchingItemProbe() {
+  const [activeId, setActiveId] = useState<'animated' | 'static'>('animated');
+  const activeItem = activeId === 'animated' ? ANIMATED_ITEM : STATIC_ITEM;
+  const { transform } = useAnimatedTransform(activeItem, PROJECT_SIZE);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="switch-item"
+        onClick={() => setActiveId(activeId === 'animated' ? 'static' : 'animated')}
+      >
+        Switch
+      </button>
+      <div data-testid="switch-probe" data-x={String(transform.x)} />
+    </>
   );
 }
 
@@ -73,7 +111,7 @@ function resetStores() {
   useTimelineStore.setState({
     keyframes: [
       {
-        itemId: ITEM.id,
+        itemId: ANIMATED_ITEM.id,
         properties: [
           {
             property: 'x',
@@ -156,6 +194,20 @@ describe('useAnimatedTransform skimming frame resolution', () => {
     await waitFor(() => {
       expect(screen.getByTestId('single-probe')).toHaveAttribute('data-x', '330');
       expect(screen.getByTestId('single-probe')).toHaveAttribute('data-relative-frame', '30');
+    });
+  });
+
+  it('updates keyframe source when switching items without timeline changes', async () => {
+    render(<SwitchingItemProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('switch-probe')).toHaveAttribute('data-x', '110');
+    });
+
+    fireEvent.click(screen.getByTestId('switch-item'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('switch-probe')).toHaveAttribute('data-x', '480');
     });
   });
 });

--- a/src/features/keyframes/hooks/use-animated-transform.ts
+++ b/src/features/keyframes/hooks/use-animated-transform.ts
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo } from 'react';
 import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransform } from '@/types/transform';
 import { useTimelineStore } from '@/features/keyframes/deps/timeline';
@@ -36,9 +36,13 @@ export function useAnimatedTransform(
   item: TimelineItem,
   projectSize: ProjectSize
 ): AnimatedTransformResult {
-  // Get keyframes for this item (granular selector)
-  const itemKeyframes = useTimelineStore(
-    useCallback((s) => s.keyframes.find((k) => k.itemId === item.id), [item.id])
+  // Important: avoid selectors that close over item.id here.
+  // The timeline facade memoizes by snapshot reference, so changing item.id due
+  // to a different store (selection) can otherwise return stale keyframes.
+  const allKeyframes = useTimelineStore((s) => s.keyframes);
+  const itemKeyframes = useMemo(
+    () => allKeyframes.find((k) => k.itemId === item.id),
+    [allKeyframes, item.id]
   );
 
   // Get current frame from playback store


### PR DESCRIPTION
## Summary
- fix stale keyframe resolution in `useAnimatedTransform` when selected item changes without timeline snapshot change
- prevent previously selected animated segment transform from leaking into a newly selected non-animated layer gizmo
- add regression test that switches from animated item to static item and verifies transform resolves correctly

## Verification
- npm test -- src/features/keyframes/hooks/use-animated-transform.test.tsx
- npm test -- src/features/preview/hooks/use-visual-transform.test.tsx

Fixes #101