### PR TITLE
[codex] Promote EQ, mixer, and transition fixes to staging

### DIFF
--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -38,6 +38,8 @@ export interface FloatingPanelProps {
   resizable?: boolean;
   /** When true, panel height fits content instead of using a fixed value */
   autoHeight?: boolean;
+  /** When true, panel width fits content instead of using a fixed value */
+  autoWidth?: boolean;
   /** Called when the panel requests to close / dock */
   onClose?: () => void;
   /** Additional className on the outer container */
@@ -115,22 +117,24 @@ export const FloatingPanel = memo(function FloatingPanel({
   storageKey,
   resizable = true,
   autoHeight = false,
+  autoWidth = false,
   onClose,
   className = '',
 }: FloatingPanelProps) {
   const [bounds, setBounds] = useState<FloatingPanelBounds>(() => {
     const initial = storageKey ? loadBounds(storageKey, defaultBounds) : defaultBounds;
-    // When autoHeight, use a small placeholder height for initial Y positioning
-    // so the panel isn't clamped too far up. Actual height comes from content.
+    // When autoHeight/autoWidth, use small placeholders for positioning
+    // so the panel isn't clamped too far. Actual size comes from content.
     const heightForLayout = autoHeight ? 100 : initial.height;
+    const widthForLayout = autoWidth ? 200 : initial.width;
     const resolved = {
       ...initial,
-      x: initial.x < 0 ? window.innerWidth - initial.width - EDGE_MARGIN * 4 : initial.x,
+      x: initial.x < 0 ? window.innerWidth - widthForLayout - EDGE_MARGIN * 4 : initial.x,
       y: initial.y < 0 ? window.innerHeight - heightForLayout - EDGE_MARGIN * 4 : initial.y,
     };
     return clampToViewport({
       ...resolved,
-      width: Math.max(minWidth, resolved.width),
+      width: autoWidth ? widthForLayout : Math.max(minWidth, resolved.width),
       height: autoHeight ? heightForLayout : Math.max(minHeight, initial.height),
     });
   });
@@ -158,26 +162,30 @@ export const FloatingPanel = memo(function FloatingPanel({
         const effectiveHeight = autoHeight && panelRef.current
           ? panelRef.current.offsetHeight
           : prev.height;
-        return clampToViewport({ ...prev, height: effectiveHeight });
+        const effectiveWidth = autoWidth && panelRef.current
+          ? panelRef.current.offsetWidth
+          : prev.width;
+        return clampToViewport({ ...prev, width: effectiveWidth, height: effectiveHeight });
       });
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [autoHeight]);
+  }, [autoHeight, autoWidth]);
 
   useEffect(() => {
-    if (!autoHeight || !panelRef.current) return;
+    if ((!autoHeight && !autoWidth) || !panelRef.current) return;
     const ro = new ResizeObserver(() => {
       if (!panelRef.current) return;
-      const contentHeight = panelRef.current.offsetHeight;
-      setBounds((prev) => clampToViewport({
-        ...prev,
-        height: contentHeight,
-      }));
+      setBounds((prev) => {
+        const next = { ...prev };
+        if (autoHeight) next.height = panelRef.current!.offsetHeight;
+        if (autoWidth) next.width = panelRef.current!.offsetWidth;
+        return clampToViewport(next);
+      });
     });
     ro.observe(panelRef.current);
     return () => ro.disconnect();
-  }, [autoHeight]);
+  }, [autoHeight, autoWidth]);
 
   useEffect(() => {
     const handlePointerMove = (e: PointerEvent) => {
@@ -266,7 +274,7 @@ export const FloatingPanel = memo(function FloatingPanel({
       style={{
         left: bounds.x,
         top: bounds.y,
-        width: bounds.width,
+        ...(autoWidth ? {} : { width: bounds.width }),
         ...(autoHeight ? {} : { height: bounds.height }),
       }}
     >

--- a/src/components/ui/floating-panel.tsx
+++ b/src/components/ui/floating-panel.tsx
@@ -208,8 +208,8 @@ export const FloatingPanel = memo(function FloatingPanel({
       let { x, y, width, height } = s;
       const edge = drag.edge!;
 
-      if (edge.includes('e')) width = Math.max(minWidth, s.width + dx);
-      if (edge.includes('w')) {
+      if (!autoWidth && edge.includes('e')) width = Math.max(minWidth, s.width + dx);
+      if (!autoWidth && edge.includes('w')) {
         const newWidth = Math.max(minWidth, s.width - dx);
         x = s.x + (s.width - newWidth);
         width = newWidth;
@@ -274,7 +274,7 @@ export const FloatingPanel = memo(function FloatingPanel({
       style={{
         left: bounds.x,
         top: bounds.y,
-        ...(autoWidth ? {} : { width: bounds.width }),
+        ...(autoWidth ? { maxWidth: window.innerWidth - bounds.x - EDGE_MARGIN } : { width: bounds.width }),
         ...(autoHeight ? {} : { height: bounds.height }),
       }}
     >
@@ -282,12 +282,12 @@ export const FloatingPanel = memo(function FloatingPanel({
         <>
           {resizeHandle('n', 'top-0 left-2 right-2 h-[4px]')}
           {resizeHandle('s', 'bottom-0 left-2 right-2 h-[4px]')}
-          {resizeHandle('e', 'right-0 top-2 bottom-2 w-[4px]')}
-          {resizeHandle('w', 'left-0 top-2 bottom-2 w-[4px]')}
-          {resizeHandle('nw', 'top-0 left-0 w-[8px] h-[8px]')}
-          {resizeHandle('ne', 'top-0 right-0 w-[8px] h-[8px]')}
-          {resizeHandle('sw', 'bottom-0 left-0 w-[8px] h-[8px]')}
-          {resizeHandle('se', 'bottom-0 right-0 w-[8px] h-[8px]')}
+          {!autoWidth && resizeHandle('e', 'right-0 top-2 bottom-2 w-[4px]')}
+          {!autoWidth && resizeHandle('w', 'left-0 top-2 bottom-2 w-[4px]')}
+          {resizeHandle('nw', autoWidth ? 'top-0 left-0 w-[8px] h-[8px] !cursor-ns-resize' : 'top-0 left-0 w-[8px] h-[8px]')}
+          {resizeHandle('ne', autoWidth ? 'top-0 right-0 w-[8px] h-[8px] !cursor-ns-resize' : 'top-0 right-0 w-[8px] h-[8px]')}
+          {resizeHandle('sw', autoWidth ? 'bottom-0 left-0 w-[8px] h-[8px] !cursor-ns-resize' : 'bottom-0 left-0 w-[8px] h-[8px]')}
+          {resizeHandle('se', autoWidth ? 'bottom-0 right-0 w-[8px] h-[8px] !cursor-ns-resize' : 'bottom-0 right-0 w-[8px] h-[8px]')}
         </>
       ) : null}
 

--- a/src/components/ui/window-portal.tsx
+++ b/src/components/ui/window-portal.tsx
@@ -10,11 +10,11 @@ export interface WindowPortalProps {
   children: ReactNode;
   /** Window title */
   title: string;
-  /** Window width */
+  /** Window width (inner/content-area pixels) */
   width?: number;
-  /** Window height */
+  /** Window height (inner/content-area pixels) */
   height?: number;
-  /** localStorage key for persisting window position/size */
+  /** localStorage key for persisting window position */
   storageKey?: string;
   /** Reuse an already-opened window (useful for pop-out actions initiated by a click) */
   externalWindow?: Window | null;
@@ -27,28 +27,26 @@ export interface WindowPortalProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — position only (size comes from props)
 // ---------------------------------------------------------------------------
 
-interface WindowBounds {
+interface WindowPosition {
   left: number;
   top: number;
-  width: number;
-  height: number;
 }
 
-function loadBounds(key: string, fallback: WindowBounds): WindowBounds {
+function loadPosition(key: string, fallback: WindowPosition): WindowPosition {
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return fallback;
-    const parsed = JSON.parse(raw) as Partial<WindowBounds>;
-    if (
-      typeof parsed.left === 'number' &&
-      typeof parsed.top === 'number' &&
-      typeof parsed.width === 'number' &&
-      typeof parsed.height === 'number'
-    ) {
-      return { left: parsed.left, top: parsed.top, width: parsed.width, height: parsed.height };
+    const parsed = JSON.parse(raw) as Partial<WindowPosition>;
+    if (typeof parsed.left === 'number' && typeof parsed.top === 'number') {
+      const sw = window.screen.availWidth;
+      const sh = window.screen.availHeight;
+      return {
+        left: Math.max(0, Math.min(parsed.left, sw - 200)),
+        top: Math.max(0, Math.min(parsed.top, sh - 100)),
+      };
     }
   } catch {
     // ignore
@@ -56,9 +54,9 @@ function loadBounds(key: string, fallback: WindowBounds): WindowBounds {
   return fallback;
 }
 
-function saveBounds(key: string, bounds: WindowBounds): void {
+function savePosition(key: string, pos: WindowPosition): void {
   try {
-    localStorage.setItem(key, JSON.stringify(bounds));
+    localStorage.setItem(key, JSON.stringify(pos));
   } catch {
     // ignore
   }
@@ -137,23 +135,20 @@ export function WindowPortal({
   useEffect(() => {
     mountedRef.current = true;
 
+    const defaultPos: WindowPosition = {
+      left: window.screenX + 100,
+      top: window.screenY + 100,
+    };
+    const pos = storageKey ? loadPosition(storageKey, defaultPos) : defaultPos;
+
     // Reuse a provided window or one from a previous mount (survives StrictMode double-mount)
     let externalWindow = providedExternalWindow ?? externalWindowRef.current;
     if (!(externalWindow && !externalWindow.closed)) {
-      // Open fresh window
-      const defaultBounds: WindowBounds = {
-        left: window.screenX + 100,
-        top: window.screenY + 100,
-        width,
-        height,
-      };
-      const bounds = storageKey ? loadBounds(storageKey, defaultBounds) : defaultBounds;
-
       const features = [
-        `width=${bounds.width}`,
-        `height=${bounds.height}`,
-        `left=${bounds.left}`,
-        `top=${bounds.top}`,
+        `width=${width}`,
+        `height=${height}`,
+        `left=${pos.left}`,
+        `top=${pos.top}`,
         'menubar=no',
         'toolbar=no',
         'location=no',
@@ -191,21 +186,26 @@ export function WindowPortal({
     }
     setContainer(root);
 
+    // Force correct size — window.open() features are unreliable on Windows Chrome.
+    try {
+      const chromeW = Math.max(0, externalWindow.outerWidth - externalWindow.innerWidth);
+      const chromeH = Math.max(0, externalWindow.outerHeight - externalWindow.innerHeight);
+      externalWindow.resizeTo(width + chromeW, (autoHeight ? externalWindow.outerHeight : height + chromeH));
+      externalWindow.moveTo(pos.left, pos.top);
+    } catch {
+      // ignore
+    }
+
     const win = externalWindow;
 
-    const persistBounds = () => {
+    const persistPosition = () => {
       if (!storageKey || !win || win.closed) return;
-      saveBounds(storageKey, {
-        left: win.screenX,
-        top: win.screenY,
-        width: win.outerWidth,
-        height: win.outerHeight,
-      });
+      savePosition(storageKey, { left: win.screenX, top: win.screenY });
     };
 
     // Child window closed by user
     const handleUnload = () => {
-      persistBounds();
+      persistPosition();
       externalWindowRef.current = null;
       setContainer(null);
       onCloseRef.current();
@@ -217,7 +217,6 @@ export function WindowPortal({
     };
 
     win.addEventListener('beforeunload', handleUnload);
-    win.addEventListener('resize', persistBounds);
     window.addEventListener('beforeunload', handleParentUnload);
 
     // autoHeight: wait for stylesheets to load, then measure content and resize
@@ -228,7 +227,7 @@ export function WindowPortal({
         if (cancelled || win.closed) return;
         const contentHeight = rootEl.scrollHeight;
         if (contentHeight > 0) {
-          const chromeHeight = win.outerHeight - win.innerHeight;
+          const chromeHeight = Math.max(0, win.outerHeight - win.innerHeight);
           win.resizeTo(win.outerWidth, contentHeight + chromeHeight);
         }
       };
@@ -236,14 +235,12 @@ export function WindowPortal({
       const links = Array.from(win.document.querySelectorAll('link[rel="stylesheet"]'));
       const pending = links.filter((link) => !(link as HTMLLinkElement).sheet);
       if (pending.length === 0) {
-        // Styles already loaded — measure after React paints
         setTimeout(fitWindowToContent, 50);
       } else {
         let remaining = pending.length;
         const onDone = () => {
           remaining--;
           if (remaining <= 0) {
-            // Styles loaded — wait a frame for reflow, then measure
             setTimeout(fitWindowToContent, 50);
           }
         };
@@ -262,7 +259,7 @@ export function WindowPortal({
         if (cancelled || win.closed) return;
         const contentHeight = rootEl.scrollHeight;
         if (contentHeight > 0) {
-          const chromeHeight = win.outerHeight - win.innerHeight;
+          const chromeHeight = Math.max(0, win.outerHeight - win.innerHeight);
           win.resizeTo(win.outerWidth, contentHeight + chromeHeight);
         }
       });
@@ -274,9 +271,8 @@ export function WindowPortal({
       cancelled = true;
       resizeObserver?.disconnect();
       win.removeEventListener('beforeunload', handleUnload);
-      win.removeEventListener('resize', persistBounds);
       window.removeEventListener('beforeunload', handleParentUnload);
-      persistBounds();
+      persistPosition();
       // Don't close the window here — it may be a StrictMode remount.
       // Schedule a deferred close that only fires if the component
       // doesn't remount (i.e. it was a real unmount).

--- a/src/components/ui/window-portal.tsx
+++ b/src/components/ui/window-portal.tsx
@@ -35,7 +35,7 @@ interface WindowPosition {
   top: number;
 }
 
-function loadPosition(key: string, fallback: WindowPosition): WindowPosition {
+function loadPosition(key: string, fallback: WindowPosition, winWidth: number, winHeight: number): WindowPosition {
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return fallback;
@@ -44,8 +44,8 @@ function loadPosition(key: string, fallback: WindowPosition): WindowPosition {
       const sw = window.screen.availWidth;
       const sh = window.screen.availHeight;
       return {
-        left: Math.max(0, Math.min(parsed.left, sw - 200)),
-        top: Math.max(0, Math.min(parsed.top, sh - 100)),
+        left: Math.max(0, Math.min(parsed.left, sw - winWidth)),
+        top: Math.max(0, Math.min(parsed.top, sh - winHeight)),
       };
     }
   } catch {
@@ -139,7 +139,7 @@ export function WindowPortal({
       left: window.screenX + 100,
       top: window.screenY + 100,
     };
-    const pos = storageKey ? loadPosition(storageKey, defaultPos) : defaultPos;
+    const pos = storageKey ? loadPosition(storageKey, defaultPos, width, height) : defaultPos;
 
     // Reuse a provided window or one from a previous mount (survives StrictMode double-mount)
     let externalWindow = providedExternalWindow ?? externalWindowRef.current;

--- a/src/domain/timeline/transitions/renderers/mask.test.ts
+++ b/src/domain/timeline/transitions/renderers/mask.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { TransitionRegistry } from '../registry';
+import {
+  getClockWipeMaskState,
+  getIrisMaskState,
+  registerMaskTransitions,
+} from './mask';
+
+function getRenderer(id: 'clockWipe' | 'iris') {
+  const registry = new TransitionRegistry();
+  registerMaskTransitions(registry);
+  const renderer = registry.getRenderer(id);
+  if (!renderer) {
+    throw new Error(`Missing renderer for ${id}`);
+  }
+  return renderer;
+}
+
+describe('mask transitions', () => {
+  it('keeps clock wipe endpoints crisp in the CSS preview path', () => {
+    const renderer = getRenderer('clockWipe');
+
+    expect(renderer.calculateStyles(0, true, 1920, 1080, undefined, { edgeSoftness: 12 })).toEqual({
+      opacity: 1,
+    });
+    expect(renderer.calculateStyles(1, true, 1920, 1080, undefined, { edgeSoftness: 12 })).toEqual({
+      opacity: 0,
+    });
+
+    const midpoint = renderer.calculateStyles(0.5, true, 1920, 1080, undefined, { edgeSoftness: 12 });
+    expect(midpoint.maskImage).toContain('conic-gradient');
+  });
+
+  it('collapses clock wipe feathering when the sweep is at either endpoint', () => {
+    expect(getClockWipeMaskState(0, 12)).toEqual({
+      degrees: 0,
+      effectiveEdgeSoftness: 0,
+    });
+    expect(getClockWipeMaskState(1, 12)).toEqual({
+      degrees: 360,
+      effectiveEdgeSoftness: 0,
+    });
+    expect(getClockWipeMaskState(0.5, 12)).toEqual({
+      degrees: 180,
+      effectiveEdgeSoftness: 12,
+    });
+  });
+
+  it('shrinks iris feathering as the aperture approaches open or closed', () => {
+    const renderer = getRenderer('iris');
+    const start = getIrisMaskState(0, 1920, 1080, 32);
+    const nearStart = getIrisMaskState(0.01, 1920, 1080, 32);
+    const midpoint = getIrisMaskState(0.5, 1920, 1080, 32);
+    const nearEnd = getIrisMaskState(0.99, 1920, 1080, 32);
+    const end = getIrisMaskState(1, 1920, 1080, 32);
+
+    expect(start.radius).toBe(0);
+    expect(start.effectiveEdgeSoftness).toBe(0);
+    expect(nearStart.effectiveEdgeSoftness).toBeCloseTo(nearStart.radius, 5);
+    expect(midpoint.effectiveEdgeSoftness).toBe(32);
+    expect(nearEnd.effectiveEdgeSoftness).toBeCloseTo(nearEnd.maxRadius - nearEnd.radius, 5);
+    expect(end.effectiveEdgeSoftness).toBe(0);
+
+    expect(renderer.calculateStyles(0, true, 1920, 1080, undefined, { edgeSoftness: 32 })).toEqual({
+      opacity: 1,
+    });
+    expect(renderer.calculateStyles(1, true, 1920, 1080, undefined, { edgeSoftness: 32 })).toEqual({
+      opacity: 0,
+    });
+  });
+});

--- a/src/domain/timeline/transitions/renderers/mask.ts
+++ b/src/domain/timeline/transitions/renderers/mask.ts
@@ -30,6 +30,40 @@ function getIrisMaxRadius(width: number, height: number): number {
   return Math.sqrt(Math.pow(width / 2, 2) + Math.pow(height / 2, 2)) * 1.2;
 }
 
+function getEndpointSafeSoftness(edgeSoftness: number, distanceFromStart: number, distanceToEnd: number): number {
+  return Math.max(0, Math.min(edgeSoftness, distanceFromStart, distanceToEnd));
+}
+
+export function getClockWipeMaskState(progress: number, edgeSoftness: number): {
+  degrees: number;
+  effectiveEdgeSoftness: number;
+} {
+  const degrees = clamp01(progress) * 360;
+  return {
+    degrees,
+    effectiveEdgeSoftness: getEndpointSafeSoftness(edgeSoftness, degrees, 360 - degrees),
+  };
+}
+
+export function getIrisMaskState(
+  progress: number,
+  width: number,
+  height: number,
+  edgeSoftness: number
+): {
+  maxRadius: number;
+  radius: number;
+  effectiveEdgeSoftness: number;
+} {
+  const maxRadius = getIrisMaxRadius(width, height);
+  const radius = clamp01(progress) * maxRadius;
+  return {
+    maxRadius,
+    radius,
+    effectiveEdgeSoftness: getEndpointSafeSoftness(edgeSoftness, radius, maxRadius - radius),
+  };
+}
+
 
 // ============================================================================
 // Clock Wipe
@@ -42,9 +76,17 @@ const clockWipeRenderer: TransitionRenderer = {
     const edgeSoftness = Math.max(0, getNumericProperty(properties, 'edgeSoftness', 8));
 
     if (isOutgoing) {
-      const degrees = p * 360;
-      const featherStart = Math.max(0, degrees - edgeSoftness);
-      const maskImage = `conic-gradient(from -90deg, transparent ${featherStart}deg, rgba(0,0,0,0.8) ${degrees}deg, black ${Math.min(360, degrees + edgeSoftness)}deg)`;
+      if (p <= 0) {
+        return { opacity: 1 };
+      }
+      if (p >= 1) {
+        return { opacity: 0 };
+      }
+
+      const { degrees, effectiveEdgeSoftness } = getClockWipeMaskState(p, edgeSoftness);
+      const featherStart = Math.max(0, degrees - effectiveEdgeSoftness);
+      const featherEnd = Math.min(360, degrees + effectiveEdgeSoftness);
+      const maskImage = `conic-gradient(from -90deg, transparent ${featherStart}deg, rgba(0,0,0,0.8) ${degrees}deg, black ${featherEnd}deg)`;
       return {
         maskImage,
         webkitMaskImage: maskImage,
@@ -110,10 +152,16 @@ const irisRenderer: TransitionRenderer = {
     const edgeSoftness = Math.max(0, getNumericProperty(properties, 'edgeSoftness', 6));
 
     if (isOutgoing) {
-      const maxRadius = getIrisMaxRadius(canvasWidth, canvasHeight);
-      const radius = p * maxRadius;
-      const inner = Math.max(0, radius - edgeSoftness);
-      const outer = radius + edgeSoftness;
+      if (p <= 0) {
+        return { opacity: 1 };
+      }
+      if (p >= 1) {
+        return { opacity: 0 };
+      }
+
+      const { radius, effectiveEdgeSoftness } = getIrisMaskState(p, canvasWidth, canvasHeight, edgeSoftness);
+      const inner = Math.max(0, radius - effectiveEdgeSoftness);
+      const outer = radius + effectiveEdgeSoftness;
       const maskImage = `radial-gradient(circle at center, transparent ${inner}px, rgba(0,0,0,0.85) ${radius}px, black ${outer}px)`;
       return {
         maskImage,

--- a/src/domain/timeline/transitions/renderers/mask.ts
+++ b/src/domain/timeline/transitions/renderers/mask.ts
@@ -69,6 +69,8 @@ export function getIrisMaskState(
 // Clock Wipe
 // ============================================================================
 
+// The CSS preview mirrors mask geometry and opacity only. The production WebGPU
+// shaders also apply a subtle UV zoom envelope that is intentionally shader-only.
 const clockWipeRenderer: TransitionRenderer = {
   gpuTransitionId: 'clockWipe',
   calculateStyles(progress, isOutgoing, _cw, _ch, _dir, properties): TransitionStyleCalculation {

--- a/src/features/editor/components/audio-meter-panel.tsx
+++ b/src/features/editor/components/audio-meter-panel.tsx
@@ -93,43 +93,11 @@ const EMPTY_PER_TRACK_LEVELS = new Map<string, AudioMeterEstimate>();
 
 const FLOATING_MIXER_STORAGE_KEY = 'editor:floatingMixerBounds';
 const FLOATING_MIXER_DEFAULT_BOUNDS = { x: -1, y: -1, width: 420, height: 500 };
-const DETACHED_EQ_STORAGE_KEY = 'editor:detachedEqBounds:v6';
+const DETACHED_EQ_STORAGE_KEY = 'editor:detachedEqPos';
 const DETACHED_EQ_DEFAULT_BOUNDS = {
   width: 780,
   height: 660,
 };
-
-interface DetachedWindowBounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
-
-function loadDetachedWindowBounds(storageKey: string, fallback: DetachedWindowBounds): DetachedWindowBounds {
-  try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) return fallback;
-    const parsed = JSON.parse(raw) as Partial<DetachedWindowBounds>;
-    if (
-      typeof parsed.left === 'number' &&
-      typeof parsed.top === 'number' &&
-      typeof parsed.width === 'number' &&
-      typeof parsed.height === 'number'
-    ) {
-      return {
-        left: parsed.left,
-        top: parsed.top,
-        width: parsed.width,
-        height: parsed.height,
-      };
-    }
-  } catch {
-    // Ignore invalid persisted window bounds.
-  }
-
-  return fallback;
-}
 
 interface AudioEqPanelSurfaceProps {
   targetLabel: string;
@@ -643,21 +611,17 @@ export const AudioMeterPanel = memo(function AudioMeterPanel() {
       return true;
     }
 
-    const fallbackBounds: DetachedWindowBounds = {
-      left: window.screenX + 120,
-      top: window.screenY + 80,
-      width: DETACHED_EQ_DEFAULT_BOUNDS.width,
-      height: DETACHED_EQ_DEFAULT_BOUNDS.height,
-    };
-    const bounds = loadDetachedWindowBounds(DETACHED_EQ_STORAGE_KEY, fallbackBounds);
+    // Size is fixed from DETACHED_EQ_DEFAULT_BOUNDS; position is a hint —
+    // WindowPortal will apply the persisted position and force correct size
+    // via resizeTo on mount.
     const nextWindow = window.open(
       '',
       '',
       [
-        `width=${bounds.width}`,
-        `height=${bounds.height}`,
-        `left=${bounds.left}`,
-        `top=${bounds.top}`,
+        `width=${DETACHED_EQ_DEFAULT_BOUNDS.width}`,
+        `height=${DETACHED_EQ_DEFAULT_BOUNDS.height}`,
+        `left=${window.screenX + 120}`,
+        `top=${window.screenY + 80}`,
         'menubar=no',
         'toolbar=no',
         'location=no',

--- a/src/features/editor/components/audio-meter-panel.tsx
+++ b/src/features/editor/components/audio-meter-panel.tsx
@@ -840,6 +840,7 @@ export const AudioMeterPanel = memo(function AudioMeterPanel() {
       storageKey={FLOATING_MIXER_STORAGE_KEY}
       onClose={() => setMixerFloating(false)}
       headerExtra={modeDropdown}
+      autoWidth
     >
       <AudioMixerView
         tracks={mixerTracks}

--- a/src/features/editor/components/audio-mixer-view.tsx
+++ b/src/features/editor/components/audio-mixer-view.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, type HTMLAttributes, type ReactNode, type RefObject } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type HTMLAttributes, type ReactNode, type RefObject } from 'react';
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/shared/ui/editor-layout';
 import { linearLevelToPercent, setLiveTrackVolumeOverride, clearLiveTrackVolumeOverride, setLiveBusVolumeOverride, clearLiveBusVolumeOverride } from './audio-meter-utils';
 import { getMixerLiveGain, setMixerLiveGains } from '@/shared/state/mixer-live-gain';
@@ -915,6 +915,168 @@ const ScaleColumn = memo(function ScaleColumn() {
 });
 
 // ---------------------------------------------------------------------------
+// Tracks resize handle — drag to tuck channel strips behind the bus
+// ---------------------------------------------------------------------------
+
+const TRACKS_PEEK_WIDTH = 4; // min visible sliver when fully tucked
+
+interface MixerBodyProps {
+  tracks: AudioMixerTrack[];
+  perTrackLevels: AudioMixerViewProps['perTrackLevels'];
+  masterEstimate: AudioMixerViewProps['masterEstimate'];
+  isPlaying: boolean;
+  expanded?: boolean;
+  masterVolumeDb: number;
+  masterMuted: boolean;
+  allItemIds: string[];
+  onMasterVolumeChange: (volumeDb: number) => void;
+  onMasterMuteToggle: () => void;
+  onTrackVolumeChange: (trackId: string, volumeDb: number) => void;
+  onTrackMuteToggle: (trackId: string) => void;
+  onTrackSoloToggle: (trackId: string) => void;
+  onTrackEqToggle?: (trackId: string) => void;
+  onBusEqToggle?: () => void;
+  busEqEnabled?: boolean;
+}
+
+const MixerBody = memo(function MixerBody({
+  tracks,
+  perTrackLevels,
+  masterEstimate,
+  isPlaying,
+  expanded,
+  masterVolumeDb,
+  masterMuted,
+  allItemIds,
+  onMasterVolumeChange,
+  onMasterMuteToggle,
+  onTrackVolumeChange,
+  onTrackMuteToggle,
+  onTrackSoloToggle,
+  onTrackEqToggle,
+  onBusEqToggle,
+  busEqEnabled,
+}: MixerBodyProps) {
+  const stripPx = expanded ? 68 : 52;
+  // Channel strips + trailing border (scale column is outside the tuckable area)
+  const naturalWidth = tracks.length * stripPx + (tracks.length > 0 ? 2 : 0);
+  const [tracksWidth, setTracksWidth] = useState<number | null>(null); // null = natural
+  const [animating, setAnimating] = useState(false);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const didDragRef = useRef(false);
+
+  // Reset to natural width when track count changes
+  useEffect(() => {
+    setTracksWidth(null);
+  }, [tracks.length]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    setAnimating(false); // kill transition during drag
+    const current = tracksWidth ?? naturalWidth;
+    dragRef.current = { startX: e.clientX, startWidth: current };
+    didDragRef.current = false;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, [tracksWidth, naturalWidth]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const dx = e.clientX - drag.startX;
+    if (Math.abs(dx) > 2) didDragRef.current = true;
+    // Left-edge resize: drag left = wider, drag right = narrower
+    const next = Math.max(TRACKS_PEEK_WIDTH, Math.min(naturalWidth, drag.startWidth - dx));
+    setTracksWidth(next);
+  }, [naturalWidth]);
+
+  const handlePointerUp = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const effectiveWidth = tracksWidth ?? naturalWidth;
+  const isTucked = effectiveWidth < naturalWidth;
+
+  const handleClick = useCallback(() => {
+    if (didDragRef.current) return; // don't toggle after a drag
+    setAnimating(true);
+    setTracksWidth(isTucked ? null : TRACKS_PEEK_WIDTH);
+  }, [isTucked]);
+
+  return (
+    <div className={`flex-1 min-h-0 flex ${expanded ? 'px-1 py-1.5' : 'px-0.5 py-1'} gap-0.5`}>
+      {/* Drag handle — left edge of the mixer, click to toggle */}
+      {tracks.length > 0 && (
+        <div
+          className="w-[5px] shrink-0 flex items-center justify-center cursor-col-resize select-none group"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onClick={handleClick}
+        >
+          <div className={`w-[2px] h-8 rounded-full transition-colors ${
+            isTucked
+              ? 'bg-primary/70 group-hover:bg-primary'
+              : 'bg-primary/30 group-hover:bg-primary/60'
+          }`} />
+        </div>
+      )}
+
+      {/* dB scale — always visible */}
+      <ScaleColumn />
+
+      {/* Channel strips — tuckable from the right (rightmost tracks hide first) */}
+      <div
+        className={`min-h-0 overflow-hidden shrink-0 ${animating ? 'transition-[width] duration-200 ease-out' : ''}`}
+        style={{ width: effectiveWidth }}
+        onTransitionEnd={() => setAnimating(false)}
+      >
+        <div className="flex h-full">
+          {tracks.map((track) => (
+            <ChannelStrip
+              key={track.id}
+              track={track}
+              level={perTrackLevels.get(track.id)}
+              isPlaying={isPlaying}
+              expanded={expanded}
+              onVolumeChange={onTrackVolumeChange}
+              onMuteToggle={onTrackMuteToggle}
+              onSoloToggle={onTrackSoloToggle}
+              onEqToggle={onTrackEqToggle}
+              eqActive={!!track.eqEnabled}
+            />
+          ))}
+
+          {/* Trailing border after last strip */}
+          {tracks.length > 0 && (
+            <div className="w-[2px] shrink-0 bg-border/40" />
+          )}
+
+          {tracks.length === 0 && (
+            <div className="flex-1 flex items-center justify-center text-[10px] text-muted-foreground/30 italic">
+              No audio tracks
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Bus / master strip — ml-auto pins it to the right when tracks are tucked */}
+      <BusMeter
+        masterEstimate={masterEstimate}
+        isPlaying={isPlaying}
+        volumeDb={masterVolumeDb}
+        muted={masterMuted}
+        allItemIds={allItemIds}
+        onVolumeChange={onMasterVolumeChange}
+        onMuteToggle={onMasterMuteToggle}
+        onEqToggle={onBusEqToggle}
+        eqActive={!!busEqEnabled}
+      />
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Main mixer view
 // ---------------------------------------------------------------------------
 
@@ -936,9 +1098,8 @@ export const AudioMixerView = memo(function AudioMixerView({
   headerExtra,
   expanded,
 }: AudioMixerViewProps) {
-  // When expanded (floating), fill the panel; when docked, size to content
   const outerClassName = expanded
-    ? 'panel-bg flex h-full flex-col overflow-hidden'
+    ? 'panel-bg flex h-full flex-col overflow-hidden w-fit'
     : 'panel-bg border-l border-border flex h-full flex-col overflow-hidden w-fit';
 
   const allItemIds = useMemo(
@@ -970,54 +1131,24 @@ export const AudioMixerView = memo(function AudioMixerView({
       )}
 
       {/* Mixer body */}
-      <div className={`flex-1 min-h-0 flex ${expanded ? 'px-1 py-1.5' : 'px-0.5 py-1'} gap-0.5`}>
-        {/* dB scale column */}
-        <ScaleColumn />
-
-        {/* Channel strips (scrollable) */}
-        <div className={`${expanded ? 'flex-1' : ''} min-w-0 overflow-x-auto overflow-y-hidden`}>
-          <div className="flex h-full">
-            {tracks.map((track) => (
-              <ChannelStrip
-                key={track.id}
-                track={track}
-                level={perTrackLevels.get(track.id)}
-                isPlaying={isPlaying}
-                expanded={expanded}
-                onVolumeChange={onTrackVolumeChange}
-                onMuteToggle={onTrackMuteToggle}
-                onSoloToggle={onTrackSoloToggle}
-                onEqToggle={onTrackEqToggle}
-                eqActive={!!track.eqEnabled}
-              />
-            ))}
-
-            {/* Trailing border after last strip */}
-            {tracks.length > 0 && (
-              <div className="w-[2px] shrink-0 bg-border/40" />
-            )}
-
-            {tracks.length === 0 && (
-              <div className="flex-1 flex items-center justify-center text-[10px] text-muted-foreground/30 italic">
-                No audio tracks
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Bus / master strip */}
-        <BusMeter
-          masterEstimate={masterEstimate}
-          isPlaying={isPlaying}
-          volumeDb={masterVolumeDb}
-          muted={masterMuted}
-          allItemIds={allItemIds}
-          onVolumeChange={onMasterVolumeChange}
-          onMuteToggle={onMasterMuteToggle}
-          onEqToggle={onBusEqToggle}
-          eqActive={!!busEqEnabled}
-        />
-      </div>
+      <MixerBody
+        tracks={tracks}
+        perTrackLevels={perTrackLevels}
+        masterEstimate={masterEstimate}
+        isPlaying={isPlaying}
+        expanded={expanded}
+        masterVolumeDb={masterVolumeDb}
+        masterMuted={masterMuted}
+        allItemIds={allItemIds}
+        onMasterVolumeChange={onMasterVolumeChange}
+        onMasterMuteToggle={onMasterMuteToggle}
+        onTrackVolumeChange={onTrackVolumeChange}
+        onTrackMuteToggle={onTrackMuteToggle}
+        onTrackSoloToggle={onTrackSoloToggle}
+        onTrackEqToggle={onTrackEqToggle}
+        onBusEqToggle={onBusEqToggle}
+        busEqEnabled={busEqEnabled}
+      />
     </aside>
   );
 });

--- a/src/features/editor/components/audio-mixer-view.tsx
+++ b/src/features/editor/components/audio-mixer-view.tsx
@@ -959,7 +959,10 @@ const MixerBody = memo(function MixerBody({
 }: MixerBodyProps) {
   const stripPx = expanded ? 68 : 52;
   // Channel strips + trailing border (scale column is outside the tuckable area)
-  const naturalWidth = tracks.length * stripPx + (tracks.length > 0 ? 2 : 0);
+  const MIN_EMPTY_WIDTH = 80;
+  const naturalWidth = tracks.length > 0
+    ? tracks.length * stripPx + 2
+    : MIN_EMPTY_WIDTH;
   const [tracksWidth, setTracksWidth] = useState<number | null>(null); // null = natural
   const [animating, setAnimating] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
@@ -1008,8 +1011,11 @@ const MixerBody = memo(function MixerBody({
     <div className={`flex-1 min-h-0 flex ${expanded ? 'px-1 py-1.5' : 'px-0.5 py-1'} gap-0.5`}>
       {/* Drag handle — left edge of the mixer, click to toggle */}
       {tracks.length > 0 && (
-        <div
-          className="w-[5px] shrink-0 flex items-center justify-center cursor-col-resize select-none group"
+        <button
+          type="button"
+          aria-label="Tuck mixer"
+          aria-pressed={isTucked}
+          className="w-[5px] shrink-0 flex items-center justify-center cursor-col-resize select-none group border-0 bg-transparent p-0"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
@@ -1021,7 +1027,7 @@ const MixerBody = memo(function MixerBody({
               ? 'bg-primary/70 group-hover:bg-primary'
               : 'bg-primary/30 group-hover:bg-primary/60'
           }`} />
-        </div>
+        </button>
       )}
 
       {/* dB scale — always visible */}

--- a/src/features/editor/components/audio-mixer-view.tsx
+++ b/src/features/editor/components/audio-mixer-view.tsx
@@ -964,6 +964,8 @@ const MixerBody = memo(function MixerBody({
   const [animating, setAnimating] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const didDragRef = useRef(false);
+  const tracksWidthRef = useRef<number | null>(tracksWidth);
+  tracksWidthRef.current = tracksWidth;
 
   // Reset to natural width when track count changes
   useEffect(() => {
@@ -973,11 +975,11 @@ const MixerBody = memo(function MixerBody({
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
     setAnimating(false); // kill transition during drag
-    const current = tracksWidth ?? naturalWidth;
+    const current = tracksWidthRef.current ?? naturalWidth;
     dragRef.current = { startX: e.clientX, startWidth: current };
     didDragRef.current = false;
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  }, [tracksWidth, naturalWidth]);
+  }, [naturalWidth]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     const drag = dragRef.current;

--- a/src/features/editor/components/properties-sidebar/clip-panel/audio-eq-panel-content.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/audio-eq-panel-content.tsx
@@ -700,6 +700,8 @@ export function AudioEqPanelContent({
     eqBand6SlopeDbPerOct,
   ].some((value) => value === 'mixed');
 
+  const eqControlsDisabled = hasMixedEqSettings || (isCompactLayout ? !clipEqEnabled : !eqEnabled);
+
   const eqCurveSettings = useMemo(
     () => resolveAudioEqSettings({
       outputGainDb: eqOutputGainDb === 'mixed' ? 0 : eqOutputGainDb,
@@ -898,8 +900,9 @@ export function AudioEqPanelContent({
           <Select
             value={selectedEqPresetId ?? undefined}
             onValueChange={handleEqPresetChange}
+            disabled={!eqEnabled}
           >
-            <SelectTrigger className="h-8 w-[220px] border-border bg-secondary/30 text-xs text-foreground">
+            <SelectTrigger className={cn('h-8 w-[220px] border-border bg-secondary/30 text-xs text-foreground', !eqEnabled && 'opacity-40')}>
               <SelectValue placeholder={eqPresetPlaceholder} />
             </SelectTrigger>
             <SelectContent container={portalContainer ?? undefined}>
@@ -913,7 +916,7 @@ export function AudioEqPanelContent({
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 shrink-0 px-3 text-muted-foreground hover:text-foreground"
+            className={cn('h-8 shrink-0 px-3 text-muted-foreground hover:text-foreground', !eqEnabled && 'opacity-40 pointer-events-none')}
             onClick={() => handleEqPresetChange('flat')}
           >
             Reset EQ
@@ -933,8 +936,9 @@ export function AudioEqPanelContent({
             <Select
               value={selectedEqPresetId ?? undefined}
               onValueChange={handleEqPresetChange}
+              disabled={!clipEqEnabled}
             >
-              <SelectTrigger className="h-7 flex-1 min-w-0 text-xs">
+              <SelectTrigger className={cn('h-7 flex-1 min-w-0 text-xs', !clipEqEnabled && 'opacity-40')}>
                 <SelectValue placeholder={eqPresetPlaceholder} />
               </SelectTrigger>
               <SelectContent container={portalContainer ?? undefined}>
@@ -948,7 +952,7 @@ export function AudioEqPanelContent({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+              className={cn('h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground', !clipEqEnabled && 'opacity-40 pointer-events-none')}
               onClick={() => handleEqPresetChange('flat')}
               aria-label="Reset EQ"
             >
@@ -966,7 +970,7 @@ export function AudioEqPanelContent({
             <div className="min-w-0 flex-1">
               <AudioEqCurveEditor
                 settings={eqCurveSettings}
-                disabled={hasMixedEqSettings}
+                disabled={eqControlsDisabled}
                 className="text-zinc-300"
                 graphClassName={cn(
                   'bg-background',
@@ -979,7 +983,7 @@ export function AudioEqPanelContent({
             {!isCompactLayout ? (
               <EqOutputGainControl
                 value={eqOutputGainDb}
-                disabled={hasMixedEqSettings}
+                disabled={eqControlsDisabled}
                 compact={!isDetachedLayout}
                 onLiveChange={(value) => handleEqPatchLiveChange({ audioEqOutputGainDb: value })}
                 onChange={(value) => handleEqFieldChange('audioEqOutputGainDb', value)}
@@ -989,6 +993,7 @@ export function AudioEqPanelContent({
         </div>
 
         {isCompactLayout ? (
+          <div className={cn(eqControlsDisabled && 'pointer-events-none opacity-40')}>
           <CompactBandRows
             eqBand1Type={eqBand1Type} eqBand1Enabled={eqBand1Enabled} eqBand1FrequencyHz={eqBand1FrequencyHz} eqBand1GainDb={eqBand1GainDb} eqBand1Q={eqBand1Q}
             eqLowType={eqLowType} eqLowEnabled={eqLowEnabled} eqLowFrequencyHz={eqLowFrequencyHz} eqLow={eqLow} eqLowQ={eqLowQ} lowRange={lowRange}
@@ -998,8 +1003,9 @@ export function AudioEqPanelContent({
             eqBand6Type={eqBand6Type} eqBand6Enabled={eqBand6Enabled} eqBand6FrequencyHz={eqBand6FrequencyHz} eqBand6GainDb={eqBand6GainDb} eqBand6Q={eqBand6Q}
             onFieldChange={handleEqFieldChange} onLiveChange={handleEqPatchLiveChange} portalContainer={portalContainer}
           />
+          </div>
         ) : (
-        <div className={cn(isDetachedLayout ? 'space-y-3 p-3' : 'space-y-2 p-2')}>
+        <div className={cn(isDetachedLayout ? 'space-y-3 p-3' : 'space-y-2 p-2', eqControlsDisabled && 'pointer-events-none opacity-40')}>
           <div className={cn(isDetachedLayout && 'overflow-x-auto pb-1')}>
             <div
               className={cn(

--- a/src/features/editor/components/properties-sidebar/clip-panel/audio-eq-panel-content.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/audio-eq-panel-content.tsx
@@ -916,8 +916,9 @@ export function AudioEqPanelContent({
           <Button
             variant="ghost"
             size="sm"
-            className={cn('h-8 shrink-0 px-3 text-muted-foreground hover:text-foreground', !eqEnabled && 'opacity-40 pointer-events-none')}
+            className={cn('h-8 shrink-0 px-3 text-muted-foreground hover:text-foreground', !eqEnabled && 'opacity-40')}
             onClick={() => handleEqPresetChange('flat')}
+            disabled={!eqEnabled}
           >
             Reset EQ
           </Button>
@@ -952,8 +953,9 @@ export function AudioEqPanelContent({
             <Button
               variant="ghost"
               size="sm"
-              className={cn('h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground', !clipEqEnabled && 'opacity-40 pointer-events-none')}
+              className={cn('h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground', !clipEqEnabled && 'opacity-40')}
               onClick={() => handleEqPresetChange('flat')}
+              disabled={!clipEqEnabled}
               aria-label="Reset EQ"
             >
               <RotateCcw className="h-3 w-3" />

--- a/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
@@ -1,8 +1,50 @@
 import { describe, expect, it } from 'vitest';
 import type { ItemEffect } from '@/types/effects';
 import type { VideoItem } from '@/types/timeline';
+import type { ActiveTransition } from './canvas-transitions';
 import type { ItemRenderContext } from './canvas-item-renderer';
 import { resolveTransitionParticipantRenderState } from './canvas-item-renderer';
+
+function createActiveTransition(overrides?: Partial<ActiveTransition>): ActiveTransition {
+  return {
+    transition: {
+      id: 'transition-1',
+      type: 'crossfade',
+      presentation: 'iris',
+      timing: 'linear',
+      leftClipId: 'left',
+      rightClipId: 'right',
+      trackId: 'track-1',
+      durationInFrames: 20,
+    },
+    leftClip: {
+      id: 'left',
+      type: 'video',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      src: 'left.mp4',
+      label: 'Left',
+    },
+    rightClip: {
+      id: 'right',
+      type: 'video',
+      trackId: 'track-1',
+      from: 60,
+      durationInFrames: 60,
+      src: 'right.mp4',
+      label: 'Right',
+    },
+    progress: 0,
+    transitionStart: 50,
+    transitionEnd: 70,
+    durationInFrames: 20,
+    leftPortion: 10,
+    rightPortion: 10,
+    cutPoint: 60,
+    ...overrides,
+  } as ActiveTransition;
+}
 
 describe('resolveTransitionParticipantRenderState', () => {
   it('uses the current clip snapshot and preview overrides for transition participants', () => {
@@ -81,8 +123,16 @@ describe('resolveTransitionParticipantRenderState', () => {
       adjustmentLayers: [],
       subCompRenderData: new Map(),
     };
+    const activeTransition = createActiveTransition({
+      leftClip: baseItem,
+      rightClip: {
+        ...baseItem,
+        id: 'video-2',
+        from: 60,
+      },
+    });
 
-    const result = resolveTransitionParticipantRenderState(baseItem, 12, 4, rctx);
+    const result = resolveTransitionParticipantRenderState(baseItem, activeTransition, 12, 4, rctx);
 
     expect(result.item.crop).toEqual(liveCrop);
     expect(result.item.cornerPin).toEqual(liveCornerPin);
@@ -92,5 +142,93 @@ describe('resolveTransitionParticipantRenderState', () => {
     expect(result.transform.height).toBe(150);
     expect(result.transform.cornerRadius).toBe(12);
     expect(result.effects).toEqual([previewEffect]);
+  });
+
+  it('extends the incoming clip to the transition start so preroll frames stay visible', () => {
+    const incomingClip: VideoItem = {
+      id: 'right',
+      type: 'video',
+      trackId: 'track-1',
+      from: 60,
+      durationInFrames: 40,
+      label: 'Incoming',
+      src: 'right.mp4',
+      transform: {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        rotation: 0,
+        opacity: 1,
+      },
+    };
+    const activeTransition = createActiveTransition({ rightClip: incomingClip });
+    const rctx: ItemRenderContext = {
+      fps: 30,
+      canvasSettings: { width: 1920, height: 1080, fps: 30 },
+      canvasPool: {} as ItemRenderContext['canvasPool'],
+      textMeasureCache: {} as ItemRenderContext['textMeasureCache'],
+      renderMode: 'preview',
+      videoExtractors: new Map(),
+      videoElements: new Map(),
+      useMediabunny: new Set(),
+      mediabunnyDisabledItems: new Set(),
+      mediabunnyFailureCountByItem: new Map(),
+      imageElements: new Map(),
+      gifFramesMap: new Map(),
+      keyframesMap: new Map(),
+      adjustmentLayers: [],
+      subCompRenderData: new Map(),
+    };
+
+    const result = resolveTransitionParticipantRenderState(incomingClip, activeTransition, 50, 4, rctx);
+
+    expect(result.item.from).toBe(50);
+    expect(result.item.durationInFrames).toBe(50);
+    expect(result.transform.opacity).toBe(1);
+  });
+
+  it('extends the outgoing clip past its visible end for transition postroll', () => {
+    const outgoingClip: VideoItem = {
+      id: 'left',
+      type: 'video',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Outgoing',
+      src: 'left.mp4',
+      transform: {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        rotation: 0,
+        opacity: 1,
+      },
+    };
+    const activeTransition = createActiveTransition({ leftClip: outgoingClip });
+    const rctx: ItemRenderContext = {
+      fps: 30,
+      canvasSettings: { width: 1920, height: 1080, fps: 30 },
+      canvasPool: {} as ItemRenderContext['canvasPool'],
+      textMeasureCache: {} as ItemRenderContext['textMeasureCache'],
+      renderMode: 'preview',
+      videoExtractors: new Map(),
+      videoElements: new Map(),
+      useMediabunny: new Set(),
+      mediabunnyDisabledItems: new Set(),
+      mediabunnyFailureCountByItem: new Map(),
+      imageElements: new Map(),
+      gifFramesMap: new Map(),
+      keyframesMap: new Map(),
+      adjustmentLayers: [],
+      subCompRenderData: new Map(),
+    };
+
+    const result = resolveTransitionParticipantRenderState(outgoingClip, activeTransition, 65, 4, rctx);
+
+    expect(result.item.from).toBe(0);
+    expect(result.item.durationInFrames).toBe(70);
+    expect(result.transform.opacity).toBe(1);
   });
 });

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -188,6 +188,11 @@ export interface TransitionParticipantRenderState<TItem extends TimelineItem = T
   effects: ItemEffect[];
 }
 
+interface TransitionParticipantFrameWindow {
+  from: number;
+  durationInFrames: number;
+}
+
 // ---------------------------------------------------------------------------
 // Core item dispatch
 // ---------------------------------------------------------------------------
@@ -1502,8 +1507,8 @@ export async function renderTransitionToCanvas(
 ): Promise<void> {
   const { canvasPool, canvasSettings } = rctx;
   const { leftClip, rightClip } = activeTransition;
-  const leftParticipant = resolveTransitionParticipantRenderState(leftClip, frame, trackOrder, rctx);
-  const rightParticipant = resolveTransitionParticipantRenderState(rightClip, frame, trackOrder, rctx);
+  const leftParticipant = resolveTransitionParticipantRenderState(leftClip, activeTransition, frame, trackOrder, rctx);
+  const rightParticipant = resolveTransitionParticipantRenderState(rightClip, activeTransition, frame, trackOrder, rctx);
 
   // === PERFORMANCE: Render both clips in parallel ===
   // Video decode (mediabunny or DOM zero-copy) is the bottleneck.
@@ -1579,15 +1584,41 @@ export async function renderTransitionToCanvas(
   canvasPool.release(rightCanvas);
 }
 
+function resolveTransitionParticipantFrameWindow<TItem extends TimelineItem>(
+  clip: TItem,
+  activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
+): TransitionParticipantFrameWindow {
+  const beforeFrames = Math.max(0, clip.from - activeTransition.transitionStart);
+  const clipEnd = clip.from + clip.durationInFrames;
+  const afterFrames = Math.max(0, activeTransition.transitionEnd - clipEnd);
+
+  return {
+    from: clip.from - beforeFrames,
+    durationInFrames: clip.durationInFrames + beforeFrames + afterFrames,
+  };
+}
+
 export function resolveTransitionParticipantRenderState<TItem extends TimelineItem>(
   clip: TItem,
+  activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
   frame: number,
   trackOrder: number,
   rctx: ItemRenderContext,
 ): TransitionParticipantRenderState<TItem> {
   const currentClip = rctx.getCurrentItemSnapshot?.(clip) ?? clip;
+  const transitionWindow = resolveTransitionParticipantFrameWindow(currentClip, activeTransition);
+  const transitionClip = (
+    transitionWindow.from === currentClip.from
+      && transitionWindow.durationInFrames === currentClip.durationInFrames
+  )
+    ? currentClip
+    : {
+      ...currentClip,
+      from: transitionWindow.from,
+      durationInFrames: transitionWindow.durationInFrames,
+    } as TItem;
   const itemKeyframes = rctx.getCurrentKeyframes?.(currentClip.id) ?? rctx.keyframesMap.get(currentClip.id);
-  let transform = getAnimatedTransform(currentClip, itemKeyframes, frame, rctx.canvasSettings);
+  let transform = getAnimatedTransform(transitionClip, itemKeyframes, frame, rctx.canvasSettings);
 
   if (rctx.renderMode === 'preview') {
     const previewOverride = rctx.getPreviewTransformOverride?.(currentClip.id);
@@ -1600,12 +1631,12 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
     }
   }
 
-  let effectiveClip = currentClip;
+  let effectiveClip = transitionClip;
   if (rctx.renderMode === 'preview') {
     const cornerPinOverride = rctx.getPreviewCornerPinOverride?.(currentClip.id);
     if (cornerPinOverride !== undefined) {
       effectiveClip = {
-        ...currentClip,
+        ...transitionClip,
         cornerPin: cornerPinOverride,
       } as TItem;
     }

--- a/src/lib/gpu-transitions/common.ts
+++ b/src/lib/gpu-transitions/common.ts
@@ -60,3 +60,10 @@ fn fbm(p: vec2f) -> f32 {
   return value;
 }
 `;
+
+export const SCALE_UV_WGSL = /* wgsl */ `
+fn scaleUv(uv: vec2f, scale: f32) -> vec2f {
+  let safeScale = max(scale, 0.001);
+  return ((uv - vec2f(0.5, 0.5)) / safeScale) + vec2f(0.5, 0.5);
+}
+`;

--- a/src/lib/gpu-transitions/transitions/clock-wipe.ts
+++ b/src/lib/gpu-transitions/transitions/clock-wipe.ts
@@ -20,10 +20,28 @@ struct ClockWipeParams {
 @group(0) @binding(2) var rightTex: texture_2d<f32>;
 @group(0) @binding(3) var<uniform> params: ClockWipeParams;
 
+fn scaleUv(uv: vec2f, scale: f32) -> vec2f {
+  let safeScale = max(scale, 0.001);
+  return ((uv - vec2f(0.5, 0.5)) / safeScale) + vec2f(0.5, 0.5);
+}
+
+fn clockSweepMask(angle: f32, sweepAngle: f32, feather: f32) -> f32 {
+  if (sweepAngle <= 0.0) {
+    return 0.0;
+  }
+  if (sweepAngle >= TAU) {
+    return 1.0;
+  }
+  if (feather <= 0.0001) {
+    return select(0.0, 1.0, angle <= sweepAngle);
+  }
+  return 1.0 - smoothstep(sweepAngle - feather, sweepAngle + feather, angle);
+}
+
 @fragment
 fn clockWipeFragment(input: VertexOutput) -> @location(0) vec4f {
   let uv = input.uv;
-  let p = params.progress;
+  let p = clamp(params.progress, 0.0, 1.0);
 
   // Compute angle from center in pixel space (preserves aspect ratio)
   let pixelPos = uv * vec2f(params.width, params.height);
@@ -36,22 +54,23 @@ fn clockWipeFragment(input: VertexOutput) -> @location(0) vec4f {
   // Normalize angle from [-PI, PI] to [0, TAU]
   let normalizedAngle = select(angle, angle + TAU, angle < 0.0);
   let sweepAngle = p * TAU;
-
-  // Alpha envelopes matching CPU implementation
-  let inAlpha = 0.85 + 0.15 * p;
-  let outAlpha = 1.0 - 0.1 * p;
+  let feather = max(0.0, min(params.edgeSoftness * TAU / 360.0, min(sweepAngle, TAU - sweepAngle)));
+  let outgoingScale = 1.0 - (0.04 * p);
+  let incomingScale = 1.04 - (0.04 * p);
+  let outgoingOpacity = 1.0 - (0.1 * p);
+  let incomingOpacity = 0.85 + (0.15 * p);
+  let leftUv = scaleUv(uv, outgoingScale);
+  let rightUv = scaleUv(uv, incomingScale);
 
   // Sample both textures upfront (uniform control flow required)
-  let left = textureSample(leftTex, texSampler, uv);
-  let right = textureSample(rightTex, texSampler, uv);
+  let left = textureSample(leftTex, texSampler, leftUv);
+  let right = textureSample(rightTex, texSampler, rightUv);
+  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a);
+  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a);
 
-  // Edge softness in radians (convert degrees to radians)
-  let edge = params.edgeSoftness * TAU / 360.0;
   // Swept region with soft edge: incoming; un-swept: outgoing
-  let swept = 1.0 - smoothstep(max(sweepAngle - edge, 0.0), sweepAngle + edge, normalizedAngle);
-  let inColor = vec4f(right.rgb * inAlpha, 1.0);
-  let outColor = vec4f(left.rgb * outAlpha, 1.0);
-  return mix(outColor, inColor, swept);
+  let swept = clockSweepMask(normalizedAngle, sweepAngle, feather);
+  return mix(outgoingColor, incomingColor, swept);
 }`,
   packUniforms: (progress, width, height, _direction, properties) => {
     const edgeSoftness = (properties?.edgeSoftness as number) ?? 8.0;

--- a/src/lib/gpu-transitions/transitions/clock-wipe.ts
+++ b/src/lib/gpu-transitions/transitions/clock-wipe.ts
@@ -63,8 +63,8 @@ fn clockWipeFragment(input: VertexOutput) -> @location(0) vec4f {
   // Sample both textures upfront (uniform control flow required)
   let left = textureSample(leftTex, texSampler, leftUv);
   let right = textureSample(rightTex, texSampler, rightUv);
-  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a);
-  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a);
+  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a * outgoingOpacity);
+  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a * incomingOpacity);
 
   // Swept region with soft edge: incoming; un-swept: outgoing
   let swept = clockSweepMask(normalizedAngle, sweepAngle, feather);

--- a/src/lib/gpu-transitions/transitions/clock-wipe.ts
+++ b/src/lib/gpu-transitions/transitions/clock-wipe.ts
@@ -1,3 +1,4 @@
+import { SCALE_UV_WGSL } from '../common';
 import type { GpuTransitionDefinition } from '../types';
 
 export const clockWipe: GpuTransitionDefinition = {
@@ -20,10 +21,7 @@ struct ClockWipeParams {
 @group(0) @binding(2) var rightTex: texture_2d<f32>;
 @group(0) @binding(3) var<uniform> params: ClockWipeParams;
 
-fn scaleUv(uv: vec2f, scale: f32) -> vec2f {
-  let safeScale = max(scale, 0.001);
-  return ((uv - vec2f(0.5, 0.5)) / safeScale) + vec2f(0.5, 0.5);
-}
+${SCALE_UV_WGSL}
 
 fn clockSweepMask(angle: f32, sweepAngle: f32, feather: f32) -> f32 {
   if (sweepAngle <= 0.0) {

--- a/src/lib/gpu-transitions/transitions/iris.ts
+++ b/src/lib/gpu-transitions/transitions/iris.ts
@@ -20,10 +20,25 @@ struct IrisParams {
 @group(0) @binding(2) var rightTex: texture_2d<f32>;
 @group(0) @binding(3) var<uniform> params: IrisParams;
 
+fn scaleUv(uv: vec2f, scale: f32) -> vec2f {
+  let safeScale = max(scale, 0.001);
+  return ((uv - vec2f(0.5, 0.5)) / safeScale) + vec2f(0.5, 0.5);
+}
+
+fn circleMask(distanceFromCenter: f32, radius: f32, feather: f32) -> f32 {
+  if (radius <= 0.0) {
+    return 0.0;
+  }
+  if (feather <= 0.001) {
+    return select(0.0, 1.0, distanceFromCenter <= radius);
+  }
+  return 1.0 - smoothstep(radius - feather, radius + feather, distanceFromCenter);
+}
+
 @fragment
 fn irisFragment(input: VertexOutput) -> @location(0) vec4f {
   let uv = input.uv;
-  let p = params.progress;
+  let p = clamp(params.progress, 0.0, 1.0);
 
   // Compute distance from center in pixel space
   let pixelPos = uv * vec2f(params.width, params.height);
@@ -35,22 +50,23 @@ fn irisFragment(input: VertexOutput) -> @location(0) vec4f {
   // Max radius = diagonal from center to corner * 1.2 (matches CPU)
   let maxRadius = sqrt(halfW * halfW + halfH * halfH) * 1.2;
   let radius = p * maxRadius;
-
-  // Alpha envelopes matching CPU implementation
-  let inAlpha = 0.85 + 0.15 * p;
-  let outAlpha = 1.0 - 0.1 * p;
+  let feather = max(0.0, min(params.edgeSoftness, min(radius, maxRadius - radius)));
+  let outgoingScale = 1.0 - (0.04 * p);
+  let incomingScale = 1.04 - (0.04 * p);
+  let outgoingOpacity = 1.0 - (0.1 * p);
+  let incomingOpacity = 0.85 + (0.15 * p);
+  let leftUv = scaleUv(uv, outgoingScale);
+  let rightUv = scaleUv(uv, incomingScale);
 
   // Sample both textures upfront (uniform control flow required)
-  let left = textureSample(leftTex, texSampler, uv);
-  let right = textureSample(rightTex, texSampler, uv);
+  let left = textureSample(leftTex, texSampler, leftUv);
+  let right = textureSample(rightTex, texSampler, rightUv);
+  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a);
+  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a);
 
-  // Edge softness in pixels
-  let edge = params.edgeSoftness;
   // Inside circle with soft edge: incoming; outside: outgoing
-  let inside = 1.0 - smoothstep(max(radius - edge, 0.0), radius + edge, dist);
-  let inColor = vec4f(right.rgb * inAlpha, 1.0);
-  let outColor = vec4f(left.rgb * outAlpha, 1.0);
-  return mix(outColor, inColor, inside);
+  let inside = circleMask(dist, radius, feather);
+  return mix(outgoingColor, incomingColor, inside);
 }`,
   packUniforms: (progress, width, height, _direction, properties) => {
     const edgeSoftness = (properties?.edgeSoftness as number) ?? 6.0;

--- a/src/lib/gpu-transitions/transitions/iris.ts
+++ b/src/lib/gpu-transitions/transitions/iris.ts
@@ -1,3 +1,4 @@
+import { SCALE_UV_WGSL } from '../common';
 import type { GpuTransitionDefinition } from '../types';
 
 export const iris: GpuTransitionDefinition = {
@@ -20,10 +21,7 @@ struct IrisParams {
 @group(0) @binding(2) var rightTex: texture_2d<f32>;
 @group(0) @binding(3) var<uniform> params: IrisParams;
 
-fn scaleUv(uv: vec2f, scale: f32) -> vec2f {
-  let safeScale = max(scale, 0.001);
-  return ((uv - vec2f(0.5, 0.5)) / safeScale) + vec2f(0.5, 0.5);
-}
+${SCALE_UV_WGSL}
 
 fn circleMask(distanceFromCenter: f32, radius: f32, feather: f32) -> f32 {
   if (radius <= 0.0) {

--- a/src/lib/gpu-transitions/transitions/iris.ts
+++ b/src/lib/gpu-transitions/transitions/iris.ts
@@ -59,8 +59,8 @@ fn irisFragment(input: VertexOutput) -> @location(0) vec4f {
   // Sample both textures upfront (uniform control flow required)
   let left = textureSample(leftTex, texSampler, leftUv);
   let right = textureSample(rightTex, texSampler, rightUv);
-  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a);
-  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a);
+  let outgoingColor = vec4f(left.rgb * outgoingOpacity, left.a * outgoingOpacity);
+  let incomingColor = vec4f(right.rgb * incomingOpacity, right.a * incomingOpacity);
 
   // Inside circle with soft edge: incoming; outside: outgoing
   let inside = circleMask(dist, radius, feather);


### PR DESCRIPTION
## What changed
- add a draggable tuck handle in the audio mixer so channel strips can slide behind the bus while keeping the dB scale visible
- fix the detached EQ window so reopening it no longer grows wider on every open/close cycle
- disable EQ rows, curve controls, output gain, and preset selection when the equalizer itself is turned off
- fix transition participant rendering so `IRIS` and `CLOCKWIPE` no longer reveal black during preroll/postroll, and tighten the mask endpoints so those transitions land cleanly

## Why it changed
- the mixer needed a more compact interaction for dense sessions without fully hiding track controls
- the detached EQ panel was persisting outer window size and reopening with compounding chrome inflation on Windows Chrome
- EQ controls staying interactive while the EQ toggle was off was misleading and made the panel feel inconsistent
- the transition black-circle artifact was caused by rendering transition participants against their normal timeline bounds instead of the transition window, so entry and exit frames could arrive transparent before the shader ever ran

## User impact
- mixer layouts are easier to manage in crowded projects
- the detached EQ window reopens at a stable size and position
- disabled EQ state now behaves clearly and predictably
- iris and clock wipe transitions should render without black entry/exit artifacts and with cleaner start/end frames

## Root cause
The transition artifact was not primarily a shader problem. Transition participant clips were rendered as ordinary timeline items, which meant the incoming clip could be sampled before its `from` frame and the outgoing clip after its visible duration. That produced transparent transition inputs, and the mask shader was simply exposing those empty regions.

## Validation
- `npx vitest run src/features/export/utils/canvas-item-renderer.transition-state.test.ts src/domain/timeline/transitions/renderers/mask.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mixer supports tuckable/resizable channel-strip with drag-to-collapse
  * Floating panels can auto-size width to content

* **Improvements**
  * Window persistence now stores position only; sizing uses current window dimensions
  * Transition rendering tightened for endpoint-safe softness and more accurate GPU shaders
  * EQ controls: clearer disablement and pointer/opacity handling in compact layouts
  * Export rendering extended transition clip ranges for correct frame coverage

* **Tests**
  * Added mask transition unit tests and transition participant render tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->