### PR TITLE
Release: disabled track fixes, pen mask/shape defaults, audio restore

### DIFF
--- a/src/features/composition-runtime/components/composition-content.keyframes.test.tsx
+++ b/src/features/composition-runtime/components/composition-content.keyframes.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { VideoConfigProvider } from '@/features/composition-runtime/deps/player';
+import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 import { useCompositionsStore, useTimelineStore, useGizmoStore } from '@/features/composition-runtime/deps/stores';
 import type { CompositionItem, ShapeItem, TimelineTrack } from '@/types/timeline';
 import { CompositionContent } from './composition-content';
 
 type TestSubComposition = ReturnType<typeof useCompositionsStore.getState>['compositions'][number];
+const blobUrlManagerGetSpy = vi.spyOn(blobUrlManager, 'get');
 
 vi.mock('@/features/composition-runtime/deps/player', async () => {
   const React = await import('react');
@@ -79,7 +81,7 @@ vi.mock('./item', async () => {
   const { useItemKeyframesFromContext } = await import('../contexts/keyframes-context');
 
   return {
-    Item: ({ item, muted }: { item: { id: string }; muted?: boolean }) => {
+    Item: ({ item, muted }: { item: { id: string; src?: string }; muted?: boolean }) => {
       const keyframes = useItemKeyframesFromContext(item.id);
       const keyframeCount = keyframes?.properties.reduce((count, property) => count + property.keyframes.length, 0) ?? 0;
 
@@ -88,6 +90,7 @@ vi.mock('./item', async () => {
           data-testid={`sub-item-${item.id}`}
           data-muted={muted ? 'true' : 'false'}
           data-keyframe-count={String(keyframeCount)}
+          data-src={item.src ?? ''}
         />
       );
     },
@@ -96,6 +99,7 @@ vi.mock('./item', async () => {
 
 describe('CompositionContent keyframes', () => {
   beforeEach(() => {
+    blobUrlManagerGetSpy.mockImplementation(() => null);
     useCompositionsStore.setState({
       compositions: [],
       compositionById: {},
@@ -471,6 +475,111 @@ describe('CompositionContent keyframes', () => {
 
     expect(screen.queryByTestId('sub-item-sub-video-audio-only')).toBeNull();
     expect(screen.getByTestId('sub-item-sub-audio-audio-only')).toBeInTheDocument();
+  });
+
+  it('clears stale nested audio src until a fresh blob url exists', () => {
+    const subTracks: TimelineTrack[] = [
+      {
+        id: 'sub-track-audio-stale',
+        name: 'A1',
+        kind: 'audio',
+        height: 60,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 0,
+        items: [],
+      },
+    ];
+
+    const subComp: TestSubComposition = {
+      id: 'sub-comp-stale-audio',
+      name: 'Stale audio precomp',
+      items: [
+        {
+          id: 'sub-audio-stale',
+          type: 'audio',
+          trackId: 'sub-track-audio-stale',
+          from: 0,
+          durationInFrames: 60,
+          label: 'Nested audio',
+          src: 'blob:stale-audio',
+          mediaId: 'media-stale',
+        },
+      ],
+      tracks: subTracks,
+      transitions: [],
+      keyframes: [],
+      fps: 30,
+      width: 1280,
+      height: 720,
+      durationInFrames: 60,
+    };
+
+    useCompositionsStore.setState({
+      compositions: [subComp],
+      compositionById: { [subComp.id]: subComp },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    });
+
+    const { rerender } = render(
+      <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
+        <CompositionContent
+          item={{
+            id: 'parent-comp-stale-audio-wrapper',
+            type: 'audio',
+            trackId: 'parent-audio-track',
+            from: 0,
+            durationInFrames: 60,
+            label: 'Nested stale comp audio',
+            compositionId: subComp.id,
+            src: '',
+          }}
+          renderMode="audio-only"
+        />
+      </VideoConfigProvider>
+    );
+
+    expect(screen.getByTestId('sub-item-sub-audio-stale')).toHaveAttribute('data-src', '');
+
+    blobUrlManagerGetSpy.mockImplementation((mediaId: string) => (
+      mediaId === 'media-stale' ? 'blob:fresh-stale-audio' : null
+    ));
+
+    const refreshedSubComp: TestSubComposition = {
+      ...subComp,
+      items: [...subComp.items],
+    };
+    act(() => {
+      useCompositionsStore.setState({
+        compositions: [refreshedSubComp],
+        compositionById: { [refreshedSubComp.id]: refreshedSubComp },
+        mediaDependencyIds: [],
+        mediaDependencyVersion: 1,
+      });
+    });
+
+    rerender(
+      <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
+        <CompositionContent
+          item={{
+            id: 'parent-comp-stale-audio-wrapper',
+            type: 'audio',
+            trackId: 'parent-audio-track',
+            from: 0,
+            durationInFrames: 60,
+            label: 'Nested stale comp audio',
+            compositionId: subComp.id,
+            src: '',
+          }}
+          renderMode="audio-only"
+        />
+      </VideoConfigProvider>
+    );
+
+    expect(screen.getByTestId('sub-item-sub-audio-stale')).toHaveAttribute('data-src', 'blob:fresh-stale-audio');
   });
 
   it('keeps nested compound visuals hidden when the parent wrapper is hidden', () => {

--- a/src/features/composition-runtime/components/composition-content.keyframes.test.tsx
+++ b/src/features/composition-runtime/components/composition-content.keyframes.test.tsx
@@ -81,7 +81,7 @@ vi.mock('./item', async () => {
   const { useItemKeyframesFromContext } = await import('../contexts/keyframes-context');
 
   return {
-    Item: ({ item, muted }: { item: { id: string; src?: string }; muted?: boolean }) => {
+    Item: ({ item, muted }: { item: { id: string; src?: string; audioSrc?: string }; muted?: boolean }) => {
       const keyframes = useItemKeyframesFromContext(item.id);
       const keyframeCount = keyframes?.properties.reduce((count, property) => count + property.keyframes.length, 0) ?? 0;
 
@@ -91,6 +91,7 @@ vi.mock('./item', async () => {
           data-muted={muted ? 'true' : 'false'}
           data-keyframe-count={String(keyframeCount)}
           data-src={item.src ?? ''}
+          data-audio-src={item.audioSrc ?? ''}
         />
       );
     },
@@ -477,8 +478,20 @@ describe('CompositionContent keyframes', () => {
     expect(screen.getByTestId('sub-item-sub-audio-audio-only')).toBeInTheDocument();
   });
 
-  it('clears stale nested audio src until a fresh blob url exists', () => {
+  it('clears stale nested media src until fresh blob urls exist', () => {
     const subTracks: TimelineTrack[] = [
+      {
+        id: 'sub-track-video-stale',
+        name: 'V1',
+        kind: 'video',
+        height: 60,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 0,
+        items: [],
+      },
       {
         id: 'sub-track-audio-stale',
         name: 'A1',
@@ -497,6 +510,17 @@ describe('CompositionContent keyframes', () => {
       id: 'sub-comp-stale-audio',
       name: 'Stale audio precomp',
       items: [
+        {
+          id: 'sub-video-stale',
+          type: 'video',
+          trackId: 'sub-track-video-stale',
+          from: 0,
+          durationInFrames: 60,
+          label: 'Nested video',
+          src: 'blob:stale-video',
+          audioSrc: 'blob:stale-video-audio',
+          mediaId: 'media-video-stale',
+        },
         {
           id: 'sub-audio-stale',
           type: 'audio',
@@ -528,24 +552,30 @@ describe('CompositionContent keyframes', () => {
       <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
         <CompositionContent
           item={{
-            id: 'parent-comp-stale-audio-wrapper',
-            type: 'audio',
-            trackId: 'parent-audio-track',
+            id: 'parent-comp-stale-wrapper',
+            type: 'composition',
+            trackId: 'parent-video-track',
             from: 0,
             durationInFrames: 60,
-            label: 'Nested stale comp audio',
+            label: 'Nested stale comp',
             compositionId: subComp.id,
-            src: '',
+            compositionWidth: 1280,
+            compositionHeight: 720,
           }}
-          renderMode="audio-only"
         />
       </VideoConfigProvider>
     );
 
+    expect(screen.getByTestId('sub-item-sub-video-stale')).toHaveAttribute('data-src', '');
+    expect(screen.getByTestId('sub-item-sub-video-stale')).toHaveAttribute('data-audio-src', '');
     expect(screen.getByTestId('sub-item-sub-audio-stale')).toHaveAttribute('data-src', '');
 
     blobUrlManagerGetSpy.mockImplementation((mediaId: string) => (
-      mediaId === 'media-stale' ? 'blob:fresh-stale-audio' : null
+      mediaId === 'media-stale'
+        ? 'blob:fresh-stale-audio'
+        : mediaId === 'media-video-stale'
+          ? 'blob:fresh-stale-video'
+          : null
     ));
 
     const refreshedSubComp: TestSubComposition = {
@@ -565,20 +595,22 @@ describe('CompositionContent keyframes', () => {
       <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
         <CompositionContent
           item={{
-            id: 'parent-comp-stale-audio-wrapper',
-            type: 'audio',
-            trackId: 'parent-audio-track',
+            id: 'parent-comp-stale-wrapper',
+            type: 'composition',
+            trackId: 'parent-video-track',
             from: 0,
             durationInFrames: 60,
-            label: 'Nested stale comp audio',
+            label: 'Nested stale comp',
             compositionId: subComp.id,
-            src: '',
+            compositionWidth: 1280,
+            compositionHeight: 720,
           }}
-          renderMode="audio-only"
         />
       </VideoConfigProvider>
     );
 
+    expect(screen.getByTestId('sub-item-sub-video-stale')).toHaveAttribute('data-src', 'blob:fresh-stale-video');
+    expect(screen.getByTestId('sub-item-sub-video-stale')).toHaveAttribute('data-audio-src', 'blob:fresh-stale-video');
     expect(screen.getByTestId('sub-item-sub-audio-stale')).toHaveAttribute('data-src', 'blob:fresh-stale-audio');
   });
 

--- a/src/features/composition-runtime/components/composition-content.tsx
+++ b/src/features/composition-runtime/components/composition-content.tsx
@@ -74,21 +74,21 @@ function resolveSubCompItem(
     subItem.mediaId &&
     (subItem.type === 'video' || subItem.type === 'audio' || subItem.type === 'image')
   ) {
-    const sourceSrc = blobUrlManager.get(subItem.mediaId);
+    const sourceSrc = blobUrlManager.get(subItem.mediaId) ?? '';
 
     if (subItem.type === 'video') {
       const proxySrc = nestedMediaResolutionMode === 'proxy'
         ? resolveProxyUrl(subItem.mediaId)
         : null;
-      const resolvedSrc = proxySrc || sourceSrc || '';
-      const resolvedAudioSrc = sourceSrc || subItem.audioSrc;
+      const resolvedSrc = proxySrc || sourceSrc;
+      const resolvedAudioSrc = sourceSrc || undefined;
       if (resolvedSrc !== subItem.src || subItem.audioSrc !== resolvedAudioSrc) {
         return { ...subItem, src: resolvedSrc, audioSrc: resolvedAudioSrc };
       }
       return subItem;
     }
 
-    if (sourceSrc && sourceSrc !== subItem.src) {
+    if (sourceSrc !== subItem.src) {
       return { ...subItem, src: sourceSrc } as TimelineItem;
     }
   }

--- a/src/features/editor/components/audio-meter-panel.tsx
+++ b/src/features/editor/components/audio-meter-panel.tsx
@@ -43,15 +43,12 @@ import { AudioMixerView, type AudioMixerTrack } from './audio-mixer-view';
 import { AudioEqPanelContent } from './properties-sidebar/clip-panel/audio-eq-panel-content';
 import { type AudioEqPatch } from './properties-sidebar/clip-panel/audio-eq-curve-editor';
 import { getSparseAudioEqSettings } from '@/shared/utils/audio-eq';
-import { clearMixerLiveGainLayer, setMixerLiveGainLayer } from '@/shared/state/mixer-live-gain';
 import { type AudioEqSettings } from '@/types/audio';
 
 type PanelMode = 'meter' | 'mixer';
 type EqPanelTarget =
   | { kind: 'track'; trackId: string }
   | { kind: 'bus' };
-
-const MUTE_SOLO_GAIN_LAYER_ID = 'audio-meter-mute-solo';
 
 function toWaveformSnapshot(
   waveform: { peaks: Float32Array; sampleRate: number; channels?: number; stereo?: boolean } | null | undefined,
@@ -637,7 +634,6 @@ export const AudioMeterPanel = memo(function AudioMeterPanel() {
     return true;
   }, []);
 
-
   // Collect all item IDs for a track (needed for live gain bridging)
   const getTrackItemIds = useCallback((trackId: string): string[] => {
     const items = useItemsStore.getState().itemsByTrackId[trackId];
@@ -659,20 +655,17 @@ export const AudioMeterPanel = memo(function AudioMeterPanel() {
       }))
       .filter((track) => isAudioMixerTrack(track, currentTimelineItems));
     if (audioTracks.length === 0) {
-      clearMixerLiveGainLayer(MUTE_SOLO_GAIN_LAYER_ID);
       return;
     }
     const anySoloed = audioTracks.some((t) => t.solo);
 
-    const entries: Array<{ itemId: string; gain: number }> = [];
     for (const t of audioTracks) {
       const shouldMute = t.muted || (anySoloed && !t.solo);
       const gain = shouldMute ? 0 : 1;
       for (const itemId of getTrackItemIds(t.id)) {
-        entries.push({ itemId, gain });
+        usePlaybackStore.getState().setLiveItemGain(itemId, gain);
       }
     }
-    setMixerLiveGainLayer(MUTE_SOLO_GAIN_LAYER_ID, entries);
   }, [getTrackItemIds]);
 
   // In-place mutation for mute/solo — same pattern as volume change.

--- a/src/features/editor/components/media-sidebar.tsx
+++ b/src/features/editor/components/media-sidebar.tsx
@@ -643,7 +643,7 @@ export const MediaSidebar = memo(function MediaSidebar() {
                   <button
                     onClick={() => useMaskEditorStore.getState().startShapePenMode()}
                     className="flex flex-col items-center justify-center gap-1 p-2 rounded-lg border border-border bg-secondary/30 hover:bg-secondary/50 hover:border-primary/50 transition-colors group"
-                    title="Draw a custom shape mask with the pen tool"
+                    title="Draw a custom path shape with the pen tool"
                   >
                     <div className="w-7 h-7 rounded border border-border bg-secondary/50 flex items-center justify-center group-hover:bg-secondary/70">
                       <Pen className="w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground" />

--- a/src/features/editor/components/preview-area.test.tsx
+++ b/src/features/editor/components/preview-area.test.tsx
@@ -88,7 +88,7 @@ describe('PreviewArea mask editor toolbar', () => {
     expect(screen.getByText('Path Edit')).toBeInTheDocument();
     expect(screen.getByText('4 points')).toBeInTheDocument();
     expect(
-      screen.getByText('Drag points, handles, or the mask body to adjust the shape.')
+      screen.getByText('Drag points, handles, or the path body to adjust the shape.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Corner' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Bezier' })).toBeDisabled();

--- a/src/features/editor/components/preview-area.tsx
+++ b/src/features/editor/components/preview-area.tsx
@@ -194,8 +194,8 @@ export const PreviewArea = memo(function PreviewArea({ project }: PreviewAreaPro
       ? 'Click in the preview to place your first point.'
       : `Add ${remainingPenPoints} more ${remainingPenPoints === 1 ? 'point' : 'points'} to finish.`;
   const editModeHint = displayedEditVertexCount > 0
-    ? 'Drag points, handles, or the mask body to adjust the shape.'
-    : 'Drag inside the mask to move it.';
+    ? 'Drag points, handles, or the path body to adjust the shape.'
+    : 'Drag inside the path to move it.';
   const selectedVertexHint = selectedVertexCount === 0
     ? 'Select a point to enable corner and bezier conversion.'
     : selectedVertexCount === 1 && selectedVertexIndex !== null
@@ -504,7 +504,7 @@ export const PreviewArea = memo(function PreviewArea({ project }: PreviewAreaPro
               className="border-t border-border panel-header flex items-center px-3 flex-shrink-0 gap-3 overflow-hidden"
               style={{ height: EDITOR_LAYOUT_CSS_VALUES.previewControlsHeight }}
               role="toolbar"
-              aria-label="Mask pen controls"
+              aria-label="Path pen controls"
             >
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <div className="flex items-center gap-2 flex-shrink-0">
@@ -548,7 +548,7 @@ export const PreviewArea = memo(function PreviewArea({ project }: PreviewAreaPro
               className="border-t border-border panel-header flex items-center px-3 flex-shrink-0 gap-3 overflow-hidden"
               style={{ height: EDITOR_LAYOUT_CSS_VALUES.previewControlsHeight }}
               role="toolbar"
-              aria-label="Mask path edit controls"
+              aria-label="Path edit controls"
             >
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <div className="flex items-center gap-2 flex-shrink-0">

--- a/src/features/preview/components/mask-editor-overlay.test.tsx
+++ b/src/features/preview/components/mask-editor-overlay.test.tsx
@@ -357,6 +357,96 @@ describe('MaskEditorOverlay shape pen flow', () => {
     expect(useSelectionStore.getState().activeTrackId).toBe(newTrack?.id ?? null);
   });
 
+  it('creates a video track when pen masks spill into a new classic track lane', async () => {
+    useMaskEditorStore.getState().startShapePenMode();
+    usePlaybackStore.getState().setCurrentFrame(120);
+    useSelectionStore.getState().setActiveTrack('track-v1');
+    useItemsStore.getState().setTracks([
+      {
+        id: 'track-v1',
+        name: 'V1',
+        kind: 'video',
+        height: 72,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 0,
+        items: [],
+      },
+      {
+        id: 'track-a1',
+        name: 'A1',
+        kind: 'audio',
+        height: 72,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 1,
+        items: [],
+      },
+    ]);
+    useItemsStore.getState().setItems([
+      {
+        id: 'busy-video-track',
+        type: 'shape',
+        trackId: 'track-v1',
+        from: 100,
+        durationInFrames: 120,
+        label: 'Busy',
+        shapeType: 'rectangle',
+        fillColor: '#ffffff',
+      },
+    ]);
+
+    const coordParams: CoordinateParams = {
+      containerRect: createRect(),
+      playerSize: PLAYER_SIZE,
+      projectSize: PROJECT_SIZE,
+      zoom: 1,
+    };
+
+    const { container } = render(
+      <MaskEditorOverlay
+        coordParams={coordParams}
+        playerSize={PLAYER_SIZE}
+        itemTransform={FULL_CANVAS_TRANSFORM}
+      />
+    );
+
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    vi.spyOn(canvas!, 'getBoundingClientRect').mockReturnValue(createRect());
+
+    const clickPoint = (x: number, y: number, pointerId: number) => {
+      fireEvent.pointerDown(canvas!, { clientX: x, clientY: y, pointerId });
+      fireEvent.pointerUp(canvas!, { clientX: x, clientY: y, pointerId });
+    };
+
+    clickPoint(20, 20, 1);
+    clickPoint(120, 20, 2);
+    clickPoint(120, 80, 3);
+    clickPoint(20, 20, 4);
+
+    await waitFor(() => {
+      expect(useMaskEditorStore.getState().isEditing).toBe(false);
+    });
+
+    const tracks = useItemsStore.getState().tracks;
+    const newTrack = tracks.find((track) => track.id !== 'track-v1' && track.id !== 'track-a1');
+    const shape = useItemsStore.getState().items.find((item) => item.id !== 'busy-video-track');
+
+    expect(newTrack).toBeDefined();
+    expect(newTrack?.kind).toBe('video');
+    expect(newTrack?.name).toBe('V2');
+    expect(newTrack?.order).toBeLessThan(0);
+    expect(shape?.trackId).toBe(newTrack?.id);
+    expect(shape?.from).toBe(120);
+    expect(useSelectionStore.getState().activeTrackId).toBe(newTrack?.id ?? null);
+  });
+
   it('creates a new track to keep the mask at the playhead when all tracks are occupied', async () => {
     useMaskEditorStore.getState().startShapePenMode();
     usePlaybackStore.getState().setCurrentFrame(120);

--- a/src/features/preview/components/mask-editor-overlay.test.tsx
+++ b/src/features/preview/components/mask-editor-overlay.test.tsx
@@ -174,8 +174,12 @@ describe('MaskEditorOverlay shape pen flow', () => {
     const shape = items[0];
     expect(shape?.type).toBe('shape');
     expect(shape?.shapeType).toBe('path');
-    expect(shape?.isMask).toBe(true);
+    expect(shape?.label).toBe('Path');
+    expect(shape?.fillColor).toBe('#3b82f6');
+    expect(shape?.isMask).toBe(false);
+    expect(shape?.maskType).toBeUndefined();
     expect(shape?.from).toBe(48);
+    expect(shape?.durationInFrames).toBe(150);
     expect(useSelectionStore.getState().selectedItemIds).toEqual([shape!.id]);
 
     expect(shape?.transform?.width).toBeCloseTo(100);
@@ -357,7 +361,7 @@ describe('MaskEditorOverlay shape pen flow', () => {
     expect(useSelectionStore.getState().activeTrackId).toBe(newTrack?.id ?? null);
   });
 
-  it('creates a video track when pen masks spill into a new classic track lane', async () => {
+  it('creates a video track when pen paths spill into a new classic track lane', async () => {
     useMaskEditorStore.getState().startShapePenMode();
     usePlaybackStore.getState().setCurrentFrame(120);
     useSelectionStore.getState().setActiveTrack('track-v1');
@@ -442,6 +446,7 @@ describe('MaskEditorOverlay shape pen flow', () => {
     expect(newTrack?.kind).toBe('video');
     expect(newTrack?.name).toBe('V2');
     expect(newTrack?.order).toBeLessThan(0);
+    expect(shape?.isMask).toBe(false);
     expect(shape?.trackId).toBe(newTrack?.id);
     expect(shape?.from).toBe(120);
     expect(useSelectionStore.getState().activeTrackId).toBe(newTrack?.id ?? null);
@@ -671,7 +676,7 @@ describe('MaskEditorOverlay shape pen flow', () => {
     const shape = useItemsStore.getState().items[0];
     expect(shape?.type).toBe('shape');
     expect(shape?.shapeType).toBe('path');
-    expect(shape?.isMask).toBe(true);
+    expect(shape?.isMask).toBe(false);
   });
 
   it('renders the closing segment while dragging the final bezier', async () => {

--- a/src/features/preview/components/mask-editor-overlay.tsx
+++ b/src/features/preview/components/mask-editor-overlay.tsx
@@ -86,6 +86,7 @@ const DRAG_THRESHOLD = 3;
 const PEN_BEZIER_DRAG_THRESHOLD = 10;
 /** Segment sampling density for interior hit testing on curved paths */
 const CURVE_HIT_TEST_STEPS = 16;
+const DEFAULT_PATH_SHAPE_DURATION_SECONDS = 5;
 type PenInteraction =
   | {
       type: 'create';
@@ -921,7 +922,7 @@ export const MaskEditorOverlay = memo(function MaskEditorOverlay({
     [hitTestPen, penVertices, setPenVertices, setHover]
   );
 
-  /** Commit pen vertices as a new ShapeItem with shapeType='path' and isMask=true */
+  /** Commit pen vertices as a new ShapeItem with shapeType='path'. */
   const commitShapePenPath = useCallback((verts: MaskVertex[]) => {
     const bounds = getPathBounds(verts);
     if (!bounds) {
@@ -966,7 +967,7 @@ export const MaskEditorOverlay = memo(function MaskEditorOverlay({
     const items = useItemsStore.getState().items;
     const { activeTrackId, selectItems, setActiveTrack } = useSelectionStore.getState();
     const currentFrame = usePlaybackStore.getState().currentFrame;
-    const durationInFrames = fps * 60;
+    const durationInFrames = Math.max(1, Math.round(fps * DEFAULT_PATH_SHAPE_DURATION_SECONDS));
     let placement = findBestCanvasDropPlacement({
       tracks,
       items,
@@ -1037,12 +1038,11 @@ export const MaskEditorOverlay = memo(function MaskEditorOverlay({
       trackId: placement.trackId,
       from: placement.from,
       durationInFrames,
-      label: 'Path Mask',
+      label: 'Path',
       shapeType: 'path',
       pathVertices: localVerts,
-      fillColor: '#ffffff',
-      isMask: true,
-      maskType: 'alpha',
+      fillColor: '#3b82f6',
+      isMask: false,
       transform: {
         x: centerX,
         y: centerY,

--- a/src/features/preview/components/mask-editor-overlay.tsx
+++ b/src/features/preview/components/mask-editor-overlay.tsx
@@ -62,6 +62,8 @@ import {
 } from './mask-editor-overlay-utils';
 import {
   findBestCanvasDropPlacement,
+  createClassicTrack,
+  getTrackKind,
   resolveEffectiveTrackStates,
 } from '../deps/timeline-utils';
 import {
@@ -1001,17 +1003,25 @@ export const MaskEditorOverlay = memo(function MaskEditorOverlay({
       const minOrder = tracks.length > 0
         ? Math.min(...tracks.map((track) => track.order ?? 0))
         : 0;
-      const newTrack: TimelineTrack = {
-        id: `track-${Date.now()}`,
-        name: getNextTrackName(tracks),
-        height: referenceTrack?.height ?? 72,
-        locked: false,
-        visible: true,
-        muted: false,
-        solo: false,
-        order: minOrder - 1,
-        items: [],
-      };
+      const usesClassicTrackKinds = tracks.some((track) => getTrackKind(track) !== null);
+      const newTrack: TimelineTrack = usesClassicTrackKinds
+        ? createClassicTrack({
+          tracks,
+          kind: 'video',
+          order: minOrder - 1,
+          height: referenceTrack?.height ?? 72,
+        })
+        : {
+          id: `track-${Date.now()}`,
+          name: getNextTrackName(tracks),
+          height: referenceTrack?.height ?? 72,
+          locked: false,
+          visible: true,
+          muted: false,
+          solo: false,
+          order: minOrder - 1,
+          items: [],
+        };
 
       setTracks([newTrack, ...tracks]);
       placement = {

--- a/src/features/preview/components/mask-editor-overlay.tsx
+++ b/src/features/preview/components/mask-editor-overlay.tsx
@@ -984,7 +984,7 @@ export const MaskEditorOverlay = memo(function MaskEditorOverlay({
 
     const placementTrackId = placement.trackId;
     const eligibleTracks = resolveEffectiveTrackStates(tracks).filter(
-      (track) => track.visible !== false && !track.locked && !track.muted && !track.isGroup
+      (track) => !track.locked && !track.isGroup
     );
     const activeTrack = activeTrackId
       ? eligibleTracks.find((track) => track.id === activeTrackId)

--- a/src/features/preview/deps/timeline-utils.ts
+++ b/src/features/preview/deps/timeline-utils.ts
@@ -7,6 +7,8 @@ export { resolveEffectiveTrackStates } from './timeline-contract';
 export {
   findBestCanvasDropPlacement,
   buildDroppedMediaTimelineItem,
+  createClassicTrack,
   getDroppedMediaDurationInFrames,
+  getTrackKind,
   type DroppableMediaType,
 } from './timeline-contract';

--- a/src/features/preview/hooks/use-canvas-media-drop.ts
+++ b/src/features/preview/hooks/use-canvas-media-drop.ts
@@ -234,12 +234,12 @@ export function useCanvasMediaDrop({
       proposedFrame: playbackState.currentFrame,
       durationInFrames,
       itemType: mediaType === 'image' ? 'image' : 'video',
-    });
+      });
 
-    if (!placement) {
-      toast.warning('No unlocked visible track is available for this drop.');
-      return;
-    }
+      if (!placement) {
+        toast.warning('No unlocked compatible track is available for this drop.');
+        return;
+      }
 
     const blobUrl = await resolveMediaUrl(media.id);
     if (!blobUrl) {

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { createRef, type ReactNode } from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -52,7 +52,12 @@ vi.mock('./timeline-preview-scrubber', () => ({
 }));
 
 vi.mock('./timeline-track', () => ({
-  TimelineTrack: () => null,
+  TimelineTrack: ({ track }: { track: { id: string; height: number } }) => (
+    <div
+      data-track-id={track.id}
+      style={{ height: `${track.height}px` }}
+    />
+  ),
 }));
 
 vi.mock('./timeline-guidelines', () => ({
@@ -97,6 +102,14 @@ const VIDEO_ITEM: VideoItem = {
 };
 
 beforeAll(() => {
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  }
+
   if (!globalThis.requestIdleCallback) {
     globalThis.requestIdleCallback = ((callback: IdleRequestCallback) => {
       return window.setTimeout(() => {
@@ -200,6 +213,78 @@ describe('TimelineContent playback selection behavior', () => {
 
     await waitFor(() => {
       expect(useSelectionStore.getState().selectedItemIds).toEqual([VIDEO_ITEM.id]);
+    });
+  });
+
+  it('reveals the active track when selection moves to an offscreen lane', async () => {
+    const videoTracks: TimelineTrack[] = [
+      { ...VIDEO_TRACK, id: 'track-video-1', name: 'V1', order: 0 },
+      { ...VIDEO_TRACK, id: 'track-video-2', name: 'V2', order: 1 },
+      { ...VIDEO_TRACK, id: 'track-video-3', name: 'V3', order: 2 },
+    ];
+
+    useTimelineStore.setState({
+      tracks: videoTracks,
+      items: [],
+    });
+
+    const allTracksScrollRef = createRef<HTMLDivElement>();
+    const { container } = render(
+      <TimelineContent
+        duration={10}
+        tracks={videoTracks}
+        allTracksScrollRef={allTracksScrollRef}
+      />
+    );
+    const scrollContainer = allTracksScrollRef.current
+      ?? container.querySelector('[data-track-section-scroll="video"]') as HTMLDivElement | null;
+    expect(scrollContainer).toBeTruthy();
+
+    const trackElements = Array.from(container.querySelectorAll<HTMLElement>('[data-track-id]'));
+    expect(trackElements).toHaveLength(3);
+
+    Object.defineProperty(scrollContainer!, 'clientHeight', {
+      configurable: true,
+      value: 100,
+    });
+    scrollContainer!.scrollTop = 120;
+    vi.spyOn(scrollContainer!, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 100,
+      width: 200,
+      height: 100,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const trackRects = new Map<string, DOMRect>([
+      ['track-video-1', {
+        x: 0, y: -120, left: 0, top: -120, right: 200, bottom: -48, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+      ['track-video-2', {
+        x: 0, y: -48, left: 0, top: -48, right: 200, bottom: 24, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+      ['track-video-3', {
+        x: 0, y: 24, left: 0, top: 24, right: 200, bottom: 96, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+    ]);
+
+    for (const element of trackElements) {
+      const trackId = element.getAttribute('data-track-id');
+      const rect = trackId ? trackRects.get(trackId) : null;
+      expect(rect).toBeTruthy();
+      vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rect!);
+    }
+
+    act(() => {
+      useSelectionStore.getState().setActiveTrack('track-video-1');
+    });
+
+    await waitFor(() => {
+      expect(scrollContainer!.scrollTop).toBe(0);
     });
   });
 });

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -287,4 +287,92 @@ describe('TimelineContent playback selection behavior', () => {
       expect(scrollContainer!.scrollTop).toBe(0);
     });
   });
+
+  it('reveals the active track through the split-pane video scroll ref', async () => {
+    const tracks: TimelineTrack[] = [
+      { ...VIDEO_TRACK, id: 'track-video-1', name: 'V1', order: 0 },
+      { ...VIDEO_TRACK, id: 'track-video-2', name: 'V2', order: 1 },
+      { ...VIDEO_TRACK, id: 'track-video-3', name: 'V3', order: 2 },
+      {
+        ...VIDEO_TRACK,
+        id: 'track-audio-1',
+        name: 'A1',
+        kind: 'audio',
+        order: 3,
+      },
+    ];
+
+    useTimelineStore.setState({
+      tracks,
+      items: [],
+    });
+
+    const videoTracksScrollRef = createRef<HTMLDivElement>();
+    const audioTracksScrollRef = createRef<HTMLDivElement>();
+    const { container } = render(
+      <TimelineContent
+        duration={10}
+        tracks={tracks}
+        videoTracksScrollRef={videoTracksScrollRef}
+        audioTracksScrollRef={audioTracksScrollRef}
+      />
+    );
+    const videoScrollContainer = videoTracksScrollRef.current
+      ?? container.querySelector('[data-track-section-scroll="video"]') as HTMLDivElement | null;
+    const audioScrollContainer = audioTracksScrollRef.current
+      ?? container.querySelector('[data-track-section-scroll="audio"]') as HTMLDivElement | null;
+    expect(videoScrollContainer).toBeTruthy();
+    expect(audioScrollContainer).toBeTruthy();
+
+    const videoTrackElements = Array.from(
+      videoScrollContainer!.querySelectorAll<HTMLElement>('[data-track-id]')
+    );
+    expect(videoTrackElements).toHaveLength(3);
+
+    Object.defineProperty(videoScrollContainer!, 'clientHeight', {
+      configurable: true,
+      value: 100,
+    });
+    videoScrollContainer!.scrollTop = 120;
+    audioScrollContainer!.scrollTop = 55;
+    vi.spyOn(videoScrollContainer!, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 100,
+      width: 200,
+      height: 100,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const trackRects = new Map<string, DOMRect>([
+      ['track-video-1', {
+        x: 0, y: -120, left: 0, top: -120, right: 200, bottom: -48, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+      ['track-video-2', {
+        x: 0, y: -48, left: 0, top: -48, right: 200, bottom: 24, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+      ['track-video-3', {
+        x: 0, y: 24, left: 0, top: 24, right: 200, bottom: 96, width: 200, height: 72, toJSON: () => ({})
+      } as DOMRect],
+    ]);
+
+    for (const element of videoTrackElements) {
+      const trackId = element.getAttribute('data-track-id');
+      const rect = trackId ? trackRects.get(trackId) : null;
+      expect(rect).toBeTruthy();
+      vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rect!);
+    }
+
+    act(() => {
+      useSelectionStore.getState().setActiveTrack('track-video-1');
+    });
+
+    await waitFor(() => {
+      expect(videoScrollContainer!.scrollTop).toBe(0);
+    });
+    expect(audioScrollContainer!.scrollTop).toBe(55);
+  });
 });

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -63,6 +63,37 @@ const ACTIVE_TIMELINE_GESTURE_CURSOR_CLASSES = [
 
 type TrackScrollbarSection = 'video' | 'audio' | 'single';
 
+function revealTrackInScrollContainer(
+  container: HTMLDivElement | null,
+  trackId: string
+): boolean {
+  if (!container) {
+    return false;
+  }
+
+  const trackElement = Array.from(container.querySelectorAll<HTMLElement>('[data-track-id]'))
+    .find((element) => element.getAttribute('data-track-id') === trackId);
+
+  if (!trackElement) {
+    return false;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const trackRect = trackElement.getBoundingClientRect();
+  const trackTop = trackRect.top - containerRect.top + container.scrollTop;
+  const trackBottom = trackTop + trackRect.height;
+  const viewTop = container.scrollTop;
+  const viewBottom = viewTop + container.clientHeight;
+
+  if (trackTop < viewTop) {
+    container.scrollTop = Math.max(0, trackTop);
+  } else if (trackBottom > viewBottom) {
+    container.scrollTop = Math.max(0, trackBottom - container.clientHeight);
+  }
+
+  return true;
+}
+
 /**
  * Tracks whether a scroll container has vertical overflow.
  * Only re-renders the parent when overflow state changes (resize/content change),
@@ -490,6 +521,7 @@ export const TimelineContent = memo(function TimelineContent({
   const selectItems = useSelectionStore((s) => s.selectItems);
   const selectMarker = useSelectionStore((s) => s.selectMarker);
   const clearItemSelection = useSelectionStore((s) => s.clearItemSelection);
+  const activeTrackId = useSelectionStore((s) => s.activeTrackId);
   // Granular selectors for drag state - avoid subscribing to entire dragState object
   const isDragging = useSelectionStore((s) => !!s.dragState?.isDragging);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -730,6 +762,24 @@ export const TimelineContent = memo(function TimelineContent({
     container.scrollLeft = Math.max(0, frameX - vw / 2);
     syncViewportFromContainer();
   }, [pendingScrollToFrame, syncViewportFromContainer]);
+
+  useLayoutEffect(() => {
+    if (!activeTrackId) {
+      return;
+    }
+
+    const scrollContainers = [
+      videoTracksScrollRef?.current ?? null,
+      audioTracksScrollRef?.current ?? null,
+      allTracksScrollRef?.current ?? null,
+    ];
+
+    for (const container of scrollContainers) {
+      if (revealTrackInScrollContainer(container, activeTrackId)) {
+        break;
+      }
+    }
+  }, [activeTrackId, videoTracks.length, audioTracks.length, tracks.length]);
 
   // Marquee selection - create items array for getBoundingRect lookups
   // Use derived selector for item IDs only (doesn't re-render when positions change)

--- a/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
+++ b/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
@@ -24,9 +24,11 @@ function makeVideoItem(overrides: Partial<VideoItem> = {}): VideoItem {
 function DragVisualHarness({
   item,
   isDragging = false,
+  initialOpacity = '0.3',
 }: {
   item: VideoItem;
   isDragging?: boolean;
+  initialOpacity?: string;
 }) {
   const transformRef = useRef<HTMLDivElement>(null);
   const ghostRef = useRef<HTMLDivElement>(null);
@@ -40,7 +42,7 @@ function DragVisualHarness({
 
   return (
     <>
-      <div data-testid="body" ref={transformRef} />
+      <div data-testid="body" ref={transformRef} style={{ opacity: initialOpacity }} />
       <div data-testid="ghost" ref={ghostRef} />
       <div data-testid="join-state">
         {String(dragVisualState.dragAffectsJoin.left)}
@@ -95,9 +97,18 @@ describe('useDragVisualState', () => {
     expect(screen.getByTestId('join-state')).toHaveTextContent('false:false');
   });
 
+  it('preserves the host opacity when no drag visuals are active', async () => {
+    const item = makeVideoItem();
+    render(<DragVisualHarness item={item} initialOpacity="0.3" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('body').style.opacity).toBe('0.3');
+    });
+  });
+
   it('applies follower transforms during move drags and cleans them up when the drag ends', async () => {
     const item = makeVideoItem();
-    render(<DragVisualHarness item={item} />);
+    render(<DragVisualHarness item={item} initialOpacity="0.3" />);
 
     dragOffsetRef.current = { x: 18, y: 6 };
     setDragState([item.id]);
@@ -116,7 +127,7 @@ describe('useDragVisualState', () => {
 
     await waitFor(() => {
       expect(body.style.transform).toBe('');
-      expect(body.style.opacity).toBe('');
+      expect(body.style.opacity).toBe('0.3');
       expect(body.style.pointerEvents).toBe('');
       expect(body.style.zIndex).toBe('');
     });
@@ -135,7 +146,7 @@ describe('useDragVisualState', () => {
     const ghost = screen.getByTestId('ghost');
     await waitFor(() => {
       expect(body.style.transform).toBe('');
-      expect(body.style.opacity).toBe('');
+      expect(body.style.opacity).toBe('0.3');
       expect(body.style.pointerEvents).toBe('none');
       expect(ghost.style.display).toBe('block');
       expect(ghost.style.transform).toBe('translate(11px, 7px)');

--- a/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
+++ b/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import type { VideoItem } from '@/types/timeline';
 import { useSelectionStore } from '@/shared/state/selection';
 import { useItemsStore } from '../../stores/items-store';
-import { DRAG_OPACITY } from '../../constants';
+import { DRAG_OPACITY } from '@/features/timeline/constants';
 import { dragOffsetRef, dragPreviewOffsetByItemRef } from '../../hooks/use-timeline-drag';
 import { useDragVisualState } from './use-drag-visual-state';
 

--- a/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
+++ b/src/features/timeline/components/timeline-item/use-drag-visual-state.test.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import type { VideoItem } from '@/types/timeline';
 import { useSelectionStore } from '@/shared/state/selection';
 import { useItemsStore } from '../../stores/items-store';
+import { DRAG_OPACITY } from '../../constants';
 import { dragOffsetRef, dragPreviewOffsetByItemRef } from '../../hooks/use-timeline-drag';
 import { useDragVisualState } from './use-drag-visual-state';
 
@@ -42,7 +43,11 @@ function DragVisualHarness({
 
   return (
     <>
-      <div data-testid="body" ref={transformRef} style={{ opacity: initialOpacity }} />
+      <div
+        data-testid="body"
+        ref={transformRef}
+        style={{ opacity: dragVisualState.shouldDimForDrag ? String(DRAG_OPACITY) : initialOpacity }}
+      />
       <div data-testid="ghost" ref={ghostRef} />
       <div data-testid="join-state">
         {String(dragVisualState.dragAffectsJoin.left)}
@@ -116,7 +121,7 @@ describe('useDragVisualState', () => {
     const body = screen.getByTestId('body');
     await waitFor(() => {
       expect(body.style.transform).toBe('translate(18px, 6px)');
-      expect(body.style.opacity).toBe('0.8');
+      expect(body.style.opacity).toBe(String(DRAG_OPACITY));
       expect(body.style.pointerEvents).toBe('none');
       expect(body.style.zIndex).toBe('50');
     });
@@ -150,6 +155,29 @@ describe('useDragVisualState', () => {
       expect(body.style.pointerEvents).toBe('none');
       expect(ghost.style.display).toBe('block');
       expect(ghost.style.transform).toBe('translate(11px, 7px)');
+    });
+  });
+
+  it('honors updated host opacity after a drop into a dimmed track', async () => {
+    const item = makeVideoItem();
+    const { rerender } = render(<DragVisualHarness item={item} initialOpacity="1" />);
+
+    dragOffsetRef.current = { x: 12, y: 4 };
+    setDragState([item.id]);
+
+    const body = screen.getByTestId('body');
+    await waitFor(() => {
+      expect(body.style.opacity).toBe(String(DRAG_OPACITY));
+    });
+
+    rerender(<DragVisualHarness item={item} initialOpacity="0.3" />);
+
+    act(() => {
+      useSelectionStore.getState().setDragState(null);
+    });
+
+    await waitFor(() => {
+      expect(body.style.opacity).toBe('0.3');
     });
   });
 });

--- a/src/features/timeline/components/timeline-item/use-drag-visual-state.ts
+++ b/src/features/timeline/components/timeline-item/use-drag-visual-state.ts
@@ -47,6 +47,7 @@ export function useDragVisualState({
   const dragWasActiveRef = useRef(false);
   const rafIdRef = useRef<number | null>(null);
   const dragWasActiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousOpacityRef = useRef<string | null>(null);
 
   const neighboringJoinIds = useItemsStore(
     useShallow((state) => {
@@ -113,6 +114,14 @@ export function useDragVisualState({
   }, [isDragActive]);
 
   useEffect(() => {
+    const preserveCurrentOpacity = () => {
+      if (!transformRef.current || previousOpacityRef.current !== null) {
+        return;
+      }
+
+      previousOpacityRef.current = transformRef.current.style.opacity;
+    };
+
     const cleanupDragStyles = () => {
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
@@ -122,7 +131,10 @@ export function useDragVisualState({
       if (transformRef.current) {
         transformRef.current.style.transition = 'none';
         transformRef.current.style.transform = '';
-        transformRef.current.style.opacity = '';
+        if (previousOpacityRef.current !== null) {
+          transformRef.current.style.opacity = previousOpacityRef.current;
+          previousOpacityRef.current = null;
+        }
         transformRef.current.style.pointerEvents = '';
         transformRef.current.style.zIndex = '';
       }
@@ -148,7 +160,6 @@ export function useDragVisualState({
 
       if (isAltPreviewDrag) {
         transformRef.current.style.transform = '';
-        transformRef.current.style.opacity = '';
         transformRef.current.style.transition = 'none';
         transformRef.current.style.pointerEvents = 'none';
 
@@ -157,6 +168,7 @@ export function useDragVisualState({
           ghostRef.current.style.display = 'block';
         }
       } else {
+        preserveCurrentOpacity();
         transformRef.current.style.transform = `translate(${offset.x}px, ${offset.y}px)`;
         transformRef.current.style.opacity = String(DRAG_OPACITY);
         transformRef.current.style.transition = 'none';
@@ -172,6 +184,7 @@ export function useDragVisualState({
     };
 
     if (dragParticipation > 0 && !isDragging) {
+      preserveCurrentOpacity();
       rafIdRef.current = requestAnimationFrame(updateTransform);
       return cleanupDragStyles;
     }

--- a/src/features/timeline/components/timeline-item/use-drag-visual-state.ts
+++ b/src/features/timeline/components/timeline-item/use-drag-visual-state.ts
@@ -4,7 +4,6 @@ import type { MutableRefObject, RefObject } from 'react';
 import type { TimelineItem } from '@/types/timeline';
 import { useItemsStore } from '../../stores/items-store';
 import { useSelectionStore } from '@/shared/state/selection';
-import { DRAG_OPACITY } from '../../constants';
 import { dragOffsetRef, dragPreviewOffsetByItemRef } from '../../hooks/use-timeline-drag';
 import {
   getTimelineItemDragParticipation,
@@ -47,7 +46,6 @@ export function useDragVisualState({
   const dragWasActiveRef = useRef(false);
   const rafIdRef = useRef<number | null>(null);
   const dragWasActiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const previousOpacityRef = useRef<string | null>(null);
 
   const neighboringJoinIds = useItemsStore(
     useShallow((state) => {
@@ -114,14 +112,6 @@ export function useDragVisualState({
   }, [isDragActive]);
 
   useEffect(() => {
-    const preserveCurrentOpacity = () => {
-      if (!transformRef.current || previousOpacityRef.current !== null) {
-        return;
-      }
-
-      previousOpacityRef.current = transformRef.current.style.opacity;
-    };
-
     const cleanupDragStyles = () => {
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
@@ -131,10 +121,6 @@ export function useDragVisualState({
       if (transformRef.current) {
         transformRef.current.style.transition = 'none';
         transformRef.current.style.transform = '';
-        if (previousOpacityRef.current !== null) {
-          transformRef.current.style.opacity = previousOpacityRef.current;
-          previousOpacityRef.current = null;
-        }
         transformRef.current.style.pointerEvents = '';
         transformRef.current.style.zIndex = '';
       }
@@ -168,9 +154,7 @@ export function useDragVisualState({
           ghostRef.current.style.display = 'block';
         }
       } else {
-        preserveCurrentOpacity();
         transformRef.current.style.transform = `translate(${offset.x}px, ${offset.y}px)`;
-        transformRef.current.style.opacity = String(DRAG_OPACITY);
         transformRef.current.style.transition = 'none';
         transformRef.current.style.pointerEvents = 'none';
         transformRef.current.style.zIndex = '50';
@@ -184,7 +168,6 @@ export function useDragVisualState({
     };
 
     if (dragParticipation > 0 && !isDragging) {
-      preserveCurrentOpacity();
       rafIdRef.current = requestAnimationFrame(updateTransform);
       return cleanupDragStyles;
     }

--- a/src/features/timeline/components/timeline-track.tsx
+++ b/src/features/timeline/components/timeline-track.tsx
@@ -88,6 +88,7 @@ import {
   captureContextMenuEventInit,
   replayContextMenuEvent,
 } from '../utils/lazy-context-menu';
+import { getTrackKind, isTrackDisabled as getIsTrackDisabled } from '@/features/timeline/utils/classic-tracks';
 
 /**
  * Lightweight on-demand context menu for track gaps.
@@ -364,18 +365,16 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
   const pendingDragPreviewRef = useRef<PendingDragPreview | null>(null);
   const dragOverFlagsRef = useRef({ isDragOver: false, isExternalDragOver: false });
 
-  // Resolve whether this track is effectively disabled for drops.
+  // Resolve whether this track is effectively disabled for rendering or drops.
   // Uses the shared resolveEffectiveTrackStates helper so group-inherited
-  // locked/visible/muted flags are consistent with the rest of the codebase.
-  const isDropDisabled = useTimelineStore((s) => {
-    const effective = resolveEffectiveTrackStates(s.tracks).find((t) => t.id === track.id);
-    if (!effective) return track.locked;
-    if (effective.locked) return true;
-    const kind = effective.kind;
-    if (kind === 'audio') return effective.muted;
-    if (kind === 'video') return effective.visible === false;
-    return effective.visible === false || effective.muted;
+  // locked/visible/muted flags stay consistent with the rest of the timeline.
+  const trackInteractionState = useTimelineStore((s) => {
+    const effective = resolveEffectiveTrackStates(s.tracks).find((t) => t.id === track.id) ?? track;
+    return (effective.locked ? 1 : 0) | (getIsTrackDisabled(effective) ? 2 : 0);
   });
+  const isTrackDisabled = (trackInteractionState & 2) !== 0;
+  const isDropDisabled = trackInteractionState !== 0;
+  const trackKind = getTrackKind(track);
 
   // Virtualized items/transitions â€” only those overlapping the visible viewport + buffer
   const { visibleItems: trackItems, visibleTransitions: trackTransitions } = useVisibleItems(track.id);
@@ -1246,12 +1245,12 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
           />
         )}
 
-        {/* Render all items for this track - dimmed when track is hidden */}
-        <TimelineTrackItems trackItems={trackItems} trackLocked={track.locked} trackHidden={!track.visible} />
+        {/* Render all items for this track - dimmed when the track is disabled */}
+        <TimelineTrackItems trackItems={trackItems} trackLocked={track.locked} trackHidden={isTrackDisabled} />
 
         {/* Render transitions for this track */}
-        {track.kind !== 'audio' && trackTransitions.map((transition) => (
-          <TransitionItem key={transition.id} transition={transition} trackHidden={!track.visible} />
+        {trackKind !== 'audio' && trackTransitions.map((transition) => (
+          <TransitionItem key={transition.id} transition={transition} trackHidden={isTrackDisabled} />
         ))}
 
         {/* Locked track overlay indicator */}

--- a/src/features/timeline/components/timeline-track.tsx
+++ b/src/features/timeline/components/timeline-track.tsx
@@ -372,8 +372,9 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
     const effective = resolveEffectiveTrackStates(s.tracks).find((t) => t.id === track.id) ?? track;
     return (effective.locked ? 1 : 0) | (getIsTrackDisabled(effective) ? 2 : 0);
   });
+  const isTrackLocked = (trackInteractionState & 1) !== 0;
   const isTrackDisabled = (trackInteractionState & 2) !== 0;
-  const isDropDisabled = trackInteractionState !== 0;
+  const isDropDisabled = isTrackLocked;
   const trackKind = getTrackKind(track);
 
   // Virtualized items/transitions â€” only those overlapping the visible viewport + buffer

--- a/src/features/timeline/components/timeline-track.tsx
+++ b/src/features/timeline/components/timeline-track.tsx
@@ -1247,7 +1247,7 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
         )}
 
         {/* Render all items for this track - dimmed when the track is disabled */}
-        <TimelineTrackItems trackItems={trackItems} trackLocked={track.locked} trackHidden={isTrackDisabled} />
+        <TimelineTrackItems trackItems={trackItems} trackLocked={isTrackLocked} trackHidden={isTrackDisabled} />
 
         {/* Render transitions for this track */}
         {trackKind !== 'audio' && trackTransitions.map((transition) => (
@@ -1255,7 +1255,7 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
         ))}
 
         {/* Locked track overlay indicator */}
-        {track.locked && (
+        {isTrackLocked && (
           <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
             <div className="text-xs text-muted-foreground/50 font-mono">LOCKED</div>
           </div>

--- a/src/features/timeline/components/track-header.test.tsx
+++ b/src/features/timeline/components/track-header.test.tsx
@@ -30,7 +30,7 @@ function makeTrack(overrides: Partial<TimelineTrack> = {}): TimelineTrack {
 }
 
 function renderTrackHeader(track: TimelineTrack, onToggleDisabled = vi.fn()) {
-  render(
+  const renderResult = render(
     <TrackHeader
       track={track}
       isActive={false}
@@ -50,7 +50,7 @@ function renderTrackHeader(track: TimelineTrack, onToggleDisabled = vi.fn()) {
     />
   );
 
-  return { onToggleDisabled };
+  return { ...renderResult, onToggleDisabled };
 }
 
 describe('TrackHeader', () => {
@@ -71,11 +71,12 @@ describe('TrackHeader', () => {
   });
 
   it('derives the disable state from audio mute status', () => {
-    renderTrackHeader(makeTrack({ id: 'track-2', name: 'A1', kind: 'audio', muted: true }));
+    const { container } = renderTrackHeader(makeTrack({ id: 'track-2', name: 'A1', kind: 'audio', muted: true }));
 
     expect(screen.getByRole('button', { name: 'Enable track' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Show track' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Unmute track' })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-track-id="track-2"]')).toHaveAttribute('data-track-disabled', 'true');
   });
 
   it('calls onToggleDisabled when clicking Enable track on a muted audio track', () => {

--- a/src/features/timeline/components/track-header.tsx
+++ b/src/features/timeline/components/track-header.tsx
@@ -13,7 +13,7 @@ import { useTrackDrag } from '../hooks/use-track-drag';
 import { TIMELINE_SIDEBAR_WIDTH } from '../constants';
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/shared/ui/editor-layout';
 import { useItemsStore } from '../stores/items-store';
-import { getTrackKind } from '@/features/timeline/utils/classic-tracks';
+import { isTrackDisabled } from '@/features/timeline/utils/classic-tracks';
 import { isTrackSyncLockActive } from '../utils/track-sync-lock';
 
 interface TrackHeaderProps {
@@ -75,13 +75,8 @@ export const TrackHeader = memo(function TrackHeader({
   onDeleteEmptyTracks,
 }: TrackHeaderProps) {
   const itemCount = useItemsStore((s) => s.itemsByTrackId[track.id]?.length ?? 0);
-  const trackKind = getTrackKind(track);
   const syncLockEnabled = isTrackSyncLockActive(track);
-  const isTrackDisabled = trackKind === 'audio'
-    ? track.muted
-    : trackKind === 'video'
-      ? track.visible === false
-      : track.visible === false || track.muted;
+  const trackDisabled = isTrackDisabled(track);
 
   // Use track drag hook (visuals handled centrally by timeline.tsx via DOM)
   const { handleDragStart } = useTrackDrag(track);
@@ -94,8 +89,9 @@ export const TrackHeader = memo(function TrackHeader({
           className={`
             flex flex-col overflow-hidden px-1
             cursor-grab active:cursor-grabbing relative
-            ${isSelected ? 'bg-primary/10' : 'hover:bg-secondary/50'}
+            ${isSelected ? 'bg-primary/10' : trackDisabled ? 'bg-muted/30 hover:bg-muted/40' : 'hover:bg-secondary/50'}
             ${isActive ? 'border-l-3 border-l-primary' : 'border-l-3 border-l-transparent'}
+            ${trackDisabled ? 'text-muted-foreground' : ''}
             transition-colors duration-150
           `}
           style={{
@@ -107,6 +103,7 @@ export const TrackHeader = memo(function TrackHeader({
           onClick={onSelect}
           onMouseDown={handleDragStart}
           data-track-id={track.id}
+          data-track-disabled={trackDisabled ? 'true' : undefined}
         >
           <div className="flex h-6 shrink-0 items-center gap-0.5 overflow-hidden border-b border-border/60">
             <div className="flex h-5 w-4 shrink-0 items-center justify-center">
@@ -123,10 +120,10 @@ export const TrackHeader = memo(function TrackHeader({
                 onToggleDisabled();
               }}
               onMouseDown={(e) => e.stopPropagation()}
-              aria-label={isTrackDisabled ? 'Enable track' : 'Disable track'}
-              data-tooltip={isTrackDisabled ? 'Enable track' : 'Disable track'}
+              aria-label={trackDisabled ? 'Enable track' : 'Disable track'}
+              data-tooltip={trackDisabled ? 'Enable track' : 'Disable track'}
             >
-              {isTrackDisabled ? (
+              {trackDisabled ? (
                 <PowerOff className="w-3 h-3 text-primary" />
               ) : (
                 <Power className="w-3 h-3 opacity-70" />

--- a/src/features/timeline/contracts/preview.ts
+++ b/src/features/timeline/contracts/preview.ts
@@ -27,6 +27,7 @@ export {
 } from '../stores/actions/source-edit-actions';
 export { resolveSourceEditTrackTargets } from '../utils/source-edit-targeting';
 export { getTrackKind } from '../utils/classic-tracks';
+export { createClassicTrack } from '../utils/classic-tracks';
 export {
   useCompositionsStore,
 } from '../stores/compositions-store';

--- a/src/features/timeline/utils/classic-tracks.test.ts
+++ b/src/features/timeline/utils/classic-tracks.test.ts
@@ -5,6 +5,7 @@ import {
   findNearestTrackByKind,
   getAdjacentTrackOrder,
   getNextClassicTrackName,
+  isTrackDisabled,
   getTrackKind,
   renameTrackForKind,
 } from './classic-tracks';
@@ -31,6 +32,14 @@ describe('classic tracks', () => {
     expect(getTrackKind(makeTrack({ name: 'V2' }))).toBe('video');
     expect(getTrackKind(makeTrack({ name: 'A4' }))).toBe('audio');
     expect(getTrackKind(makeTrack({ name: 'Track 1' }))).toBeNull();
+  });
+
+  it('derives disabled state from stored visibility or mute flags', () => {
+    expect(isTrackDisabled(makeTrack({ kind: 'video', visible: false }))).toBe(true);
+    expect(isTrackDisabled(makeTrack({ kind: 'audio', muted: true }))).toBe(true);
+    expect(isTrackDisabled(makeTrack({ name: 'V2', kind: undefined, visible: false }))).toBe(true);
+    expect(isTrackDisabled(makeTrack({ name: 'A4', kind: undefined, muted: true }))).toBe(true);
+    expect(isTrackDisabled(makeTrack({ name: 'Track 1', visible: true, muted: false }))).toBe(false);
   });
 
   it('renames generic tracks into classic names when assigning a kind', () => {

--- a/src/features/timeline/utils/classic-tracks.ts
+++ b/src/features/timeline/utils/classic-tracks.ts
@@ -28,6 +28,17 @@ export function getTrackKind(track: TimelineTrack): TrackKind | null {
   return null;
 }
 
+export function isTrackDisabled(track: TimelineTrack): boolean {
+  const kind = getTrackKind(track);
+  if (kind === 'audio') {
+    return track.muted;
+  }
+  if (kind === 'video') {
+    return track.visible === false;
+  }
+  return track.visible === false || track.muted;
+}
+
 export function getNextClassicTrackName(tracks: TimelineTrack[], kind: TrackKind): string {
   const regex = getTrackNameRegex(kind);
   const numbers = new Set<number>();

--- a/src/features/timeline/utils/drop-placement.test.ts
+++ b/src/features/timeline/utils/drop-placement.test.ts
@@ -105,7 +105,7 @@ describe('findBestCanvasDropPlacement', () => {
     });
   });
 
-  it('skips muted tracks', () => {
+  it('allows disabled tracks when they are not locked', () => {
     const placement = findBestCanvasDropPlacement({
       tracks: [
         makeTrack('track-1', 0, { muted: true }),
@@ -119,18 +119,18 @@ describe('findBestCanvasDropPlacement', () => {
     });
 
     expect(placement).toEqual({
-      trackId: 'track-2',
+      trackId: 'track-1',
       from: 0,
       preservedTime: true,
     });
   });
 
-  it('returns null when all tracks are disabled', () => {
+  it('returns null when every compatible track is locked', () => {
     const placement = findBestCanvasDropPlacement({
       tracks: [
         makeTrack('track-1', 0, { locked: true }),
-        makeTrack('track-2', 1, { muted: true }),
-        makeTrack('track-3', 2, { visible: false }),
+        makeTrack('track-2', 1, { locked: true, muted: true }),
+        makeTrack('track-3', 2, { locked: true, visible: false }),
       ],
       items: [],
       activeTrackId: 'track-1',

--- a/src/features/timeline/utils/drop-placement.test.ts
+++ b/src/features/timeline/utils/drop-placement.test.ts
@@ -108,7 +108,7 @@ describe('findBestCanvasDropPlacement', () => {
   it('allows disabled tracks when they are not locked', () => {
     const placement = findBestCanvasDropPlacement({
       tracks: [
-        makeTrack('track-1', 0, { muted: true }),
+        makeTrack('track-1', 0, { kind: 'video', visible: false }),
         makeTrack('track-2', 1),
       ],
       items: [],
@@ -121,6 +121,26 @@ describe('findBestCanvasDropPlacement', () => {
     expect(placement).toEqual({
       trackId: 'track-1',
       from: 0,
+      preservedTime: true,
+    });
+  });
+
+  it('never targets group header tracks', () => {
+    const placement = findBestCanvasDropPlacement({
+      tracks: [
+        makeTrack('group-1', 0, { isGroup: true }),
+        makeTrack('track-1', 1, { kind: 'video' }),
+      ],
+      items: [],
+      activeTrackId: 'group-1',
+      proposedFrame: 24,
+      durationInFrames: 30,
+      itemType: 'video',
+    });
+
+    expect(placement).toEqual({
+      trackId: 'track-1',
+      from: 24,
       preservedTime: true,
     });
   });

--- a/src/features/timeline/utils/drop-placement.ts
+++ b/src/features/timeline/utils/drop-placement.ts
@@ -26,7 +26,7 @@ export function findBestCanvasDropPlacement(
 ): CanvasDropPlacement | null {
   const { tracks, items, activeTrackId, proposedFrame, durationInFrames, itemType } = params;
   const effectiveTracks = resolveEffectiveTrackStates(tracks).filter(
-    (track) => !track.locked
+    (track) => !track.locked && !track.isGroup
   );
 
   if (effectiveTracks.length === 0) {

--- a/src/features/timeline/utils/drop-placement.ts
+++ b/src/features/timeline/utils/drop-placement.ts
@@ -26,7 +26,7 @@ export function findBestCanvasDropPlacement(
 ): CanvasDropPlacement | null {
   const { tracks, items, activeTrackId, proposedFrame, durationInFrames, itemType } = params;
   const effectiveTracks = resolveEffectiveTrackStates(tracks).filter(
-    (track) => track.visible !== false && !track.locked && !track.muted
+    (track) => !track.locked
   );
 
   if (effectiveTracks.length === 0) {

--- a/src/features/timeline/utils/track-item-compatibility.test.ts
+++ b/src/features/timeline/utils/track-item-compatibility.test.ts
@@ -46,4 +46,34 @@ describe('findCompatibleTrackForItemType', () => {
       allowPreferredTrackFallback: false,
     })).toBeNull();
   });
+
+  it('treats hidden tracks as compatible by default', () => {
+    const tracks = [
+      { ...makeTrack('video-1', 0, 'video'), visible: false },
+      makeTrack('video-2', 1, 'video'),
+    ];
+
+    expect(findCompatibleTrackForItemType({
+      tracks,
+      items: [] as TimelineItem[],
+      itemType: 'text',
+      preferredTrackId: 'video-1',
+      allowPreferredTrackFallback: false,
+    })?.id).toBe('video-1');
+  });
+
+  it('still allows callers to exclude hidden tracks explicitly', () => {
+    const tracks = [
+      { ...makeTrack('video-1', 0, 'video'), visible: false },
+      makeTrack('video-2', 1, 'video'),
+    ];
+
+    expect(findCompatibleTrackForItemType({
+      tracks,
+      items: [] as TimelineItem[],
+      itemType: 'text',
+      preferredTrackId: 'video-1',
+      includeHidden: false,
+    })?.id).toBe('video-2');
+  });
 });

--- a/src/features/timeline/utils/track-item-compatibility.ts
+++ b/src/features/timeline/utils/track-item-compatibility.ts
@@ -54,7 +54,7 @@ export function findCompatibleTrackForItemType(params: {
     itemType,
     preferredTrackId,
     includeLocked = false,
-    includeHidden = false,
+    includeHidden = true,
     allowPreferredTrackFallback = true,
   } = params;
 


### PR DESCRIPTION
## Summary
- Fix compound audio restore with fresh blob URL sync
- Keep disabled tracks editable and dim dropped clips appropriately
- Preserve disabled track styling after reload
- Default pen paths to shapes with 5s duration
- Reveal pen mask tracks in classic timelines

## Changes
- 24 files changed across editor, timeline, preview features
- Improved disabled track UX (editing, styling, drop visuals)
- Fixed pen tool defaults and mask track visibility
- Fixed audio meter blob URL sync on restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active timeline tracks auto-scroll into view when selected.
  * Pen paths can create a new video track when drawn outside existing lanes.

* **Changes**
  * Pen-created shapes are regular "Path" shapes (blue fill), not masks; default path duration is 5s.
  * Editing UI text and toolbar labels now use "path" instead of "mask".
  * Hidden/muted tracks are eligible for media placement; track disabled state now updates header styling and a data attribute.
  * Drag-handling no longer forces global opacity changes.
  * Audio live-gain is applied per item for mute/solo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->