### PR TITLE
fix(timeline): waveform not rendering on initial media drop

### DIFF
--- a/src/features/timeline/hooks/use-waveform.ts
+++ b/src/features/timeline/hooks/use-waveform.ts
@@ -106,8 +106,18 @@ export function useWaveform({
       return;
     }
 
-    // Skip if not visible and not already loading
-    if (!isVisible && !isGeneratingRef.current) {
+    // Skip if already generating — prevents premature re-starts when the
+    // subscription updates waveform state (e.g. init message changes
+    // waveform?.isComplete from undefined to false).  Without this guard the
+    // re-fire hits the memory cache, returns the incomplete (all-zero) peaks
+    // immediately, and sets isLoading=false before any real data has arrived,
+    // leaving the waveform area visually empty.
+    if (isGeneratingRef.current) {
+      return;
+    }
+
+    // Skip if not visible
+    if (!isVisible) {
       return;
     }
 

--- a/src/features/timeline/services/waveform-cache.ts
+++ b/src/features/timeline/services/waveform-cache.ts
@@ -166,9 +166,12 @@ class WaveformCacheService {
     } catch (error) {
       queued.reject(error instanceof Error ? error : new Error(String(error)));
     } finally {
-      this.activeGenerations.delete(queued.mediaId);
+      // Guard both deletes with requestId so a stale finally from an aborted
+      // run doesn't stomp a newer generation's tracking entries.
       const pending = this.pendingRequests.get(queued.mediaId);
-      if (pending && pending.requestId === queued.requestId) {
+      const isStale = pending && pending.requestId !== queued.requestId;
+      if (!isStale) {
+        this.activeGenerations.delete(queued.mediaId);
         this.pendingRequests.delete(queued.mediaId);
       }
       this.processGenerationQueue();

--- a/src/features/timeline/services/waveform-cache.ts
+++ b/src/features/timeline/services/waveform-cache.ts
@@ -933,7 +933,12 @@ class WaveformCacheService {
       return;
     }
 
-    // Running request
+    // Running request — clean up tracking state synchronously so that a
+    // subsequent getWaveform() call (e.g. React StrictMode remount) doesn't
+    // receive the stale, already-rejected promise.
+    this.pendingRequests.delete(mediaId);
+    this.activeGenerations.delete(mediaId);
+
     const activeWorker = this.workerManager.peekWorker();
     if (activeWorker) {
       activeWorker.postMessage({
@@ -948,6 +953,8 @@ class WaveformCacheService {
     if (rejector) {
       rejector(new AbortError());
     }
+
+    this.processGenerationQueue();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix waveform generation effect re-firing prematurely when the worker's `init` message updates `waveform?.isComplete` from `undefined` to `false` — the re-fire hit the memory cache (all-zero peaks), set `isLoading=false` before real data arrived, hiding the skeleton and leaving the waveform area empty
- Add `isGeneratingRef` guard so the effect skips re-starts while generation is in progress
- Fix `waveformCache.abort()` for running requests: clean up `pendingRequests` and `activeGenerations` synchronously so a subsequent `getWaveform()` call doesn't receive a stale rejected promise (affects React StrictMode remount)

## Test plan
- [ ] Drop a video with audio onto the timeline — waveform skeleton should stay visible until waveform data renders progressively
- [ ] Drop a short clip (< 5s) — waveform should appear after worker finishes, no empty gap
- [ ] Scroll a clip out of view and back — waveform should re-render from cache without re-generation
- [ ] Verify in dev mode (StrictMode) — waveform loads correctly despite double-mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate or restarted waveform generation when a generation is already in progress, avoiding unnecessary restarts from subscription-driven updates.
  * Fixed abort/cleanup behavior for waveform generation so cancelled or stale requests no longer block or misroute queued generations; queued work now reliably resumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->