### PR TITLE
Fix ClipPanel tab selection when selected clip types change

### DIFF
--- a/src/features/editor/components/properties-sidebar/clip-panel/index.test.ts
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveClipPanelTab } from './tab-selection';
+
+describe('resolveClipPanelTab', () => {
+  it('keeps the current tab when it is still available', () => {
+    expect(
+      resolveClipPanelTab('effects', {
+        showTransformTab: true,
+        showEffectsTab: true,
+        showMediaTab: true,
+      })
+    ).toBe('effects');
+  });
+
+  it('falls back to the first available tab when the current tab is disabled', () => {
+    expect(
+      resolveClipPanelTab('transform', {
+        showTransformTab: false,
+        showEffectsTab: true,
+        showMediaTab: true,
+      })
+    ).toBe('effects');
+  });
+
+  it('falls back to media when it is the only enabled tab', () => {
+    expect(
+      resolveClipPanelTab('effects', {
+        showTransformTab: false,
+        showEffectsTab: false,
+        showMediaTab: true,
+      })
+    ).toBe('media');
+  });
+});

--- a/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, memo } from 'react';
+import { useMemo, useCallback, useEffect, useState, memo } from 'react';
 import { Move, Sparkles, Film } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Separator } from '@/components/ui/separator';
@@ -19,6 +19,7 @@ import { AudioSection } from './audio-section';
 import { TextSection } from './text-section';
 import { ShapeSection } from './shape-section';
 import { EffectsSection } from '@/features/editor/deps/effects-contract';
+import { resolveClipPanelTab, type ClipPanelTab } from './tab-selection';
 
 /**
  * Check if an item is a GIF (image with .gif extension)
@@ -156,8 +157,18 @@ export const ClipPanel = memo(function ClipPanel() {
   const showEffectsTab = hasVisualItems;
   const showMediaTab = hasTextItems || hasShapeItems || hasVideoItems || hasGifItems || hasAudioItems;
 
-  // Determine default tab based on what's available
-  const defaultTab = showTransformTab ? 'transform' : showEffectsTab ? 'effects' : 'media';
+  const tabAvailability = useMemo(
+    () => ({ showTransformTab, showEffectsTab, showMediaTab }),
+    [showTransformTab, showEffectsTab, showMediaTab]
+  );
+
+  const [activeTab, setActiveTab] = useState<ClipPanelTab>(
+    resolveClipPanelTab('transform', tabAvailability)
+  );
+
+  useEffect(() => {
+    setActiveTab((currentTab) => resolveClipPanelTab(currentTab, tabAvailability));
+  }, [tabAvailability]);
 
   if (selectedItems.length === 0) {
     return null;
@@ -171,7 +182,7 @@ export const ClipPanel = memo(function ClipPanel() {
       <Separator />
 
       {/* Tabbed sections */}
-      <Tabs defaultValue={defaultTab} className="w-full">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as ClipPanelTab)} className="w-full">
         <TabsList className="grid w-full grid-cols-3 h-8">
           <TabsTrigger
             value="transform"
@@ -276,4 +287,3 @@ export const ClipPanel = memo(function ClipPanel() {
     </div>
   );
 });
-

--- a/src/features/editor/components/properties-sidebar/clip-panel/tab-selection.ts
+++ b/src/features/editor/components/properties-sidebar/clip-panel/tab-selection.ts
@@ -1,0 +1,26 @@
+export type ClipPanelTab = 'transform' | 'effects' | 'media';
+
+interface ClipPanelTabAvailability {
+  showTransformTab: boolean;
+  showEffectsTab: boolean;
+  showMediaTab: boolean;
+}
+
+export function resolveClipPanelTab(
+  currentTab: ClipPanelTab,
+  tabAvailability: ClipPanelTabAvailability
+): ClipPanelTab {
+  const orderedTabs: ClipPanelTab[] = ['transform', 'effects', 'media'];
+
+  const isEnabled = (tab: ClipPanelTab) => {
+    if (tab === 'transform') return tabAvailability.showTransformTab;
+    if (tab === 'effects') return tabAvailability.showEffectsTab;
+    return tabAvailability.showMediaTab;
+  };
+
+  if (isEnabled(currentTab)) {
+    return currentTab;
+  }
+
+  return orderedTabs.find(isEnabled) ?? 'media';
+}


### PR DESCRIPTION
### Motivation
- The ClipPanel used uncontrolled tabs (`defaultValue`) so when the selection changed to clips that disabled the currently active tab the UI could remain on an invalid/disabled tab and show empty or incorrect content. 
- The change ensures the selected tab is always valid as selection/available-tab state changes to avoid confusing UX and potential runtime issues in the properties sidebar.

### Description
- Convert the ClipPanel to controlled tab state by adding `activeTab` state and wiring it to the `Tabs` component via `value` and `onValueChange` instead of using `defaultValue`.
- Add a deterministic resolver `resolveClipPanelTab` (`tab-selection.ts`) that preserves the current tab when possible and falls back to the first enabled tab in priority order `transform`, `effects`, `media`.
- Add unit tests (`index.test.ts`) for `resolveClipPanelTab` covering keep-current, fallback to first enabled, and fallback-to-media cases to prevent regressions.

### Testing
- Ran the targeted unit tests with `npm run test:run -- src/features/editor/components/properties-sidebar/clip-panel/index.test.ts` and the new test suite passed (3 tests).
- Ran `npm run lint` and the code passed linting after moving the tab resolver into its own module to satisfy the fast-refresh rule.
- Prior to the targeted change a full test run of the repo (`npm run test:run`) had completed successfully (all tests passed), and the focused tests confirm the new behavior is correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8319ffb948322ba4406249e57189a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for clip panel tab selection logic to verify behavior when tabs are enabled, disabled, or when fallback options are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->