### PR TITLE
Timeline compact clips, zoom perf, and filmstrip gap coverage

### DIFF
--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -203,7 +203,15 @@ describe('MediaLibraryService', () => {
       expect(indexedDbMocks.createMedia).toHaveBeenCalledTimes(1);
       expect(indexedDbMocks.associateMediaWithProject).toHaveBeenCalledWith('project-1', result.id);
       expect(indexedDbMocks.saveThumbnail).toHaveBeenCalledTimes(1);
-      expect(filmstripCacheMocks.prewarmPriorityWindow).toHaveBeenCalledWith(
+      expect(filmstripCacheMocks.prewarmPriorityWindow).toHaveBeenNthCalledWith(
+        1,
+        result.id,
+        mockFile,
+        10,
+        { startTime: 0, endTime: 1 },
+      );
+      expect(filmstripCacheMocks.prewarmPriorityWindow).toHaveBeenNthCalledWith(
+        2,
         result.id,
         mockFile,
         10,

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -46,7 +46,9 @@ import {
 } from '@/features/media-library/deps/composition-runtime';
 export { FileAccessError } from './file-access';
 
+const IMPORT_FILMSTRIP_COVER_PREWARM_SECONDS = 1;
 const IMPORT_FILMSTRIP_PREWARM_SECONDS = 12;
+const IMPORT_BACKGROUND_COVER_WARM_DELAY_MS = 0;
 const IMPORT_BACKGROUND_WARM_DELAY_MS = 600;
 const IMPORT_BACKGROUND_HEAVY_DELAY_MS = 2200;
 
@@ -289,6 +291,20 @@ class MediaLibraryService {
     await associateMediaWithProject(projectId, id);
 
     if (metadata.type === 'video' && mediaMetadata.duration > 0) {
+      const coverWarmEndTime = Math.min(
+        mediaMetadata.duration,
+        IMPORT_FILMSTRIP_COVER_PREWARM_SECONDS,
+      );
+      enqueueBackgroundMediaWork(() => (
+        filmstripCache.prewarmPriorityWindow(id, file, mediaMetadata.duration, {
+          startTime: 0,
+          endTime: coverWarmEndTime,
+        })
+      ), {
+        priority: 'warm',
+        delayMs: IMPORT_BACKGROUND_COVER_WARM_DELAY_MS,
+      });
+
       const warmEndTime = Math.min(mediaMetadata.duration, IMPORT_FILMSTRIP_PREWARM_SECONDS);
       enqueueBackgroundMediaWork(() => (
         filmstripCache.prewarmPriorityWindow(id, file, mediaMetadata.duration, {

--- a/src/features/media-library/services/proxy-service.test.ts
+++ b/src/features/media-library/services/proxy-service.test.ts
@@ -387,7 +387,15 @@ describe('proxyService.loadExistingProxies', () => {
       loadCompletedProxy: (proxyKey: string) => Promise<void>;
     }).loadCompletedProxy('proxy-video-4');
 
-    expect(timelineServiceMocks.filmstripCache.prewarmPriorityWindow).toHaveBeenCalledWith(
+    expect(timelineServiceMocks.filmstripCache.prewarmPriorityWindow).toHaveBeenNthCalledWith(
+      1,
+      'video-4',
+      expect.objectContaining({ size: 1024 }),
+      20,
+      { startTime: 0, endTime: 1 },
+    );
+    expect(timelineServiceMocks.filmstripCache.prewarmPriorityWindow).toHaveBeenNthCalledWith(
+      2,
       'video-4',
       expect.objectContaining({ size: 1024 }),
       20,

--- a/src/features/media-library/services/proxy-service.ts
+++ b/src/features/media-library/services/proxy-service.ts
@@ -129,7 +129,9 @@ interface ProgressEmissionState {
 
 const PROXY_PROGRESS_EMIT_INTERVAL_MS = 150;
 const PROXY_PROGRESS_EMIT_MIN_DELTA = 0.01;
+const PROXY_FILMSTRIP_COVER_PREWARM_SECONDS = 1;
 const PROXY_FILMSTRIP_PREWARM_SECONDS = 12;
+const PROXY_FILMSTRIP_COVER_PREWARM_DELAY_MS = 0;
 const PROXY_FILMSTRIP_PREWARM_DELAY_MS = 900;
 const PROXY_PLAYBACK_ISSUE_SCORE_THRESHOLD = 5;
 const PROXY_PLAYBACK_ISSUE_WEIGHTS: Record<ProxyPlaybackIssue, number> = {
@@ -734,6 +736,17 @@ class ProxyService {
       if (!media || !media.mimeType.startsWith('video/') || media.duration <= 0) {
         continue;
       }
+
+      const coverWarmEndTime = Math.min(media.duration, PROXY_FILMSTRIP_COVER_PREWARM_SECONDS);
+      enqueueBackgroundMediaWork(() => (
+        filmstripCache.prewarmPriorityWindow(mediaId, proxyFile, media.duration, {
+          startTime: 0,
+          endTime: coverWarmEndTime,
+        })
+      ), {
+        priority: 'warm',
+        delayMs: PROXY_FILMSTRIP_COVER_PREWARM_DELAY_MS,
+      });
 
       const warmEndTime = Math.min(media.duration, PROXY_FILMSTRIP_PREWARM_SECONDS);
       enqueueBackgroundMediaWork(() => (

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -531,7 +531,9 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
       const tileTime = effectiveStart + (tileCenterX / renderPixelsPerSecond) * speed;
       const nearestFrameIndex = Math.max(0, Math.round(tileTime));
       const frame = candidateFrameByIndex?.get(nearestFrameIndex)
-        ?? findClosestFrame(candidateFrames, tileTime);
+        ?? findClosestFrame(candidateFrames, tileTime)
+        // Fall back to full frame set — always cover gaps with the closest available frame
+        ?? findClosestFrame(frames, tileTime);
 
       if (frame) {
         result.push({ tileIndex: tile, frame, x: tileX, width: tileWidth });
@@ -552,6 +554,15 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     thumbnailWidth,
     renderWindow,
   ]);
+
+  // Pick a cover frame from the middle of available frames — used as a repeating
+  // CSS background behind tiles so gaps during zoom reconciliation show a frame
+  // instead of black.
+  const coverFrameUrl = useMemo(() => {
+    if (!frames || frames.length === 0) return null;
+    const mid = Math.floor(frames.length / 2);
+    return frames[mid]?.url ?? frames[0]?.url ?? null;
+  }, [frames]);
 
   if (error) {
     return null;
@@ -577,6 +588,11 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
       )}
       <div
         className="absolute inset-0 overflow-hidden pointer-events-none"
+        style={coverFrameUrl ? {
+          backgroundImage: `url(${coverFrameUrl})`,
+          backgroundRepeat: 'repeat-x',
+          backgroundSize: `${thumbnailWidth}px ${height}px`,
+        } : undefined}
       >
         {tiles.map(({ tileIndex, frame, x, width }) => (
           <FilmstripTile

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -557,12 +557,13 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
 
   // Pick a cover frame from the middle of available frames — used as a repeating
   // CSS background behind tiles so gaps during zoom reconciliation show a frame
-  // instead of black.
-  const coverFrameUrl = useMemo(() => {
+  // instead of black. Track the full frame for stale-URL probing.
+  const coverFrame = useMemo(() => {
     if (!frames || frames.length === 0) return null;
     const mid = Math.floor(frames.length / 2);
-    return frames[mid]?.url ?? frames[0]?.url ?? null;
+    return frames[mid] ?? frames[0] ?? null;
   }, [frames]);
+  const coverFrameUrl = coverFrame?.url ?? null;
 
   if (error) {
     return null;
@@ -607,6 +608,17 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
             onSourceError={handleFrameSourceError}
           />
         ))}
+        {/* Hidden probe to detect stale cover background URL */}
+        {coverFrame && !coverFrame.bitmap && (
+          <img
+            src={coverFrame.url}
+            alt=""
+            aria-hidden
+            className="absolute h-px w-px opacity-0 pointer-events-none"
+            style={{ left: 0, top: 0 }}
+            onError={() => handleFrameSourceError(coverFrame.index)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/features/timeline/components/clip-waveform/adaptive-render-version.test.ts
+++ b/src/features/timeline/components/clip-waveform/adaptive-render-version.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getWaveformActiveTileCount,
+  getWaveformZoomCommitPhaseMs,
   getWaveformZoomRedrawIntervalMs,
 } from './adaptive-render-version';
 
@@ -26,5 +27,14 @@ describe('adaptive waveform render version helpers', () => {
     expect(getWaveformZoomRedrawIntervalMs(4)).toBe(20);
     expect(getWaveformZoomRedrawIntervalMs(8)).toBe(24);
     expect(getWaveformZoomRedrawIntervalMs(12)).toBe(32);
+  });
+
+  it('adds a stable phase delay for heavier redraw batches', () => {
+    expect(getWaveformZoomCommitPhaseMs(2, 'media-1')).toBe(0);
+    expect(getWaveformZoomCommitPhaseMs(8, 'media-1')).toBe(
+      getWaveformZoomCommitPhaseMs(8, 'media-1'),
+    );
+    expect(getWaveformZoomCommitPhaseMs(12, 'media-1')).toBeGreaterThanOrEqual(0);
+    expect(getWaveformZoomCommitPhaseMs(12, 'media-1')).toBeLessThanOrEqual(72);
   });
 });

--- a/src/features/timeline/components/clip-waveform/adaptive-render-version.ts
+++ b/src/features/timeline/components/clip-waveform/adaptive-render-version.ts
@@ -12,6 +12,7 @@ interface AdaptiveWaveformRenderVersionOptions {
   baseVersion: string;
   pixelsPerSecond: number;
   activeTileCount: number;
+  phaseKey?: string;
 }
 
 function nowMs(): number {
@@ -46,10 +47,36 @@ export function getWaveformZoomRedrawIntervalMs(activeTileCount: number): number
   return 32;
 }
 
+function hashPhaseKey(phaseKey: string): number {
+  let hash = 0;
+  for (let i = 0; i < phaseKey.length; i += 1) {
+    hash = ((hash << 5) - hash) + phaseKey.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function getWaveformZoomCommitPhaseMs(activeTileCount: number, phaseKey?: string): number {
+  if (!phaseKey || activeTileCount <= 2) {
+    return 0;
+  }
+
+  if (activeTileCount <= 4) {
+    return (hashPhaseKey(phaseKey) % 2) * 8;
+  }
+
+  if (activeTileCount <= 8) {
+    return (hashPhaseKey(phaseKey) % 4) * 8;
+  }
+
+  return (hashPhaseKey(phaseKey) % 6) * 10;
+}
+
 export function useAdaptiveWaveformRenderVersion({
   baseVersion,
   pixelsPerSecond,
   activeTileCount,
+  phaseKey,
 }: AdaptiveWaveformRenderVersionOptions): string {
   const zoomVersion = useMemo(
     () => `e${Math.round(Math.max(1, pixelsPerSecond) * 1000)}`,
@@ -58,6 +85,10 @@ export function useAdaptiveWaveformRenderVersion({
   const redrawIntervalMs = useMemo(
     () => getWaveformZoomRedrawIntervalMs(activeTileCount),
     [activeTileCount],
+  );
+  const phaseDelayMs = useMemo(
+    () => getWaveformZoomCommitPhaseMs(activeTileCount, phaseKey),
+    [activeTileCount, phaseKey],
   );
   const [committedZoomVersion, setCommittedZoomVersion] = useState(zoomVersion);
   const latestZoomVersionRef = useRef(zoomVersion);
@@ -89,7 +120,11 @@ export function useAdaptiveWaveformRenderVersion({
     };
 
     const now = nowMs();
-    if (lastCommitAtRef.current === 0 || now - lastCommitAtRef.current >= redrawIntervalMs) {
+    const elapsedMs = now - lastCommitAtRef.current;
+    if (
+      lastCommitAtRef.current === 0
+      || (elapsedMs >= redrawIntervalMs && phaseDelayMs === 0)
+    ) {
       clearPending();
       commit();
       return;
@@ -99,17 +134,19 @@ export function useAdaptiveWaveformRenderVersion({
       return;
     }
 
-    const remainingMs = Math.max(0, redrawIntervalMs - (now - lastCommitAtRef.current));
+    const remainingMs = Math.max(0, redrawIntervalMs - elapsedMs);
+    const scheduledDelayMs = lastCommitAtRef.current === 0
+      ? phaseDelayMs
+      : remainingMs + phaseDelayMs;
     timeoutRef.current = setTimeout(() => {
       timeoutRef.current = null;
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null;
         commit();
       });
-    }, remainingMs);
-
+    }, scheduledDelayMs);
     return clearPending;
-  }, [committedZoomVersion, redrawIntervalMs, zoomVersion]);
+  }, [committedZoomVersion, phaseDelayMs, redrawIntervalMs, zoomVersion]);
 
   useEffect(() => {
     return () => {

--- a/src/features/timeline/components/clip-waveform/compound-clip-waveform.tsx
+++ b/src/features/timeline/components/clip-waveform/compound-clip-waveform.tsx
@@ -47,6 +47,7 @@ export const CompoundClipWaveform = memo(function CompoundClipWaveform({
   const requestTokenRef = useRef(0);
   const pixelsPerSecondRef = useRef(pixelsPerSecond);
   pixelsPerSecondRef.current = pixelsPerSecond;
+  const amplitudesBufferRef = useRef<Float32Array>(new Float32Array(0));
   const [height, setHeight] = useState(0);
   const [waveformsByMediaId, setWaveformsByMediaId] = useState<Map<string, CachedWaveform>>(new Map());
   const [isLoading, setIsLoading] = useState(false);
@@ -217,12 +218,17 @@ export const CompoundClipWaveform = memo(function CompoundClipWaveform({
     const currentPps = Math.max(1, pixelsPerSecondRef.current);
     const centerY = height / 2;
     const maxWaveHeight = Math.max(1, (height / 2) - WAVEFORM_VERTICAL_PADDING_PX);
-    const amplitudes = new Array<number>(tileWidth + 1).fill(0);
+    const amplitudeCount = tileWidth + 1;
+    if (amplitudesBufferRef.current.length < amplitudeCount) {
+      amplitudesBufferRef.current = new Float32Array(amplitudeCount);
+    }
+    const amplitudes = amplitudesBufferRef.current;
+    amplitudes.fill(0, 0, amplitudeCount);
 
     ctx.beginPath();
     ctx.moveTo(0, centerY);
 
-    for (let x = 0; x <= tileWidth; x += 1) {
+    for (let x = 0; x < amplitudeCount; x += 1) {
       const timelinePosition = (tileOffset + x) / currentPps;
       const compoundTime = sourceStart + timelinePosition;
 
@@ -273,10 +279,10 @@ export const CompoundClipWaveform = memo(function CompoundClipWaveform({
       amplitudes[x] = amp * maxWaveHeight;
     }
 
-    for (let x = 0; x <= tileWidth; x += 1) {
+    for (let x = 0; x < amplitudeCount; x += 1) {
       ctx.lineTo(x, centerY - amplitudes[x]!);
     }
-    for (let x = tileWidth; x >= 0; x -= 1) {
+    for (let x = amplitudeCount - 1; x >= 0; x -= 1) {
       ctx.lineTo(x, centerY + amplitudes[x]!);
     }
     ctx.closePath();
@@ -296,6 +302,7 @@ export const CompoundClipWaveform = memo(function CompoundClipWaveform({
     baseVersion: `${peaks?.length ?? 0}:${height}:${waveformsByMediaId.size}`,
     pixelsPerSecond,
     activeTileCount,
+    phaseKey: mediaIdsKey,
   });
 
   if (hasError) {

--- a/src/features/timeline/components/clip-waveform/index.tsx
+++ b/src/features/timeline/components/clip-waveform/index.tsx
@@ -73,6 +73,7 @@ export const ClipWaveform = memo(function ClipWaveform({
   const containerRef = useRef<HTMLDivElement>(null);
   const pixelsPerSecondRef = useRef(pixelsPerSecond);
   pixelsPerSecondRef.current = pixelsPerSecond;
+  const amplitudesBufferRef = useRef<Float32Array>(new Float32Array(0));
   const [height, setHeight] = useState(0);
   const conformStartedRef = useRef(false);
   const { blobUrl, setBlobUrl, hasStartedLoadingRef, blobUrlVersion } = useMediaBlobUrl(mediaId);
@@ -212,12 +213,17 @@ export const ClipWaveform = memo(function ClipWaveform({
       const currentPps = Math.max(1, pixelsPerSecondRef.current);
       const centerY = height / 2;
       const maxWaveHeight = Math.max(1, (height / 2) - WAVEFORM_VERTICAL_PADDING_PX);
-      const amplitudes = new Array<number>(tileWidth + 1).fill(0);
+      const amplitudeCount = tileWidth + 1;
+      if (amplitudesBufferRef.current.length < amplitudeCount) {
+        amplitudesBufferRef.current = new Float32Array(amplitudeCount);
+      }
+      const amplitudes = amplitudesBufferRef.current;
+      amplitudes.fill(0, 0, amplitudeCount);
 
       ctx.beginPath();
       ctx.moveTo(0, centerY);
 
-      for (let x = 0; x <= tileWidth; x++) {
+      for (let x = 0; x < amplitudeCount; x++) {
         const timelinePosition = (tileOffset + x) / currentPps;
         const sourceTime = effectiveStart + (timelinePosition * speed);
 
@@ -274,10 +280,10 @@ export const ClipWaveform = memo(function ClipWaveform({
         amplitudes[x] = amp * maxWaveHeight;
       }
 
-      for (let x = 0; x <= tileWidth; x++) {
+      for (let x = 0; x < amplitudeCount; x++) {
         ctx.lineTo(x, centerY - amplitudes[x]!);
       }
-      for (let x = tileWidth; x >= 0; x--) {
+      for (let x = amplitudeCount - 1; x >= 0; x--) {
         ctx.lineTo(x, centerY + amplitudes[x]!);
       }
       ctx.closePath();
@@ -314,6 +320,7 @@ export const ClipWaveform = memo(function ClipWaveform({
     baseVersion: `${loadedSamples}:${height}`,
     pixelsPerSecond,
     activeTileCount,
+    phaseKey: mediaId,
   });
 
   // Show empty state for unsupported/failed waveforms (no infinite skeleton).

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -7,7 +7,7 @@ import { useItemsStore } from '../stores/items-store';
 import { useTimelineSettingsStore } from '../stores/timeline-settings-store';
 import { useTimelineViewportStore } from '../stores/timeline-viewport-store';
 import { useTimelineZoom } from '../hooks/use-timeline-zoom';
-import { registerZoomTo100 } from '../stores/zoom-store';
+import { registerZoomTo100, useZoomStore } from '../stores/zoom-store';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useEditorStore } from '@/shared/state/editor';
 import { useSelectionStore } from '@/shared/state/selection';
@@ -443,6 +443,197 @@ const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
   return <MarqueeOverlay marqueeState={marqueeState} />;
 });
 
+interface TimelineTrackSectionsSurfaceProps {
+  tracksContainerRef: React.RefObject<HTMLDivElement | null>;
+  fps: number;
+  actualDuration: number;
+  containerWidth: number;
+  initialTimelineWidth: number;
+  hasTrackSections: boolean;
+  videoTracks: TimelineTrackType[];
+  audioTracks: TimelineTrackType[];
+  singleSectionTracks: TimelineTrackType[];
+  singleSectionKind: 'video' | 'audio';
+  videoPaneHeight: number;
+  audioPaneHeight: number;
+  singleSectionHeight: number;
+  videoZoneHeight: number;
+  audioZoneHeight: number;
+  singleSectionZoneHeight: number;
+  topZoneAnchorTrackId: string | null;
+  bottomZoneAnchorTrackId: string | null;
+  singleSectionAnchorTrackId: string | null;
+  onSectionDividerMouseDown?: (event: React.MouseEvent) => void;
+  allTracksScrollRef?: React.RefObject<HTMLDivElement | null>;
+  videoTracksScrollRef?: React.RefObject<HTMLDivElement | null>;
+  audioTracksScrollRef?: React.RefObject<HTMLDivElement | null>;
+  children?: React.ReactNode;
+}
+
+const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface({
+  tracksContainerRef,
+  fps,
+  actualDuration,
+  containerWidth,
+  initialTimelineWidth,
+  hasTrackSections,
+  videoTracks,
+  audioTracks,
+  singleSectionTracks,
+  singleSectionKind,
+  videoPaneHeight,
+  audioPaneHeight,
+  singleSectionHeight,
+  videoZoneHeight,
+  audioZoneHeight,
+  singleSectionZoneHeight,
+  topZoneAnchorTrackId,
+  bottomZoneAnchorTrackId,
+  singleSectionAnchorTrackId,
+  onSectionDividerMouseDown,
+  allTracksScrollRef,
+  videoTracksScrollRef,
+  audioTracksScrollRef,
+  children,
+}: TimelineTrackSectionsSurfaceProps) {
+  const initialPixelsPerSecondRef = useRef(useZoomStore.getState().pixelsPerSecond);
+
+  const applyLiveTrackSurfaceStyles = useCallback(() => {
+    const node = tracksContainerRef.current;
+    if (!node) {
+      return;
+    }
+
+    const { pixelsPerSecond } = useZoomStore.getState();
+    const effectiveContainerWidth = containerWidth > 0 ? containerWidth : 1920;
+    const liveTimelineWidth = getTimelineWidth({
+      contentWidth: actualDuration * pixelsPerSecond,
+      viewportWidth: effectiveContainerWidth,
+    });
+
+    node.style.width = `${liveTimelineWidth}px`;
+    node.style.setProperty(
+      '--timeline-px-per-frame',
+      fps > 0 ? `${pixelsPerSecond / fps}px` : '0px',
+    );
+    node.style.setProperty('--timeline-pixels-per-second', `${pixelsPerSecond}px`);
+  }, [actualDuration, containerWidth, fps, tracksContainerRef]);
+
+  useLayoutEffect(() => {
+    applyLiveTrackSurfaceStyles();
+  }, [applyLiveTrackSurfaceStyles]);
+
+  useEffect(() => {
+    return useZoomStore.subscribe((state, previousState) => {
+      if (
+        state.pixelsPerSecond === previousState.pixelsPerSecond
+        && state.level === previousState.level
+      ) {
+        return;
+      }
+      applyLiveTrackSurfaceStyles();
+    });
+  }, [applyLiveTrackSurfaceStyles]);
+
+  const renderTrackSection = (
+    sectionTracks: TimelineTrackType[],
+    options: {
+      section: 'video' | 'audio';
+      height: number;
+      zoneHeight: number;
+      anchorTrackId: string | null;
+      showTopDividerForFirstTrack: boolean;
+      scrollRef?: React.RefObject<HTMLDivElement | null>;
+    }
+  ) => (
+    <div
+      ref={options.scrollRef}
+      data-track-section-scroll={options.section}
+      className="min-h-0 overflow-y-auto overflow-x-hidden"
+      style={{ height: `${options.height}px` }}
+    >
+      <div className="relative min-h-full">
+        {options.section === 'video' && options.anchorTrackId && (
+          <TimelineMediaDropZone
+            height={options.zoneHeight}
+            zone="video"
+            anchorTrackId={options.anchorTrackId}
+          />
+        )}
+        {options.section === 'video' && !options.anchorTrackId && (
+          <div aria-hidden="true" style={{ height: `${options.zoneHeight}px` }} />
+        )}
+
+        {sectionTracks.map((track, index) => (
+          <TrackRowFrame
+            key={track.id}
+            showTopDivider={options.showTopDividerForFirstTrack && index === 0}
+          >
+            <TimelineTrack track={track} />
+          </TrackRowFrame>
+        ))}
+
+        {options.section === 'audio' && options.anchorTrackId && (
+          <TimelineMediaDropZone
+            height={options.zoneHeight}
+            zone="audio"
+            anchorTrackId={options.anchorTrackId}
+          />
+        )}
+        {options.section === 'audio' && !options.anchorTrackId && (
+          <div aria-hidden="true" style={{ height: `${options.zoneHeight}px` }} />
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div
+      id="timeline-track-sections"
+      ref={tracksContainerRef}
+      className="relative timeline-tracks flex flex-1 min-h-0 flex-col"
+      style={{
+        width: `${initialTimelineWidth}px`,
+        contain: 'layout style paint',
+        '--timeline-px-per-frame': fps > 0 ? `${initialPixelsPerSecondRef.current / fps}px` : '0px',
+        '--timeline-pixels-per-second': `${initialPixelsPerSecondRef.current}px`,
+      } as React.CSSProperties}
+    >
+      {hasTrackSections ? (
+        <>
+          {renderTrackSection(videoTracks, {
+            section: 'video',
+            height: videoPaneHeight,
+            zoneHeight: videoZoneHeight,
+            anchorTrackId: topZoneAnchorTrackId,
+            showTopDividerForFirstTrack: true,
+            scrollRef: videoTracksScrollRef,
+          })}
+          <TrackSectionDivider onMouseDown={onSectionDividerMouseDown} />
+          {renderTrackSection(audioTracks, {
+            section: 'audio',
+            height: audioPaneHeight,
+            zoneHeight: audioZoneHeight,
+            anchorTrackId: bottomZoneAnchorTrackId,
+            showTopDividerForFirstTrack: false,
+            scrollRef: audioTracksScrollRef,
+          })}
+        </>
+      ) : (
+        renderTrackSection(singleSectionTracks, {
+          section: singleSectionKind,
+          height: singleSectionHeight,
+          zoneHeight: singleSectionZoneHeight,
+          anchorTrackId: singleSectionAnchorTrackId,
+          showTopDividerForFirstTrack: true,
+          scrollRef: allTracksScrollRef,
+        })
+      )}
+      {children}
+    </div>
+  );
+});
+
 /**
  * Timeline Content Component
  *
@@ -512,10 +703,17 @@ export const TimelineContent = memo(function TimelineContent({
   // O(1) pre-computed value from items store instead of O(n) reduce on every change
   const furthestItemEndFrame = useItemsStore((s) => s.maxItemEndFrame);
   const maxTimelineFrame = Math.floor(Math.max(furthestItemEndFrame / fps, 10) * fps);
-  const { timeToPixels, frameToPixels, pixelsToFrame, setZoomImmediate, zoomLevel } = useTimelineZoom({
+  const {
+    pixelsPerSecond,
+    frameToPixels,
+    pixelsToFrame,
+    setZoomImmediate,
+    zoomLevel,
+  } = useTimelineZoom({
     minZoom: 0.01,
     maxZoom: 2, // Match slider range
   });
+  const contentPixelsPerSecond = useZoomStore((s) => s.contentPixelsPerSecond);
   // NOTE: Don't subscribe to currentFrame here - it would cause re-renders every frame!
   // Use refs to access it in callbacks instead (see currentFrameRef below)
   const selectItems = useSelectionStore((s) => s.selectItems);
@@ -1007,7 +1205,7 @@ export const TimelineContent = memo(function TimelineContent({
 
   // Calculate the actual timeline duration and width based on content
   // Uses derived furthestItemEndFrame selector instead of full items array
-  const { actualDuration, timelineWidth } = useMemo(() => {
+  const { actualDuration, timelineWidth, contentTimelineWidth } = useMemo(() => {
     // Convert furthest item end from frames to seconds
     const furthestItemEnd = furthestItemEndFrame / fps;
 
@@ -1017,18 +1215,23 @@ export const TimelineContent = memo(function TimelineContent({
     // Keep the visible fit behavior, but leave extra space after the project end
     // so the user can still scroll a bit farther to the right when needed.
     const effectiveContainerWidth = containerWidth > 0 ? containerWidth : 1920;
-    const contentWidth = timeToPixels(contentDuration);
+    const liveContentWidth = contentDuration * pixelsPerSecond;
+    const settledContentWidth = contentDuration * contentPixelsPerSecond;
 
     // Timeline width is based on content only - don't depend on scroll position
     // This prevents feedback loops during zoom where scroll->width->scroll causes gradual shifts
     return {
       actualDuration: contentDuration,
       timelineWidth: getTimelineWidth({
-        contentWidth,
+        contentWidth: liveContentWidth,
+        viewportWidth: effectiveContainerWidth,
+      }),
+      contentTimelineWidth: getTimelineWidth({
+        contentWidth: settledContentWidth,
         viewportWidth: effectiveContainerWidth,
       }),
     };
-  }, [furthestItemEndFrame, fps, timeToPixels, containerWidth]);
+  }, [furthestItemEndFrame, fps, pixelsPerSecond, contentPixelsPerSecond, containerWidth]);
 
   actualDurationRef.current = actualDuration;
 
@@ -1154,9 +1357,9 @@ export const TimelineContent = memo(function TimelineContent({
     // Apply zoom and reset scroll to start
     pendingScrollRef.current = 0;
     scrollLeftRef.current = 0;
-    setZoomImmediate(newZoomLevel);
+    useZoomStore.getState().setZoomLevelSynchronized(newZoomLevel);
     container.scrollLeft = 0;
-  }, [clearQueuedZoomApply, setZoomImmediate]);
+  }, [clearQueuedZoomApply]);
 
   const handleZoomTo100 = useCallback((centerFrame: number) => {
     const container = containerRef.current;
@@ -1174,8 +1377,8 @@ export const TimelineContent = memo(function TimelineContent({
     pendingScrollRef.current = newScrollLeft;
     scrollLeftRef.current = newScrollLeft;
 
-    setZoomImmediate(1);
-  }, [clearQueuedZoomApply, setZoomImmediate]);
+    useZoomStore.getState().setZoomLevelSynchronized(1);
+  }, [clearQueuedZoomApply]);
 
   // Register zoom-to-100 handler globally so keyboard shortcuts can use it
   useEffect(() => {
@@ -1412,58 +1615,6 @@ export const TimelineContent = memo(function TimelineContent({
     videoSectionContentHeight,
     audioSectionContentHeight,
   ]);
-  const renderTrackSection = (
-    sectionTracks: TimelineTrackType[],
-    options: {
-      section: 'video' | 'audio';
-      height: number;
-      zoneHeight: number;
-      anchorTrackId: string | null;
-      showTopDividerForFirstTrack: boolean;
-      scrollRef?: React.RefObject<HTMLDivElement | null>;
-    }
-  ) => (
-    <div
-      ref={options.scrollRef}
-      data-track-section-scroll={options.section}
-      className="min-h-0 overflow-y-auto overflow-x-hidden"
-      style={{ height: `${options.height}px` }}
-    >
-      <div className="relative min-h-full">
-        {options.section === 'video' && options.anchorTrackId && (
-          <TimelineMediaDropZone
-            height={options.zoneHeight}
-            zone="video"
-            anchorTrackId={options.anchorTrackId}
-          />
-        )}
-        {options.section === 'video' && !options.anchorTrackId && (
-          <div aria-hidden="true" style={{ height: `${options.zoneHeight}px` }} />
-        )}
-
-        {sectionTracks.map((track, index) => (
-          <TrackRowFrame
-            key={track.id}
-            showTopDivider={options.showTopDividerForFirstTrack && index === 0}
-          >
-            <TimelineTrack track={track} />
-          </TrackRowFrame>
-        ))}
-
-        {options.section === 'audio' && options.anchorTrackId && (
-          <TimelineMediaDropZone
-            height={options.zoneHeight}
-            zone="audio"
-            anchorTrackId={options.anchorTrackId}
-          />
-        )}
-        {options.section === 'audio' && !options.anchorTrackId && (
-          <div aria-hidden="true" style={{ height: `${options.zoneHeight}px` }} />
-        )}
-      </div>
-    </div>
-  );
-
   const anyOverflow = hasTrackSections
     ? (videoSectionHasOverflow || audioSectionHasOverflow)
     : singleSectionHasOverflow;
@@ -1496,55 +1647,38 @@ export const TimelineContent = memo(function TimelineContent({
           <TimelinePlayhead inRuler maxFrame={maxTimelineFrame} />
         </div>
 
-        <div
-          id="timeline-track-sections"
-          ref={tracksContainerRef}
-          className="relative timeline-tracks flex flex-1 min-h-0 flex-col"
-          style={{
-            width: `${timelineWidth}px`,
-            contain: 'layout style paint',
-            '--timeline-px-per-frame': fps > 0 ? `${(zoomLevel * 100) / fps}px` : '0px',
-            '--timeline-pixels-per-second': `${zoomLevel * 100}px`,
-          } as React.CSSProperties}
+        <TimelineTrackSectionsSurface
+          tracksContainerRef={tracksContainerRef}
+          fps={fps}
+          actualDuration={actualDuration}
+          containerWidth={containerWidth}
+          initialTimelineWidth={contentTimelineWidth}
+          hasTrackSections={hasTrackSections}
+          videoTracks={videoTracks}
+          audioTracks={audioTracks}
+          singleSectionTracks={singleSectionTracks}
+          singleSectionKind={singleSectionKind}
+          videoPaneHeight={videoPaneHeight}
+          audioPaneHeight={audioPaneHeight}
+          singleSectionHeight={singleSectionHeight}
+          videoZoneHeight={videoZoneHeight}
+          audioZoneHeight={audioZoneHeight}
+          singleSectionZoneHeight={singleSectionZoneHeight}
+          topZoneAnchorTrackId={topZoneAnchorTrackId}
+          bottomZoneAnchorTrackId={bottomZoneAnchorTrackId}
+          singleSectionAnchorTrackId={singleSectionAnchorTrackId}
+          onSectionDividerMouseDown={onSectionDividerMouseDown}
+          allTracksScrollRef={allTracksScrollRef}
+          videoTracksScrollRef={videoTracksScrollRef}
+          audioTracksScrollRef={audioTracksScrollRef}
         >
-          {hasTrackSections ? (
-            <>
-              {renderTrackSection(videoTracks, {
-                section: 'video',
-                height: videoPaneHeight,
-                zoneHeight: videoZoneHeight,
-                anchorTrackId: topZoneAnchorTrackId,
-                showTopDividerForFirstTrack: true,
-                scrollRef: videoTracksScrollRef,
-              })}
-              <TrackSectionDivider onMouseDown={onSectionDividerMouseDown} />
-              {renderTrackSection(audioTracks, {
-                section: 'audio',
-                height: audioPaneHeight,
-                zoneHeight: audioZoneHeight,
-                anchorTrackId: bottomZoneAnchorTrackId,
-                showTopDividerForFirstTrack: false,
-                scrollRef: audioTracksScrollRef,
-              })}
-            </>
-          ) : (
-            renderTrackSection(singleSectionTracks, {
-              section: singleSectionKind,
-              height: singleSectionHeight,
-              zoneHeight: singleSectionZoneHeight,
-              anchorTrackId: singleSectionAnchorTrackId,
-              showTopDividerForFirstTrack: true,
-              scrollRef: allTracksScrollRef,
-            })
-          )}
-
           {isDragging && (
             <TimelineGuidelines />
           )}
 
           <TimelinePreviewScrubber maxFrame={maxTimelineFrame} />
           <TimelinePlayhead maxFrame={maxTimelineFrame} />
-        </div>
+        </TimelineTrackSectionsSurface>
       </div>
 
       {anyOverflow && (
@@ -1577,3 +1711,4 @@ export const TimelineContent = memo(function TimelineContent({
     </div>
   );
 });
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -1619,6 +1619,15 @@ export const TimelineContent = memo(function TimelineContent({
     ? (videoSectionHasOverflow || audioSectionHasOverflow)
     : singleSectionHasOverflow;
 
+  // Stable children reference for TimelineTrackSectionsSurface memo boundary
+  const trackSurfaceOverlayChildren = useMemo(() => (
+    <>
+      {isDragging && <TimelineGuidelines />}
+      <TimelinePreviewScrubber maxFrame={maxTimelineFrame} />
+      <TimelinePlayhead maxFrame={maxTimelineFrame} />
+    </>
+  ), [isDragging, maxTimelineFrame]);
+
   return (
     <div className="flex flex-1 min-h-0 min-w-0 bg-background/30">
       <div
@@ -1672,12 +1681,7 @@ export const TimelineContent = memo(function TimelineContent({
           videoTracksScrollRef={videoTracksScrollRef}
           audioTracksScrollRef={audioTracksScrollRef}
         >
-          {isDragging && (
-            <TimelineGuidelines />
-          )}
-
-          <TimelinePreviewScrubber maxFrame={maxTimelineFrame} />
-          <TimelinePlayhead maxFrame={maxTimelineFrame} />
+          {trackSurfaceOverlayChildren}
         </TimelineTrackSectionsSurface>
       </div>
 

--- a/src/features/timeline/components/timeline-in-out-markers.tsx
+++ b/src/features/timeline/components/timeline-in-out-markers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, memo, forwardRef } from 'react';
+import { useCallback, useMemo, useRef, useEffect, memo, forwardRef } from 'react';
 
 import { useTimelineStore } from '../stores/timeline-store';
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context';
@@ -28,6 +28,9 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
   setInPointRef.current = setInPoint;
   setOutPointRef.current = setOutPoint;
 
+  // Store active drag cleanup so we can tear down on unmount
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
   const startDrag = useCallback(
     (handle: 'in' | 'out') => (e: React.MouseEvent) => {
       e.preventDefault();
@@ -46,19 +49,24 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
         const x = ev.clientX - rect.left;
         setter.current(Math.max(0, pixelsToFrameRef.current(x)));
       };
-      const onUp = () => {
+      const cleanup = () => {
         document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
+        document.removeEventListener('mouseup', cleanup);
         document.body.style.cursor = prevCursor;
+        dragCleanupRef.current = null;
       };
       document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
+      document.addEventListener('mouseup', cleanup);
+      dragCleanupRef.current = cleanup;
     },
     [],
   );
 
-  const handleInDown = useRef(startDrag('in')).current;
-  const handleOutDown = useRef(startDrag('out')).current;
+  // Tear down listeners if component unmounts mid-drag
+  useEffect(() => () => { dragCleanupRef.current?.(); }, []);
+
+  const handleInDown = useMemo(() => startDrag('in'), [startDrag]);
+  const handleOutDown = useMemo(() => startDrag('out'), [startDrag]);
 
   return (
     <>

--- a/src/features/timeline/components/timeline-in-out-markers.tsx
+++ b/src/features/timeline/components/timeline-in-out-markers.tsx
@@ -1,19 +1,16 @@
-// React and external libraries
-import { useState, useCallback, useEffect, useRef, memo } from 'react';
+import { useCallback, useRef, memo, forwardRef } from 'react';
 
-// Stores and selectors
 import { useTimelineStore } from '../stores/timeline-store';
-
-// Utilities and hooks
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context';
 
+const IO_LANE_HEIGHT = 14;
+const IO_HIT_AREA_HEIGHT = IO_LANE_HEIGHT + 6;
+const IO_HANDLE_WIDTH = 6;
+const IO_HANDLE_COLOR = 'var(--color-timeline-io-handle)';
+
 /**
- * Timeline In/Out Markers Component
- *
- * Renders in and out point markers on the timeline ruler
- * - Vertical bars with 'I' and 'O' flags
- * - Draggable for adjusting marker positions
- * - Synchronized with timeline store
+ * Timeline In/Out Markers — isolated in its own memo boundary so zoom-driven
+ * position updates only re-render these 2 marker divs, not the parent ruler.
  */
 export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
   const inPoint = useTimelineStore((s) => s.inPoint);
@@ -22,164 +19,117 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
   const setOutPoint = useTimelineStore((s) => s.setOutPoint);
   const { frameToPixels, pixelsToFrame } = useTimelineZoomContext();
 
-  const [isDraggingIn, setIsDraggingIn] = useState(false);
-  const [isDraggingOut, setIsDraggingOut] = useState(false);
   const inMarkerRef = useRef<HTMLDivElement>(null);
   const outMarkerRef = useRef<HTMLDivElement>(null);
-
-  // Use refs to avoid stale closures
   const pixelsToFrameRef = useRef(pixelsToFrame);
   const setInPointRef = useRef(setInPoint);
   const setOutPointRef = useRef(setOutPoint);
+  pixelsToFrameRef.current = pixelsToFrame;
+  setInPointRef.current = setInPoint;
+  setOutPointRef.current = setOutPoint;
 
-  // Update refs when functions change
-  useEffect(() => {
-    pixelsToFrameRef.current = pixelsToFrame;
-    setInPointRef.current = setInPoint;
-    setOutPointRef.current = setOutPoint;
-  }, [pixelsToFrame, setInPoint, setOutPoint]);
+  const startDrag = useCallback(
+    (handle: 'in' | 'out') => (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-  // Handle drag start for in-point
-  const handleInMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDraggingIn(true);
-  }, []);
-
-  // Handle drag start for out-point
-  const handleOutMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDraggingOut(true);
-  }, []);
-
-  // Handle dragging in-point
-  useEffect(() => {
-    if (!isDraggingIn) return;
-
-    const originalCursor = document.body.style.cursor;
-    document.body.style.cursor = 'col-resize';
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const container = inMarkerRef.current?.closest('.timeline-ruler');
+      const container = (handle === 'in' ? inMarkerRef : outMarkerRef)
+        .current?.closest('.timeline-ruler');
       if (!container) return;
 
-      const rect = container.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const frame = Math.max(0, pixelsToFrameRef.current(x));
+      const setter = handle === 'in' ? setInPointRef : setOutPointRef;
+      const prevCursor = document.body.style.cursor;
+      document.body.style.cursor = 'col-resize';
 
-      // setInPoint will handle validation (moving out-point to last frame if needed)
-      setInPointRef.current(frame);
-    };
-
-    const handleMouseUp = () => {
-      setIsDraggingIn(false);
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      document.body.style.cursor = originalCursor;
-    };
-  }, [isDraggingIn]);
-
-  // Handle dragging out-point
-  useEffect(() => {
-    if (!isDraggingOut) return;
-
-    const originalCursor = document.body.style.cursor;
-    document.body.style.cursor = 'col-resize';
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const container = outMarkerRef.current?.closest('.timeline-ruler');
-      if (!container) return;
-
-      const rect = container.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const frame = Math.max(0, pixelsToFrameRef.current(x));
-
-      // setOutPoint will handle validation (moving in-point to frame 0 if needed)
-      setOutPointRef.current(frame);
-    };
-
-    const handleMouseUp = () => {
-      setIsDraggingOut(false);
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      document.body.style.cursor = originalCursor;
-    };
-  }, [isDraggingOut]);
-
-  const ioHandleColor = 'var(--color-timeline-io-handle)';
-  const ioLaneHeight = 14;
-  const ioHitAreaHeight = ioLaneHeight + 6;
-  const ioHandleWidth = 6;
-  const ioHandleInset = 0;
-
-  const renderMarker = (
-    markerRef: React.RefObject<HTMLDivElement | null>,
-    positionPx: number,
-    onMouseDown: (e: React.MouseEvent) => void,
-    side: 'in' | 'out'
-  ) => (
-    <div
-      ref={markerRef}
-      className="absolute top-0"
-      style={{
-        left: `${positionPx}px`,
-        width: '2px',
-        height: '100%',
-        pointerEvents: 'none',
-        zIndex: 22,
-      }}
-    >
-      {/* Side grip handle aligned to range edge */}
-        <div
-          className="absolute pointer-events-none"
-          style={{
-            bottom: '0px',
-            left: side === 'in' ? `${ioHandleInset}px` : `${-ioHandleWidth}px`,
-            width: `${ioHandleWidth}px`,
-            height: `${ioLaneHeight}px`,
-          borderRadius: '2px',
-          background: `linear-gradient(to bottom, ${ioHandleColor}, color-mix(in oklch, ${ioHandleColor} 75%, black))`,
-          boxShadow: `0 0 6px color-mix(in oklch, ${ioHandleColor} 55%, transparent)`,
-        }}
-      />
-
-      {/* Invisible hit area for dragging */}
-      <div
-        className="absolute pointer-events-auto"
-        style={{
-          bottom: '0px',
-          height: `${ioHitAreaHeight}px`,
-          left: '-8px',
-          width: '18px',
-          cursor: 'col-resize',
-        }}
-        onMouseDown={onMouseDown}
-      />
-    </div>
+      const onMove = (ev: MouseEvent) => {
+        const rect = container.getBoundingClientRect();
+        const x = ev.clientX - rect.left;
+        setter.current(Math.max(0, pixelsToFrameRef.current(x)));
+      };
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.style.cursor = prevCursor;
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [],
   );
+
+  const handleInDown = useRef(startDrag('in')).current;
+  const handleOutDown = useRef(startDrag('out')).current;
 
   return (
     <>
-      {/* In-point marker */}
-      {inPoint !== null &&
-        renderMarker(inMarkerRef, frameToPixels(inPoint), handleInMouseDown, 'in')}
-
-      {/* Out-point marker */}
-      {outPoint !== null &&
-        renderMarker(outMarkerRef, frameToPixels(outPoint), handleOutMouseDown, 'out')}
+      {inPoint !== null && (
+        <IOMarker
+          ref={inMarkerRef}
+          positionPx={frameToPixels(inPoint)}
+          side="in"
+          onMouseDown={handleInDown}
+        />
+      )}
+      {outPoint !== null && (
+        <IOMarker
+          ref={outMarkerRef}
+          positionPx={frameToPixels(outPoint)}
+          side="out"
+          onMouseDown={handleOutDown}
+        />
+      )}
     </>
   );
 });
+
+interface IOMarkerProps {
+  positionPx: number;
+  side: 'in' | 'out';
+  onMouseDown: (e: React.MouseEvent) => void;
+}
+
+const IOMarker = memo(
+  forwardRef<HTMLDivElement, IOMarkerProps>(function IOMarker({ positionPx, side, onMouseDown }, ref) {
+    return (
+      <div
+        ref={ref}
+        className="absolute top-0"
+        style={{
+          left: positionPx,
+          width: '2px',
+          height: '100%',
+          pointerEvents: 'none',
+          zIndex: 22,
+        }}
+      >
+        {/* Side grip handle */}
+        <div
+          className="absolute pointer-events-none"
+          style={{
+            bottom: 0,
+            left: side === 'in' ? 0 : -IO_HANDLE_WIDTH,
+            width: IO_HANDLE_WIDTH,
+            height: IO_LANE_HEIGHT,
+            borderRadius: '2px',
+            background: `linear-gradient(to bottom, ${IO_HANDLE_COLOR}, color-mix(in oklch, ${IO_HANDLE_COLOR} 75%, black))`,
+            boxShadow: `0 0 6px color-mix(in oklch, ${IO_HANDLE_COLOR} 55%, transparent)`,
+          }}
+        />
+
+        {/* Invisible hit area for dragging */}
+        <div
+          className="absolute pointer-events-auto"
+          style={{
+            bottom: 0,
+            height: IO_HIT_AREA_HEIGHT,
+            left: -8,
+            width: 18,
+            cursor: 'col-resize',
+          }}
+          onMouseDown={onMouseDown}
+        />
+      </div>
+    );
+  }),
+);
+IOMarker.displayName = 'IOMarker';

--- a/src/features/timeline/components/timeline-item/clip-content.test.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { TimelineItem } from '@/types/timeline';
 import { useSettingsStore } from '@/features/timeline/deps/settings';
@@ -7,6 +7,30 @@ import { useItemsStore } from '../../stores/items-store';
 import { useTimelineStore } from '../../stores/timeline-store';
 import { useZoomStore, _resetZoomStoreForTest } from '../../stores/zoom-store';
 import { ClipContent } from './clip-content';
+
+vi.mock('../clip-filmstrip', () => ({
+  ClipFilmstrip: ({ pixelsPerSecond }: { pixelsPerSecond: number }) => (
+    <div data-testid="clip-filmstrip" data-pps={String(pixelsPerSecond)} />
+  ),
+}));
+
+vi.mock('../clip-filmstrip/image-filmstrip', () => ({
+  ImageFilmstrip: ({ pixelsPerSecond }: { pixelsPerSecond: number }) => (
+    <div data-testid="image-filmstrip" data-pps={String(pixelsPerSecond)} />
+  ),
+}));
+
+vi.mock('../clip-waveform', () => ({
+  ClipWaveform: ({ pixelsPerSecond }: { pixelsPerSecond: number }) => (
+    <div data-testid="clip-waveform" data-pps={String(pixelsPerSecond)} />
+  ),
+}));
+
+vi.mock('../clip-waveform/compound-clip-waveform', () => ({
+  CompoundClipWaveform: ({ pixelsPerSecond }: { pixelsPerSecond: number }) => (
+    <div data-testid="compound-clip-waveform" data-pps={String(pixelsPerSecond)} />
+  ),
+}));
 
 describe('ClipContent', () => {
   beforeEach(() => {
@@ -79,5 +103,78 @@ describe('ClipContent', () => {
 
     expect(screen.getByTitle('Linked audio/video pair')).toBeInTheDocument();
     expect(screen.getByText('Linked clip')).toBeInTheDocument();
+  });
+
+  it('uses settled zoom for filmstrip content by default', () => {
+    useZoomStore.setState({
+      level: 1.8,
+      pixelsPerSecond: 180,
+      contentLevel: 1,
+      contentPixelsPerSecond: 100,
+      isZoomInteracting: true,
+    });
+    useSettingsStore.setState({
+      showFilmstrips: true,
+      showWaveforms: false,
+    });
+
+    const item: TimelineItem = {
+      id: 'video-1',
+      type: 'video',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Video clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+    } as TimelineItem;
+
+    render(
+      <ClipContent
+        item={item}
+        clipLeftFrames={0}
+        clipWidthFrames={96}
+        fps={30}
+      />,
+    );
+
+    expect(screen.getByTestId('clip-filmstrip')).toHaveAttribute('data-pps', '180');
+  });
+
+  it('can opt clip internals into live zoom for immediate edit previews', () => {
+    useZoomStore.setState({
+      level: 1.8,
+      pixelsPerSecond: 180,
+      contentLevel: 1,
+      contentPixelsPerSecond: 100,
+      isZoomInteracting: true,
+    });
+    useSettingsStore.setState({
+      showFilmstrips: false,
+      showWaveforms: true,
+    });
+
+    const item: TimelineItem = {
+      id: 'audio-1',
+      type: 'audio',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Audio clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+    } as TimelineItem;
+
+    render(
+      <ClipContent
+        item={item}
+        clipLeftFrames={0}
+        clipWidthFrames={96}
+        fps={30}
+        preferImmediateRendering={true}
+      />,
+    );
+
+    expect(screen.getByTestId('clip-waveform')).toHaveAttribute('data-pps', '180');
   });
 });

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -94,7 +94,8 @@ export const ClipContent = memo(function ClipContent({
   );
   const compositionSummary = useMemo(() => {
     if (!composition) {
-      return {   visualMediaId: null,
+      return {
+        visualMediaId: null,
         audioMediaId: null,
         hasOwnedAudio: false,
         hasMultipleOwnedAudioSources: false,

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -58,13 +58,15 @@ export const ClipContent = memo(function ClipContent({
   audioWaveformScale = 1,
   linkedSyncOffsetFrames = null,
 }: ClipContentProps) {
-  //   // Keep clip visuals in live zoom space while zooming so inner content stays locked to the shell
-  const isZoomInteracting = useZoomStore((s) => s.isZoomInteracting);
-  const livePixelsPerSecond = useZoomStore((s) => s.pixelsPerSecond);
-  const settledPixelsPerSecond = useZoomStore((s) => s.contentPixelsPerSecond);
-  const pixelsPerSecond = (preferImmediateRendering || isZoomInteracting)
-    ? livePixelsPerSecond
-    : settledPixelsPerSecond;
+  // Single zoom subscription: live value only for clips that need immediate rendering
+  // (e.g. during drag), settled value for everything else — avoids N re-renders per zoom tick.
+  const pixelsPerSecond = useZoomStore(
+    useCallback(
+      (s: { pixelsPerSecond: number; contentPixelsPerSecond: number }) =>
+        preferImmediateRendering ? s.pixelsPerSecond : s.contentPixelsPerSecond,
+      [preferImmediateRendering]
+    )
+  );
   const showWaveforms = useSettingsStore((s) => s.showWaveforms);
   const showFilmstrips = useSettingsStore((s) => s.showFilmstrips);
   const clipLeftPx = useMemo(

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -18,6 +18,7 @@ import { formatSignedFrameDelta } from '@/utils/time-utils';
 import { isGifUrl, isWebpUrl } from '@/utils/media-utils';
 
 const EMPTY_COMPOSITION_LOOKUP: Record<string, never> = {};
+const FILMSTRIP_MIN_WIDTH_PX = 5;
 
 /**
  * Small render buffer: filmstrip/waveform are rendered slightly wider than the
@@ -229,6 +230,8 @@ export const ClipContent = memo(function ClipContent({
     </div>
   ), [renderTitleText]);
 
+  const showVisualContent = clipWidth >= FILMSTRIP_MIN_WIDTH_PX;
+
   // Video clip 2-row layout: label | filmstrip
   if (item.type === 'video' && item.mediaId) {
     return (
@@ -244,25 +247,27 @@ export const ClipContent = memo(function ClipContent({
           {renderTitleText(item.label)}
         </div>
         {/* Row 2: Filmstrip - flex-1 to fill remaining space */}
-        <div className="relative overflow-hidden flex-1 min-h-0">
-          {showFilmstrips && (
-            <ClipFilmstrip
-              mediaId={item.mediaId}
-              clipWidth={clipWidth}
-              renderWidth={renderWidth}
-              sourceStart={sourceStart}
-              sourceDuration={sourceDuration}
-              trimStart={trimStart}
-              speed={speed}
-              fps={fps}
-              isVisible={clipVisibility.isVisible}
-              visibleStartRatio={clipVisibility.visibleStartRatio}
-              visibleEndRatio={clipVisibility.visibleEndRatio}
-              pixelsPerSecond={pixelsPerSecond}
-              preferImmediateRendering={preferImmediateRendering}
-            />
-          )}
-        </div>
+        {showVisualContent && (
+          <div className="relative overflow-hidden flex-1 min-h-0">
+            {showFilmstrips && (
+              <ClipFilmstrip
+                mediaId={item.mediaId}
+                clipWidth={clipWidth}
+                renderWidth={renderWidth}
+                sourceStart={sourceStart}
+                sourceDuration={sourceDuration}
+                trimStart={trimStart}
+                speed={speed}
+                fps={fps}
+                isVisible={clipVisibility.isVisible}
+                visibleStartRatio={clipVisibility.visibleStartRatio}
+                visibleEndRatio={clipVisibility.visibleEndRatio}
+                pixelsPerSecond={pixelsPerSecond}
+                preferImmediateRendering={preferImmediateRendering}
+              />
+            )}
+          </div>
+        )}
       </div>
     );
   }
@@ -282,7 +287,7 @@ export const ClipContent = memo(function ClipContent({
           {renderTitleText(item.label)}
         </div>
         {/* Row 2: Waveform - fills remaining space */}
-        {showWaveforms && (
+        {showVisualContent && showWaveforms && (
           <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
             <div
               className="absolute inset-0"
@@ -316,7 +321,7 @@ export const ClipContent = memo(function ClipContent({
     return (
       <div className="absolute inset-0 flex flex-col">
         {renderCompoundClipLabel(item.label || 'Compound Clip')}
-        {showWaveforms && (
+        {showVisualContent && showWaveforms && (
           <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
             <CompoundClipWaveform
               composition={composition}
@@ -353,44 +358,48 @@ export const ClipContent = memo(function ClipContent({
       return (
         <div className="absolute inset-0 flex flex-col">
           {renderCompoundClipLabel(item.label || 'Compound Clip')}
-          {/* Row 2: Filmstrip - flex-1 */}
-          <div className="relative overflow-hidden flex-1 min-h-0">
-            {showFilmstrips && (
-              <ClipFilmstrip
-                mediaId={compositionVisualMediaId}
-                clipWidth={clipWidth}
-                renderWidth={renderWidth}
-                sourceStart={compositionVisualSourceStart}
-                sourceDuration={compositionVisualSourceDuration}
-                trimStart={0}
-                speed={compositionVisualSpeed}
-                fps={fps}
-                isVisible={clipVisibility.isVisible}
-                visibleStartRatio={clipVisibility.visibleStartRatio}
-                visibleEndRatio={clipVisibility.visibleEndRatio}
-                pixelsPerSecond={pixelsPerSecond}
-                preferImmediateRendering={preferImmediateRendering}
-              />
-            )}
-          </div>
-          {/* Row 3: Waveform */}
-          {showCompositionWaveform && composition && (
-            <div
-              className="relative overflow-hidden bg-waveform-gradient"
-              style={{ height: EDITOR_LAYOUT_CSS_VALUES.timelineWaveformRowHeight }}
-            >
-              <CompoundClipWaveform
-                composition={composition}
-                clipWidth={clipWidth}
-                renderWidth={renderWidth}
-                sourceStart={compoundClipSourceStart}
-                sourceDuration={compoundClipSourceDuration}
-                isVisible={clipVisibility.isVisible}
-                visibleStartRatio={clipVisibility.visibleStartRatio}
-                visibleEndRatio={clipVisibility.visibleEndRatio}
-                pixelsPerSecond={pixelsPerSecond}
-              />
-            </div>
+          {showVisualContent && (
+            <>
+              {/* Row 2: Filmstrip - flex-1 */}
+              <div className="relative overflow-hidden flex-1 min-h-0">
+                {showFilmstrips && (
+                  <ClipFilmstrip
+                    mediaId={compositionVisualMediaId}
+                    clipWidth={clipWidth}
+                    renderWidth={renderWidth}
+                    sourceStart={compositionVisualSourceStart}
+                    sourceDuration={compositionVisualSourceDuration}
+                    trimStart={0}
+                    speed={compositionVisualSpeed}
+                    fps={fps}
+                    isVisible={clipVisibility.isVisible}
+                    visibleStartRatio={clipVisibility.visibleStartRatio}
+                    visibleEndRatio={clipVisibility.visibleEndRatio}
+                    pixelsPerSecond={pixelsPerSecond}
+                    preferImmediateRendering={preferImmediateRendering}
+                  />
+                )}
+              </div>
+              {/* Row 3: Waveform */}
+              {showCompositionWaveform && composition && (
+                <div
+                  className="relative overflow-hidden bg-waveform-gradient"
+                  style={{ height: EDITOR_LAYOUT_CSS_VALUES.timelineWaveformRowHeight }}
+                >
+                  <CompoundClipWaveform
+                    composition={composition}
+                    clipWidth={clipWidth}
+                    renderWidth={renderWidth}
+                    sourceStart={compoundClipSourceStart}
+                    sourceDuration={compoundClipSourceDuration}
+                    isVisible={clipVisibility.isVisible}
+                    visibleStartRatio={clipVisibility.visibleStartRatio}
+                    visibleEndRatio={clipVisibility.visibleEndRatio}
+                    pixelsPerSecond={pixelsPerSecond}
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
       );
@@ -399,7 +408,7 @@ export const ClipContent = memo(function ClipContent({
       return (
         <div className="absolute inset-0 flex flex-col">
           {renderCompoundClipLabel(item.label || 'Compound Clip')}
-          {showWaveforms && (
+          {showVisualContent && showWaveforms && (
             <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
               <CompoundClipWaveform
                 composition={composition}
@@ -458,27 +467,29 @@ export const ClipContent = memo(function ClipContent({
         >
           {renderTitleText(item.label)}
         </div>
-        <div className="relative overflow-hidden flex-1 min-h-0">
-          {showFilmstrips && (
-            <ImageFilmstrip
-              mediaId={item.mediaId}
-              isAnimated={isAnimated}
-              animationFormat={isAnimatedWebp ? 'webp' : 'gif'}
-              clipWidth={clipWidth}
-              renderWidth={renderWidth}
-              isVisible={clipVisibility.isVisible}
-              src={item.src}
-              sourceStart={sourceStart}
-              sourceDuration={sourceDuration}
-              trimStart={trimStart}
-              speed={speed}
-              fps={fps}
-              visibleStartRatio={clipVisibility.visibleStartRatio}
-              visibleEndRatio={clipVisibility.visibleEndRatio}
-              pixelsPerSecond={pixelsPerSecond}
-            />
-          )}
-        </div>
+        {showVisualContent && (
+          <div className="relative overflow-hidden flex-1 min-h-0">
+            {showFilmstrips && (
+              <ImageFilmstrip
+                mediaId={item.mediaId}
+                isAnimated={isAnimated}
+                animationFormat={isAnimatedWebp ? 'webp' : 'gif'}
+                clipWidth={clipWidth}
+                renderWidth={renderWidth}
+                isVisible={clipVisibility.isVisible}
+                src={item.src}
+                sourceStart={sourceStart}
+                sourceDuration={sourceDuration}
+                trimStart={trimStart}
+                speed={speed}
+                fps={fps}
+                visibleStartRatio={clipVisibility.visibleStartRatio}
+                visibleEndRatio={clipVisibility.visibleEndRatio}
+                pixelsPerSecond={pixelsPerSecond}
+              />
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -57,11 +57,13 @@ export const ClipContent = memo(function ClipContent({
   audioWaveformScale = 1,
   linkedSyncOffsetFrames = null,
 }: ClipContentProps) {
-  // Track the live pixelsPerSecond directly — filmstrip updates on every zoom
-  // tick (~0.23ms for 89 clips) so it tracks the zoom perfectly with zero
-  // visual jumps.  This is safe because drag/edit hooks now use imperative
-  // reads, keeping the total per-tick render cost under 0.5ms.
-  const pixelsPerSecond = useZoomStore((s) => s.pixelsPerSecond);
+  //   // Keep clip visuals in live zoom space while zooming so inner content stays locked to the shell
+  const isZoomInteracting = useZoomStore((s) => s.isZoomInteracting);
+  const livePixelsPerSecond = useZoomStore((s) => s.pixelsPerSecond);
+  const settledPixelsPerSecond = useZoomStore((s) => s.contentPixelsPerSecond);
+  const pixelsPerSecond = (preferImmediateRendering || isZoomInteracting)
+    ? livePixelsPerSecond
+    : settledPixelsPerSecond;
   const showWaveforms = useSettingsStore((s) => s.showWaveforms);
   const showFilmstrips = useSettingsStore((s) => s.showFilmstrips);
   const clipLeftPx = useMemo(
@@ -72,12 +74,12 @@ export const ClipContent = memo(function ClipContent({
     () => Math.max(0, fps > 0 ? (clipWidthFrames / fps) * pixelsPerSecond : 0),
     [clipWidthFrames, fps, pixelsPerSecond],
   );
-  // Small safety buffer — clips the excess via overflow:hidden.
+  // Small safety buffer - clips the excess via overflow:hidden.
   const renderWidth = Math.ceil(clipWidth * RENDER_BUFFER);
   const clipVisibility = useClipVisibility(clipLeftPx, clipWidth);
   const isCompositionAudioWrapper = item.type === 'audio' && !!item.compositionId;
 
-  // For composition items: find the topmost video in the sub-comp for filmstrip
+  // For composition items: find the topmost video in the sub-comp for filmstrip.
   const compositionId = item.type === 'composition' || isCompositionAudioWrapper ? item.compositionId : undefined;
   const composition = useCompositionsStore(
     useCallback((s) => (compositionId ? s.compositionById[compositionId] ?? null : null), [compositionId])
@@ -93,8 +95,7 @@ export const ClipContent = memo(function ClipContent({
   );
   const compositionSummary = useMemo(() => {
     if (!composition) {
-      return {
-        visualMediaId: null,
+      return {   visualMediaId: null,
         audioMediaId: null,
         hasOwnedAudio: false,
         hasMultipleOwnedAudioSources: false,

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -58,15 +58,11 @@ export const ClipContent = memo(function ClipContent({
   audioWaveformScale = 1,
   linkedSyncOffsetFrames = null,
 }: ClipContentProps) {
-  // Single zoom subscription: live value only for clips that need immediate rendering
-  // (e.g. during drag), settled value for everything else — avoids N re-renders per zoom tick.
-  const pixelsPerSecond = useZoomStore(
-    useCallback(
-      (s: { pixelsPerSecond: number; contentPixelsPerSecond: number }) =>
-        preferImmediateRendering ? s.pixelsPerSecond : s.contentPixelsPerSecond,
-      [preferImmediateRendering]
-    )
-  );
+  // Subscribe to live pixelsPerSecond so filmstrip/waveform content stays in sync
+  // with the CSS-variable-driven clip shell during zoom — avoids a visible catchup
+  // jump at settle. Per-item render cost is kept low by the filmstrip skip (<5px)
+  // and compact clip shell optimizations in the parent.
+  const pixelsPerSecond = useZoomStore((s) => s.pixelsPerSecond);
   const showWaveforms = useSettingsStore((s) => s.showWaveforms);
   const showFilmstrips = useSettingsStore((s) => s.showFilmstrips);
   const clipLeftPx = useMemo(

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -1526,45 +1526,69 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   const displayedAudioVolumeDb = item.type === 'audio'
     ? (item.volume ?? 0)
     : 0;
+  // Hoisted before fade memos so the compact guard can account for active interactions.
+  // A narrow clip that is selected/edited should still compute its fade ratios.
+  const hasActiveClipInteraction =
+    isSelected
+    || isBeingDragged
+    || isPartOfDrag
+    || isTrimming
+    || isStretching
+    || isSlipSlideActive
+    || isTrackPushActive
+    || isEffectDropTarget
+    || videoFadeEdit !== null
+    || audioFadeEdit !== null
+    || audioFadeCurveEdit !== null
+    || audioVolumeEdit !== null
+    || transitionDropGhost !== null
+    || draggedTransition !== null
+    || pointerHint !== null
+    || hoveredEdge !== null
+    || smartTrimIntent !== null
+    || smartBodyIntent !== null
+    || rollHoverEdge !== null
+    || activeEdges !== null;
+  const skipFadeComputation = isCompactWidth && !hasActiveClipInteraction;
   const clipFadeDurationFrames = Math.max(1, Math.round(visualWidthFrames));
   const videoFadeInRatio = useMemo(
-    () => isCompactWidth ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeIn, fps, clipFadeDurationFrames) : 0),
-    [isCompactWidth, clipFadeDurationFrames, displayedVideoFadeIn, fps, isVisualFadeItem]
+    () => skipFadeComputation ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeIn, fps, clipFadeDurationFrames) : 0),
+    [skipFadeComputation, clipFadeDurationFrames, displayedVideoFadeIn, fps, isVisualFadeItem]
   );
   const videoFadeOutRatio = useMemo(
-    () => isCompactWidth ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeOut, fps, clipFadeDurationFrames) : 0),
-    [isCompactWidth, clipFadeDurationFrames, displayedVideoFadeOut, fps, isVisualFadeItem]
+    () => skipFadeComputation ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeOut, fps, clipFadeDurationFrames) : 0),
+    [skipFadeComputation, clipFadeDurationFrames, displayedVideoFadeOut, fps, isVisualFadeItem]
   );
   const videoFadeLineYPercent = 50;
   const audioFadeInRatio = useMemo(
-    () => isCompactWidth ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeIn, fps, clipFadeDurationFrames) : 0),
-    [isCompactWidth, clipFadeDurationFrames, displayedAudioFadeIn, fps, item.type]
+    () => skipFadeComputation ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeIn, fps, clipFadeDurationFrames) : 0),
+    [skipFadeComputation, clipFadeDurationFrames, displayedAudioFadeIn, fps, item.type]
   );
   const audioFadeOutRatio = useMemo(
-    () => isCompactWidth ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeOut, fps, clipFadeDurationFrames) : 0),
-    [isCompactWidth, clipFadeDurationFrames, displayedAudioFadeOut, fps, item.type]
+    () => skipFadeComputation ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeOut, fps, clipFadeDurationFrames) : 0),
+    [skipFadeComputation, clipFadeDurationFrames, displayedAudioFadeOut, fps, item.type]
   );
   const audioFadeInHoverLabel = useMemo(
-    () => isCompactWidth ? '' : `Fade In ${displayedAudioFadeIn.toFixed(2)}s`,
-    [isCompactWidth, displayedAudioFadeIn]
+    () => skipFadeComputation ? '' : `Fade In ${displayedAudioFadeIn.toFixed(2)}s`,
+    [skipFadeComputation, displayedAudioFadeIn]
   );
   const audioFadeOutHoverLabel = useMemo(
-    () => isCompactWidth ? '' : `Fade Out ${displayedAudioFadeOut.toFixed(2)}s`,
-    [isCompactWidth, displayedAudioFadeOut]
+    () => skipFadeComputation ? '' : `Fade Out ${displayedAudioFadeOut.toFixed(2)}s`,
+    [skipFadeComputation, displayedAudioFadeOut]
   );
   const videoFadeInHoverLabel = useMemo(
-    () => isCompactWidth ? '' : `Fade In ${displayedVideoFadeIn.toFixed(2)}s`,
-    [isCompactWidth, displayedVideoFadeIn]
+    () => skipFadeComputation ? '' : `Fade In ${displayedVideoFadeIn.toFixed(2)}s`,
+    [skipFadeComputation, displayedVideoFadeIn]
   );
   const videoFadeOutHoverLabel = useMemo(
-    () => isCompactWidth ? '' : `Fade Out ${displayedVideoFadeOut.toFixed(2)}s`,
-    [isCompactWidth, displayedVideoFadeOut]
+    () => skipFadeComputation ? '' : `Fade Out ${displayedVideoFadeOut.toFixed(2)}s`,
+    [skipFadeComputation, displayedVideoFadeOut]
   );
   const audioVolumeEditLabel = useMemo(() => {
-    if (isCompactWidth || !audioVolumeEdit) return null;
+    if (skipFadeComputation || !audioVolumeEdit) return null;
     const previewVolume = audioVolumePreviewRef.current;
     return `Volume ${previewVolume >= 0 ? '+' : ''}${previewVolume.toFixed(1)} dB`;
-  }, [isCompactWidth, audioVolumeEdit]);
+  }, [skipFadeComputation, audioVolumeEdit]);
   const audioVolumeLineY = useMemo(
     () => item.type === 'audio' ? getAudioVolumeLineY(displayedAudioVolumeDb, AUDIO_ENVELOPE_VIEWBOX_HEIGHT) : AUDIO_ENVELOPE_VIEWBOX_HEIGHT / 2,
     [displayedAudioVolumeDb, item.type]
@@ -1586,64 +1610,64 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   const videoFadeInViewboxWidth = videoFadeInRatio * FADE_VIEWBOX_WIDTH;
   const videoFadeOutViewboxWidth = videoFadeOutRatio * FADE_VIEWBOX_WIDTH;
   const audioFadeInCurvePoint = useMemo(
-    () => isCompactWidth ? null : getAudioFadeCurveControlPoint({
+    () => skipFadeComputation ? null : getAudioFadeCurveControlPoint({
       handle: 'in',
       fadePixels: audioFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeInCurve,
       curveX: displayedAudioFadeInCurveX,
     }),
-    [isCompactWidth, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
+    [skipFadeComputation, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
   );
   const audioFadeOutCurvePoint = useMemo(
-    () => isCompactWidth ? null : getAudioFadeCurveControlPoint({
+    () => skipFadeComputation ? null : getAudioFadeCurveControlPoint({
       handle: 'out',
       fadePixels: audioFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeOutCurve,
       curveX: displayedAudioFadeOutCurveX,
     }),
-    [isCompactWidth, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
+    [skipFadeComputation, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
   );
   const audioFadeInCurvePath = useMemo(
-    () => isCompactWidth ? '' : getAudioFadeCurvePath({
+    () => skipFadeComputation ? '' : getAudioFadeCurvePath({
       handle: 'in',
       fadePixels: audioFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeInCurve,
       curveX: displayedAudioFadeInCurveX,
     }),
-    [isCompactWidth, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
+    [skipFadeComputation, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
   );
   const audioFadeOutCurvePath = useMemo(
-    () => isCompactWidth ? '' : getAudioFadeCurvePath({
+    () => skipFadeComputation ? '' : getAudioFadeCurvePath({
       handle: 'out',
       fadePixels: audioFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeOutCurve,
       curveX: displayedAudioFadeOutCurveX,
     }),
-    [isCompactWidth, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
+    [skipFadeComputation, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
   );
   const videoFadeInPath = useMemo(
-    () => isCompactWidth ? '' : getAudioFadeCurvePath({
+    () => skipFadeComputation ? '' : getAudioFadeCurvePath({
       handle: 'in',
       fadePixels: videoFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: 0,
       curveX: 0.52,
     }),
-    [isCompactWidth, videoFadeInViewboxWidth]
+    [skipFadeComputation, videoFadeInViewboxWidth]
   );
   const videoFadeOutPath = useMemo(
-    () => isCompactWidth ? '' : getAudioFadeCurvePath({
+    () => skipFadeComputation ? '' : getAudioFadeCurvePath({
       handle: 'out',
       fadePixels: videoFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: 0,
       curveX: 0.52,
     }),
-    [isCompactWidth, videoFadeOutViewboxWidth]
+    [skipFadeComputation, videoFadeOutViewboxWidth]
   );
   const videoControlsRef = useRef<HTMLDivElement>(null);
   const audioControlsRef = useRef<HTMLDivElement>(null);
@@ -2294,27 +2318,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
     || Math.abs(currentSpeed - 1) > SPEED_BADGE_EPSILON
     || linkedSyncOffsetFrames !== null
     || (item.type === 'shape' && (item.isMask ?? false));
-  const hasActiveClipInteraction =
-    isSelected
-    || isBeingDragged
-    || isPartOfDrag
-    || isTrimming
-    || isStretching
-    || isSlipSlideActive
-    || isTrackPushActive
-    || isEffectDropTarget
-    || videoFadeEdit !== null
-    || audioFadeEdit !== null
-    || audioFadeCurveEdit !== null
-    || audioVolumeEdit !== null
-    || transitionDropGhost !== null
-    || draggedTransition !== null
-    || pointerHint !== null
-    || hoveredEdge !== null
-    || smartTrimIntent !== null
-    || smartBodyIntent !== null
-    || rollHoverEdge !== null
-    || activeEdges !== null;
+  // hasActiveClipInteraction is hoisted before fade memos (see above)
   const useCompactClipShell =
     activeTool === 'select'
     && visualWidth > 0

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -121,6 +121,9 @@ const EDGE_HOVER_ZONE = SMART_TRIM_EDGE_ZONE_PX;
 const TRACK_PUSH_MIN_PX = 6;
 const TRACK_PUSH_MAX_PX = 14;
 const TRACK_PUSH_ZOOM_THRESHOLD = 120;
+const COMPACT_CLIP_MAX_WIDTH_PX = 36;
+const JOIN_INDICATOR_MIN_ZOOM_PPS = 30;
+const SPEED_BADGE_EPSILON = 0.005;
 
 function getPixelsPerSecondNow(): number {
   return useZoomStore.getState().pixelsPerSecond;
@@ -221,6 +224,9 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   const linkedSelectionEnabled = useEditorStore((s) => s.linkedSelectionEnabled);
   const segmentOverlays = useTimelineItemOverlayStore(
     useCallback((s) => s.overlaysByItemId[item.id] ?? EMPTY_SEGMENT_OVERLAYS, [item.id])
+  );
+  const showJoinIndicators = useZoomStore(
+    (s) => s.pixelsPerSecond >= JOIN_INDICATOR_MIN_ZOOM_PPS
   );
 
   // O(1) lookup via keyframesByItemId index instead of O(n) array scan
@@ -853,6 +859,9 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   ]);
   const visualLeft = Math.round(frameToPixelsNow(visualLeftFrame));
   const visualWidth = Math.round(frameToPixelsNow(visualWidthFrames));
+  // Early width check — used to short-circuit expensive computations below.
+  // The full useCompactClipShell (which also checks interaction/badge state) is computed later for JSX gating.
+  const isCompactWidth = visualWidth > 0 && visualWidth <= COMPACT_CLIP_MAX_WIDTH_PX;
 
   const toolOperationOverlay = useMemo(() => {
     if (visualWidth <= 0) return null;
@@ -1519,43 +1528,43 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
     : 0;
   const clipFadeDurationFrames = Math.max(1, Math.round(visualWidthFrames));
   const videoFadeInRatio = useMemo(
-    () => isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeIn, fps, clipFadeDurationFrames) : 0,
-    [clipFadeDurationFrames, displayedVideoFadeIn, fps, isVisualFadeItem]
+    () => isCompactWidth ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeIn, fps, clipFadeDurationFrames) : 0),
+    [isCompactWidth, clipFadeDurationFrames, displayedVideoFadeIn, fps, isVisualFadeItem]
   );
   const videoFadeOutRatio = useMemo(
-    () => isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeOut, fps, clipFadeDurationFrames) : 0,
-    [clipFadeDurationFrames, displayedVideoFadeOut, fps, isVisualFadeItem]
+    () => isCompactWidth ? 0 : (isVisualFadeItem ? getAudioFadeRatio(displayedVideoFadeOut, fps, clipFadeDurationFrames) : 0),
+    [isCompactWidth, clipFadeDurationFrames, displayedVideoFadeOut, fps, isVisualFadeItem]
   );
   const videoFadeLineYPercent = 50;
   const audioFadeInRatio = useMemo(
-    () => item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeIn, fps, clipFadeDurationFrames) : 0,
-    [clipFadeDurationFrames, displayedAudioFadeIn, fps, item.type]
+    () => isCompactWidth ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeIn, fps, clipFadeDurationFrames) : 0),
+    [isCompactWidth, clipFadeDurationFrames, displayedAudioFadeIn, fps, item.type]
   );
   const audioFadeOutRatio = useMemo(
-    () => item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeOut, fps, clipFadeDurationFrames) : 0,
-    [clipFadeDurationFrames, displayedAudioFadeOut, fps, item.type]
+    () => isCompactWidth ? 0 : (item.type === 'audio' ? getAudioFadeRatio(displayedAudioFadeOut, fps, clipFadeDurationFrames) : 0),
+    [isCompactWidth, clipFadeDurationFrames, displayedAudioFadeOut, fps, item.type]
   );
   const audioFadeInHoverLabel = useMemo(
-    () => `Fade In ${displayedAudioFadeIn.toFixed(2)}s`,
-    [displayedAudioFadeIn]
+    () => isCompactWidth ? '' : `Fade In ${displayedAudioFadeIn.toFixed(2)}s`,
+    [isCompactWidth, displayedAudioFadeIn]
   );
   const audioFadeOutHoverLabel = useMemo(
-    () => `Fade Out ${displayedAudioFadeOut.toFixed(2)}s`,
-    [displayedAudioFadeOut]
+    () => isCompactWidth ? '' : `Fade Out ${displayedAudioFadeOut.toFixed(2)}s`,
+    [isCompactWidth, displayedAudioFadeOut]
   );
   const videoFadeInHoverLabel = useMemo(
-    () => `Fade In ${displayedVideoFadeIn.toFixed(2)}s`,
-    [displayedVideoFadeIn]
+    () => isCompactWidth ? '' : `Fade In ${displayedVideoFadeIn.toFixed(2)}s`,
+    [isCompactWidth, displayedVideoFadeIn]
   );
   const videoFadeOutHoverLabel = useMemo(
-    () => `Fade Out ${displayedVideoFadeOut.toFixed(2)}s`,
-    [displayedVideoFadeOut]
+    () => isCompactWidth ? '' : `Fade Out ${displayedVideoFadeOut.toFixed(2)}s`,
+    [isCompactWidth, displayedVideoFadeOut]
   );
   const audioVolumeEditLabel = useMemo(() => {
-    if (!audioVolumeEdit) return null;
+    if (isCompactWidth || !audioVolumeEdit) return null;
     const previewVolume = audioVolumePreviewRef.current;
     return `Volume ${previewVolume >= 0 ? '+' : ''}${previewVolume.toFixed(1)} dB`;
-  }, [audioVolumeEdit]);
+  }, [isCompactWidth, audioVolumeEdit]);
   const audioVolumeLineY = useMemo(
     () => item.type === 'audio' ? getAudioVolumeLineY(displayedAudioVolumeDb, AUDIO_ENVELOPE_VIEWBOX_HEIGHT) : AUDIO_ENVELOPE_VIEWBOX_HEIGHT / 2,
     [displayedAudioVolumeDb, item.type]
@@ -1577,64 +1586,64 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   const videoFadeInViewboxWidth = videoFadeInRatio * FADE_VIEWBOX_WIDTH;
   const videoFadeOutViewboxWidth = videoFadeOutRatio * FADE_VIEWBOX_WIDTH;
   const audioFadeInCurvePoint = useMemo(
-    () => getAudioFadeCurveControlPoint({
+    () => isCompactWidth ? null : getAudioFadeCurveControlPoint({
       handle: 'in',
       fadePixels: audioFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeInCurve,
       curveX: displayedAudioFadeInCurveX,
     }),
-    [audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
+    [isCompactWidth, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
   );
   const audioFadeOutCurvePoint = useMemo(
-    () => getAudioFadeCurveControlPoint({
+    () => isCompactWidth ? null : getAudioFadeCurveControlPoint({
       handle: 'out',
       fadePixels: audioFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeOutCurve,
       curveX: displayedAudioFadeOutCurveX,
     }),
-    [audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
+    [isCompactWidth, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
   );
   const audioFadeInCurvePath = useMemo(
-    () => getAudioFadeCurvePath({
+    () => isCompactWidth ? '' : getAudioFadeCurvePath({
       handle: 'in',
       fadePixels: audioFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeInCurve,
       curveX: displayedAudioFadeInCurveX,
     }),
-    [audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
+    [isCompactWidth, audioFadeInViewboxWidth, displayedAudioFadeInCurve, displayedAudioFadeInCurveX]
   );
   const audioFadeOutCurvePath = useMemo(
-    () => getAudioFadeCurvePath({
+    () => isCompactWidth ? '' : getAudioFadeCurvePath({
       handle: 'out',
       fadePixels: audioFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: displayedAudioFadeOutCurve,
       curveX: displayedAudioFadeOutCurveX,
     }),
-    [audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
+    [isCompactWidth, audioFadeOutViewboxWidth, displayedAudioFadeOutCurve, displayedAudioFadeOutCurveX]
   );
   const videoFadeInPath = useMemo(
-    () => getAudioFadeCurvePath({
+    () => isCompactWidth ? '' : getAudioFadeCurvePath({
       handle: 'in',
       fadePixels: videoFadeInViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: 0,
       curveX: 0.52,
     }),
-    [videoFadeInViewboxWidth]
+    [isCompactWidth, videoFadeInViewboxWidth]
   );
   const videoFadeOutPath = useMemo(
-    () => getAudioFadeCurvePath({
+    () => isCompactWidth ? '' : getAudioFadeCurvePath({
       handle: 'out',
       fadePixels: videoFadeOutViewboxWidth,
       clipWidthPixels: FADE_VIEWBOX_WIDTH,
       curve: 0,
       curveX: 0.52,
     }),
-    [videoFadeOutViewboxWidth]
+    [isCompactWidth, videoFadeOutViewboxWidth]
   );
   const videoControlsRef = useRef<HTMLDivElement>(null);
   const audioControlsRef = useRef<HTMLDivElement>(null);
@@ -2279,6 +2288,39 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
       ? getLinkedSyncOffsetFrames([linkedSyncPreviewItem, ...linkedItemsForSync], linkedSyncPreviewItem.id, fps, linkedSyncPreviewUpdatesById)
       : null
   ), [linkedItemsForSync, linkedSyncPreviewItem, fps, linkedSyncPreviewUpdatesById, suppressLinkedSyncBadge]);
+  const hasDetailBadges =
+    hasKeyframes
+    || isBroken
+    || Math.abs(currentSpeed - 1) > SPEED_BADGE_EPSILON
+    || linkedSyncOffsetFrames !== null
+    || (item.type === 'shape' && (item.isMask ?? false));
+  const hasActiveClipInteraction =
+    isSelected
+    || isBeingDragged
+    || isPartOfDrag
+    || isTrimming
+    || isStretching
+    || isSlipSlideActive
+    || isTrackPushActive
+    || isEffectDropTarget
+    || videoFadeEdit !== null
+    || audioFadeEdit !== null
+    || audioFadeCurveEdit !== null
+    || audioVolumeEdit !== null
+    || transitionDropGhost !== null
+    || draggedTransition !== null
+    || pointerHint !== null
+    || hoveredEdge !== null
+    || smartTrimIntent !== null
+    || smartBodyIntent !== null
+    || rollHoverEdge !== null
+    || activeEdges !== null;
+  const useCompactClipShell =
+    activeTool === 'select'
+    && visualWidth > 0
+    && visualWidth <= COMPACT_CLIP_MAX_WIDTH_PX
+    && !hasDetailBadges
+    && !hasActiveClipInteraction;
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -2452,6 +2494,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
         <div
           ref={transformRef}
           data-item-id={item.id}
+          data-compact-clip={useCompactClipShell ? 'true' : undefined}
           className={cn(
             "absolute inset-y-px rounded overflow-visible group/timeline-item",
             itemColorClasses,
@@ -2509,67 +2552,71 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
           )}
 
           <div className="absolute inset-px rounded-[3px] overflow-hidden">
-            <SegmentStatusOverlays overlays={segmentOverlays} />
+            {!useCompactClipShell && (
+              <>
+                <SegmentStatusOverlays overlays={segmentOverlays} />
 
-            {isVisualFadeItem && (
-              <div
-                ref={videoControlsRef}
-                className="absolute inset-x-0 bottom-0 pointer-events-none z-10"
-                style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
-              >
-                <svg
-                  className="absolute inset-0 h-full w-full"
-                  viewBox={`0 0 ${FADE_VIEWBOX_WIDTH} ${AUDIO_ENVELOPE_VIEWBOX_HEIGHT}`}
-                  preserveAspectRatio="none"
-                >
-                  {videoFadeInRatio > 0 && (
-                    <path
-                      d={videoFadeInPath}
-                      fill="rgba(15,23,42,0.46)"
-                    />
-                  )}
-                  {videoFadeOutRatio > 0 && (
-                    <path
-                      d={videoFadeOutPath}
-                      fill="rgba(15,23,42,0.46)"
-                    />
-                  )}
-                </svg>
-              </div>
-            )}
+                {isVisualFadeItem && (
+                  <div
+                    ref={videoControlsRef}
+                    className="absolute inset-x-0 bottom-0 pointer-events-none z-10"
+                    style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
+                  >
+                    <svg
+                      className="absolute inset-0 h-full w-full"
+                      viewBox={`0 0 ${FADE_VIEWBOX_WIDTH} ${AUDIO_ENVELOPE_VIEWBOX_HEIGHT}`}
+                      preserveAspectRatio="none"
+                    >
+                      {videoFadeInRatio > 0 && (
+                        <path
+                          d={videoFadeInPath}
+                          fill="rgba(15,23,42,0.46)"
+                        />
+                      )}
+                      {videoFadeOutRatio > 0 && (
+                        <path
+                          d={videoFadeOutPath}
+                          fill="rgba(15,23,42,0.46)"
+                        />
+                      )}
+                    </svg>
+                  </div>
+                )}
 
-            {item.type === 'audio' && (
-              <div
-                ref={audioControlsRef}
-                className="absolute inset-x-0 bottom-0 pointer-events-none z-10"
-                style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
-              >
-                <div
-                  className="absolute left-0 right-0 h-px -translate-y-1/2 pointer-events-none"
-                  style={{
-                    top: `var(--timeline-audio-volume-line-y, ${audioVolumeLineYPercent}%)`,
-                    backgroundColor: audioVolumeLineStroke,
-                  }}
-                />
-                <svg
-                  className="absolute inset-0 h-full w-full"
-                  viewBox={`0 0 ${FADE_VIEWBOX_WIDTH} ${AUDIO_ENVELOPE_VIEWBOX_HEIGHT}`}
-                  preserveAspectRatio="none"
-                >
-                  {audioFadeInRatio > 0 && (
-                    <path
-                      d={audioFadeInCurvePath}
-                      fill="rgba(0,0,0,0.5)"
+                {item.type === 'audio' && (
+                  <div
+                    ref={audioControlsRef}
+                    className="absolute inset-x-0 bottom-0 pointer-events-none z-10"
+                    style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
+                  >
+                    <div
+                      className="absolute left-0 right-0 h-px -translate-y-1/2 pointer-events-none"
+                      style={{
+                        top: `var(--timeline-audio-volume-line-y, ${audioVolumeLineYPercent}%)`,
+                        backgroundColor: audioVolumeLineStroke,
+                      }}
                     />
-                  )}
-                  {audioFadeOutRatio > 0 && (
-                    <path
-                      d={audioFadeOutCurvePath}
-                      fill="rgba(0,0,0,0.5)"
-                    />
-                  )}
-                </svg>
-              </div>
+                    <svg
+                      className="absolute inset-0 h-full w-full"
+                      viewBox={`0 0 ${FADE_VIEWBOX_WIDTH} ${AUDIO_ENVELOPE_VIEWBOX_HEIGHT}`}
+                      preserveAspectRatio="none"
+                    >
+                      {audioFadeInRatio > 0 && (
+                        <path
+                          d={audioFadeInCurvePath}
+                          fill="rgba(0,0,0,0.5)"
+                        />
+                      )}
+                      {audioFadeOutRatio > 0 && (
+                        <path
+                          d={audioFadeOutCurvePath}
+                          fill="rgba(0,0,0,0.5)"
+                        />
+                      )}
+                    </svg>
+                  </div>
+                )}
+              </>
             )}
 
             <ClipContent
@@ -2583,20 +2630,22 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
               linkedSyncOffsetFrames={linkedSyncOffsetFrames}
             />
 
-            {/* Status indicators */}
-            <ClipIndicators
-              hasKeyframes={hasKeyframes}
-              currentSpeed={currentSpeed}
-              isStretching={isStretching}
-              stretchFeedback={stretchFeedback}
-              isBroken={isBroken}
-              hasMediaId={!!item.mediaId}
-              isMask={item.type === 'shape' ? item.isMask ?? false : false}
-              isShape={item.type === 'shape'}
-            />
+            {!useCompactClipShell && (
+              /* Status indicators */
+              <ClipIndicators
+                hasKeyframes={hasKeyframes}
+                currentSpeed={currentSpeed}
+                isStretching={isStretching}
+                stretchFeedback={stretchFeedback}
+                isBroken={isBroken}
+                hasMediaId={!!item.mediaId}
+                isMask={item.type === 'shape' ? item.isMask ?? false : false}
+                isShape={item.type === 'shape'}
+              />
+            )}
           </div>
 
-          {isVisualFadeItem && (
+          {!useCompactClipShell && isVisualFadeItem && (
             <div
               className="absolute inset-x-0 bottom-0 z-30 pointer-events-none"
               style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
@@ -2618,7 +2667,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
           )}
 
           {/* Trim handles */}
-          {item.type === 'audio' && (
+          {!useCompactClipShell && item.type === 'audio' && (
             <div
               className="absolute inset-x-0 bottom-0 z-30 pointer-events-none"
               style={{ top: EDITOR_LAYOUT_CSS_VALUES.timelineClipLabelRowHeight }}
@@ -2634,8 +2683,8 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
                 curveEditingHandle={audioFadeCurveEdit?.handle ?? null}
                 fadeInLabel={audioFadeInHoverLabel}
                 fadeOutLabel={audioFadeOutHoverLabel}
-                fadeInCurveDot={audioFadeInRatio > 0 ? { xPercent: (audioFadeInCurvePoint.x / FADE_VIEWBOX_WIDTH) * 100, yPercent: audioFadeInCurvePoint.y } : null}
-                fadeOutCurveDot={audioFadeOutRatio > 0 ? { xPercent: (audioFadeOutCurvePoint.x / FADE_VIEWBOX_WIDTH) * 100, yPercent: audioFadeOutCurvePoint.y } : null}
+                fadeInCurveDot={audioFadeInRatio > 0 && audioFadeInCurvePoint ? { xPercent: (audioFadeInCurvePoint.x / FADE_VIEWBOX_WIDTH) * 100, yPercent: audioFadeInCurvePoint.y } : null}
+                fadeOutCurveDot={audioFadeOutRatio > 0 && audioFadeOutCurvePoint ? { xPercent: (audioFadeOutCurvePoint.x / FADE_VIEWBOX_WIDTH) * 100, yPercent: audioFadeOutCurvePoint.y } : null}
                 onFadeHandleMouseDown={handleAudioFadeHandleMouseDown}
                 onFadeHandleDoubleClick={handleAudioFadeHandleDoubleClick}
                 onFadeCurveDotMouseDown={handleAudioFadeCurveDotMouseDown}
@@ -2655,63 +2704,69 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
           )}
 
           {/* Trim handles */}
-          <TrimHandles
-            trackLocked={trackLocked}
-            isAnyDragActive={isAnyDragActiveRef.current}
-            isTrimming={isTrimming}
-            trimHandle={trimHandle}
-            activeTool={activeTool}
-            hoveredEdge={hoveredEdge}
-            smartTrimIntent={smartTrimIntent}
-            rollHoverEdge={rollHoverEdge}
-            activeEdges={activeEdges}
-            startCursorClass={
-              smartTrimIntent === 'ripple-start'
-                ? 'cursor-ripple-left'
-                : smartTrimIntent === 'roll-start'
-                ? 'cursor-trim-center'
-                : 'cursor-trim-left'
-            }
-            endCursorClass={
-              smartTrimIntent === 'ripple-end'
-                ? 'cursor-ripple-right'
-                : smartTrimIntent === 'roll-end'
-                ? 'cursor-trim-center'
-                : 'cursor-trim-right'
-            }
-            startTone={smartTrimIntent === 'ripple-start' || (isTrimming && trimHandle === 'start' && isRippleEdit) ? 'ripple' : 'default'}
-            endTone={smartTrimIntent === 'ripple-end' || (isTrimming && trimHandle === 'end' && isRippleEdit) ? 'ripple' : 'default'}
-            hasJoinableLeft={hasJoinableLeft}
-            hasJoinableRight={hasJoinableRight}
-            onTrimStart={handleSmartTrimStart}
-            onJoinLeft={handleJoinLeft}
-            onJoinRight={handleJoinRight}
-          />
+          {!useCompactClipShell && (
+            <TrimHandles
+              trackLocked={trackLocked}
+              isAnyDragActive={isAnyDragActiveRef.current}
+              isTrimming={isTrimming}
+              trimHandle={trimHandle}
+              activeTool={activeTool}
+              hoveredEdge={hoveredEdge}
+              smartTrimIntent={smartTrimIntent}
+              rollHoverEdge={rollHoverEdge}
+              activeEdges={activeEdges}
+              startCursorClass={
+                smartTrimIntent === 'ripple-start'
+                  ? 'cursor-ripple-left'
+                  : smartTrimIntent === 'roll-start'
+                  ? 'cursor-trim-center'
+                  : 'cursor-trim-left'
+              }
+              endCursorClass={
+                smartTrimIntent === 'ripple-end'
+                  ? 'cursor-ripple-right'
+                  : smartTrimIntent === 'roll-end'
+                  ? 'cursor-trim-center'
+                  : 'cursor-trim-right'
+              }
+              startTone={smartTrimIntent === 'ripple-start' || (isTrimming && trimHandle === 'start' && isRippleEdit) ? 'ripple' : 'default'}
+              endTone={smartTrimIntent === 'ripple-end' || (isTrimming && trimHandle === 'end' && isRippleEdit) ? 'ripple' : 'default'}
+              hasJoinableLeft={hasJoinableLeft}
+              hasJoinableRight={hasJoinableRight}
+              onTrimStart={handleSmartTrimStart}
+              onJoinLeft={handleJoinLeft}
+              onJoinRight={handleJoinRight}
+            />
+          )}
 
           {/* Rate stretch handles */}
-          <StretchHandles
-            trackLocked={trackLocked}
-            isAnyDragActive={isAnyDragActiveRef.current}
-            isStretching={isStretching}
-            stretchHandle={stretchHandle}
-            stretchConstrained={stretchConstrained}
-            isRateStretchItem={isRateStretchItem}
-            onStretchStart={handleStretchStart}
-          />
+          {!useCompactClipShell && (
+            <StretchHandles
+              trackLocked={trackLocked}
+              isAnyDragActive={isAnyDragActiveRef.current}
+              isStretching={isStretching}
+              stretchHandle={stretchHandle}
+              stretchConstrained={stretchConstrained}
+              isRateStretchItem={isRateStretchItem}
+              onStretchStart={handleStretchStart}
+            />
+          )}
 
-          {/* Join indicators */}
-          <JoinIndicators
-            hasJoinableLeft={hasJoinableLeft}
-            hasJoinableRight={hasJoinableRight}
-            trackLocked={trackLocked}
-            dragAffectsJoin={dragAffectsJoin}
-            hoveredEdge={hoveredEdge}
-            isTrimming={isTrimming}
-            isStretching={isStretching}
-            isBeingDragged={isBeingDragged}
-          />
+          {/* Join indicators — hide globally below a zoom threshold so they're always consistent between neighbors */}
+          {showJoinIndicators && (
+            <JoinIndicators
+              hasJoinableLeft={hasJoinableLeft}
+              hasJoinableRight={hasJoinableRight}
+              trackLocked={trackLocked}
+              dragAffectsJoin={dragAffectsJoin}
+              hoveredEdge={hoveredEdge}
+              isTrimming={isTrimming}
+              isStretching={isStretching}
+              isBeingDragged={isBeingDragged}
+            />
+          )}
 
-          {draggedTransition && !trackLocked && (item.type === 'video' || item.type === 'image') && (
+          {!useCompactClipShell && draggedTransition && !trackLocked && (item.type === 'video' || item.type === 'image') && (
             <>
               <div
                 className="absolute inset-y-0 -left-2 z-40 w-4"

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -510,6 +510,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({ duration, width }
     const ch = canvasHeightRef.current;
     const qPPS = quantizedPPSRef.current;
     const ck = cacheKeyRef.current;
+    if (dw <= 0 || ch <= 0 || qPPS <= 0) return;
 
     // ── Tile visibility ──
     const startTile = Math.max(0, Math.floor(sl / TILE_WIDTH));

--- a/src/features/timeline/components/timeline-track.tsx
+++ b/src/features/timeline/components/timeline-track.tsx
@@ -377,9 +377,9 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
   const isDropDisabled = isTrackLocked;
   const trackKind = getTrackKind(track);
 
-  // Virtualized items/transitions â€” only those overlapping the visible viewport + buffer
+  // Virtualized items/transitions — only those overlapping the visible viewport + buffer
   const { visibleItems: trackItems, visibleTransitions: trackTransitions } = useVisibleItems(track.id);
-  // Full item count â€” used for context menu guard (must not depend on virtualized subset)
+  // Full item count — used for context menu guard (must not depend on virtualized subset)
   const hasAnyItems = useItemsStore((s) => (s.itemsByTrackId[track.id]?.length ?? 0) > 0);
   const addItem = useTimelineStore((s) => s.addItem);
   const addItems = useTimelineStore((s) => s.addItems);

--- a/src/features/timeline/hooks/use-timeline-zoom.ts
+++ b/src/features/timeline/hooks/use-timeline-zoom.ts
@@ -34,6 +34,7 @@ function useTimelineZoomInternal(
   const zoomLevel = useZoomStore(selectors.zoomLevel);
   const setZoomLevel = useZoomStore((s) => s.setZoomLevel);
   const setZoomLevelImmediate = useZoomStore((s) => s.setZoomLevelImmediate);
+  const setZoomLevelSynchronized = useZoomStore((s) => s.setZoomLevelSynchronized);
   const zoomInAction = useZoomStore((s) => s.zoomIn);
   const zoomOutAction = useZoomStore((s) => s.zoomOut);
   const pixelsPerSecond = useZoomStore(selectors.pixelsPerSecond);
@@ -113,6 +114,7 @@ function useTimelineZoomInternal(
     resetZoom,
     setZoom: (level: number) => setZoomLevel(Math.max(minZoom, Math.min(maxZoom, level))),
     setZoomImmediate: (level: number) => setZoomLevelImmediate(Math.max(minZoom, Math.min(maxZoom, level))),
+    setZoomSynchronized: (level: number) => setZoomLevelSynchronized(Math.max(minZoom, Math.min(maxZoom, level))),
   };
 }
 

--- a/src/features/timeline/hooks/use-visible-items.test.ts
+++ b/src/features/timeline/hooks/use-visible-items.test.ts
@@ -216,7 +216,7 @@ describe('useVisibleItems filtering logic', () => {
     vi.useRealTimers();
   });
 
-  it('culls items outside the buffered viewport during live zoom-in', () => {
+  it('keeps the mounted item set stable during live zoom-in and culls on settle', () => {
     vi.useFakeTimers();
 
     useItemsStore.getState().setItems([
@@ -230,21 +230,61 @@ describe('useVisibleItems filtering logic', () => {
     expect(screen.getByTestId('visible-items')).toHaveTextContent('a,b');
     expect(onRender).toHaveBeenCalledTimes(1);
 
-    // Zoom in — culling now uses live pps (matching the viewport coordinate
-    // space) so item b at frame 500 correctly exits the buffered range.
+    // Zoom in — keep the mounted set stable during the interaction so clips do
+    // not thrash in and out while the live geometry is still moving.
     act(() => {
       useZoomStore.getState().setZoomLevelImmediate(2);
     });
 
-    expect(screen.getByTestId('visible-items')).toHaveTextContent('a');
-    expect(onRender).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('visible-items')).toHaveTextContent('a,b');
+    expect(onRender).toHaveBeenCalledTimes(1);
 
-    // After settle, same result
+    // After settle, recompute once in the committed coordinate space.
     act(() => {
       vi.advanceTimersByTime(100);
     });
 
     expect(screen.getByTestId('visible-items')).toHaveTextContent('a');
+    expect(onRender).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('expands the mounted item set during live zoom-out before settle', () => {
+    vi.useFakeTimers();
+
+    useZoomStore.setState({
+      level: 2,
+      pixelsPerSecond: 200,
+      contentLevel: 2,
+      contentPixelsPerSecond: 200,
+      isZoomInteracting: false,
+    });
+    useItemsStore.getState().setItems([
+      makeItem('a', 0, 30),
+      makeItem('b', 700, 30), // outside at 2x zoom, visible again once we zoom out
+      makeItem('c', 940, 30),
+    ]);
+
+    const onRender = vi.fn();
+    render(createElement(VisibleItemsProbe, { onRender }));
+
+    expect(screen.getByTestId('visible-items')).toHaveTextContent('a');
+    expect(onRender).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useZoomStore.getState().setZoomLevelImmediate(1);
+    });
+
+    expect(screen.getByTestId('visible-items')).toHaveTextContent('a,b');
+    expect(onRender).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.getByTestId('visible-items')).toHaveTextContent('a,b');
+    expect(onRender).toHaveBeenCalledTimes(3);
 
     vi.useRealTimers();
   });

--- a/src/features/timeline/hooks/use-visible-items.ts
+++ b/src/features/timeline/hooks/use-visible-items.ts
@@ -38,6 +38,34 @@ interface VisibleItemsSnapshot {
   visibleTransitions: Transition[];
 }
 
+function getHysteresisFrames(
+  pixelsPerSecond: number,
+  fps: number,
+): number {
+  return fps > 0 && pixelsPerSecond > 0
+    ? (HYSTERESIS_PX / pixelsPerSecond) * fps
+    : 0;
+}
+
+function shouldExpandMountedRange(
+  previousRange: VisibleFrameRange,
+  nextRange: VisibleFrameRange,
+  hysteresisFrames: number,
+): boolean {
+  return nextRange.start < previousRange.start - hysteresisFrames
+    || nextRange.end > previousRange.end + hysteresisFrames;
+}
+
+function mergeVisibleRanges(
+  previousRange: VisibleFrameRange,
+  nextRange: VisibleFrameRange,
+): VisibleFrameRange {
+  return {
+    start: Math.min(previousRange.start, nextRange.start),
+    end: Math.max(previousRange.end, nextRange.end),
+  };
+}
+
 function quantizeInteractionPixelsPerSecond(pixelsPerSecond: number): number {
   if (!Number.isFinite(pixelsPerSecond) || pixelsPerSecond <= 0) {
     return 1;
@@ -105,21 +133,52 @@ export function useVisibleItems(trackId: string) {
 
   useEffect(() => {
     const apply = () => {
-      const cullingPixelsPerSecond = getCullingPixelsPerSecond(useZoomStore.getState());
+      const zoomState = useZoomStore.getState();
+      const cullingPixelsPerSecond = getCullingPixelsPerSecond(zoomState);
       const { fps } = useTimelineSettingsStore.getState();
       const itemsState = useItemsStore.getState();
       const items = itemsState.itemsByTrackId[trackId];
       const transitions = getTrackVisibleTransitions(trackId);
+      const prev = lastVersionRef.current;
+
       const { scrollLeft, viewportWidth } = useTimelineViewportStore.getState();
       const newRange = getVisibleFrameRange(scrollLeft, viewportWidth, cullingPixelsPerSecond, fps);
+      const lastRange = lastRangeRef.current;
+      const hysteresisFrames = getHysteresisFrames(cullingPixelsPerSecond, fps);
+
+      // Keep zoom-in stable, but allow zoom-out to expand the mounted set during
+      // the gesture so newly visible clips do not wait for the settle timeout.
+      if (
+        zoomState.isZoomInteracting
+        && prev.fps === fps
+        && prev.itemsRef === items
+        && prev.transRef === transitions
+      ) {
+        if (!lastRange || !shouldExpandMountedRange(lastRange, newRange, hysteresisFrames)) {
+          return;
+        }
+
+        const expandedRange = mergeVisibleRanges(lastRange, newRange);
+        const visibleItems = getVisibleItemsForRange(items, expandedRange);
+        const visibleTransitions = getVisibleTransitionsForRange(
+          transitions,
+          itemsState.itemById,
+          visibleItems,
+          expandedRange
+        );
+        const next: VisibleItemsSnapshot = { visibleItems, visibleTransitions };
+
+        lastRangeRef.current = expandedRange;
+        lastVersionRef.current = { pps: cullingPixelsPerSecond, fps, itemsRef: items, transRef: transitions };
+        setSnapshot((prevSnap) => (areVisibleSnapshotsEqual(prevSnap, next) ? prevSnap : next));
+        return;
+      }
 
       // Fast path: if only scroll changed and the range shift is within
       // hysteresis, the visible item set is guaranteed unchanged.
       // Array references are compared (not lengths) so in-place mutations
       // (move, trim, property edits) that produce a new array always
       // bypass the fast path and recompute.
-      const prev = lastVersionRef.current;
-      const lastRange = lastRangeRef.current;
       if (
         lastRange
         && prev.pps === cullingPixelsPerSecond
@@ -127,9 +186,6 @@ export function useVisibleItems(trackId: string) {
         && prev.itemsRef === items
         && prev.transRef === transitions
       ) {
-        const hysteresisFrames = fps > 0 && cullingPixelsPerSecond > 0
-          ? (HYSTERESIS_PX / cullingPixelsPerSecond) * fps
-          : 0;
         if (
           Math.abs(newRange.start - lastRange.start) < hysteresisFrames
           && Math.abs(newRange.end - lastRange.end) < hysteresisFrames
@@ -156,9 +212,20 @@ export function useVisibleItems(trackId: string) {
     // Zoom-specific subscriber: skip when the quantized culling pps hasn't
     // changed — avoids redundant store reads on every wheel tick.
     let lastCullingPps = getCullingPixelsPerSecond(useZoomStore.getState());
+    let wasZoomInteracting = useZoomStore.getState().isZoomInteracting;
     const applyZoom = () => {
-      const nextPps = getCullingPixelsPerSecond(useZoomStore.getState());
-      if (nextPps === lastCullingPps) return;
+      const zoomState = useZoomStore.getState();
+      const nextPps = getCullingPixelsPerSecond(zoomState);
+      if (zoomState.isZoomInteracting) {
+        wasZoomInteracting = true;
+        if (nextPps === lastCullingPps) return;
+        lastCullingPps = nextPps;
+        apply();
+        return;
+      }
+
+      if (!wasZoomInteracting && nextPps === lastCullingPps) return;
+      wasZoomInteracting = false;
       lastCullingPps = nextPps;
       apply();
     };

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -115,6 +115,68 @@ function cloneTransitionForProject(transition: Transition): Transition {
   };
 }
 
+function stripTimelineItemThumbnailUrl<T extends { thumbnailUrl?: string }>(item: T): T {
+  if (item.thumbnailUrl === undefined) {
+    return item;
+  }
+
+  const rest = { ...item };
+  delete rest.thumbnailUrl;
+  return rest as T;
+}
+
+function sanitizeTimelineEphemeralFields(timeline: ProjectTimeline): {
+  timeline: ProjectTimeline;
+  cleaned: boolean;
+} {
+  let cleaned = false;
+
+  const items = timeline.items.map((item) => {
+    if (item.thumbnailUrl === undefined) {
+      return item;
+    }
+
+    cleaned = true;
+    return stripTimelineItemThumbnailUrl(item);
+  }) as ProjectTimeline['items'];
+
+  const compositions = timeline.compositions?.map((composition) => {
+    let compositionCleaned = false;
+
+    const nextItems = composition.items.map((item) => {
+      if (item.thumbnailUrl === undefined) {
+        return item;
+      }
+
+      cleaned = true;
+      compositionCleaned = true;
+      return stripTimelineItemThumbnailUrl(item);
+    }) as ProjectTimeline['items'];
+
+    if (!compositionCleaned) {
+      return composition;
+    }
+
+    return {
+      ...composition,
+      items: nextItems,
+    };
+  }) as ProjectTimeline['compositions'];
+
+  if (!cleaned) {
+    return { timeline, cleaned: false };
+  }
+
+  return {
+    timeline: {
+      ...timeline,
+      items,
+      ...(compositions && { compositions }),
+    },
+    cleaned: true,
+  };
+}
+
 async function buildVideoHasAudioMap(mediaIds: string[]): Promise<Record<string, boolean | undefined>> {
   const mediaById = useMediaLibraryStore.getState().mediaById;
   const entries = await Promise.all(mediaIds.map(async (mediaId) => {
@@ -634,6 +696,7 @@ export async function saveTimeline(projectId: string): Promise<void> {
         };
       })(),
     };
+    const { timeline: sanitizedTimeline } = sanitizeTimelineEphemeralFields(timeline);
 
     // Generate thumbnail — prefer capturing the existing preview canvas
     // (near-free: reuses the already-initialized scrub renderer with cached
@@ -722,7 +785,7 @@ export async function saveTimeline(projectId: string): Promise<void> {
     // Update project
     // Clear deprecated thumbnail field when using thumbnailId to save space
     await updateProject(projectId, {
-      timeline,
+      timeline: sanitizedTimeline,
       ...(thumbnailId && { thumbnailId, thumbnail: undefined }),
       updatedAt: Date.now(),
     });
@@ -782,15 +845,25 @@ export async function loadTimeline(
     // Run migrations and normalization
     const migrationResult = migrateProject(rawProject);
     const repairedLegacyLayouts = await repairLegacyProjectAvLayouts(migrationResult.project);
-    const project = repairedLegacyLayouts.project;
+    const sanitizedTimeline = repairedLegacyLayouts.project.timeline
+      ? sanitizeTimelineEphemeralFields(repairedLegacyLayouts.project.timeline)
+      : { timeline: repairedLegacyLayouts.project.timeline, cleaned: false };
+    const project = sanitizedTimeline.cleaned
+      ? {
+        ...repairedLegacyLayouts.project,
+        timeline: sanitizedTimeline.timeline,
+      }
+      : repairedLegacyLayouts.project;
 
     // Log migration activity
-    if (migrationResult.migrated || repairedLegacyLayouts.repaired) {
+    if (migrationResult.migrated || repairedLegacyLayouts.repaired || sanitizedTimeline.cleaned) {
       if (migrationResult.appliedMigrations.length > 0) {
         logger.info(
           `Migrated project from v${migrationResult.fromVersion} to v${migrationResult.toVersion}`,
           { migrations: migrationResult.appliedMigrations }
         );
+      } else if (sanitizedTimeline.cleaned) {
+        logger.info('Removed ephemeral thumbnail URLs from stored timeline items', { projectId });
       } else if (repairedLegacyLayouts.repaired) {
         logger.info('Repaired legacy A/V track layout for project', { projectId });
       } else {

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -131,7 +131,7 @@ function sanitizeTimelineEphemeralFields(timeline: ProjectTimeline): {
 } {
   let cleaned = false;
 
-  const items = timeline.items.map((item) => {
+  const items = (timeline.items ?? []).map((item) => {
     if (item.thumbnailUrl === undefined) {
       return item;
     }
@@ -143,7 +143,7 @@ function sanitizeTimelineEphemeralFields(timeline: ProjectTimeline): {
   const compositions = timeline.compositions?.map((composition) => {
     let compositionCleaned = false;
 
-    const nextItems = composition.items.map((item) => {
+    const nextItems = (composition.items ?? []).map((item) => {
       if (item.thumbnailUrl === undefined) {
         return item;
       }

--- a/src/features/timeline/stores/timeline-store-facade.test.ts
+++ b/src/features/timeline/stores/timeline-store-facade.test.ts
@@ -9,7 +9,11 @@ const indexedDbMocks = vi.hoisted(() => ({
 
 const playbackMocks = vi.hoisted(() => ({
   currentFrame: 0,
+  busAudioEq: undefined,
   setCurrentFrame: vi.fn(),
+  setBusAudioEq: vi.fn((value) => {
+    playbackMocks.busAudioEq = value;
+  }),
   pause: vi.fn(),
   play: vi.fn(),
   setPreviewFrame: vi.fn(),
@@ -97,8 +101,12 @@ describe('TimelineStoreFacade', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     playbackMocks.currentFrame = 0;
+    playbackMocks.busAudioEq = undefined;
     playbackMocks.setCurrentFrame.mockImplementation((frame: number) => {
       playbackMocks.currentFrame = frame;
+    });
+    playbackMocks.setBusAudioEq.mockImplementation((value) => {
+      playbackMocks.busAudioEq = value;
     });
     zoomMocks.level = 1;
     zoomMocks.setZoomLevel.mockImplementation((level: number) => {
@@ -611,6 +619,51 @@ describe('TimelineStoreFacade', () => {
       );
     });
 
+    it('does not persist ephemeral clip thumbnail URLs into the project timeline', async () => {
+      indexedDbMocks.getProject.mockResolvedValue({
+        id: 'project-1',
+        metadata: { fps: 30, width: 1920, height: 1080 },
+      });
+
+      useItemsStore.getState().setTracks([{
+        id: 'track-1',
+        name: 'Video',
+        height: 80,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 0,
+        items: [],
+      }]);
+      useItemsStore.getState().setItems([{
+        id: 'clip-1',
+        type: 'video',
+        trackId: 'track-1',
+        from: 0,
+        durationInFrames: 90,
+        label: 'clip.mp4',
+        src: 'blob:video',
+        mediaId: 'media-1',
+        thumbnailUrl: 'blob:thumb',
+      }]);
+
+      await useTimelineStore.getState().saveTimeline('project-1');
+
+      expect(indexedDbMocks.updateProject).toHaveBeenCalledWith(
+        'project-1',
+        expect.objectContaining({
+          timeline: expect.objectContaining({
+            items: [
+              expect.not.objectContaining({
+                thumbnailUrl: expect.anything(),
+              }),
+            ],
+          }),
+        }),
+      );
+    });
+
     it('restores the full nested composition path after saving', async () => {
       indexedDbMocks.getProject.mockResolvedValue({
         id: 'project-1',
@@ -864,6 +917,50 @@ describe('TimelineStoreFacade', () => {
       expect(itemsState.items[0]!.id).toBe('i1');
       expect(useTimelineSettingsStore.getState().fps).toBe(24);
       expect(playbackMocks.setCurrentFrame).toHaveBeenCalledWith(50);
+    });
+
+    it('strips persisted clip thumbnail URLs while loading an existing project', async () => {
+      indexedDbMocks.getProject.mockResolvedValue({
+        id: 'project-1',
+        metadata: { fps: 24 },
+        timeline: {
+          tracks: [{ id: 't1', name: 'Video', order: 0, height: 80, locked: false, visible: true, muted: false, solo: false }],
+          items: [{
+            id: 'i1',
+            type: 'video',
+            trackId: 't1',
+            from: 0,
+            durationInFrames: 100,
+            label: 'test.mp4',
+            thumbnailUrl: 'blob:thumb',
+          }],
+          currentFrame: 50,
+          zoomLevel: 2,
+          scrollPosition: 100,
+          keyframes: [],
+          transitions: [],
+          markers: [],
+        },
+      });
+      mediaValidationMocks.validateProjectMediaReferences.mockResolvedValue([]);
+
+      await useTimelineStore.getState().loadTimeline('project-1');
+
+      const itemsState = useItemsStore.getState();
+      expect(itemsState.items).toHaveLength(1);
+      expect(itemsState.items[0]).not.toHaveProperty('thumbnailUrl');
+      expect(indexedDbMocks.updateProject).toHaveBeenCalledWith(
+        'project-1',
+        expect.objectContaining({
+          timeline: expect.objectContaining({
+            items: [
+              expect.not.objectContaining({
+                thumbnailUrl: expect.anything(),
+              }),
+            ],
+          }),
+        }),
+      );
     });
 
     it('throws when project not found', async () => {

--- a/src/features/timeline/stores/zoom-store.test.ts
+++ b/src/features/timeline/stores/zoom-store.test.ts
@@ -70,4 +70,31 @@ describe('zoom-store interaction split', () => {
     expect(state.contentPixelsPerSecond).toBeCloseTo(110);
     expect(state.isZoomInteracting).toBe(false);
   });
+
+  it('can synchronize a direct zoom level update without leaving content behind', () => {
+    useZoomStore.getState().setZoomLevelImmediate(1.8);
+
+    expect(useZoomStore.getState()).toMatchObject({
+      level: 1.8,
+      contentLevel: 1,
+      isZoomInteracting: true,
+    });
+
+    useZoomStore.getState().setZoomLevelSynchronized(0.75);
+
+    expect(useZoomStore.getState()).toMatchObject({
+      level: 0.75,
+      pixelsPerSecond: 75,
+      contentLevel: 0.75,
+      contentPixelsPerSecond: 75,
+      isZoomInteracting: false,
+    });
+
+    vi.advanceTimersByTime(100);
+    expect(useZoomStore.getState()).toMatchObject({
+      level: 0.75,
+      contentLevel: 0.75,
+      isZoomInteracting: false,
+    });
+  });
 });

--- a/src/features/timeline/stores/zoom-store.ts
+++ b/src/features/timeline/stores/zoom-store.ts
@@ -15,6 +15,7 @@ interface ZoomState {
 interface ZoomActions {
   setZoomLevel: (level: number) => void;
   setZoomLevelImmediate: (level: number) => void; // Bypasses throttle for smooth momentum zoom
+  setZoomLevelSynchronized: (level: number) => void;
   zoomIn: () => void;
   zoomOut: () => void;
   zoomToFit: (containerWidth: number, contentDurationSeconds: number) => void;
@@ -161,6 +162,9 @@ export const useZoomStore = create<ZoomState & ZoomActions>((set, get) => ({
     lastVisualZoomUpdate = performance.now();
     setVisualZoom(set, level, true);
     stageContentZoomCommit(set, level);
+  },
+  setZoomLevelSynchronized: (level) => {
+    applySynchronizedZoom(set, level);
   },
   zoomIn: () => {
     const newLevel = Math.min(get().level * 1.1, 50); // 10% per step for finer control


### PR DESCRIPTION
## Summary

- **Compact clip shell**: skip interactive overlays (trim/stretch/fade handles) and expensive fade computations for narrow clips (≤36px), keeping clip content always visible
- **Zoom performance**: reduce ClipContent zoom subscriptions from 3→1, use live `pixelsPerSecond` with compact clip cost amortization (1 long task at 69ms vs 9 at 143ms avg)
- **Filmstrip gap coverage**: skip filmstrip/waveform for sub-5px clips using reactive width, fill zoom gaps with repeating CSS cover frame background and full-set frame fallback
- **Join indicators**: zoom-based threshold (reactive) instead of per-clip width for consistent show/hide
- **IO markers**: simplify with imperative drag and memoized children to avoid parent ruler re-renders

## Test plan
- [ ] Zoom in/out rapidly — filmstrip should have no black gaps
- [ ] Narrow clips (many splits) should show label text, no blank rectangles
- [ ] Join indicators appear/disappear consistently across all clips at same zoom level
- [ ] In/out markers position correctly and drag works
- [ ] Playback with effects still renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, prioritized filmstrip "cover" prewarming during imports and proxy loads
  * Deterministic waveform redraw phasing to stagger commits across tiles
  * Synchronized zoom action to immediately align visual and content zoom

* **Performance / Chores**
  * Reduced per-render allocations in waveform rendering
  * Improved visible-item hysteresis for smoother zoom interactions
  * Timeline track rendering and compact-clip display optimizations

* **Bug Fixes / Reliability**
  * Strip transient thumbnail URLs from persisted timelines

* **Tests**
  * Added and adjusted tests for prewarm ordering, zoom sync, waveform phasing, and persistence behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->