### PR TITLE
Fix Go To Start not resetting preview/precomp frame state

### DIFF
--- a/src/features/preview/components/playback-controls.tsx
+++ b/src/features/preview/components/playback-controls.tsx
@@ -35,6 +35,8 @@ export function PlaybackControls({ totalFrames }: PlaybackControlsProps) {
   const useProxy = usePlaybackStore((s) => s.useProxy);
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause);
   const setCurrentFrame = usePlaybackStore((s) => s.setCurrentFrame);
+  const setPreviewFrame = usePlaybackStore((s) => s.setPreviewFrame);
+  const setDisplayedFrame = usePlaybackStore((s) => s.setDisplayedFrame);
   const setVolume = usePlaybackStore((s) => s.setVolume);
   const toggleUseProxy = usePlaybackStore((s) => s.toggleUseProxy);
 
@@ -44,15 +46,23 @@ export function PlaybackControls({ totalFrames }: PlaybackControlsProps) {
   // Note: totalFrames is the count, so valid frame indices are [0, totalFrames - 1]
   const lastValidFrame = Math.max(0, totalFrames - 1);
   
-  const handleGoToStart = () => setCurrentFrame(0);
-  const handleGoToEnd = () => setCurrentFrame(lastValidFrame);
+  const commitTimelineSeek = (frame: number) => {
+    // Transport seeks should exit hover-scrub state so Player rendering
+    // follows the actual playhead immediately.
+    setPreviewFrame(null);
+    setDisplayedFrame(null);
+    setCurrentFrame(frame);
+  };
+
+  const handleGoToStart = () => commitTimelineSeek(0);
+  const handleGoToEnd = () => commitTimelineSeek(lastValidFrame);
   const handlePreviousFrame = () => {
     const currentFrame = usePlaybackStore.getState().currentFrame;
-    setCurrentFrame(Math.max(0, currentFrame - 1));
+    commitTimelineSeek(Math.max(0, currentFrame - 1));
   };
   const handleNextFrame = () => {
     const currentFrame = usePlaybackStore.getState().currentFrame;
-    setCurrentFrame(Math.min(lastValidFrame, currentFrame + 1));
+    commitTimelineSeek(Math.min(lastValidFrame, currentFrame + 1));
   };
 
   return (

--- a/src/features/timeline/hooks/shortcuts/use-playback-shortcuts.ts
+++ b/src/features/timeline/hooks/shortcuts/use-playback-shortcuts.ts
@@ -2,6 +2,7 @@
  * Playback & Navigation shortcuts: Space, Arrow Left/Right, Home/End, Up/Down snap points.
  */
 
+import { useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useItemsStore } from '../../stores/items-store';
@@ -36,7 +37,14 @@ export function usePlaybackShortcuts(
 ) {
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause);
   const setCurrentFrame = usePlaybackStore((s) => s.setCurrentFrame);
+  const setPreviewFrame = usePlaybackStore((s) => s.setPreviewFrame);
+  const setDisplayedFrame = usePlaybackStore((s) => s.setDisplayedFrame);
   const isPlaying = usePlaybackStore((s) => s.isPlaying);
+  const commitTimelineSeek = useCallback((frame: number) => {
+    setPreviewFrame(null);
+    setDisplayedFrame(null);
+    setCurrentFrame(frame);
+  }, [setPreviewFrame, setDisplayedFrame, setCurrentFrame]);
 
   // Playback: Space - Play/Pause
   useHotkeys(
@@ -70,10 +78,10 @@ export function usePlaybackShortcuts(
         return;
       }
       const currentFrame = usePlaybackStore.getState().currentFrame;
-      setCurrentFrame(Math.max(0, currentFrame - 1));
+      commitTimelineSeek(Math.max(0, currentFrame - 1));
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 
   // Navigation: Arrow Right - Next frame
@@ -87,10 +95,10 @@ export function usePlaybackShortcuts(
         return;
       }
       const currentFrame = usePlaybackStore.getState().currentFrame;
-      setCurrentFrame(currentFrame + 1);
+      commitTimelineSeek(currentFrame + 1);
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 
   // Navigation: Home - Go to start
@@ -103,10 +111,10 @@ export function usePlaybackShortcuts(
         playerMethods.seek(0);
         return;
       }
-      setCurrentFrame(0);
+      commitTimelineSeek(0);
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 
   // Navigation: End - Go to end of timeline (last frame of last item)
@@ -124,10 +132,10 @@ export function usePlaybackShortcuts(
         const itemEnd = item.from + item.durationInFrames;
         return Math.max(max, itemEnd);
       }, 0);
-      setCurrentFrame(lastFrame);
+      commitTimelineSeek(lastFrame);
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 
   // Navigation: Down - Jump to next snap point (clip edge or marker)
@@ -138,11 +146,11 @@ export function usePlaybackShortcuts(
       const currentFrame = usePlaybackStore.getState().currentFrame;
       const nextEdge = getSnapPoints().find((edge) => edge > currentFrame);
       if (nextEdge !== undefined) {
-        setCurrentFrame(nextEdge);
+        commitTimelineSeek(nextEdge);
       }
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 
   // Navigation: Up - Jump to previous snap point (clip edge or marker)
@@ -160,10 +168,10 @@ export function usePlaybackShortcuts(
         }
       }
       if (previousEdge !== undefined) {
-        setCurrentFrame(previousEdge);
+        commitTimelineSeek(previousEdge);
       }
     },
     HOTKEY_OPTIONS,
-    [setCurrentFrame]
+    [commitTimelineSeek]
   );
 }


### PR DESCRIPTION
## Summary
- clear previewFrame and displayedFrame before transport seeks in preview playback controls
- apply the same reset behavior to timeline navigation hotkeys (Home/End/arrow/snap seeks)
- ensure Go To Start follows the real playhead immediately so nested/precomp animated frames reset correctly

## Validation
- npx eslint src/features/preview/components/playback-controls.tsx src/features/timeline/hooks/shortcuts/use-playback-shortcuts.ts
- npm run test:preview-sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frame navigation controls and keyboard shortcuts now properly reset preview state before seeking to ensure clean state transitions and prevent lingering preview states during playback control and timeline navigation.
  * Enhanced overall frame navigation behavior across all available methods including previous/next, go to start/end, and snap point navigation with improved state management for a more consistent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->