### PR TITLE
Add husky pre-push hook for CI quality checks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,29 @@
+# Pre-push hook: mirrors CI "Quality Checks" (fast subset)
+# Skip with: git push --no-verify
+
+set -e
+
+echo "Running quality checks before push..."
+
+echo "  [1/6] check:boundaries"
+npm run check:boundaries --silent
+
+echo "  [2/6] check:deps-contracts"
+npm run check:deps-contracts --silent
+
+echo "  [3/6] check:legacy-lib-imports"
+npm run check:legacy-lib-imports --silent
+
+echo "  [4/6] check:deps-wrapper-health"
+npm run check:deps-wrapper-health --silent
+
+echo "  [5/6] check:edge-budgets"
+EDGE_REPORT=$(mktemp)
+trap 'rm -f "$EDGE_REPORT"' EXIT
+npm run -s report:feature-edges:json > "$EDGE_REPORT"
+npm run check:edge-budgets --silent -- --input "$EDGE_REPORT"
+
+echo "  [6/6] lint"
+npm run lint --silent
+
+echo "All quality checks passed."

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-react-hooks": "^6.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "husky": "^9.1.7",
         "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.17",
         "typescript": "~5.9.3",
@@ -5619,6 +5620,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/idb": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:run": "vitest run",
     "test:preview-sync": "vitest run src/features/preview/components/video-preview.sync.test.tsx",
     "test:preview-sync:stress": "node scripts/preview-sync-stress.mjs --runs 20",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -83,6 +84,7 @@
     "eslint-plugin-react-hooks": "^6.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "husky": "^9.1.7",
     "jsdom": "^27.4.0",
     "tailwindcss": "^4.1.17",
     "typescript": "~5.9.3",


### PR DESCRIPTION
## Summary
- Add husky with a pre-push hook that runs the fast subset of CI quality checks locally before every push
- Checks: feature boundaries, deps contracts, legacy lib imports, deps wrapper health, edge budgets, lint
- Skip with `git push --no-verify`

## Test plan
- [x] All 6 checks pass locally
- [x] Hook triggered automatically on `git push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated quality checks that run locally before pushing code, validating boundaries, dependencies, imports, edge budgets, and code style to maintain standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->