### PR TITLE
[codex] Harden transition participant source anchoring

### DIFF
--- a/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
@@ -151,6 +151,7 @@ describe('resolveTransitionParticipantRenderState', () => {
       trackId: 'track-1',
       from: 60,
       durationInFrames: 40,
+      sourceStart: 30,
       label: 'Incoming',
       src: 'right.mp4',
       transform: {
@@ -185,6 +186,7 @@ describe('resolveTransitionParticipantRenderState', () => {
 
     expect(result.item.from).toBe(50);
     expect(result.item.durationInFrames).toBe(50);
+    expect(result.item.sourceStart).toBe(20);
     expect(result.transform.opacity).toBe(1);
   });
 
@@ -230,5 +232,50 @@ describe('resolveTransitionParticipantRenderState', () => {
     expect(result.item.from).toBe(0);
     expect(result.item.durationInFrames).toBe(70);
     expect(result.transform.opacity).toBe(1);
+  });
+
+  it('clamps transition preroll to the available source head handle', () => {
+    const incomingClip: VideoItem = {
+      id: 'right',
+      type: 'video',
+      trackId: 'track-1',
+      from: 60,
+      durationInFrames: 40,
+      sourceStart: 6,
+      label: 'Incoming',
+      src: 'right.mp4',
+      transform: {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        rotation: 0,
+        opacity: 1,
+      },
+    };
+    const activeTransition = createActiveTransition({ rightClip: incomingClip });
+    const rctx: ItemRenderContext = {
+      fps: 30,
+      canvasSettings: { width: 1920, height: 1080, fps: 30 },
+      canvasPool: {} as ItemRenderContext['canvasPool'],
+      textMeasureCache: {} as ItemRenderContext['textMeasureCache'],
+      renderMode: 'preview',
+      videoExtractors: new Map(),
+      videoElements: new Map(),
+      useMediabunny: new Set(),
+      mediabunnyDisabledItems: new Set(),
+      mediabunnyFailureCountByItem: new Map(),
+      imageElements: new Map(),
+      gifFramesMap: new Map(),
+      keyframesMap: new Map(),
+      adjustmentLayers: [],
+      subCompRenderData: new Map(),
+    };
+
+    const result = resolveTransitionParticipantRenderState(incomingClip, activeTransition, 50, 4, rctx);
+
+    expect(result.item.from).toBe(50);
+    expect(result.item.durationInFrames).toBe(50);
+    expect(result.item.sourceStart).toBe(0);
   });
 });

--- a/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
@@ -142,6 +142,11 @@ describe('resolveTransitionParticipantRenderState', () => {
     expect(result.transform.height).toBe(150);
     expect(result.transform.cornerRadius).toBe(12);
     expect(result.effects).toEqual([previewEffect]);
+    expect(result.renderSpan).toEqual({
+      from: 0,
+      durationInFrames: 90,
+      sourceStart: 0,
+    });
   });
 
   it('extends the incoming clip to the transition start so preroll frames stay visible', () => {
@@ -184,9 +189,14 @@ describe('resolveTransitionParticipantRenderState', () => {
 
     const result = resolveTransitionParticipantRenderState(incomingClip, activeTransition, 50, 4, rctx);
 
-    expect(result.item.from).toBe(50);
-    expect(result.item.durationInFrames).toBe(50);
-    expect(result.item.sourceStart).toBe(20);
+    expect(result.item.from).toBe(60);
+    expect(result.item.durationInFrames).toBe(40);
+    expect(result.item.sourceStart).toBe(30);
+    expect(result.renderSpan).toEqual({
+      from: 50,
+      durationInFrames: 50,
+      sourceStart: 20,
+    });
     expect(result.transform.opacity).toBe(1);
   });
 
@@ -230,7 +240,12 @@ describe('resolveTransitionParticipantRenderState', () => {
     const result = resolveTransitionParticipantRenderState(outgoingClip, activeTransition, 65, 4, rctx);
 
     expect(result.item.from).toBe(0);
-    expect(result.item.durationInFrames).toBe(70);
+    expect(result.item.durationInFrames).toBe(60);
+    expect(result.renderSpan).toEqual({
+      from: 0,
+      durationInFrames: 70,
+      sourceStart: 0,
+    });
     expect(result.transform.opacity).toBe(1);
   });
 
@@ -274,8 +289,13 @@ describe('resolveTransitionParticipantRenderState', () => {
 
     const result = resolveTransitionParticipantRenderState(incomingClip, activeTransition, 50, 4, rctx);
 
-    expect(result.item.from).toBe(50);
-    expect(result.item.durationInFrames).toBe(50);
-    expect(result.item.sourceStart).toBe(0);
+    expect(result.item.from).toBe(60);
+    expect(result.item.durationInFrames).toBe(40);
+    expect(result.item.sourceStart).toBe(6);
+    expect(result.renderSpan).toEqual({
+      from: 50,
+      durationInFrames: 50,
+      sourceStart: 0,
+    });
   });
 });

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -58,6 +58,7 @@ import {
   rotatePath,
   type PreviewPathVerticesOverride,
 } from '@/features/export/deps/composition-runtime';
+import { timelineToSourceFrames } from '@/features/export/deps/timeline';
 import { calculateMediaCropLayout } from '@/shared/utils/media-crop';
 
 const log = createLogger('CanvasItemRenderer');
@@ -392,6 +393,21 @@ function getTier2VideoFrameToleranceSeconds(sourceFps: number): number {
   return (1 / normalizedSourceFps) * TIER2_VIDEO_FRAME_TOLERANCE_FACTOR;
 }
 
+function clampVideoSourceTime(
+  sourceTime: number,
+  sourceFps: number,
+  sourceDurationFrames: number | undefined,
+): number {
+  const clampedToStart = Math.max(0, sourceTime);
+  if (sourceDurationFrames === undefined || !Number.isFinite(sourceDurationFrames) || sourceDurationFrames <= 0) {
+    return clampedToStart;
+  }
+
+  const lastFrame = Math.max(0, sourceDurationFrames - 1);
+  const maxTime = (lastFrame + 1e-4) / sourceFps;
+  return Math.min(clampedToStart, maxTime);
+}
+
 function drawTier2VideoFrame(
   ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
   frame: ImageBitmap | VideoFrame,
@@ -511,7 +527,11 @@ async function renderVideoItem(
   // Snap to nearest source frame boundary to avoid floating-point drift
   // that can cause Math.floor(sourceTime * sourceFps) to land on the wrong frame.
   const adjustedSourceStart = sourceStart + sourceFrameOffset;
-  const rawSourceTime = adjustedSourceStart / sourceFps + localTime * speed;
+  const rawSourceTime = clampVideoSourceTime(
+    adjustedSourceStart / sourceFps + localTime * speed,
+    sourceFps,
+    item.sourceDuration,
+  );
   const snappedSourceFrame = Math.round(rawSourceTime * sourceFps);
   const sourceTime = Math.abs(rawSourceTime * sourceFps - snappedSourceFrame) < 1e-6
     ? (snappedSourceFrame + 1e-4) / sourceFps
@@ -1598,6 +1618,27 @@ function resolveTransitionParticipantFrameWindow<TItem extends TimelineItem>(
   };
 }
 
+function getTransitionParticipantSourceStart<TItem extends TimelineItem>(
+  clip: TItem,
+  transitionWindow: TransitionParticipantFrameWindow,
+  fps: number,
+): number | undefined {
+  if (clip.type !== 'video' && clip.type !== 'audio' && clip.type !== 'composition') {
+    return undefined;
+  }
+
+  const beforeFrames = Math.max(0, clip.from - transitionWindow.from);
+  if (beforeFrames <= 0) {
+    return clip.sourceStart;
+  }
+
+  const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0;
+  const speed = clip.speed ?? 1;
+  const sourceFps = clip.sourceFps ?? fps;
+  const prerollSourceFrames = timelineToSourceFrames(beforeFrames, speed, fps, sourceFps);
+  return Math.max(0, sourceStart - prerollSourceFrames);
+}
+
 export function resolveTransitionParticipantRenderState<TItem extends TimelineItem>(
   clip: TItem,
   activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
@@ -1607,6 +1648,7 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
 ): TransitionParticipantRenderState<TItem> {
   const currentClip = rctx.getCurrentItemSnapshot?.(clip) ?? clip;
   const transitionWindow = resolveTransitionParticipantFrameWindow(currentClip, activeTransition);
+  const transitionSourceStart = getTransitionParticipantSourceStart(currentClip, transitionWindow, rctx.fps);
   const transitionClip = (
     transitionWindow.from === currentClip.from
       && transitionWindow.durationInFrames === currentClip.durationInFrames
@@ -1616,6 +1658,9 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
       ...currentClip,
       from: transitionWindow.from,
       durationInFrames: transitionWindow.durationInFrames,
+      ...(transitionSourceStart !== undefined
+        ? { sourceStart: transitionSourceStart }
+        : {}),
     } as TItem;
   const itemKeyframes = rctx.getCurrentKeyframes?.(currentClip.id) ?? rctx.keyframesMap.get(currentClip.id);
   let transform = getAnimatedTransform(transitionClip, itemKeyframes, frame, rctx.canvasSettings);

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -58,8 +58,13 @@ import {
   rotatePath,
   type PreviewPathVerticesOverride,
 } from '@/features/export/deps/composition-runtime';
-import { timelineToSourceFrames } from '@/features/export/deps/timeline';
 import { calculateMediaCropLayout } from '@/shared/utils/media-crop';
+import {
+  getItemRenderTimelineSpan,
+  getRenderTimelineSourceStart,
+  resolveTransitionRenderTimelineSpan,
+  type RenderTimelineSpan,
+} from './render-span';
 
 const log = createLogger('CanvasItemRenderer');
 
@@ -187,11 +192,7 @@ export interface TransitionParticipantRenderState<TItem extends TimelineItem = T
   item: TItem;
   transform: ItemTransform;
   effects: ItemEffect[];
-}
-
-interface TransitionParticipantFrameWindow {
-  from: number;
-  durationInFrames: number;
+  renderSpan: RenderTimelineSpan;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,10 +213,11 @@ export async function renderItem(
   frame: number,
   rctx: ItemRenderContext,
   sourceFrameOffset: number = 0,
+  renderSpan?: RenderTimelineSpan,
 ): Promise<void> {
   // Corner pin: render to temp canvas, then warp onto main canvas
   if (hasCornerPin(item.cornerPin)) {
-    await renderItemWithCornerPin(ctx, item, transform, frame, rctx, sourceFrameOffset);
+    await renderItemWithCornerPin(ctx, item, transform, frame, rctx, sourceFrameOffset, renderSpan);
     return;
   }
 
@@ -244,7 +246,7 @@ export async function renderItem(
     ctx.clip();
   }
 
-  await renderItemContent(ctx, item, transform, frame, rctx, sourceFrameOffset);
+  await renderItemContent(ctx, item, transform, frame, rctx, sourceFrameOffset, renderSpan);
 
   ctx.restore();
 }
@@ -259,6 +261,7 @@ async function renderItemContent(
   frame: number,
   rctx: ItemRenderContext,
   sourceFrameOffset: number,
+  renderSpan?: RenderTimelineSpan,
 ): Promise<void> {
   const effectiveItem = (
     rctx.renderMode === 'preview'
@@ -268,7 +271,7 @@ async function renderItemContent(
 
   switch (effectiveItem.type) {
     case 'video':
-      await renderVideoItem(ctx, effectiveItem as VideoItem, transform, frame, rctx, sourceFrameOffset);
+      await renderVideoItem(ctx, effectiveItem as VideoItem, transform, frame, rctx, sourceFrameOffset, renderSpan);
       break;
     case 'image':
       renderImageItem(ctx, effectiveItem as ImageItem, transform, rctx, frame);
@@ -283,7 +286,7 @@ async function renderItemContent(
       });
       break;
     case 'composition':
-      await renderCompositionItem(ctx, effectiveItem as CompositionItem, transform, frame, rctx);
+      await renderCompositionItem(ctx, effectiveItem as CompositionItem, transform, frame, rctx, renderSpan);
       break;
   }
 }
@@ -299,6 +302,7 @@ async function renderItemWithCornerPin(
   frame: number,
   rctx: ItemRenderContext,
   sourceFrameOffset: number,
+  renderSpan?: RenderTimelineSpan,
 ): Promise<void> {
   const itemW = Math.ceil(transform.width);
   const itemH = Math.ceil(transform.height);
@@ -321,7 +325,7 @@ async function renderItemWithCornerPin(
   };
 
   // Render content to temp canvas
-  await renderItemContent(tempCtx, item, tempTransform, frame, tempRctx, sourceFrameOffset);
+  await renderItemContent(tempCtx, item, tempTransform, frame, tempRctx, sourceFrameOffset, renderSpan);
 
   // Apply corner radius clipping on temp canvas if needed
   if (transform.cornerRadius > 0) {
@@ -498,6 +502,7 @@ async function renderVideoItem(
   frame: number,
   rctx: ItemRenderContext,
   sourceFrameOffset: number = 0,
+  renderSpan?: RenderTimelineSpan,
 ): Promise<void> {
   const {
     fps,
@@ -514,11 +519,12 @@ async function renderVideoItem(
   const hasFallbackVideoElement = videoElements.has(item.id);
   const extractor = videoExtractors.get(item.id);
   let mediabunnyFailedThisFrame = false;
+  const effectiveRenderSpan = renderSpan ?? getItemRenderTimelineSpan(item);
 
   // Calculate source time
-  const localFrame = frame - item.from;
+  const localFrame = frame - effectiveRenderSpan.from;
   const localTime = localFrame / fps;
-  const sourceStart = item.sourceStart ?? item.trimStart ?? 0;
+  const sourceStart = getRenderTimelineSourceStart(item, effectiveRenderSpan);
   const sourceFps = item.sourceFps ?? fps;
   const speed = item.speed ?? 1;
 
@@ -1310,6 +1316,7 @@ async function renderCompositionItem(
   transform: ItemTransform,
   frame: number,
   rctx: ItemRenderContext,
+  renderSpan?: RenderTimelineSpan,
 ): Promise<void> {
   const subData = rctx.subCompRenderData.get(item.compositionId);
   if (!subData) {
@@ -1326,12 +1333,17 @@ async function renderCompositionItem(
   // Calculate the local frame within the sub-composition.
   // sourceStart accounts for trim (left-edge drag) and IO marker offsets â€”
   // it tells us how many frames into the sub-comp to start playing.
-  const sourceOffset = item.sourceStart ?? item.trimStart ?? 0;
-  const localFrame = frame - item.from + sourceOffset;
+  const effectiveRenderSpan = renderSpan ?? getItemRenderTimelineSpan(item);
+  const sourceOffset = getRenderTimelineSourceStart(item, effectiveRenderSpan);
+  const localFrame = frame - effectiveRenderSpan.from + sourceOffset;
   if (localFrame < 0 || localFrame >= subData.durationInFrames) {
     if (frame < 5) {
       log.warn('renderCompositionItem: localFrame out of range', {
-        frame, itemFrom: item.from, sourceOffset, localFrame, durationInFrames: subData.durationInFrames,
+        frame,
+        itemFrom: effectiveRenderSpan.from,
+        sourceOffset,
+        localFrame,
+        durationInFrames: subData.durationInFrames,
       });
     }
     return;
@@ -1541,8 +1553,8 @@ export async function renderTransitionToCanvas(
   const prevTransitionFlag = rctx.isRenderingTransition;
   rctx.isRenderingTransition = true;
   await Promise.all([
-    renderItem(leftCtx, leftParticipant.item, leftParticipant.transform, frame, rctx, 0),
-    renderItem(rightCtx, rightParticipant.item, rightParticipant.transform, frame, rctx, 0),
+    renderItem(leftCtx, leftParticipant.item, leftParticipant.transform, frame, rctx, 0, leftParticipant.renderSpan),
+    renderItem(rightCtx, rightParticipant.item, rightParticipant.transform, frame, rctx, 0, rightParticipant.renderSpan),
   ]);
   rctx.isRenderingTransition = prevTransitionFlag;
 
@@ -1604,41 +1616,6 @@ export async function renderTransitionToCanvas(
   canvasPool.release(rightCanvas);
 }
 
-function resolveTransitionParticipantFrameWindow<TItem extends TimelineItem>(
-  clip: TItem,
-  activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
-): TransitionParticipantFrameWindow {
-  const beforeFrames = Math.max(0, clip.from - activeTransition.transitionStart);
-  const clipEnd = clip.from + clip.durationInFrames;
-  const afterFrames = Math.max(0, activeTransition.transitionEnd - clipEnd);
-
-  return {
-    from: clip.from - beforeFrames,
-    durationInFrames: clip.durationInFrames + beforeFrames + afterFrames,
-  };
-}
-
-function getTransitionParticipantSourceStart<TItem extends TimelineItem>(
-  clip: TItem,
-  transitionWindow: TransitionParticipantFrameWindow,
-  fps: number,
-): number | undefined {
-  if (clip.type !== 'video' && clip.type !== 'audio' && clip.type !== 'composition') {
-    return undefined;
-  }
-
-  const beforeFrames = Math.max(0, clip.from - transitionWindow.from);
-  if (beforeFrames <= 0) {
-    return clip.sourceStart;
-  }
-
-  const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0;
-  const speed = clip.speed ?? 1;
-  const sourceFps = clip.sourceFps ?? fps;
-  const prerollSourceFrames = timelineToSourceFrames(beforeFrames, speed, fps, sourceFps);
-  return Math.max(0, sourceStart - prerollSourceFrames);
-}
-
 export function resolveTransitionParticipantRenderState<TItem extends TimelineItem>(
   clip: TItem,
   activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
@@ -1647,23 +1624,9 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
   rctx: ItemRenderContext,
 ): TransitionParticipantRenderState<TItem> {
   const currentClip = rctx.getCurrentItemSnapshot?.(clip) ?? clip;
-  const transitionWindow = resolveTransitionParticipantFrameWindow(currentClip, activeTransition);
-  const transitionSourceStart = getTransitionParticipantSourceStart(currentClip, transitionWindow, rctx.fps);
-  const transitionClip = (
-    transitionWindow.from === currentClip.from
-      && transitionWindow.durationInFrames === currentClip.durationInFrames
-  )
-    ? currentClip
-    : {
-      ...currentClip,
-      from: transitionWindow.from,
-      durationInFrames: transitionWindow.durationInFrames,
-      ...(transitionSourceStart !== undefined
-        ? { sourceStart: transitionSourceStart }
-        : {}),
-    } as TItem;
+  const renderSpan = resolveTransitionRenderTimelineSpan(currentClip, activeTransition, rctx.fps);
   const itemKeyframes = rctx.getCurrentKeyframes?.(currentClip.id) ?? rctx.keyframesMap.get(currentClip.id);
-  let transform = getAnimatedTransform(transitionClip, itemKeyframes, frame, rctx.canvasSettings);
+  let transform = getAnimatedTransform(currentClip, itemKeyframes, frame, rctx.canvasSettings, renderSpan);
 
   if (rctx.renderMode === 'preview') {
     const previewOverride = rctx.getPreviewTransformOverride?.(currentClip.id);
@@ -1676,12 +1639,12 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
     }
   }
 
-  let effectiveClip = transitionClip;
+  let effectiveClip = currentClip;
   if (rctx.renderMode === 'preview') {
     const cornerPinOverride = rctx.getPreviewCornerPinOverride?.(currentClip.id);
     if (cornerPinOverride !== undefined) {
       effectiveClip = {
-        ...transitionClip,
+        ...currentClip,
         cornerPin: cornerPinOverride,
       } as TItem;
     }
@@ -1703,6 +1666,7 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
     item: effectiveClip,
     transform,
     effects: combineEffects(itemEffects, adjustmentEffects),
+    renderSpan,
   };
 }
 

--- a/src/features/export/utils/canvas-keyframes.ts
+++ b/src/features/export/utils/canvas-keyframes.ts
@@ -9,6 +9,7 @@ import type { TimelineItem } from '@/types/timeline';
 import type { ItemKeyframes } from '@/types/keyframe';
 import type { ResolvedTransform } from '@/types/transform';
 import { resolveItemTransformAtFrame } from '@/features/export/deps/composition-runtime';
+import { applyRenderTimelineSpan, type RenderTimelineSpan } from './render-span';
 
 function clamp01(value: number): number {
   if (value <= 0) return 0;
@@ -117,9 +118,11 @@ export function getAnimatedTransform(
   item: TimelineItem,
   keyframes: ItemKeyframes | undefined,
   frame: number,
-  canvas: CanvasRenderSettings
+  canvas: CanvasRenderSettings,
+  renderSpan?: RenderTimelineSpan,
 ): ResolvedTransform {
-  const resolved = resolveItemTransformAtFrame(item, {
+  const resolvedItem = applyRenderTimelineSpan(item, renderSpan);
+  const resolved = resolveItemTransformAtFrame(resolvedItem, {
     canvas: {
       width: canvas.width,
       height: canvas.height,
@@ -129,7 +132,7 @@ export function getAnimatedTransform(
     keyframes,
   });
 
-  const fadeOpacity = getVisualFadeOpacity(item, frame, canvas.fps);
+  const fadeOpacity = getVisualFadeOpacity(resolvedItem, frame, canvas.fps);
   if (fadeOpacity >= 1) {
     return resolved;
   }

--- a/src/features/export/utils/render-span.test.ts
+++ b/src/features/export/utils/render-span.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { VideoItem } from '@/types/timeline';
+import type { ActiveTransition } from './canvas-transitions';
+import {
+  getItemRenderTimelineSpan,
+  getRenderTimelineSourceStart,
+  resolveTransitionRenderTimelineSpan,
+} from './render-span';
+
+function createVideoItem(overrides?: Partial<VideoItem>): VideoItem {
+  return {
+    id: 'clip-1',
+    type: 'video',
+    trackId: 'track-1',
+    from: 60,
+    durationInFrames: 40,
+    label: 'Clip',
+    src: 'clip.mp4',
+    ...overrides,
+  };
+}
+
+function createActiveTransition(overrides?: Partial<ActiveTransition>): ActiveTransition {
+  return {
+    transition: {
+      id: 'transition-1',
+      type: 'crossfade',
+      presentation: 'iris',
+      timing: 'linear',
+      leftClipId: 'left',
+      rightClipId: 'right',
+      trackId: 'track-1',
+      durationInFrames: 20,
+    },
+    leftClip: createVideoItem({ id: 'left', from: 0, durationInFrames: 60 }),
+    rightClip: createVideoItem({ id: 'right', from: 60, durationInFrames: 60 }),
+    progress: 0,
+    transitionStart: 50,
+    transitionEnd: 70,
+    durationInFrames: 20,
+    leftPortion: 10,
+    rightPortion: 10,
+    cutPoint: 60,
+    ...overrides,
+  } as ActiveTransition;
+}
+
+describe('render-span', () => {
+  it('falls back to legacy offset when deriving source start', () => {
+    const clip = createVideoItem({ offset: 18 });
+
+    expect(getItemRenderTimelineSpan(clip)).toEqual({
+      from: 60,
+      durationInFrames: 40,
+      sourceStart: 18,
+    });
+    expect(getRenderTimelineSourceStart(clip)).toBe(18);
+  });
+
+  it('uses legacy offset when resolving transition preroll source anchoring', () => {
+    const clip = createVideoItem({ id: 'right', offset: 18 });
+    const transition = createActiveTransition({ rightClip: clip });
+
+    expect(resolveTransitionRenderTimelineSpan(clip, transition, 30)).toEqual({
+      from: 50,
+      durationInFrames: 50,
+      sourceStart: 8,
+    });
+  });
+});

--- a/src/features/export/utils/render-span.ts
+++ b/src/features/export/utils/render-span.ts
@@ -17,10 +17,19 @@ function isSourceTimedItem(item: TimelineItem): item is TimelineItem & {
   type: 'video' | 'audio' | 'composition';
   sourceStart?: number;
   trimStart?: number;
+  offset?: number;
   sourceFps?: number;
   speed?: number;
 } {
   return item.type === 'video' || item.type === 'audio' || item.type === 'composition';
+}
+
+function getSourceTimedItemStart(item: TimelineItem & {
+  sourceStart?: number;
+  trimStart?: number;
+  offset?: number;
+}): number {
+  return item.sourceStart ?? item.trimStart ?? item.offset ?? 0;
 }
 
 export function getItemRenderTimelineSpan(item: TimelineItem): RenderTimelineSpan {
@@ -28,7 +37,7 @@ export function getItemRenderTimelineSpan(item: TimelineItem): RenderTimelineSpa
     from: item.from,
     durationInFrames: item.durationInFrames,
     ...(isSourceTimedItem(item)
-      ? { sourceStart: item.sourceStart ?? item.trimStart ?? 0 }
+      ? { sourceStart: getSourceTimedItemStart(item) }
       : {}),
   };
 }
@@ -40,7 +49,7 @@ export function getRenderTimelineSourceStart(
   if (!isSourceTimedItem(item)) {
     return 0;
   }
-  return span?.sourceStart ?? item.sourceStart ?? item.trimStart ?? 0;
+  return span?.sourceStart ?? getSourceTimedItemStart(item);
 }
 
 export function applyRenderTimelineSpan<TItem extends TimelineItem>(
@@ -54,7 +63,7 @@ export function applyRenderTimelineSpan<TItem extends TimelineItem>(
   const hasSameTimelineWindow = item.from === span.from && item.durationInFrames === span.durationInFrames;
   const nextSourceStart = getRenderTimelineSourceStart(item, span);
   const currentSourceStart = isSourceTimedItem(item)
-    ? (item.sourceStart ?? item.trimStart ?? 0)
+    ? getSourceTimedItemStart(item)
     : undefined;
   const hasSameSourceAnchor = currentSourceStart === nextSourceStart;
 
@@ -95,10 +104,10 @@ function getTransitionParticipantSourceStart<TItem extends TimelineItem>(
 
   const beforeFrames = Math.max(0, clip.from - transitionWindow.from);
   if (beforeFrames <= 0) {
-    return clip.sourceStart ?? clip.trimStart ?? 0;
+    return getSourceTimedItemStart(clip);
   }
 
-  const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0;
+  const sourceStart = getSourceTimedItemStart(clip);
   const speed = clip.speed ?? 1;
   const sourceFps = clip.sourceFps ?? fps;
   const prerollSourceFrames = timelineToSourceFrames(beforeFrames, speed, fps, sourceFps);
@@ -111,11 +120,12 @@ export function resolveTransitionRenderTimelineSpan<TItem extends TimelineItem>(
   fps: number,
 ): RenderTimelineSpan {
   const transitionWindow = resolveTransitionParticipantFrameWindow(clip, activeTransition);
+  const sourceStart = getTransitionParticipantSourceStart(clip, transitionWindow, fps);
   return {
     from: transitionWindow.from,
     durationInFrames: transitionWindow.durationInFrames,
-    ...(getTransitionParticipantSourceStart(clip, transitionWindow, fps) !== undefined
-      ? { sourceStart: getTransitionParticipantSourceStart(clip, transitionWindow, fps) }
+    ...(sourceStart !== undefined
+      ? { sourceStart }
       : {}),
   };
 }

--- a/src/features/export/utils/render-span.ts
+++ b/src/features/export/utils/render-span.ts
@@ -1,0 +1,121 @@
+import type { TimelineItem } from '@/types/timeline';
+import type { ActiveTransition } from './canvas-transitions';
+import { timelineToSourceFrames } from '@/features/export/deps/timeline';
+
+export interface RenderTimelineSpan {
+  from: number;
+  durationInFrames: number;
+  sourceStart?: number;
+}
+
+interface TransitionParticipantFrameWindow {
+  from: number;
+  durationInFrames: number;
+}
+
+function isSourceTimedItem(item: TimelineItem): item is TimelineItem & {
+  type: 'video' | 'audio' | 'composition';
+  sourceStart?: number;
+  trimStart?: number;
+  sourceFps?: number;
+  speed?: number;
+} {
+  return item.type === 'video' || item.type === 'audio' || item.type === 'composition';
+}
+
+export function getItemRenderTimelineSpan(item: TimelineItem): RenderTimelineSpan {
+  return {
+    from: item.from,
+    durationInFrames: item.durationInFrames,
+    ...(isSourceTimedItem(item)
+      ? { sourceStart: item.sourceStart ?? item.trimStart ?? 0 }
+      : {}),
+  };
+}
+
+export function getRenderTimelineSourceStart(
+  item: TimelineItem,
+  span?: RenderTimelineSpan,
+): number {
+  if (!isSourceTimedItem(item)) {
+    return 0;
+  }
+  return span?.sourceStart ?? item.sourceStart ?? item.trimStart ?? 0;
+}
+
+export function applyRenderTimelineSpan<TItem extends TimelineItem>(
+  item: TItem,
+  span?: RenderTimelineSpan,
+): TItem {
+  if (!span) {
+    return item;
+  }
+
+  const hasSameTimelineWindow = item.from === span.from && item.durationInFrames === span.durationInFrames;
+  const nextSourceStart = getRenderTimelineSourceStart(item, span);
+  const currentSourceStart = isSourceTimedItem(item)
+    ? (item.sourceStart ?? item.trimStart ?? 0)
+    : undefined;
+  const hasSameSourceAnchor = currentSourceStart === nextSourceStart;
+
+  if (hasSameTimelineWindow && hasSameSourceAnchor) {
+    return item;
+  }
+
+  return {
+    ...item,
+    from: span.from,
+    durationInFrames: span.durationInFrames,
+    ...(isSourceTimedItem(item) ? { sourceStart: nextSourceStart } : {}),
+  };
+}
+
+function resolveTransitionParticipantFrameWindow<TItem extends TimelineItem>(
+  clip: TItem,
+  activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
+): TransitionParticipantFrameWindow {
+  const beforeFrames = Math.max(0, clip.from - activeTransition.transitionStart);
+  const clipEnd = clip.from + clip.durationInFrames;
+  const afterFrames = Math.max(0, activeTransition.transitionEnd - clipEnd);
+
+  return {
+    from: clip.from - beforeFrames,
+    durationInFrames: clip.durationInFrames + beforeFrames + afterFrames,
+  };
+}
+
+function getTransitionParticipantSourceStart<TItem extends TimelineItem>(
+  clip: TItem,
+  transitionWindow: TransitionParticipantFrameWindow,
+  fps: number,
+): number | undefined {
+  if (!isSourceTimedItem(clip)) {
+    return undefined;
+  }
+
+  const beforeFrames = Math.max(0, clip.from - transitionWindow.from);
+  if (beforeFrames <= 0) {
+    return clip.sourceStart ?? clip.trimStart ?? 0;
+  }
+
+  const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0;
+  const speed = clip.speed ?? 1;
+  const sourceFps = clip.sourceFps ?? fps;
+  const prerollSourceFrames = timelineToSourceFrames(beforeFrames, speed, fps, sourceFps);
+  return Math.max(0, sourceStart - prerollSourceFrames);
+}
+
+export function resolveTransitionRenderTimelineSpan<TItem extends TimelineItem>(
+  clip: TItem,
+  activeTransition: Pick<ActiveTransition<TItem>, 'transitionStart' | 'transitionEnd'>,
+  fps: number,
+): RenderTimelineSpan {
+  const transitionWindow = resolveTransitionParticipantFrameWindow(clip, activeTransition);
+  return {
+    from: transitionWindow.from,
+    durationInFrames: transitionWindow.durationInFrames,
+    ...(getTransitionParticipantSourceStart(clip, transitionWindow, fps) !== undefined
+      ? { sourceStart: getTransitionParticipantSourceStart(clip, transitionWindow, fps) }
+      : {}),
+  };
+}


### PR DESCRIPTION
## What changed
- fix transition participant source anchoring so widened transition windows stay attached to the correct source media
- introduce a source-anchored `RenderTimelineSpan` abstraction and route transition rendering through it instead of hand-editing clip timing fields
- keep transform resolution and media sampling on the same render span, with tests covering preroll, postroll, and head-handle clamping

## Why it changed
- transition exit could replay or repeat the wrong portion of a clip because the render path widened timeline bounds without making the source anchor a first-class part of the same operation
- that coupling was spread across multiple fields (`from`, `durationInFrames`, `sourceStart`), which made the code easy to break whenever transition timing changed

## User impact
- transition exits should stop replaying a repeated tail
- transition preroll and postroll should stay visually continuous
- future transition timing changes are less likely to regress source alignment because render timing is now centralized

## Root cause
The transition path represented a widened participant clip by patching timeline fields directly and relying on nearby code to also keep the source anchor in sync. That let timeline-window changes and media-time sampling drift apart. On exit, the outgoing participant could sample the wrong source range even though the transition mask itself was working correctly.

## Validation
- `npx vitest run src/features/export/utils/canvas-item-renderer.transition-state.test.ts src/domain/timeline/transitions/renderers/mask.test.ts src/features/editor/components/audio-mixer-view.test.tsx`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved export render timeline handling to align clip/transition timing more accurately and consistently, including span-aware source timing and clamping.
* **Bug Fixes**
  * Fixed several transition timing edge cases (preroll/postroll and source-start clamping) that caused incorrect frame ranges during export.
* **Tests**
  * Added tests covering render-span logic and transition timing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->