### PR TITLE
Optimize RGB split effect performance during export

### DIFF
--- a/src/features/export/utils/canvas-effects.ts
+++ b/src/features/export/utils/canvas-effects.ts
@@ -233,6 +233,7 @@ function applyRGBSplit(
   const { width, height } = sourceCanvas;
   const { ctx: scratchCtx, imageData: outputData } = getRGBSplitBuffers(width, height);
 
+  scratchCtx.clearRect(0, 0, width, height);
   scratchCtx.drawImage(sourceCanvas, 0, 0);
   const sourceData = scratchCtx.getImageData(0, 0, width, height).data;
 


### PR DESCRIPTION
### Motivation
- Exporting videos with the `rgb-split` glitch was allocating multiple full-frame canvases and reading back three full image buffers per frame, creating a large memory and CPU bottleneck.
- Reduce per-frame allocations and memory bandwidth to speed up exports while preserving deterministic output and alpha handling.

### Description
- Added a reusable `RGBSplitBuffers` scratch area (an `OffscreenCanvas`, its 2D context, and an `ImageData`) with `getRGBSplitBuffers(width, height)` to reuse buffers across frames at the same resolution.
- Replaced the previous 3-canvas pipeline with a single scratch read via `scratchCtx.getImageData(...)` and a single-pass channel remapping that computes integer `x` shifts and composes channels into one `ImageData` buffer.
- Kept the existing seeded jitter/offset logic and preserved alpha composition by taking the max alpha of sampled channels.
- Reduced per-frame allocations and memory reads by removing temporary canvases and per-channel `getImageData` calls.

### Testing
- Ran `npm run lint -- src/features/export/utils/canvas-effects.ts`, which completed successfully.
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8346239e48322be608350b503775c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved RGB split effect performance by switching to a shared offscreen buffer and single-pass pixel processing.
  * Replaced multiple per-channel temporary canvases with a reusable scratch buffer and preallocated image data to reduce allocations and memory churn.
  * Maintained identical visual output and kept the early bypass for negligible offsets while lowering read/write overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->