### PR TITLE
feat(preview): WebCodecs streaming decode for transitions

### DIFF
--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -165,6 +165,12 @@ export interface ItemRenderContext {
   // the correct frame — use them directly instead of mediabunny decode.
   domVideoElementProvider?: (itemId: string) => HTMLVideoElement | null;
 
+  // Streaming WebCodecs frame provider (experimental).
+  // When set, checked before DOM video and mediabunny paths.
+  // Returns a pre-decoded ImageBitmap for the given source URL and timestamp,
+  // or null if no frame is buffered yet.
+  streamingFrameProvider?: (src: string, sourceTime: number) => ImageBitmap | null;
+
   // Set to true when rendering transition participant clips. Widens the
   // DOM video drift threshold to prefer stale zero-copy frames over
   // 170ms mediabunny stalls during transition ramp-up / exit.
@@ -543,6 +549,28 @@ async function renderVideoItem(
     ? (snappedSourceFrame + 1e-4) / sourceFps
     : rawSourceTime;
   const tier2ToleranceSeconds = getTier2VideoFrameToleranceSeconds(sourceFps);
+
+  // === TRY STREAMING WEBCODECS FRAME (experimental) ===
+  // When enabled, worker-decoded frames bypass DOM video and mediabunny entirely.
+  if (isPreviewMode && rctx.streamingFrameProvider && item.src) {
+    const streamBitmap = rctx.streamingFrameProvider(item.src, sourceTime);
+    if (streamBitmap) {
+      drawContainedMediaSource(
+        ctx,
+        streamBitmap,
+        streamBitmap.width,
+        streamBitmap.height,
+        transform,
+        canvasSettings,
+        item.crop,
+        undefined,
+        rctx.canvasPool,
+      );
+      return;
+    }
+    // Fall through to DOM video / mediabunny if no frame buffered yet
+  }
+
   const domVideo = isPreviewMode && rctx.domVideoElementProvider && sourceFrameOffset === 0
     ? rctx.domVideoElementProvider(item.id)
     : null;

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -551,8 +551,10 @@ async function renderVideoItem(
     : rawSourceTime;
   const tier2ToleranceSeconds = getTier2VideoFrameToleranceSeconds(sourceFps);
 
-  // === TRY STREAMING WEBCODECS FRAME (experimental) ===
+  // === TRY STREAMING WEBCODECS FRAME ===
   // When enabled, worker-decoded frames bypass DOM video and mediabunny entirely.
+  // On buffer miss, skip DOM video fallback to avoid flicker from mixed sources.
+  // Pre-warm + 3s lookahead ensures frames are buffered before they're needed.
   if (isPreviewMode && rctx.streamingFrameProvider && item.src) {
     const streamBitmap = rctx.streamingFrameProvider(item.src, sourceTime, item.mediaId);
     if (streamBitmap) {
@@ -567,9 +569,10 @@ async function renderVideoItem(
         undefined,
         rctx.canvasPool,
       );
-      return;
     }
-    // Fall through to DOM video / mediabunny if no frame buffered yet
+    // Whether we drew a frame or not, streaming owns this source —
+    // don't fall through to DOM video / mediabunny.
+    return;
   }
 
   const domVideo = isPreviewMode && rctx.domVideoElementProvider && sourceFrameOffset === 0

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -553,8 +553,8 @@ async function renderVideoItem(
 
   // === TRY STREAMING WEBCODECS FRAME ===
   // When enabled, worker-decoded frames bypass DOM video and mediabunny entirely.
-  // On buffer miss, skip DOM video fallback to avoid flicker from mixed sources.
-  // Pre-warm + 3s lookahead ensures frames are buffered before they're needed.
+  // On buffer miss, fall through to DOM video so transitions and cold-start clips
+  // show a frame rather than black.
   if (isPreviewMode && rctx.streamingFrameProvider && item.src) {
     const streamBitmap = rctx.streamingFrameProvider(item.src, sourceTime, item.mediaId);
     if (streamBitmap) {
@@ -569,10 +569,9 @@ async function renderVideoItem(
         undefined,
         rctx.canvasPool,
       );
+      return;
     }
-    // Whether we drew a frame or not, streaming owns this source —
-    // don't fall through to DOM video / mediabunny.
-    return;
+    // No frame buffered yet — fall through to DOM video / mediabunny
   }
 
   const domVideo = isPreviewMode && rctx.domVideoElementProvider && sourceFrameOffset === 0

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -167,9 +167,10 @@ export interface ItemRenderContext {
 
   // Streaming WebCodecs frame provider (experimental).
   // When set, checked before DOM video and mediabunny paths.
-  // Returns a pre-decoded ImageBitmap for the given source URL and timestamp,
-  // or null if no frame is buffered yet.
-  streamingFrameProvider?: (src: string, sourceTime: number) => ImageBitmap | null;
+  // Returns a pre-decoded ImageBitmap for the given source URL, timestamp, and mediaId,
+  // or null if no frame is buffered yet. mediaId is used to resolve the current
+  // blob URL via blobUrlManager when the passed src is stale from a re-render.
+  streamingFrameProvider?: (src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null;
 
   // Set to true when rendering transition participant clips. Widens the
   // DOM video drift threshold to prefer stale zero-copy frames over
@@ -553,7 +554,7 @@ async function renderVideoItem(
   // === TRY STREAMING WEBCODECS FRAME (experimental) ===
   // When enabled, worker-decoded frames bypass DOM video and mediabunny entirely.
   if (isPreviewMode && rctx.streamingFrameProvider && item.src) {
-    const streamBitmap = rctx.streamingFrameProvider(item.src, sourceTime);
+    const streamBitmap = rctx.streamingFrameProvider(item.src, sourceTime, item.mediaId);
     if (streamBitmap) {
       drawContainedMediaSource(
         ctx,

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -1773,7 +1773,7 @@ export async function createCompositionRenderer(
       itemRenderContext.domVideoElementProvider = provider;
     },
 
-    setStreamingFrameProvider(provider: ((src: string, sourceTime: number) => ImageBitmap | null) | undefined) {
+    setStreamingFrameProvider(provider: ((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | undefined) {
       itemRenderContext.streamingFrameProvider = provider;
     },
 

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -1773,6 +1773,10 @@ export async function createCompositionRenderer(
       itemRenderContext.domVideoElementProvider = provider;
     },
 
+    setStreamingFrameProvider(provider: ((src: string, sourceTime: number) => ImageBitmap | null) | undefined) {
+      itemRenderContext.streamingFrameProvider = provider;
+    },
+
     /**
      * Pre-initialize mediabunny decoders for specific item IDs and optionally
      * seek them to a target frame. This warms up the WASM decoder and positions

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -353,6 +353,7 @@ export const VideoPreview = memo(function VideoPreview({
     getTransitionWindowByStartFrame,
     getActiveTransitionWindowForFrame,
     pushTransitionTrace,
+    streamingFrameProviderRef,
     ...previewRuntimeRefs.transitionSessionControllerRefs,
   });
   const {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -325,7 +325,8 @@ export const VideoPreview = memo(function VideoPreview({
     project.width,
   ]);
 
-  const forceFastScrubOverlay = showGpuEffectsOverlay;
+  const { forceCanvasOverlay: streamingPlaybackActive, streamingFrameProviderRef } = useStreamingPlaybackController();
+  const forceFastScrubOverlay = showGpuEffectsOverlay || streamingPlaybackActive;
   const {
     clearTransitionPlaybackSession,
     pinTransitionPlaybackSession,
@@ -448,12 +449,8 @@ export const VideoPreview = memo(function VideoPreview({
     isPausedTransitionOverlayActive,
     trackPlayerSeek,
     recordRenderFrameJitter,
+    streamingFrameProviderRef,
     ...previewRuntimeRefs.renderPumpRefs,
-  });
-  useStreamingPlaybackController({
-    fps,
-    combinedTracks,
-    scrubRendererRef: previewRuntimeRefs.rendererControllerRefs.scrubRendererRef,
   });
   usePreviewMediaPreload({
     fps,

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -325,7 +325,10 @@ export const VideoPreview = memo(function VideoPreview({
     project.width,
   ]);
 
-  const { forceCanvasOverlay: streamingPlaybackActive, streamingFrameProviderRef } = useStreamingPlaybackController();
+  const { forceCanvasOverlay: streamingPlaybackActive, streamingFrameProviderRef } = useStreamingPlaybackController({
+    fps,
+    combinedTracks,
+  });
   const forceFastScrubOverlay = showGpuEffectsOverlay || streamingPlaybackActive;
   const {
     clearTransitionPlaybackSession,

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -328,6 +328,8 @@ export const VideoPreview = memo(function VideoPreview({
   const { forceCanvasOverlay: streamingPlaybackActive, streamingFrameProviderRef } = useStreamingPlaybackController({
     fps,
     combinedTracks,
+    playbackTransitionWindows,
+    playbackTransitionCooldownFrames,
   });
   const forceFastScrubOverlay = showGpuEffectsOverlay || streamingPlaybackActive;
   const {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -329,7 +329,6 @@ export const VideoPreview = memo(function VideoPreview({
     fps,
     combinedTracks,
     playbackTransitionWindows,
-    playbackTransitionCooldownFrames,
   });
   const forceFastScrubOverlay = showGpuEffectsOverlay || streamingPlaybackActive;
   const {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -31,6 +31,7 @@ import { usePreviewSourceWarm } from '../hooks/use-preview-source-warm';
 import { usePreviewTransitionModel } from '../hooks/use-preview-transition-model';
 import { usePreviewViewModel } from '../hooks/use-preview-view-model';
 import { usePreviewTransitionSessionController } from '../hooks/use-preview-transition-session-controller';
+import { useStreamingPlaybackController } from '../hooks/use-streaming-playback-controller';
 
 interface VideoPreviewProps {
   project: {
@@ -448,6 +449,11 @@ export const VideoPreview = memo(function VideoPreview({
     trackPlayerSeek,
     recordRenderFrameJitter,
     ...previewRuntimeRefs.renderPumpRefs,
+  });
+  useStreamingPlaybackController({
+    fps,
+    combinedTracks,
+    scrubRendererRef: previewRuntimeRefs.rendererControllerRefs.scrubRendererRef,
   });
   usePreviewMediaPreload({
     fps,

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -150,6 +150,9 @@ interface UsePreviewRenderPumpParams {
     transitionId: string | null,
     progress: number | null,
   ) => void;
+  /** Ref to streaming frame provider from useStreamingPlaybackController.
+   *  When non-null, the render pump sets it on the renderer before each frame. */
+  streamingFrameProviderRef?: RefObject<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>;
 }
 
 export function usePreviewRenderPump({
@@ -228,6 +231,7 @@ export function usePreviewRenderPump({
   isPausedTransitionOverlayActive,
   trackPlayerSeek,
   recordRenderFrameJitter,
+  streamingFrameProviderRef,
 }: UsePreviewRenderPumpParams) {
   useEffect(() => {
     scrubMountedRef.current = true;
@@ -598,6 +602,10 @@ export function usePreviewRenderPump({
               renderer.setDomVideoElementProvider?.(getPinnedTransitionElementForItem);
             } else {
               renderer.setDomVideoElementProvider?.(undefined);
+            }
+            // Set streaming frame provider when available (experimental WebCodecs playback)
+            if ('setStreamingFrameProvider' in renderer) {
+              renderer.setStreamingFrameProvider?.(streamingFrameProviderRef?.current ?? undefined);
             }
           }
 

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -1081,6 +1081,9 @@ export function usePreviewRenderPump({
                   { requireExplicitSourceFps: true },
                 ));
                 if (!usePlaybackStore.getState().isPlaying && mainRenderer) {
+                  if ('setStreamingFrameProvider' in mainRenderer) {
+                    mainRenderer.setStreamingFrameProvider?.(streamingFrameProviderRef?.current ?? undefined);
+                  }
                   const preRenderCount = Math.min(playbackTransitionPrerenderRunwayFrames, tw.endFrame - tw.startFrame);
                   for (let fi = 0; fi < preRenderCount; fi++) {
                     if (usePlaybackStore.getState().isPlaying) break;
@@ -1443,6 +1446,9 @@ export function usePreviewRenderPump({
               try {
                 const bgRenderer = await ensureBgTransitionRenderer();
                 if (bgRenderer && !usePlaybackStore.getState().isPlaying) {
+                  if ('setStreamingFrameProvider' in bgRenderer) {
+                    bgRenderer.setStreamingFrameProvider?.(streamingFrameProviderRef?.current ?? undefined);
+                  }
                   await bgRenderer.renderFrame(tw.startFrame);
                   cacheTransitionSessionFrame(tw.startFrame);
                   pushTransitionTrace('bg_prerender', { frame: tw.startFrame });

--- a/src/features/preview/hooks/use-preview-transition-session-controller.ts
+++ b/src/features/preview/hooks/use-preview-transition-session-controller.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, type MutableRefObject } from 'react';
 import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransitionWindow } from '@/domain/timeline/transitions/transition-planner';
@@ -52,6 +53,7 @@ type TransitionRenderer = {
   renderFrame: (frame: number) => Promise<void>;
   prewarmFrame: (frame: number) => Promise<void>;
   setDomVideoElementProvider?: (provider: (itemId: string) => HTMLVideoElement | null) => void;
+  setStreamingFrameProvider?: (provider: ((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | undefined) => void;
 };
 
 interface UsePreviewTransitionSessionControllerParams {
@@ -74,6 +76,7 @@ interface UsePreviewTransitionSessionControllerParams {
   scrubOffscreenCanvasRef: MutableRefObject<OffscreenCanvas | null>;
   scrubOffscreenRenderedFrameRef: MutableRefObject<number | null>;
   resumeScrubLoopRef: MutableRefObject<() => void>;
+  streamingFrameProviderRef?: React.RefObject<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>;
   playbackTransitionPreparePromiseRef: MutableRefObject<Promise<boolean> | null>;
   playbackTransitionPreparingFrameRef: MutableRefObject<number | null>;
   transitionSessionWindowRef: MutableRefObject<ResolvedTransitionWindow<TimelineItem> | null>;
@@ -106,6 +109,7 @@ export function usePreviewTransitionSessionController({
   scrubOffscreenCanvasRef,
   scrubOffscreenRenderedFrameRef,
   resumeScrubLoopRef,
+  streamingFrameProviderRef,
   playbackTransitionPreparePromiseRef,
   playbackTransitionPreparingFrameRef,
   transitionSessionWindowRef,
@@ -487,6 +491,9 @@ export function usePreviewTransitionSessionController({
 
         if ('setDomVideoElementProvider' in renderer && renderer.setDomVideoElementProvider) {
           renderer.setDomVideoElementProvider(getPinnedTransitionElementForItem);
+        }
+        if ('setStreamingFrameProvider' in renderer && renderer.setStreamingFrameProvider) {
+          renderer.setStreamingFrameProvider(streamingFrameProviderRef?.current ?? undefined);
         }
 
         const isComplexTransitionStart = playbackTransitionComplexStartFrames.has(targetFrame);

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -30,8 +30,9 @@ const log = createLogger('StreamingPlaybackCtrl');
 const TRANSITION_PREWARM_SECONDS = 3;
 
 /** How far ahead (in seconds) to force the canvas overlay before a transition.
- *  By this point the streaming buffers should be warm. */
-const TRANSITION_OVERLAY_LEAD_SECONDS = 0.5;
+ *  The overlay must be active for the main render path to use the streaming
+ *  provider — the transition pre-render path doesn't set it. */
+const TRANSITION_OVERLAY_LEAD_SECONDS = 1;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,12 +61,14 @@ interface TransitionPrewarmTarget {
 }
 
 /**
- * Collect pre-warm targets: only video clips that participate in transitions
- * within the lookahead window. For "force all" mode (debug toggle), collects
- * ALL visible video clips.
+ * Collect pre-warm targets: only video clips that overlap with upcoming
+ * transition windows. Uses transition windows for timing only, and finds
+ * the actual clips from the raw timeline tracks (which have full item
+ * properties like mediaId, src, sourceFps, etc.).
  */
 function collectTransitionPrewarmTargets(
   transitionWindows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>,
+  tracks: TimelineTrack[],
   timelineFrame: number,
   timelineFps: number,
   useProxy: boolean,
@@ -74,16 +77,28 @@ function collectTransitionPrewarmTargets(
   const seen = new Set<string>();
   const prewarmFrames = Math.round(TRANSITION_PREWARM_SECONDS * timelineFps);
 
+  // Collect frame ranges of upcoming transitions
+  const transitionRanges: Array<{ start: number; end: number }> = [];
   for (const tw of transitionWindows) {
-    // Skip transitions that ended before current frame
     if (tw.endFrame <= timelineFrame) continue;
-    // Skip transitions beyond the prewarm window
     if (tw.startFrame > timelineFrame + prewarmFrames) continue;
+    transitionRanges.push({ start: tw.startFrame, end: tw.endFrame });
+  }
 
-    // Both clips participate in this transition
-    for (const clip of [tw.leftClip, tw.rightClip]) {
-      if (clip.type !== 'video') continue;
-      const videoItem = clip as VideoItem;
+  if (transitionRanges.length === 0) return targets;
+
+  // Find video clips from the raw timeline that overlap any transition range
+  for (const track of tracks) {
+    for (const item of track.items) {
+      if (item.type !== 'video') continue;
+      const videoItem = item as VideoItem;
+      const clipEnd = videoItem.from + videoItem.durationInFrames;
+
+      const overlapsTransition = transitionRanges.some(
+        (tr) => videoItem.from < tr.end && clipEnd > tr.start,
+      );
+      if (!overlapsTransition) continue;
+
       const src = resolveVideoSrc(videoItem, useProxy);
       if (!src || seen.has(src)) continue;
       seen.add(src);
@@ -208,7 +223,7 @@ export function useStreamingPlaybackController({
       return collectAllPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
     }
     return collectTransitionPrewarmTargets(
-      transitionWindowsRef.current, frame, fpsRef.current, useProxyRef.current,
+      transitionWindowsRef.current, tracksRef.current, frame, fpsRef.current, useProxyRef.current,
     );
   }, []);
 
@@ -233,11 +248,14 @@ export function useStreamingPlaybackController({
     const frame = state.currentFrame;
     const playback = getPlayback();
 
-    // Start streams for upcoming transition clips
+    // Start streams for upcoming transition clips, and keep existing
+    // streams decoding ahead by sending position updates.
     const targets = getTargets(frame);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
+      } else {
+        playback.updatePosition(src, sourceTime);
       }
     }
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -1,19 +1,16 @@
 /**
- * Hook to manage WebCodecs streaming playback lifecycle.
+ * Hook to manage WebCodecs streaming playback lifecycle for transitions.
  *
- * When enabled, creates a streaming decode worker that runs mediabunny's
- * forward samples() generator for each visible video source. Decoded
- * ImageBitmaps are buffered and provided to the canvas render pipeline,
- * bypassing HTML5 <video> elements entirely.
+ * Streaming decode only activates when the playhead approaches or is inside
+ * a transition window. Regular playback uses DOM <video> elements — they're
+ * lighter and handle audio, proxy toggling, and browser timing natively.
  *
- * The coordinator is self-managing: getFrame() lazily auto-starts streams
- * for new sources and idle cleanup stops streams that are no longer needed.
+ * During transitions, two clips must render simultaneously to a canvas.
+ * The streaming worker pre-decodes both clips' frames so the transition
+ * compositor can blend them without relying on DOM video timing.
  *
- * The hook exposes a `streamingFrameProviderRef` that the render pump reads
- * on each frame and sets on the renderer. This avoids timing issues with
- * renderer creation/destruction during re-renders.
- *
- * Toggle via window.__DEBUG__?.setStreamingPlayback(true)
+ * Toggle via window.__DEBUG__?.setStreamingPlayback(true) to force
+ * streaming for ALL clips (original PoC behavior).
  */
 
 import { useEffect, useRef, useCallback, useState } from 'react';
@@ -21,86 +18,160 @@ import { usePlaybackStore } from '@/shared/state/playback';
 import { createStreamingPlayback, type StreamingPlayback } from '../utils/streaming-playback';
 import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
 import { createLogger } from '@/shared/logging/logger';
-import type { TimelineTrack, VideoItem } from '@/types/timeline';
+import type { TimelineTrack, TimelineItem, VideoItem } from '@/types/timeline';
 import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 import { resolveProxyUrl } from '../deps/media-library-contract';
+import type { ResolvedTransitionWindow } from '@/domain/timeline/transitions/transition-planner';
 
 const log = createLogger('StreamingPlaybackCtrl');
 
-/** How far ahead (in seconds) to look for upcoming video clips to pre-warm.
- *  5s gives the worker enough time to init new sources (~1-2s) and buffer
- *  frames before playback reaches them. */
-const LOOKAHEAD_SECONDS = 5;
+/** How far ahead (in seconds) to start streaming transition clips.
+ *  The worker needs ~1-2s to init + buffer, so 3s provides headroom. */
+const TRANSITION_PREWARM_SECONDS = 3;
+
+/** How far ahead (in seconds) to force the canvas overlay before a transition.
+ *  By this point the streaming buffers should be warm. */
+const TRANSITION_OVERLAY_LEAD_SECONDS = 0.5;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve the best source URL for a video item (proxy when enabled). */
+function resolveVideoSrc(item: VideoItem, useProxy: boolean): string | null {
+  const mediaId = item.mediaId;
+  const proxyUrl = useProxy && mediaId ? resolveProxyUrl(mediaId) : null;
+  return proxyUrl ?? (mediaId ? blobUrlManager.get(mediaId) : null) ?? item.src;
+}
+
+/** Compute source time for a video item at a given timeline frame. */
+function computeSourceTime(item: VideoItem, timelineFrame: number, timelineFps: number): number {
+  const sourceFps = item.sourceFps ?? timelineFps;
+  const speed = item.speed ?? 1;
+  const sourceStart = item.sourceStart ?? item.trimStart ?? 0;
+  const localFrame = Math.max(0, timelineFrame - item.from);
+  return sourceStart / sourceFps + (localFrame / timelineFps) * speed;
+}
+
+interface TransitionPrewarmTarget {
+  src: string;
+  sourceTime: number;
+  mediaId?: string;
+}
 
 /**
- * Collect pre-warm targets: video items visible at the given frame,
- * plus upcoming clips within LOOKAHEAD_SECONDS that will need streams.
+ * Collect pre-warm targets: only video clips that participate in transitions
+ * within the lookahead window. For "force all" mode (debug toggle), collects
+ * ALL visible video clips.
  */
-function collectPrewarmTargets(
-  tracks: TimelineTrack[],
+function collectTransitionPrewarmTargets(
+  transitionWindows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>,
   timelineFrame: number,
   timelineFps: number,
   useProxy: boolean,
-): Array<{ src: string; sourceTime: number; mediaId?: string }> {
-  const targets: Array<{ src: string; sourceTime: number; mediaId?: string }> = [];
+): TransitionPrewarmTarget[] {
+  const targets: TransitionPrewarmTarget[] = [];
   const seen = new Set<string>();
-  const lookaheadFrames = Math.round(LOOKAHEAD_SECONDS * timelineFps);
+  const prewarmFrames = Math.round(TRANSITION_PREWARM_SECONDS * timelineFps);
 
-  for (const track of tracks) {
-    for (const item of track.items) {
-      if (item.type !== 'video') continue;
-      const videoItem = item as VideoItem;
+  for (const tw of transitionWindows) {
+    // Skip transitions that ended before current frame
+    if (tw.endFrame <= timelineFrame) continue;
+    // Skip transitions beyond the prewarm window
+    if (tw.startFrame > timelineFrame + prewarmFrames) continue;
 
-      // Skip clips that end before current frame
-      const clipEnd = videoItem.from + videoItem.durationInFrames;
-      if (clipEnd <= timelineFrame) continue;
+    // Both clips participate in this transition
+    for (const clip of [tw.leftClip, tw.rightClip]) {
+      if (clip.type !== 'video') continue;
+      const videoItem = clip as VideoItem;
+      const src = resolveVideoSrc(videoItem, useProxy);
+      if (!src || seen.has(src)) continue;
+      seen.add(src);
 
-      // Skip clips that start beyond the lookahead window
-      if (videoItem.from > timelineFrame + lookaheadFrames) continue;
-
-      const mediaId = videoItem.mediaId;
-      // Match the preview render pipeline: use proxy when enabled, original when not
-      const proxyUrl = useProxy && mediaId ? resolveProxyUrl(mediaId) : null;
-      const activeSrc = proxyUrl ?? (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
-      if (!activeSrc || seen.has(activeSrc)) continue;
-      seen.add(activeSrc);
-
-      const sourceFps = videoItem.sourceFps ?? timelineFps;
-      const speed = videoItem.speed ?? 1;
-      const sourceStart = videoItem.sourceStart ?? videoItem.trimStart ?? 0;
-
-      // For visible clips, compute source time at current frame.
-      // For upcoming clips, start from their source beginning.
-      const localFrame = Math.max(0, timelineFrame - videoItem.from);
-      const sourceTime = sourceStart / sourceFps + (localFrame / timelineFps) * speed;
-
-      targets.push({ src: activeSrc, sourceTime, mediaId });
+      const sourceTime = computeSourceTime(videoItem, timelineFrame, timelineFps);
+      targets.push({ src, sourceTime, mediaId: videoItem.mediaId });
     }
   }
 
   return targets;
 }
 
+/**
+ * Collect ALL visible video clips as pre-warm targets (force-all mode).
+ */
+function collectAllPrewarmTargets(
+  tracks: TimelineTrack[],
+  timelineFrame: number,
+  timelineFps: number,
+  useProxy: boolean,
+): TransitionPrewarmTarget[] {
+  const targets: TransitionPrewarmTarget[] = [];
+  const seen = new Set<string>();
+  const lookaheadFrames = Math.round(TRANSITION_PREWARM_SECONDS * timelineFps);
+
+  for (const track of tracks) {
+    for (const item of track.items) {
+      if (item.type !== 'video') continue;
+      const videoItem = item as VideoItem;
+      const clipEnd = videoItem.from + videoItem.durationInFrames;
+      if (clipEnd <= timelineFrame) continue;
+      if (videoItem.from > timelineFrame + lookaheadFrames) continue;
+
+      const src = resolveVideoSrc(videoItem, useProxy);
+      if (!src || seen.has(src)) continue;
+      seen.add(src);
+
+      const sourceTime = computeSourceTime(videoItem, timelineFrame, timelineFps);
+      targets.push({ src, sourceTime, mediaId: videoItem.mediaId });
+    }
+  }
+
+  return targets;
+}
+
+/** Check if a frame is within the overlay-lead window of any transition. */
+function isFrameNearTransition(
+  frame: number,
+  windows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>,
+  leadFrames: number,
+  cooldownFrames: number,
+): boolean {
+  for (const tw of windows) {
+    if (frame >= tw.startFrame - leadFrames && frame < tw.endFrame + cooldownFrames) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 interface UseStreamingPlaybackControllerParams {
   fps: number;
   combinedTracks: TimelineTrack[];
+  playbackTransitionWindows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>;
+  playbackTransitionCooldownFrames: number;
 }
 
 interface UseStreamingPlaybackControllerResult {
-  /** Whether streaming playback is enabled — when true, the canvas overlay
-   *  must be forced during playback (same as GPU effects). */
+  /** Whether the canvas overlay must be forced (near a transition during playback). */
   forceCanvasOverlay: boolean;
-  /** Ref to the streaming frame provider function. The render pump should
-   *  set this on the renderer before each frame via setStreamingFrameProvider. */
+  /** Ref to the streaming frame provider function. */
   streamingFrameProviderRef: React.RefObject<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>;
 }
 
 export function useStreamingPlaybackController({
   fps,
   combinedTracks,
+  playbackTransitionWindows,
+  playbackTransitionCooldownFrames,
 }: UseStreamingPlaybackControllerParams): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
   const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
+  /** When true, stream ALL clips (debug toggle). When false, only transition clips. */
+  const forceAllRef = useRef(STREAMING_PLAYBACK_ENABLED);
   const [forceCanvasOverlay, setForceCanvasOverlay] = useState(false);
   const streamingFrameProviderRef = useRef<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>(null);
 
@@ -111,23 +182,36 @@ export function useStreamingPlaybackController({
     return playbackRef.current;
   }, []);
 
-  // Frame provider callback — the coordinator handles everything internally
   const getStreamingFrame = useCallback((src: string, sourceTime: number, mediaId?: string): ImageBitmap | null => {
     if (!playbackRef.current) return null;
     return playbackRef.current.getFrame(src, sourceTime, mediaId);
   }, []);
 
-  // Pre-warm: start decoding at the current playhead so the buffer has frames
-  // before play starts. Restarts on seek. Tracks ref holds the latest value.
+  // Refs for latest values
   const tracksRef = useRef(combinedTracks);
   const fpsRef = useRef(fps);
   const useProxy = usePlaybackStore((s) => s.useProxy);
   const useProxyRef = useRef(useProxy);
+  const transitionWindowsRef = useRef(playbackTransitionWindows);
+  const cooldownFramesRef = useRef(playbackTransitionCooldownFrames);
   tracksRef.current = combinedTracks;
   fpsRef.current = fps;
   useProxyRef.current = useProxy;
+  transitionWindowsRef.current = playbackTransitionWindows;
+  cooldownFramesRef.current = playbackTransitionCooldownFrames;
+
   const prewarmFrameRef = useRef<number | null>(null);
   const lookaheadTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Collect targets based on mode: transition-only or force-all
+  const getTargets = useCallback((frame: number) => {
+    if (forceAllRef.current) {
+      return collectAllPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
+    }
+    return collectTransitionPrewarmTargets(
+      transitionWindowsRef.current, frame, fpsRef.current, useProxyRef.current,
+    );
+  }, []);
 
   const prewarmAtFrame = useCallback((frame: number, seekExisting = true) => {
     if (!enabledRef.current) return;
@@ -135,7 +219,7 @@ export function useStreamingPlaybackController({
     prewarmFrameRef.current = frame;
 
     const playback = getPlayback();
-    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
+    const targets = getTargets(frame);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
@@ -143,38 +227,44 @@ export function useStreamingPlaybackController({
         playback.seekStream(src, sourceTime);
       }
     }
-  }, [getPlayback]);
+  }, [getPlayback, getTargets]);
 
-  /** During playback, periodically scan for upcoming clips and start their
-   *  decode streams early. Only starts NEW streams — existing ones keep running. */
+  /** During playback, scan for upcoming transition clips and manage overlay. */
   const runPlaybackLookahead = useCallback(() => {
     if (!enabledRef.current) return;
-    const frame = usePlaybackStore.getState().currentFrame;
+    const state = usePlaybackStore.getState();
+    const frame = state.currentFrame;
     const playback = getPlayback();
-    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
+
+    // Start streams for upcoming transition clips
+    const targets = getTargets(frame);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
       }
     }
-  }, [getPlayback]);
 
-  // Subscribe to playback state: manage streaming lifecycle and expose provider via ref.
-  // The render pump reads streamingFrameProviderRef and sets it on the renderer per-frame,
-  // avoiding timing issues with renderer creation/destruction during re-renders.
+    // Toggle canvas overlay based on proximity to transitions
+    if (!forceAllRef.current) {
+      const overlayLeadFrames = Math.round(TRANSITION_OVERLAY_LEAD_SECONDS * fpsRef.current);
+      const nearTransition = isFrameNearTransition(
+        frame, transitionWindowsRef.current, overlayLeadFrames, cooldownFramesRef.current,
+      );
+      setForceCanvasOverlay(nearTransition);
+    }
+  }, [getPlayback, getTargets]);
+
+  // Subscribe to playback state
   useEffect(() => {
     const initialState = usePlaybackStore.getState();
 
-    // Activate provider immediately — it serves both playback and scrub.
-    // During scrub, buffered streaming frames are used when available,
-    // falling through to DOM video / mediabunny on miss.
     if (enabledRef.current) {
       streamingFrameProviderRef.current = getStreamingFrame;
-
       if (initialState.isPlaying) {
         getPlayback();
-        setForceCanvasOverlay(true);
-        log.info('Playback already active on mount, streaming provider activated');
+        if (forceAllRef.current) setForceCanvasOverlay(true);
+        if (lookaheadTimerRef.current) clearInterval(lookaheadTimerRef.current);
+        lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 500);
       } else {
         prewarmAtFrame(initialState.currentFrame);
       }
@@ -189,12 +279,13 @@ export function useStreamingPlaybackController({
       if (isPlaying && !wasPlaying) {
         const playback = getPlayback();
         streamingFrameProviderRef.current = getStreamingFrame;
-        setForceCanvasOverlay(true);
-        prewarmFrameRef.current = null; // clear so next pause re-prewarms
+        prewarmFrameRef.current = null;
         playback.enableIdleSweep();
-        // Start periodic lookahead for upcoming clips during playback
+        if (forceAllRef.current) setForceCanvasOverlay(true);
         if (lookaheadTimerRef.current) clearInterval(lookaheadTimerRef.current);
-        lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 1000);
+        lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 500);
+        // Run immediately to check transition proximity
+        runPlaybackLookahead();
         log.info('Playback started, streaming provider activated');
       } else if (!isPlaying && wasPlaying) {
         setForceCanvasOverlay(false);
@@ -202,7 +293,6 @@ export function useStreamingPlaybackController({
           clearInterval(lookaheadTimerRef.current);
           lookaheadTimerRef.current = null;
         }
-        // Keep streamingFrameProviderRef set — scrub uses it too
         const playback = playbackRef.current;
         if (playback) {
           const metrics = playback.getMetrics();
@@ -213,12 +303,8 @@ export function useStreamingPlaybackController({
           });
           playback.stopAll();
         }
-        // Pre-warm at the stop position
         prewarmAtFrame(state.currentFrame);
       } else if (!isPlaying && state.currentFrame !== prevState.currentFrame) {
-        // User scrubbing while paused — start new streams but don't seek
-        // active ones. Forward scrub keeps the buffer valid; backward
-        // scrub / large jumps fall through to mediabunny on miss.
         const delta = state.currentFrame - prevState.currentFrame;
         const isLargeJump = Math.abs(delta) > fpsRef.current * 2;
         const isBackward = delta < 0;
@@ -236,10 +322,7 @@ export function useStreamingPlaybackController({
     };
   }, [getPlayback, getStreamingFrame, prewarmAtFrame, runPlaybackLookahead]);
 
-  // When proxy toggle changes, restart streams with the correct source URLs.
-  // Disable the provider during the transition so the RAF pump doesn't auto-start
-  // streams with stale URLs from the old composition. Re-enable after the
-  // composition rebuilds with new proxy URLs (next animation frame).
+  // Restart streams when proxy toggle changes
   useEffect(() => {
     if (!enabledRef.current) return;
     const playback = playbackRef.current;
@@ -264,7 +347,7 @@ export function useStreamingPlaybackController({
     };
   }, []);
 
-  // Expose debug toggle
+  // Debug toggle
   useEffect(() => {
     if (!import.meta.env.DEV) return;
 
@@ -272,19 +355,17 @@ export function useStreamingPlaybackController({
       Record<string, unknown> | undefined;
     if (!debugApi) return;
 
-    debugApi.setStreamingPlayback = (enabled: boolean) => {
+    debugApi.setStreamingPlayback = (enabled: boolean, forceAll = false) => {
       enabledRef.current = enabled;
-      log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
+      forceAllRef.current = enabled && forceAll;
+      log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}${forceAll ? ' (force all)' : ''}`);
 
       if (enabled) {
         streamingFrameProviderRef.current = getStreamingFrame;
-        // Force overlay only if already playing
         const state = usePlaybackStore.getState();
-        if (state.isPlaying) setForceCanvasOverlay(true);
-        if (!state.isPlaying) {
-          prewarmFrameRef.current = null; // force re-prewarm
-          prewarmAtFrame(state.currentFrame);
-        }
+        if (state.isPlaying && forceAll) setForceCanvasOverlay(true);
+        prewarmFrameRef.current = null;
+        prewarmAtFrame(state.currentFrame);
       } else {
         setForceCanvasOverlay(false);
         streamingFrameProviderRef.current = null;

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -21,8 +21,47 @@ import { usePlaybackStore } from '@/shared/state/playback';
 import { createStreamingPlayback, type StreamingPlayback } from '../utils/streaming-playback';
 import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
 import { createLogger } from '@/shared/logging/logger';
+import type { TimelineTrack, VideoItem } from '@/types/timeline';
+import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 
 const log = createLogger('StreamingPlaybackCtrl');
+
+/** Collect (activeSrc, sourceTime, mediaId) for video items visible at the given frame. */
+function collectVisibleVideoPrewarmTargets(
+  tracks: TimelineTrack[],
+  timelineFrame: number,
+  timelineFps: number,
+): Array<{ src: string; sourceTime: number; mediaId?: string }> {
+  const targets: Array<{ src: string; sourceTime: number; mediaId?: string }> = [];
+
+  for (const track of tracks) {
+    for (const item of track.items) {
+      if (item.type !== 'video') continue;
+      const videoItem = item as VideoItem;
+      const localFrame = timelineFrame - videoItem.from;
+      if (localFrame < 0 || localFrame >= videoItem.durationInFrames) continue;
+
+      // Resolve active blob URL via mediaId (item.src may be stale)
+      const mediaId = videoItem.mediaId;
+      const activeSrc = (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
+      if (!activeSrc) continue;
+
+      const sourceFps = videoItem.sourceFps ?? timelineFps;
+      const speed = videoItem.speed ?? 1;
+      const sourceStart = videoItem.sourceStart ?? videoItem.trimStart ?? 0;
+      const sourceTime = sourceStart / sourceFps + (localFrame / timelineFps) * speed;
+
+      targets.push({ src: activeSrc, sourceTime, mediaId });
+    }
+  }
+
+  return targets;
+}
+
+interface UseStreamingPlaybackControllerParams {
+  fps: number;
+  combinedTracks: TimelineTrack[];
+}
 
 interface UseStreamingPlaybackControllerResult {
   /** Whether streaming playback is enabled — when true, the canvas overlay
@@ -33,7 +72,10 @@ interface UseStreamingPlaybackControllerResult {
   streamingFrameProviderRef: React.RefObject<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>;
 }
 
-export function useStreamingPlaybackController(): UseStreamingPlaybackControllerResult {
+export function useStreamingPlaybackController({
+  fps,
+  combinedTracks,
+}: UseStreamingPlaybackControllerParams): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
   const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
   const [forceCanvasOverlay, setForceCanvasOverlay] = useState(STREAMING_PLAYBACK_ENABLED);
@@ -52,15 +94,46 @@ export function useStreamingPlaybackController(): UseStreamingPlaybackController
     return playbackRef.current.getFrame(src, sourceTime, mediaId);
   }, []);
 
+  // Pre-warm: start decoding at the current playhead so the buffer has frames
+  // before play starts. Restarts on seek. Tracks ref holds the latest value.
+  const tracksRef = useRef(combinedTracks);
+  const fpsRef = useRef(fps);
+  tracksRef.current = combinedTracks;
+  fpsRef.current = fps;
+  const prewarmFrameRef = useRef<number | null>(null);
+
+  const prewarmAtFrame = useCallback((frame: number) => {
+    if (!enabledRef.current) return;
+    if (frame === prewarmFrameRef.current) return;
+    prewarmFrameRef.current = frame;
+
+    const playback = getPlayback();
+    const targets = collectVisibleVideoPrewarmTargets(tracksRef.current, frame, fpsRef.current);
+    for (const { src, sourceTime } of targets) {
+      if (!playback.isStreaming(src)) {
+        playback.startStream(src, sourceTime);
+      } else {
+        playback.seekStream(src, sourceTime);
+      }
+    }
+  }, [getPlayback]);
+
   // Subscribe to playback state: manage streaming lifecycle and expose provider via ref.
   // The render pump reads streamingFrameProviderRef and sets it on the renderer per-frame,
   // avoiding timing issues with renderer creation/destruction during re-renders.
   useEffect(() => {
-    // If already playing when this effect mounts, activate immediately
-    if (enabledRef.current && usePlaybackStore.getState().isPlaying) {
+    const initialState = usePlaybackStore.getState();
+
+    // If already playing on mount, activate immediately
+    if (enabledRef.current && initialState.isPlaying) {
       getPlayback();
       streamingFrameProviderRef.current = getStreamingFrame;
       log.info('Playback already active on mount, streaming provider activated');
+    }
+
+    // Pre-warm at the current frame while paused
+    if (enabledRef.current && !initialState.isPlaying) {
+      prewarmAtFrame(initialState.currentFrame);
     }
 
     const unsubscribe = usePlaybackStore.subscribe((state, prevState) => {
@@ -72,6 +145,7 @@ export function useStreamingPlaybackController(): UseStreamingPlaybackController
       if (isPlaying && !wasPlaying) {
         getPlayback();
         streamingFrameProviderRef.current = getStreamingFrame;
+        prewarmFrameRef.current = null; // clear so next pause re-prewarms
         log.info('Playback started, streaming provider activated');
       } else if (!isPlaying && wasPlaying) {
         streamingFrameProviderRef.current = null;
@@ -85,6 +159,11 @@ export function useStreamingPlaybackController(): UseStreamingPlaybackController
           });
           playback.stopAll();
         }
+        // Pre-warm at the stop position
+        prewarmAtFrame(state.currentFrame);
+      } else if (!isPlaying && state.currentFrame !== prevState.currentFrame) {
+        // User seeked while paused — pre-warm at new position
+        prewarmAtFrame(state.currentFrame);
       }
     });
 
@@ -92,7 +171,7 @@ export function useStreamingPlaybackController(): UseStreamingPlaybackController
       unsubscribe();
       streamingFrameProviderRef.current = null;
     };
-  }, [getPlayback, getStreamingFrame]);
+  }, [getPlayback, getStreamingFrame, prewarmAtFrame]);
 
   // Clean up on unmount
   useEffect(() => {
@@ -115,9 +194,17 @@ export function useStreamingPlaybackController(): UseStreamingPlaybackController
       setForceCanvasOverlay(enabled);
       log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
 
-      if (!enabled) {
+      if (enabled) {
+        // Start pre-warm immediately at current playhead
+        const state = usePlaybackStore.getState();
+        if (!state.isPlaying) {
+          prewarmFrameRef.current = null; // force re-prewarm
+          prewarmAtFrame(state.currentFrame);
+        }
+      } else {
         streamingFrameProviderRef.current = null;
         playbackRef.current?.stopAll();
+        prewarmFrameRef.current = null;
       }
     };
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -26,29 +26,46 @@ import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 
 const log = createLogger('StreamingPlaybackCtrl');
 
-/** Collect (activeSrc, sourceTime, mediaId) for video items visible at the given frame. */
-function collectVisibleVideoPrewarmTargets(
+/** How far ahead (in seconds) to look for upcoming video clips to pre-warm. */
+const LOOKAHEAD_SECONDS = 3;
+
+/**
+ * Collect pre-warm targets: video items visible at the given frame,
+ * plus upcoming clips within LOOKAHEAD_SECONDS that will need streams.
+ */
+function collectPrewarmTargets(
   tracks: TimelineTrack[],
   timelineFrame: number,
   timelineFps: number,
 ): Array<{ src: string; sourceTime: number; mediaId?: string }> {
   const targets: Array<{ src: string; sourceTime: number; mediaId?: string }> = [];
+  const seen = new Set<string>();
+  const lookaheadFrames = Math.round(LOOKAHEAD_SECONDS * timelineFps);
 
   for (const track of tracks) {
     for (const item of track.items) {
       if (item.type !== 'video') continue;
       const videoItem = item as VideoItem;
-      const localFrame = timelineFrame - videoItem.from;
-      if (localFrame < 0 || localFrame >= videoItem.durationInFrames) continue;
 
-      // Resolve active blob URL via mediaId (item.src may be stale)
+      // Skip clips that end before current frame
+      const clipEnd = videoItem.from + videoItem.durationInFrames;
+      if (clipEnd <= timelineFrame) continue;
+
+      // Skip clips that start beyond the lookahead window
+      if (videoItem.from > timelineFrame + lookaheadFrames) continue;
+
       const mediaId = videoItem.mediaId;
       const activeSrc = (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
-      if (!activeSrc) continue;
+      if (!activeSrc || seen.has(activeSrc)) continue;
+      seen.add(activeSrc);
 
       const sourceFps = videoItem.sourceFps ?? timelineFps;
       const speed = videoItem.speed ?? 1;
       const sourceStart = videoItem.sourceStart ?? videoItem.trimStart ?? 0;
+
+      // For visible clips, compute source time at current frame.
+      // For upcoming clips, start from their source beginning.
+      const localFrame = Math.max(0, timelineFrame - videoItem.from);
       const sourceTime = sourceStart / sourceFps + (localFrame / timelineFps) * speed;
 
       targets.push({ src: activeSrc, sourceTime, mediaId });
@@ -108,7 +125,7 @@ export function useStreamingPlaybackController({
     prewarmFrameRef.current = frame;
 
     const playback = getPlayback();
-    const targets = collectVisibleVideoPrewarmTargets(tracksRef.current, frame, fpsRef.current);
+    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -1,0 +1,181 @@
+/**
+ * Hook to manage WebCodecs streaming playback lifecycle.
+ *
+ * When enabled, creates a streaming decode worker that runs mediabunny's
+ * forward samples() generator for each visible video source. Decoded
+ * ImageBitmaps are buffered and provided to the canvas render pipeline,
+ * bypassing HTML5 <video> elements entirely.
+ *
+ * This is experimental — toggle via window.__DEBUG__?.setStreamingPlayback(true)
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { usePlaybackStore } from '@/shared/state/playback';
+import { createStreamingPlayback, type StreamingPlayback } from '../utils/streaming-playback';
+import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
+import { createLogger } from '@/shared/logging/logger';
+import type { TimelineTrack, VideoItem } from '@/types/timeline';
+
+const log = createLogger('StreamingPlaybackCtrl');
+
+type PreviewRenderer = {
+  setStreamingFrameProvider?: (
+    provider: ((src: string, sourceTime: number) => ImageBitmap | null) | undefined,
+  ) => void;
+};
+
+/** Collect src → startTimestamp for all video items visible at the given frame. */
+function collectVisibleVideoSources(
+  tracks: TimelineTrack[],
+  timelineFrame: number,
+  timelineFps: number,
+): Map<string, number> {
+  const sources = new Map<string, number>();
+
+  for (const track of tracks) {
+    for (const item of track.items) {
+      if (item.type !== 'video' || !item.src) continue;
+      const videoItem = item as VideoItem;
+      const localFrame = timelineFrame - videoItem.from;
+      if (localFrame < 0 || localFrame >= videoItem.durationInFrames) continue;
+
+      const sourceFps = videoItem.sourceFps ?? timelineFps;
+      const speed = videoItem.speed ?? 1;
+      const sourceStart = videoItem.sourceStart ?? videoItem.trimStart ?? 0;
+      const sourceTime = sourceStart / sourceFps + (localFrame / timelineFps) * speed;
+
+      // Keep the earliest start time per source
+      const existing = sources.get(videoItem.src);
+      if (existing === undefined || sourceTime < existing) {
+        sources.set(videoItem.src, sourceTime);
+      }
+    }
+  }
+
+  return sources;
+}
+
+interface UseStreamingPlaybackControllerParams {
+  fps: number;
+  combinedTracks: TimelineTrack[];
+  scrubRendererRef: React.RefObject<PreviewRenderer | null>;
+}
+
+export function useStreamingPlaybackController({
+  fps,
+  combinedTracks,
+  scrubRendererRef,
+}: UseStreamingPlaybackControllerParams): void {
+  const playbackRef = useRef<StreamingPlayback | null>(null);
+  const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
+  const activeSourcesRef = useRef(new Set<string>());
+
+  // Create/get the streaming playback instance
+  const getPlayback = useCallback((): StreamingPlayback => {
+    if (!playbackRef.current) {
+      playbackRef.current = createStreamingPlayback();
+    }
+    return playbackRef.current;
+  }, []);
+
+  // Frame provider callback for the renderer
+  const getStreamingFrame = useCallback((src: string, sourceTime: number): ImageBitmap | null => {
+    if (!playbackRef.current) return null;
+    return playbackRef.current.getFrame(src, sourceTime);
+  }, []);
+
+  // Subscribe to playback state changes
+  useEffect(() => {
+    const unsubscribe = usePlaybackStore.subscribe((state, prevState) => {
+      if (!enabledRef.current) return;
+
+      const wasPlaying = prevState.isPlaying;
+      const isPlaying = state.isPlaying;
+
+      if (isPlaying && !wasPlaying) {
+        // Playback started — start streaming for visible video sources
+        const playback = getPlayback();
+        const currentFrame = state.currentFrame;
+        const sources = collectVisibleVideoSources(combinedTracks, currentFrame, fps);
+
+        log.info('Starting streaming playback', {
+          frame: currentFrame,
+          sources: sources.size,
+        });
+
+        for (const [src, startTime] of sources) {
+          playback.startStream(src, startTime);
+          activeSourcesRef.current.add(src);
+        }
+
+        // Set the frame provider on the renderer
+        const renderer = scrubRendererRef.current;
+        if (renderer?.setStreamingFrameProvider) {
+          renderer.setStreamingFrameProvider(getStreamingFrame);
+        }
+      } else if (!isPlaying && wasPlaying) {
+        // Playback stopped — stop all streams
+        const playback = playbackRef.current;
+        if (playback) {
+          log.info('Stopping streaming playback', {
+            metrics: playback.getMetrics(),
+          });
+          playback.stopAll();
+          activeSourcesRef.current.clear();
+        }
+
+        // Clear the frame provider
+        const renderer = scrubRendererRef.current;
+        if (renderer?.setStreamingFrameProvider) {
+          renderer.setStreamingFrameProvider(undefined);
+        }
+      }
+    });
+
+    return unsubscribe;
+  }, [combinedTracks, fps, getPlayback, getStreamingFrame, scrubRendererRef]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      playbackRef.current?.dispose();
+      playbackRef.current = null;
+    };
+  }, []);
+
+  // Expose debug toggle
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    const debugApi = (window as unknown as Record<string, unknown>).__DEBUG__ as
+      Record<string, unknown> | undefined;
+    if (!debugApi) return;
+
+    debugApi.setStreamingPlayback = (enabled: boolean) => {
+      enabledRef.current = enabled;
+      log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
+
+      if (!enabled) {
+        // Stop any active streams
+        const playback = playbackRef.current;
+        if (playback) {
+          playback.stopAll();
+          activeSourcesRef.current.clear();
+        }
+        const renderer = scrubRendererRef.current;
+        if (renderer?.setStreamingFrameProvider) {
+          renderer.setStreamingFrameProvider(undefined);
+        }
+      }
+    };
+
+    debugApi.streamingPlaybackMetrics = () => {
+      return playbackRef.current?.getMetrics() ?? null;
+    };
+
+    return () => {
+      delete debugApi.setStreamingPlayback;
+      delete debugApi.streamingPlaybackMetrics;
+    };
+  }, [scrubRendererRef]);
+}

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -40,6 +40,7 @@ function collectPrewarmTargets(
   tracks: TimelineTrack[],
   timelineFrame: number,
   timelineFps: number,
+  useProxy: boolean,
 ): Array<{ src: string; sourceTime: number; mediaId?: string }> {
   const targets: Array<{ src: string; sourceTime: number; mediaId?: string }> = [];
   const seen = new Set<string>();
@@ -58,8 +59,8 @@ function collectPrewarmTargets(
       if (videoItem.from > timelineFrame + lookaheadFrames) continue;
 
       const mediaId = videoItem.mediaId;
-      // Prefer proxy (720p) over original — same as the preview render pipeline
-      const proxyUrl = mediaId ? resolveProxyUrl(mediaId) : null;
+      // Match the preview render pipeline: use proxy when enabled, original when not
+      const proxyUrl = useProxy && mediaId ? resolveProxyUrl(mediaId) : null;
       const activeSrc = proxyUrl ?? (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
       if (!activeSrc || seen.has(activeSrc)) continue;
       seen.add(activeSrc);
@@ -120,8 +121,11 @@ export function useStreamingPlaybackController({
   // before play starts. Restarts on seek. Tracks ref holds the latest value.
   const tracksRef = useRef(combinedTracks);
   const fpsRef = useRef(fps);
+  const useProxy = usePlaybackStore((s) => s.useProxy);
+  const useProxyRef = useRef(useProxy);
   tracksRef.current = combinedTracks;
   fpsRef.current = fps;
+  useProxyRef.current = useProxy;
   const prewarmFrameRef = useRef<number | null>(null);
   const lookaheadTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -131,7 +135,7 @@ export function useStreamingPlaybackController({
     prewarmFrameRef.current = frame;
 
     const playback = getPlayback();
-    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current);
+    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
@@ -147,7 +151,7 @@ export function useStreamingPlaybackController({
     if (!enabledRef.current) return;
     const frame = usePlaybackStore.getState().currentFrame;
     const playback = getPlayback();
-    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current);
+    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current, useProxyRef.current);
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
@@ -231,6 +235,20 @@ export function useStreamingPlaybackController({
       }
     };
   }, [getPlayback, getStreamingFrame, prewarmAtFrame, runPlaybackLookahead]);
+
+  // When proxy toggle changes, restart streams with the correct source URLs
+  useEffect(() => {
+    if (!enabledRef.current) return;
+    const playback = playbackRef.current;
+    if (playback) {
+      playback.stopAll();
+      prewarmFrameRef.current = null;
+      const state = usePlaybackStore.getState();
+      if (!state.isPlaying) {
+        prewarmAtFrame(state.currentFrame);
+      }
+    }
+  }, [useProxy, prewarmAtFrame]);
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -122,7 +122,7 @@ export function useStreamingPlaybackController({
   const prewarmFrameRef = useRef<number | null>(null);
   const lookaheadTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const prewarmAtFrame = useCallback((frame: number) => {
+  const prewarmAtFrame = useCallback((frame: number, seekExisting = true) => {
     if (!enabledRef.current) return;
     if (frame === prewarmFrameRef.current) return;
     prewarmFrameRef.current = frame;
@@ -132,7 +132,7 @@ export function useStreamingPlaybackController({
     for (const { src, sourceTime } of targets) {
       if (!playback.isStreaming(src)) {
         playback.startStream(src, sourceTime);
-      } else {
+      } else if (seekExisting) {
         playback.seekStream(src, sourceTime);
       }
     }
@@ -158,16 +158,18 @@ export function useStreamingPlaybackController({
   useEffect(() => {
     const initialState = usePlaybackStore.getState();
 
-    // If already playing on mount, activate immediately
-    if (enabledRef.current && initialState.isPlaying) {
-      getPlayback();
+    // Activate provider immediately — it serves both playback and scrub.
+    // During scrub, buffered streaming frames are used when available,
+    // falling through to DOM video / mediabunny on miss.
+    if (enabledRef.current) {
       streamingFrameProviderRef.current = getStreamingFrame;
-      log.info('Playback already active on mount, streaming provider activated');
-    }
 
-    // Pre-warm at the current frame while paused
-    if (enabledRef.current && !initialState.isPlaying) {
-      prewarmAtFrame(initialState.currentFrame);
+      if (initialState.isPlaying) {
+        getPlayback();
+        log.info('Playback already active on mount, streaming provider activated');
+      } else {
+        prewarmAtFrame(initialState.currentFrame);
+      }
     }
 
     const unsubscribe = usePlaybackStore.subscribe((state, prevState) => {
@@ -190,7 +192,7 @@ export function useStreamingPlaybackController({
           clearInterval(lookaheadTimerRef.current);
           lookaheadTimerRef.current = null;
         }
-        streamingFrameProviderRef.current = null;
+        // Keep streamingFrameProviderRef set — scrub uses it too
         const playback = playbackRef.current;
         if (playback) {
           const metrics = playback.getMetrics();
@@ -204,8 +206,13 @@ export function useStreamingPlaybackController({
         // Pre-warm at the stop position
         prewarmAtFrame(state.currentFrame);
       } else if (!isPlaying && state.currentFrame !== prevState.currentFrame) {
-        // User seeked while paused — pre-warm at new position
-        prewarmAtFrame(state.currentFrame);
+        // User scrubbing while paused — start new streams but don't seek
+        // active ones. Forward scrub keeps the buffer valid; backward
+        // scrub / large jumps fall through to mediabunny on miss.
+        const delta = state.currentFrame - prevState.currentFrame;
+        const isLargeJump = Math.abs(delta) > fpsRef.current * 2;
+        const isBackward = delta < 0;
+        prewarmAtFrame(state.currentFrame, isLargeJump || isBackward);
       }
     });
 
@@ -241,6 +248,7 @@ export function useStreamingPlaybackController({
       log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
 
       if (enabled) {
+        streamingFrameProviderRef.current = getStreamingFrame;
         // Start pre-warm immediately at current playhead
         const state = usePlaybackStore.getState();
         if (!state.isPlaying) {

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -29,10 +29,11 @@ const log = createLogger('StreamingPlaybackCtrl');
  *  The worker needs ~1-2s to init + buffer, so 3s provides headroom. */
 const TRANSITION_PREWARM_SECONDS = 3;
 
-/** How far ahead (in seconds) to force the canvas overlay before a transition.
- *  The overlay must be active for the main render path to use the streaming
- *  provider — the transition pre-render path doesn't set it. */
-const TRANSITION_OVERLAY_LEAD_SECONDS = 1;
+// Streaming is a passive frame source — it does NOT force the canvas overlay.
+// The existing transition rendering system reads streamingFrameProviderRef
+// and uses decoded frames when available, falling through to DOM video on miss.
+// Toggling forceCanvasOverlay mid-playback causes React re-renders that disrupt
+// DOM video elements and the render pump, so we avoid it entirely.
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,21 +145,6 @@ function collectAllPrewarmTargets(
   return targets;
 }
 
-/** Check if a frame is within the overlay-lead window of any transition. */
-function isFrameNearTransition(
-  frame: number,
-  windows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>,
-  leadFrames: number,
-  cooldownFrames: number,
-): boolean {
-  for (const tw of windows) {
-    if (frame >= tw.startFrame - leadFrames && frame < tw.endFrame + cooldownFrames) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -167,7 +153,6 @@ interface UseStreamingPlaybackControllerParams {
   fps: number;
   combinedTracks: TimelineTrack[];
   playbackTransitionWindows: ReadonlyArray<ResolvedTransitionWindow<TimelineItem>>;
-  playbackTransitionCooldownFrames: number;
 }
 
 interface UseStreamingPlaybackControllerResult {
@@ -181,7 +166,6 @@ export function useStreamingPlaybackController({
   fps,
   combinedTracks,
   playbackTransitionWindows,
-  playbackTransitionCooldownFrames,
 }: UseStreamingPlaybackControllerParams): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
   /** When true, stream ALL clips (debug toggle). When false, only transition clips. */
@@ -207,12 +191,10 @@ export function useStreamingPlaybackController({
   const useProxy = usePlaybackStore((s) => s.useProxy);
   const useProxyRef = useRef(useProxy);
   const transitionWindowsRef = useRef(playbackTransitionWindows);
-  const cooldownFramesRef = useRef(playbackTransitionCooldownFrames);
   tracksRef.current = combinedTracks;
   fpsRef.current = fps;
   useProxyRef.current = useProxy;
   transitionWindowsRef.current = playbackTransitionWindows;
-  cooldownFramesRef.current = playbackTransitionCooldownFrames;
 
   const prewarmFrameRef = useRef<number | null>(null);
   const lookaheadTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -259,14 +241,8 @@ export function useStreamingPlaybackController({
       }
     }
 
-    // Toggle canvas overlay based on proximity to transitions
-    if (!forceAllRef.current) {
-      const overlayLeadFrames = Math.round(TRANSITION_OVERLAY_LEAD_SECONDS * fpsRef.current);
-      const nearTransition = isFrameNearTransition(
-        frame, transitionWindowsRef.current, overlayLeadFrames, cooldownFramesRef.current,
-      );
-      setForceCanvasOverlay(nearTransition);
-    }
+    // No overlay toggle — streaming is passive. The existing transition
+    // system handles canvas rendering and uses streamingFrameProviderRef.
   }, [getPlayback, getTargets]);
 
   // Subscribe to playback state

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -15,12 +15,12 @@
 
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { usePlaybackStore } from '@/shared/state/playback';
-import { createStreamingPlayback, type StreamingPlayback } from '../utils/streaming-playback';
-import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
+import { createStreamingPlayback, type StreamingPlayback } from '@/features/preview/utils/streaming-playback';
+import { STREAMING_PLAYBACK_ENABLED } from '@/features/preview/utils/preview-constants';
 import { createLogger } from '@/shared/logging/logger';
 import type { TimelineTrack, TimelineItem, VideoItem } from '@/types/timeline';
 import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
-import { resolveProxyUrl } from '../deps/media-library-contract';
+import { resolveProxyUrl } from '@/features/preview/deps/media-library-contract';
 import type { ResolvedTransitionWindow } from '@/domain/timeline/transitions/transition-planner';
 
 const log = createLogger('StreamingPlaybackCtrl');

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -6,71 +6,39 @@
  * ImageBitmaps are buffered and provided to the canvas render pipeline,
  * bypassing HTML5 <video> elements entirely.
  *
- * This is experimental — toggle via window.__DEBUG__?.setStreamingPlayback(true)
+ * The coordinator is self-managing: getFrame() lazily auto-starts streams
+ * for new sources and idle cleanup stops streams that are no longer needed.
+ *
+ * The hook exposes a `streamingFrameProviderRef` that the render pump reads
+ * on each frame and sets on the renderer. This avoids timing issues with
+ * renderer creation/destruction during re-renders.
+ *
+ * Toggle via window.__DEBUG__?.setStreamingPlayback(true)
  */
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { createStreamingPlayback, type StreamingPlayback } from '../utils/streaming-playback';
 import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
 import { createLogger } from '@/shared/logging/logger';
-import type { TimelineTrack, VideoItem } from '@/types/timeline';
 
 const log = createLogger('StreamingPlaybackCtrl');
 
-type PreviewRenderer = {
-  setStreamingFrameProvider?: (
-    provider: ((src: string, sourceTime: number) => ImageBitmap | null) | undefined,
-  ) => void;
-};
-
-/** Collect src → startTimestamp for all video items visible at the given frame. */
-function collectVisibleVideoSources(
-  tracks: TimelineTrack[],
-  timelineFrame: number,
-  timelineFps: number,
-): Map<string, number> {
-  const sources = new Map<string, number>();
-
-  for (const track of tracks) {
-    for (const item of track.items) {
-      if (item.type !== 'video' || !item.src) continue;
-      const videoItem = item as VideoItem;
-      const localFrame = timelineFrame - videoItem.from;
-      if (localFrame < 0 || localFrame >= videoItem.durationInFrames) continue;
-
-      const sourceFps = videoItem.sourceFps ?? timelineFps;
-      const speed = videoItem.speed ?? 1;
-      const sourceStart = videoItem.sourceStart ?? videoItem.trimStart ?? 0;
-      const sourceTime = sourceStart / sourceFps + (localFrame / timelineFps) * speed;
-
-      // Keep the earliest start time per source
-      const existing = sources.get(videoItem.src);
-      if (existing === undefined || sourceTime < existing) {
-        sources.set(videoItem.src, sourceTime);
-      }
-    }
-  }
-
-  return sources;
+interface UseStreamingPlaybackControllerResult {
+  /** Whether streaming playback is enabled — when true, the canvas overlay
+   *  must be forced during playback (same as GPU effects). */
+  forceCanvasOverlay: boolean;
+  /** Ref to the streaming frame provider function. The render pump should
+   *  set this on the renderer before each frame via setStreamingFrameProvider. */
+  streamingFrameProviderRef: React.RefObject<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>;
 }
 
-interface UseStreamingPlaybackControllerParams {
-  fps: number;
-  combinedTracks: TimelineTrack[];
-  scrubRendererRef: React.RefObject<PreviewRenderer | null>;
-}
-
-export function useStreamingPlaybackController({
-  fps,
-  combinedTracks,
-  scrubRendererRef,
-}: UseStreamingPlaybackControllerParams): void {
+export function useStreamingPlaybackController(): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
   const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
-  const activeSourcesRef = useRef(new Set<string>());
+  const [forceCanvasOverlay, setForceCanvasOverlay] = useState(STREAMING_PLAYBACK_ENABLED);
+  const streamingFrameProviderRef = useRef<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>(null);
 
-  // Create/get the streaming playback instance
   const getPlayback = useCallback((): StreamingPlayback => {
     if (!playbackRef.current) {
       playbackRef.current = createStreamingPlayback();
@@ -78,14 +46,23 @@ export function useStreamingPlaybackController({
     return playbackRef.current;
   }, []);
 
-  // Frame provider callback for the renderer
-  const getStreamingFrame = useCallback((src: string, sourceTime: number): ImageBitmap | null => {
+  // Frame provider callback — the coordinator handles everything internally
+  const getStreamingFrame = useCallback((src: string, sourceTime: number, mediaId?: string): ImageBitmap | null => {
     if (!playbackRef.current) return null;
-    return playbackRef.current.getFrame(src, sourceTime);
+    return playbackRef.current.getFrame(src, sourceTime, mediaId);
   }, []);
 
-  // Subscribe to playback state changes
+  // Subscribe to playback state: manage streaming lifecycle and expose provider via ref.
+  // The render pump reads streamingFrameProviderRef and sets it on the renderer per-frame,
+  // avoiding timing issues with renderer creation/destruction during re-renders.
   useEffect(() => {
+    // If already playing when this effect mounts, activate immediately
+    if (enabledRef.current && usePlaybackStore.getState().isPlaying) {
+      getPlayback();
+      streamingFrameProviderRef.current = getStreamingFrame;
+      log.info('Playback already active on mount, streaming provider activated');
+    }
+
     const unsubscribe = usePlaybackStore.subscribe((state, prevState) => {
       if (!enabledRef.current) return;
 
@@ -93,47 +70,29 @@ export function useStreamingPlaybackController({
       const isPlaying = state.isPlaying;
 
       if (isPlaying && !wasPlaying) {
-        // Playback started — start streaming for visible video sources
-        const playback = getPlayback();
-        const currentFrame = state.currentFrame;
-        const sources = collectVisibleVideoSources(combinedTracks, currentFrame, fps);
-
-        log.info('Starting streaming playback', {
-          frame: currentFrame,
-          sources: sources.size,
-        });
-
-        for (const [src, startTime] of sources) {
-          playback.startStream(src, startTime);
-          activeSourcesRef.current.add(src);
-        }
-
-        // Set the frame provider on the renderer
-        const renderer = scrubRendererRef.current;
-        if (renderer?.setStreamingFrameProvider) {
-          renderer.setStreamingFrameProvider(getStreamingFrame);
-        }
+        getPlayback();
+        streamingFrameProviderRef.current = getStreamingFrame;
+        log.info('Playback started, streaming provider activated');
       } else if (!isPlaying && wasPlaying) {
-        // Playback stopped — stop all streams
+        streamingFrameProviderRef.current = null;
         const playback = playbackRef.current;
         if (playback) {
-          log.info('Stopping streaming playback', {
-            metrics: playback.getMetrics(),
+          const metrics = playback.getMetrics();
+          log.info('Playback stopped', {
+            received: metrics.totalFramesReceived,
+            drawn: metrics.totalFramesDrawn,
+            missed: metrics.totalFramesMissed,
           });
           playback.stopAll();
-          activeSourcesRef.current.clear();
-        }
-
-        // Clear the frame provider
-        const renderer = scrubRendererRef.current;
-        if (renderer?.setStreamingFrameProvider) {
-          renderer.setStreamingFrameProvider(undefined);
         }
       }
     });
 
-    return unsubscribe;
-  }, [combinedTracks, fps, getPlayback, getStreamingFrame, scrubRendererRef]);
+    return () => {
+      unsubscribe();
+      streamingFrameProviderRef.current = null;
+    };
+  }, [getPlayback, getStreamingFrame]);
 
   // Clean up on unmount
   useEffect(() => {
@@ -153,19 +112,12 @@ export function useStreamingPlaybackController({
 
     debugApi.setStreamingPlayback = (enabled: boolean) => {
       enabledRef.current = enabled;
+      setForceCanvasOverlay(enabled);
       log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
 
       if (!enabled) {
-        // Stop any active streams
-        const playback = playbackRef.current;
-        if (playback) {
-          playback.stopAll();
-          activeSourcesRef.current.clear();
-        }
-        const renderer = scrubRendererRef.current;
-        if (renderer?.setStreamingFrameProvider) {
-          renderer.setStreamingFrameProvider(undefined);
-        }
+        streamingFrameProviderRef.current = null;
+        playbackRef.current?.stopAll();
       }
     };
 
@@ -177,5 +129,7 @@ export function useStreamingPlaybackController({
       delete debugApi.setStreamingPlayback;
       delete debugApi.streamingPlaybackMetrics;
     };
-  }, [scrubRendererRef]);
+  }, []);
+
+  return { forceCanvasOverlay, streamingFrameProviderRef };
 }

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -169,7 +169,6 @@ export function useStreamingPlaybackController({
   playbackTransitionCooldownFrames,
 }: UseStreamingPlaybackControllerParams): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
-  const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
   /** When true, stream ALL clips (debug toggle). When false, only transition clips. */
   const forceAllRef = useRef(STREAMING_PLAYBACK_ENABLED);
   const [forceCanvasOverlay, setForceCanvasOverlay] = useState(false);
@@ -214,7 +213,6 @@ export function useStreamingPlaybackController({
   }, []);
 
   const prewarmAtFrame = useCallback((frame: number, seekExisting = true) => {
-    if (!enabledRef.current) return;
     if (frame === prewarmFrameRef.current) return;
     prewarmFrameRef.current = frame;
 
@@ -231,7 +229,6 @@ export function useStreamingPlaybackController({
 
   /** During playback, scan for upcoming transition clips and manage overlay. */
   const runPlaybackLookahead = useCallback(() => {
-    if (!enabledRef.current) return;
     const state = usePlaybackStore.getState();
     const frame = state.currentFrame;
     const playback = getPlayback();
@@ -258,20 +255,17 @@ export function useStreamingPlaybackController({
   useEffect(() => {
     const initialState = usePlaybackStore.getState();
 
-    if (enabledRef.current) {
-      streamingFrameProviderRef.current = getStreamingFrame;
-      if (initialState.isPlaying) {
-        getPlayback();
-        if (forceAllRef.current) setForceCanvasOverlay(true);
-        if (lookaheadTimerRef.current) clearInterval(lookaheadTimerRef.current);
-        lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 500);
-      } else {
-        prewarmAtFrame(initialState.currentFrame);
-      }
+    streamingFrameProviderRef.current = getStreamingFrame;
+    if (initialState.isPlaying) {
+      getPlayback();
+      if (forceAllRef.current) setForceCanvasOverlay(true);
+      if (lookaheadTimerRef.current) clearInterval(lookaheadTimerRef.current);
+      lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 500);
+    } else {
+      prewarmAtFrame(initialState.currentFrame);
     }
 
     const unsubscribe = usePlaybackStore.subscribe((state, prevState) => {
-      if (!enabledRef.current) return;
 
       const wasPlaying = prevState.isPlaying;
       const isPlaying = state.isPlaying;
@@ -324,7 +318,6 @@ export function useStreamingPlaybackController({
 
   // Restart streams when proxy toggle changes
   useEffect(() => {
-    if (!enabledRef.current) return;
     const playback = playbackRef.current;
     if (playback) {
       streamingFrameProviderRef.current = null;
@@ -332,9 +325,7 @@ export function useStreamingPlaybackController({
       prewarmFrameRef.current = null;
       prewarmAtFrame(usePlaybackStore.getState().currentFrame);
       requestAnimationFrame(() => {
-        if (enabledRef.current) {
-          streamingFrameProviderRef.current = getStreamingFrame;
-        }
+        streamingFrameProviderRef.current = getStreamingFrame;
       });
     }
   }, [useProxy, prewarmAtFrame, getStreamingFrame]);
@@ -355,26 +346,19 @@ export function useStreamingPlaybackController({
       Record<string, unknown> | undefined;
     if (!debugApi) return;
 
-    debugApi.setStreamingPlayback = (enabled: boolean, forceAll = false) => {
-      enabledRef.current = enabled;
-      forceAllRef.current = enabled && forceAll;
-      log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}${forceAll ? ' (force all)' : ''}`);
+    debugApi.setStreamingPlayback = (forceAll: boolean) => {
+      forceAllRef.current = forceAll;
+      log.info(`Streaming playback: ${forceAll ? 'force all clips' : 'transitions only'}`);
 
-      if (enabled) {
-        streamingFrameProviderRef.current = getStreamingFrame;
+      if (forceAll) {
         const state = usePlaybackStore.getState();
-        if (state.isPlaying && forceAll) setForceCanvasOverlay(true);
+        if (state.isPlaying) setForceCanvasOverlay(true);
         prewarmFrameRef.current = null;
         prewarmAtFrame(state.currentFrame);
       } else {
         setForceCanvasOverlay(false);
-        streamingFrameProviderRef.current = null;
         playbackRef.current?.stopAll();
         prewarmFrameRef.current = null;
-        if (lookaheadTimerRef.current) {
-          clearInterval(lookaheadTimerRef.current);
-          lookaheadTimerRef.current = null;
-        }
       }
     };
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -23,6 +23,7 @@ import { STREAMING_PLAYBACK_ENABLED } from '../utils/preview-constants';
 import { createLogger } from '@/shared/logging/logger';
 import type { TimelineTrack, VideoItem } from '@/types/timeline';
 import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
+import { resolveProxyUrl } from '../deps/media-library-contract';
 
 const log = createLogger('StreamingPlaybackCtrl');
 
@@ -57,7 +58,9 @@ function collectPrewarmTargets(
       if (videoItem.from > timelineFrame + lookaheadFrames) continue;
 
       const mediaId = videoItem.mediaId;
-      const activeSrc = (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
+      // Prefer proxy (720p) over original — same as the preview render pipeline
+      const proxyUrl = mediaId ? resolveProxyUrl(mediaId) : null;
+      const activeSrc = proxyUrl ?? (mediaId ? blobUrlManager.get(mediaId) : null) ?? videoItem.src;
       if (!activeSrc || seen.has(activeSrc)) continue;
       seen.add(activeSrc);
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -236,17 +236,15 @@ export function useStreamingPlaybackController({
     };
   }, [getPlayback, getStreamingFrame, prewarmAtFrame, runPlaybackLookahead]);
 
-  // When proxy toggle changes, restart streams with the correct source URLs
+  // When proxy toggle changes, restart streams with the correct source URLs.
+  // Must restart even during playback so frames switch immediately.
   useEffect(() => {
     if (!enabledRef.current) return;
     const playback = playbackRef.current;
     if (playback) {
       playback.stopAll();
       prewarmFrameRef.current = null;
-      const state = usePlaybackStore.getState();
-      if (!state.isPlaying) {
-        prewarmAtFrame(state.currentFrame);
-      }
+      prewarmAtFrame(usePlaybackStore.getState().currentFrame);
     }
   }, [useProxy, prewarmAtFrame]);
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -97,7 +97,7 @@ export function useStreamingPlaybackController({
 }: UseStreamingPlaybackControllerParams): UseStreamingPlaybackControllerResult {
   const playbackRef = useRef<StreamingPlayback | null>(null);
   const enabledRef = useRef(STREAMING_PLAYBACK_ENABLED);
-  const [forceCanvasOverlay, setForceCanvasOverlay] = useState(STREAMING_PLAYBACK_ENABLED);
+  const [forceCanvasOverlay, setForceCanvasOverlay] = useState(false);
   const streamingFrameProviderRef = useRef<((src: string, sourceTime: number, mediaId?: string) => ImageBitmap | null) | null>(null);
 
   const getPlayback = useCallback((): StreamingPlayback => {
@@ -166,6 +166,7 @@ export function useStreamingPlaybackController({
 
       if (initialState.isPlaying) {
         getPlayback();
+        setForceCanvasOverlay(true);
         log.info('Playback already active on mount, streaming provider activated');
       } else {
         prewarmAtFrame(initialState.currentFrame);
@@ -181,6 +182,7 @@ export function useStreamingPlaybackController({
       if (isPlaying && !wasPlaying) {
         const playback = getPlayback();
         streamingFrameProviderRef.current = getStreamingFrame;
+        setForceCanvasOverlay(true);
         prewarmFrameRef.current = null; // clear so next pause re-prewarms
         playback.enableIdleSweep();
         // Start periodic lookahead for upcoming clips during playback
@@ -188,6 +190,7 @@ export function useStreamingPlaybackController({
         lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 1000);
         log.info('Playback started, streaming provider activated');
       } else if (!isPlaying && wasPlaying) {
+        setForceCanvasOverlay(false);
         if (lookaheadTimerRef.current) {
           clearInterval(lookaheadTimerRef.current);
           lookaheadTimerRef.current = null;
@@ -244,18 +247,19 @@ export function useStreamingPlaybackController({
 
     debugApi.setStreamingPlayback = (enabled: boolean) => {
       enabledRef.current = enabled;
-      setForceCanvasOverlay(enabled);
       log.info(`Streaming playback ${enabled ? 'enabled' : 'disabled'}`);
 
       if (enabled) {
         streamingFrameProviderRef.current = getStreamingFrame;
-        // Start pre-warm immediately at current playhead
+        // Force overlay only if already playing
         const state = usePlaybackStore.getState();
+        if (state.isPlaying) setForceCanvasOverlay(true);
         if (!state.isPlaying) {
           prewarmFrameRef.current = null; // force re-prewarm
           prewarmAtFrame(state.currentFrame);
         }
       } else {
+        setForceCanvasOverlay(false);
         streamingFrameProviderRef.current = null;
         playbackRef.current?.stopAll();
         prewarmFrameRef.current = null;

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -26,8 +26,10 @@ import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 
 const log = createLogger('StreamingPlaybackCtrl');
 
-/** How far ahead (in seconds) to look for upcoming video clips to pre-warm. */
-const LOOKAHEAD_SECONDS = 3;
+/** How far ahead (in seconds) to look for upcoming video clips to pre-warm.
+ *  5s gives the worker enough time to init new sources (~1-2s) and buffer
+ *  frames before playback reaches them. */
+const LOOKAHEAD_SECONDS = 5;
 
 /**
  * Collect pre-warm targets: video items visible at the given frame,
@@ -118,6 +120,7 @@ export function useStreamingPlaybackController({
   tracksRef.current = combinedTracks;
   fpsRef.current = fps;
   const prewarmFrameRef = useRef<number | null>(null);
+  const lookaheadTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const prewarmAtFrame = useCallback((frame: number) => {
     if (!enabledRef.current) return;
@@ -131,6 +134,20 @@ export function useStreamingPlaybackController({
         playback.startStream(src, sourceTime);
       } else {
         playback.seekStream(src, sourceTime);
+      }
+    }
+  }, [getPlayback]);
+
+  /** During playback, periodically scan for upcoming clips and start their
+   *  decode streams early. Only starts NEW streams — existing ones keep running. */
+  const runPlaybackLookahead = useCallback(() => {
+    if (!enabledRef.current) return;
+    const frame = usePlaybackStore.getState().currentFrame;
+    const playback = getPlayback();
+    const targets = collectPrewarmTargets(tracksRef.current, frame, fpsRef.current);
+    for (const { src, sourceTime } of targets) {
+      if (!playback.isStreaming(src)) {
+        playback.startStream(src, sourceTime);
       }
     }
   }, [getPlayback]);
@@ -160,11 +177,19 @@ export function useStreamingPlaybackController({
       const isPlaying = state.isPlaying;
 
       if (isPlaying && !wasPlaying) {
-        getPlayback();
+        const playback = getPlayback();
         streamingFrameProviderRef.current = getStreamingFrame;
         prewarmFrameRef.current = null; // clear so next pause re-prewarms
+        playback.enableIdleSweep();
+        // Start periodic lookahead for upcoming clips during playback
+        if (lookaheadTimerRef.current) clearInterval(lookaheadTimerRef.current);
+        lookaheadTimerRef.current = setInterval(runPlaybackLookahead, 1000);
         log.info('Playback started, streaming provider activated');
       } else if (!isPlaying && wasPlaying) {
+        if (lookaheadTimerRef.current) {
+          clearInterval(lookaheadTimerRef.current);
+          lookaheadTimerRef.current = null;
+        }
         streamingFrameProviderRef.current = null;
         const playback = playbackRef.current;
         if (playback) {
@@ -187,8 +212,12 @@ export function useStreamingPlaybackController({
     return () => {
       unsubscribe();
       streamingFrameProviderRef.current = null;
+      if (lookaheadTimerRef.current) {
+        clearInterval(lookaheadTimerRef.current);
+        lookaheadTimerRef.current = null;
+      }
     };
-  }, [getPlayback, getStreamingFrame, prewarmAtFrame]);
+  }, [getPlayback, getStreamingFrame, prewarmAtFrame, runPlaybackLookahead]);
 
   // Clean up on unmount
   useEffect(() => {
@@ -222,6 +251,10 @@ export function useStreamingPlaybackController({
         streamingFrameProviderRef.current = null;
         playbackRef.current?.stopAll();
         prewarmFrameRef.current = null;
+        if (lookaheadTimerRef.current) {
+          clearInterval(lookaheadTimerRef.current);
+          lookaheadTimerRef.current = null;
+        }
       }
     };
 

--- a/src/features/preview/hooks/use-streaming-playback-controller.ts
+++ b/src/features/preview/hooks/use-streaming-playback-controller.ts
@@ -237,16 +237,24 @@ export function useStreamingPlaybackController({
   }, [getPlayback, getStreamingFrame, prewarmAtFrame, runPlaybackLookahead]);
 
   // When proxy toggle changes, restart streams with the correct source URLs.
-  // Must restart even during playback so frames switch immediately.
+  // Disable the provider during the transition so the RAF pump doesn't auto-start
+  // streams with stale URLs from the old composition. Re-enable after the
+  // composition rebuilds with new proxy URLs (next animation frame).
   useEffect(() => {
     if (!enabledRef.current) return;
     const playback = playbackRef.current;
     if (playback) {
+      streamingFrameProviderRef.current = null;
       playback.stopAll();
       prewarmFrameRef.current = null;
       prewarmAtFrame(usePlaybackStore.getState().currentFrame);
+      requestAnimationFrame(() => {
+        if (enabledRef.current) {
+          streamingFrameProviderRef.current = getStreamingFrame;
+        }
+      });
     }
-  }, [useProxy, prewarmAtFrame]);
+  }, [useProxy, prewarmAtFrame, getStreamingFrame]);
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/features/preview/utils/preview-constants.ts
+++ b/src/features/preview/utils/preview-constants.ts
@@ -65,6 +65,16 @@ export const PREVIEW_PERF_RENDER_SOURCE_HISTORY_MAX = 6;
 export const PREVIEW_PERF_SEEK_TIMEOUT_MS = 2500;
 export const ADAPTIVE_PREVIEW_QUALITY_ENABLED = true;
 
+/**
+ * Experimental: Use WebCodecs streaming decode for video playback instead of
+ * HTML5 <video> elements. When enabled, a background worker runs mediabunny's
+ * forward samples() generator and transfers decoded ImageBitmaps to the
+ * canvas render pipeline.
+ *
+ * Toggle via: window.__DEBUG__?.setStreamingPlayback?.(true/false)
+ */
+export const STREAMING_PLAYBACK_ENABLED = false;
+
 import type { PreviewRenderSource } from './preview-perf-metrics';
 
 export type VideoSourceSpan = { src: string; startFrame: number; endFrame: number };

--- a/src/features/preview/utils/preview-constants.ts
+++ b/src/features/preview/utils/preview-constants.ts
@@ -73,7 +73,7 @@ export const ADAPTIVE_PREVIEW_QUALITY_ENABLED = true;
  *
  * Toggle via: window.__DEBUG__?.setStreamingPlayback?.(true/false)
  */
-export const STREAMING_PLAYBACK_ENABLED = false;
+export const STREAMING_PLAYBACK_ENABLED = true;
 
 import type { PreviewRenderSource } from './preview-perf-metrics';
 

--- a/src/features/preview/utils/preview-constants.ts
+++ b/src/features/preview/utils/preview-constants.ts
@@ -73,7 +73,7 @@ export const ADAPTIVE_PREVIEW_QUALITY_ENABLED = true;
  *
  * Toggle via: window.__DEBUG__?.setStreamingPlayback?.(true/false)
  */
-export const STREAMING_PLAYBACK_ENABLED = true;
+export const STREAMING_PLAYBACK_ENABLED = false;
 
 import type { PreviewRenderSource } from './preview-perf-metrics';
 

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -472,21 +472,21 @@ export function createStreamingPlayback(): StreamingPlayback {
     getFrame(src: string, targetTimestamp: number, mediaId?: string): ImageBitmap | null {
       if (disposed) return null;
 
-      let state = streams.get(src);
+      // Resolve the active URL via mediaId. The renderer may pass a stale
+      // blob URL from a previous render cycle (e.g. after forceFastScrubOverlay flip).
+      let activeSrc = src;
+      if (mediaId) {
+        const currentUrl = blobUrlManager.get(mediaId);
+        if (currentUrl) activeSrc = currentUrl;
+      }
+
+      // Look up stream by active URL first, then stale URL
+      let state = streams.get(activeSrc) ?? streams.get(src);
 
       // Lazy auto-start: first time we see a source, start streaming
       if (!state || (!state.streaming && !state.autoStartPending)) {
-        // Resolve the active URL via mediaId. The renderer may pass a stale
-        // blob URL from a previous render cycle. We need to key the stream
-        // state by the active URL so worker frame messages match.
-        let activeSrc = src;
-        if (mediaId) {
-          const currentUrl = blobUrlManager.get(mediaId);
-          if (currentUrl) activeSrc = currentUrl;
-        }
         diag(`getFrame auto-start src=${activeSrc.slice(0, 50)} mediaId=${mediaId} ts=${targetTimestamp.toFixed(3)}`);
         state = getOrCreateState(activeSrc);
-        // Also register the original src so future lookups with either URL find the state
         if (activeSrc !== src) streams.set(src, state);
         state.autoStartPending = true;
         state.lastAccessMs = performance.now();

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -4,11 +4,16 @@
  * Manages streaming decode workers and provides decoded ImageBitmaps
  * to the render pipeline as a drop-in replacement for DOM video elements.
  *
+ * Key behaviors:
+ * - Lazy auto-start: getFrame() for an unknown source triggers async stream init
+ * - Backpressure: frame_consumed signals are sent on draw, not receive
+ * - Idle cleanup: sources not requested for IDLE_TIMEOUT_MS are stopped
+ *
  * Usage:
  *   const playback = createStreamingPlayback();
- *   playback.startStream('blob:...', 0.5);  // start decoding from 0.5s
- *   const frame = playback.getFrame('blob:...', 1.2);  // get frame at 1.2s
- *   playback.stopStream('blob:...');
+ *   playback.startStream('blob:...', 0.5);
+ *   const frame = playback.getFrame('blob:...', 1.2);
+ *   playback.stopAll();
  *   playback.dispose();
  */
 
@@ -17,9 +22,23 @@ import {
   getObjectUrlBlob,
   getObjectUrlDirectFileMetadata,
 } from '@/infrastructure/browser/object-url-registry';
+import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager';
 import { getKeyframeTimestamps } from '@/shared/utils/keyframe-index-registry';
 
 const log = createLogger('StreamingPlayback');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** How long a source can go without getFrame() calls before being stopped. */
+const IDLE_TIMEOUT_MS = 3000;
+/** How often to run the idle cleanup sweep. */
+const IDLE_SWEEP_INTERVAL_MS = 1000;
+/** Maximum frames buffered per source. */
+const MAX_BUFFER_SIZE = 30;
+/** Source time tolerance for frame lookup (seconds). */
+const FRAME_TOLERANCE_SECONDS = 0.15;
 
 // ---------------------------------------------------------------------------
 // Frame buffer
@@ -35,13 +54,12 @@ class FrameBuffer {
   private frames: BufferedFrame[] = [];
   private readonly maxSize: number;
 
-  constructor(maxSize = 30) {
+  constructor(maxSize = MAX_BUFFER_SIZE) {
     this.maxSize = maxSize;
   }
 
   /** Insert a frame, evicting the oldest if at capacity. */
   push(timestamp: number, bitmap: ImageBitmap): void {
-    // Evict oldest if full
     if (this.frames.length >= this.maxSize) {
       const evicted = this.frames.shift();
       evicted?.bitmap.close();
@@ -51,17 +69,17 @@ class FrameBuffer {
 
   /**
    * Find the best frame for a target timestamp.
-   * Returns the closest frame at or before the target, or the closest overall.
+   * Prefers the closest frame at or just before the target.
    */
-  getFrame(targetTimestamp: number, toleranceSeconds = 0.1): BufferedFrame | null {
+  getFrame(targetTimestamp: number, toleranceSeconds = FRAME_TOLERANCE_SECONDS): BufferedFrame | null {
     if (this.frames.length === 0) return null;
 
+    // Best match: closest frame at or just before target within tolerance
     let bestBefore: BufferedFrame | null = null;
     let bestBeforeDist = Infinity;
 
     for (const frame of this.frames) {
       const dist = targetTimestamp - frame.timestamp;
-      // Prefer frames at or just before target (within tolerance)
       if (dist >= -1e-4 && dist < bestBeforeDist) {
         bestBeforeDist = dist;
         bestBefore = frame;
@@ -72,36 +90,33 @@ class FrameBuffer {
       return bestBefore;
     }
 
-    // Fallback: closest frame within tolerance
-    let bestAny: BufferedFrame | null = null;
-    let bestAnyDist = Infinity;
-    for (const frame of this.frames) {
-      const dist = Math.abs(frame.timestamp - targetTimestamp);
-      if (dist < bestAnyDist) {
-        bestAnyDist = dist;
-        bestAny = frame;
-      }
+    // When the worker is behind (decode startup), show the newest frame we have
+    // rather than nothing. A slightly stale frame is better than a blank canvas.
+    if (bestBefore) {
+      return bestBefore;
     }
 
-    return bestAny && bestAnyDist <= toleranceSeconds ? bestAny : null;
+    // Fallback: closest frame overall (handles slightly-ahead frames during seek)
+    return this.frames[this.frames.length - 1] ?? null;
   }
 
-  /** Remove all frames at or before the given timestamp. */
-  consumeUpTo(timestamp: number): void {
-    // Keep frames near/after timestamp, close old ones
-    const cutoff = timestamp - 0.2; // keep a small lookback buffer
+  /** Remove frames well behind the playback position. */
+  pruneOld(currentTimestamp: number): number {
+    const cutoff = currentTimestamp - 0.2; // keep a small lookback
+    let pruned = 0;
     const kept: BufferedFrame[] = [];
     for (const frame of this.frames) {
       if (frame.timestamp < cutoff) {
         frame.bitmap.close();
+        pruned++;
       } else {
         kept.push(frame);
       }
     }
     this.frames = kept;
+    return pruned;
   }
 
-  /** Flush all frames. */
   clear(): void {
     for (const frame of this.frames) {
       frame.bitmap.close();
@@ -111,14 +126,6 @@ class FrameBuffer {
 
   get size(): number {
     return this.frames.length;
-  }
-
-  get oldestTimestamp(): number | null {
-    return this.frames.length > 0 ? this.frames[0]!.timestamp : null;
-  }
-
-  get newestTimestamp(): number | null {
-    return this.frames.length > 0 ? this.frames[this.frames.length - 1]!.timestamp : null;
   }
 }
 
@@ -136,7 +143,12 @@ interface StreamState {
   buffer: FrameBuffer;
   info: SourceInfo | null;
   streaming: boolean;
-  lastConsumedTimestamp: number | null;
+  /** Frames received from worker but not yet drawn. Used for backpressure. */
+  undrawnCount: number;
+  /** Timestamp (ms) of the last getFrame() call. Used for idle cleanup. */
+  lastAccessMs: number;
+  /** Whether a lazy auto-start is already in flight. */
+  autoStartPending: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -152,15 +164,18 @@ export interface StreamingPlayback {
   stopStream(src: string): void;
   /** Stop all active streams. */
   stopAll(): void;
-  /** Get the best decoded frame for a source at a target timestamp. Returns null if no frame available. */
-  getFrame(src: string, targetTimestamp: number): ImageBitmap | null;
+  /**
+   * Get the best decoded frame for a source at a target timestamp.
+   * If no stream exists for this source, lazily starts one and returns null.
+   * Falls through to the next render path (DOM video) until frames arrive.
+   */
+  getFrame(src: string, targetTimestamp: number, mediaId?: string): ImageBitmap | null;
   /** Get source info (dimensions, duration) if available. */
   getSourceInfo(src: string): SourceInfo | null;
   /** Whether a source is actively streaming. */
   isStreaming(src: string): boolean;
   /** Dispose all resources. */
   dispose(): void;
-
   /** Metrics for debugging. */
   getMetrics(): StreamingPlaybackMetrics;
 }
@@ -176,6 +191,7 @@ export interface StreamingPlaybackMetrics {
 export function createStreamingPlayback(): StreamingPlayback {
   let worker: Worker | null = null;
   let workerReady = false;
+  let disposed = false;
   const streams = new Map<string, StreamState>();
   const pendingStarts: Array<() => void> = [];
 
@@ -186,6 +202,9 @@ export function createStreamingPlayback(): StreamingPlayback {
 
   // Blob cache (same pattern as decoder-prewarm.ts)
   const blobByUrl = new Map<string, Blob>();
+
+  // Idle sweep timer
+  let idleSweepTimer: ReturnType<typeof setInterval> | null = null;
 
   function ensureWorker(): Worker {
     if (worker) return worker;
@@ -206,12 +225,20 @@ export function createStreamingPlayback(): StreamingPlayback {
 
   function handleWorkerMessage(event: MessageEvent): void {
     const msg = event.data;
+    // eslint-disable-next-line no-console
+    console.log('[StreamingPlayback:msg]', msg?.type, msg?.type === 'frame' ? { ts: msg.timestamp, hasBitmap: msg.bitmap instanceof ImageBitmap } : msg);
 
     if (msg.type === 'ready') {
+      diag('worker ready');
       workerReady = true;
-      // Flush pending starts
       for (const fn of pendingStarts) fn();
       pendingStarts.length = 0;
+      return;
+    }
+
+    if (msg.type === 'debug') {
+      // eslint-disable-next-line no-console
+      console.log('[StreamingPlayback:worker-debug]', msg);
       return;
     }
 
@@ -232,13 +259,18 @@ export function createStreamingPlayback(): StreamingPlayback {
       if (!state) return;
 
       totalFramesReceived++;
+      if (totalFramesReceived <= 5) {
+        diag(`frame recv #${totalFramesReceived} ts=${msg.timestamp?.toFixed(4)} hasBitmap=${msg.bitmap instanceof ImageBitmap} src=${msg.src?.slice(0, 40)}`);
+      }
 
       if (msg.bitmap instanceof ImageBitmap) {
         state.buffer.push(msg.timestamp, msg.bitmap);
+        state.undrawnCount++;
       }
-
-      // Acknowledge consumption for backpressure
-      worker?.postMessage({ type: 'frame_consumed', src: msg.src });
+      // NOTE: We do NOT send frame_consumed here.
+      // Backpressure signals are sent in getFrame() when the render pipeline
+      // actually draws a frame. This prevents the worker from racing ahead
+      // indefinitely while the main thread is busy.
       return;
     }
 
@@ -251,12 +283,15 @@ export function createStreamingPlayback(): StreamingPlayback {
     }
 
     if (msg.type === 'keyframes_extracted') {
-      // Could forward to main-thread registry if needed
       return;
     }
 
     if (msg.type === 'error') {
       log.warn('Streaming decode error', { src: msg.src, message: msg.message });
+      const state = streams.get(msg.src);
+      if (state) {
+        state.autoStartPending = false;
+      }
       return;
     }
   }
@@ -265,10 +300,12 @@ export function createStreamingPlayback(): StreamingPlayback {
     const existing = streams.get(src);
     if (existing) return existing;
     const state: StreamState = {
-      buffer: new FrameBuffer(30),
+      buffer: new FrameBuffer(MAX_BUFFER_SIZE),
       info: null,
       streaming: false,
-      lastConsumedTimestamp: null,
+      undrawnCount: 0,
+      lastAccessMs: performance.now(),
+      autoStartPending: false,
     };
     streams.set(src, state);
     return state;
@@ -287,88 +324,211 @@ export function createStreamingPlayback(): StreamingPlayback {
     return undefined;
   }
 
-  function buildStartMessage(src: string, startTimestamp: number) {
-    const sourceMetadata = getObjectUrlDirectFileMetadata(src) ?? undefined;
-    const blob = sourceMetadata ? undefined : resolveBlobForWorker(src);
-    const keyframeTimestamps = getKeyframeTimestamps(src);
-
-    return {
-      type: 'stream_start' as const,
-      src,
-      startTimestamp,
-      blob,
-      sourceMetadata,
-      keyframeTimestamps,
-    };
+  // Dev diagnostics — stash breadcrumbs on window for inspection
+  const diagLog: string[] = [];
+  if (import.meta.env.DEV) {
+    (self as unknown as Record<string, unknown>).__STREAM_LOG__ = diagLog;
+  }
+  function diag(msg: string): void {
+    diagLog.push(`${Date.now()}: ${msg}`);
+    if (diagLog.length > 100) diagLog.shift();
   }
 
-  return {
-    startStream(src: string, startTimestamp: number): void {
-      const state = getOrCreateState(src);
-      state.buffer.clear();
-      state.streaming = true;
-      state.lastConsumedTimestamp = null;
+  function postStartMessage(src: string, startTimestamp: number, mediaId?: string): void {
+    // Resolve the active blob URL via blobUrlManager when the passed src might be stale.
+    // During re-renders (e.g. forceFastScrubOverlay flip), blob URLs get revoked and
+    // recreated. The mediaId lets us find the current active URL and its blob.
+    let activeSrc = src;
+    if (mediaId) {
+      const currentUrl = blobUrlManager.get(mediaId);
+      if (currentUrl && currentUrl !== src) {
+        diag(`resolved stale URL via mediaId=${mediaId}: ${src.slice(0, 30)} → ${currentUrl.slice(0, 30)}`);
+        activeSrc = currentUrl;
+      }
+    }
 
-      const w = ensureWorker();
-      const msg = buildStartMessage(src, startTimestamp);
+    diag(`postStartMessage src=${activeSrc.slice(0, 50)} ts=${startTimestamp} workerReady=${workerReady}`);
+    const sourceMetadata = getObjectUrlDirectFileMetadata(activeSrc) ?? undefined;
+    const keyframeTimestamps = getKeyframeTimestamps(activeSrc) ?? getKeyframeTimestamps(src);
+    const w = ensureWorker();
 
+    const doPost = (blob?: Blob) => {
+      diag(`doPost hasBlob=${!!blob} hasMetadata=${!!sourceMetadata} workerReady=${workerReady}`);
+      const msg = {
+        type: 'stream_start' as const,
+        src: activeSrc,
+        startTimestamp,
+        blob,
+        sourceMetadata,
+        keyframeTimestamps,
+      };
       if (workerReady) {
         w.postMessage(msg);
       } else {
         pendingStarts.push(() => w.postMessage(msg));
       }
+    };
+
+    if (sourceMetadata) {
+      doPost();
+    } else {
+      const knownBlob = resolveBlobForWorker(activeSrc);
+      if (knownBlob) {
+        doPost(knownBlob);
+      } else if (activeSrc.startsWith('blob:')) {
+        diag(`fetching blob for ${activeSrc.slice(0, 40)}`);
+        fetch(activeSrc).then((res) => res.blob()).then((blob) => {
+          diag(`blob fetched size=${blob.size}`);
+          blobByUrl.set(activeSrc, blob);
+          doPost(blob);
+        }).catch((err) => {
+          diag(`blob fetch FAILED: ${err}`);
+        });
+      } else {
+        doPost();
+      }
+    }
+  }
+
+  /** Send backpressure acknowledgments for drawn frames. */
+  function ackDrawnFrames(src: string, count: number): void {
+    if (!worker || count <= 0) return;
+    for (let i = 0; i < count; i++) {
+      worker.postMessage({ type: 'frame_consumed', src });
+    }
+  }
+
+  /** Stop and clean up a single source. */
+  function stopSource(src: string): void {
+    const state = streams.get(src);
+    if (!state) return;
+    if (state.streaming) {
+      worker?.postMessage({ type: 'stream_stop', src });
+    }
+    state.streaming = false;
+    state.autoStartPending = false;
+    state.buffer.clear();
+    state.undrawnCount = 0;
+  }
+
+  /** Run idle cleanup: stop sources not accessed recently. */
+  function idleSweep(): void {
+    const now = performance.now();
+    const toStop: string[] = [];
+    for (const [src, state] of streams) {
+      if (state.streaming && now - state.lastAccessMs > IDLE_TIMEOUT_MS) {
+        toStop.push(src);
+      }
+    }
+    for (const src of toStop) {
+      log.debug('Stopping idle stream', { src: src.slice(0, 30) });
+      stopSource(src);
+      streams.delete(src);
+    }
+  }
+
+  function startIdleSweep(): void {
+    if (idleSweepTimer !== null) return;
+    idleSweepTimer = setInterval(idleSweep, IDLE_SWEEP_INTERVAL_MS);
+  }
+
+  function stopIdleSweep(): void {
+    if (idleSweepTimer !== null) {
+      clearInterval(idleSweepTimer);
+      idleSweepTimer = null;
+    }
+  }
+
+  return {
+    startStream(src: string, startTimestamp: number): void {
+      if (disposed) return;
+      const state = getOrCreateState(src);
+      state.buffer.clear();
+      state.streaming = true;
+      state.undrawnCount = 0;
+      state.lastAccessMs = performance.now();
+      state.autoStartPending = false;
+
+      postStartMessage(src, startTimestamp);
+      startIdleSweep();
     },
 
     seekStream(src: string, timestamp: number): void {
+      if (disposed) return;
       const state = streams.get(src);
       if (!state) return;
 
       state.buffer.clear();
       state.streaming = true;
-      state.lastConsumedTimestamp = null;
+      state.undrawnCount = 0;
+      state.lastAccessMs = performance.now();
 
-      worker?.postMessage({
-        type: 'stream_seek',
-        src,
-        timestamp,
-      });
+      worker?.postMessage({ type: 'stream_seek', src, timestamp });
     },
 
     stopStream(src: string): void {
-      const state = streams.get(src);
-      if (!state) return;
-
-      state.streaming = false;
-      worker?.postMessage({ type: 'stream_stop', src });
+      stopSource(src);
     },
 
     stopAll(): void {
-      for (const [src, state] of streams) {
-        if (state.streaming) {
-          state.streaming = false;
-          worker?.postMessage({ type: 'stream_stop', src });
-        }
+      for (const [src] of streams) {
+        stopSource(src);
       }
+      streams.clear();
+      stopIdleSweep();
     },
 
-    getFrame(src: string, targetTimestamp: number): ImageBitmap | null {
-      const state = streams.get(src);
-      if (!state) {
+    getFrame(src: string, targetTimestamp: number, mediaId?: string): ImageBitmap | null {
+      if (disposed) return null;
+
+      let state = streams.get(src);
+
+      // Lazy auto-start: first time we see a source, start streaming
+      if (!state || (!state.streaming && !state.autoStartPending)) {
+        // Resolve the active URL via mediaId. The renderer may pass a stale
+        // blob URL from a previous render cycle. We need to key the stream
+        // state by the active URL so worker frame messages match.
+        let activeSrc = src;
+        if (mediaId) {
+          const currentUrl = blobUrlManager.get(mediaId);
+          if (currentUrl) activeSrc = currentUrl;
+        }
+        diag(`getFrame auto-start src=${activeSrc.slice(0, 50)} mediaId=${mediaId} ts=${targetTimestamp.toFixed(3)}`);
+        state = getOrCreateState(activeSrc);
+        // Also register the original src so future lookups with either URL find the state
+        if (activeSrc !== src) streams.set(src, state);
+        state.autoStartPending = true;
+        state.lastAccessMs = performance.now();
+        state.streaming = true;
+        state.autoStartPending = false;
+        postStartMessage(activeSrc, targetTimestamp, mediaId);
+        startIdleSweep();
+
         totalFramesMissed++;
         return null;
       }
+
+      state.lastAccessMs = performance.now();
 
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {
+        if (totalFramesMissed < 5 || totalFramesMissed % 30 === 0) {
+          diag(`getFrame MISS ts=${targetTimestamp.toFixed(4)} bufSize=${state.buffer.size} undrawn=${state.undrawnCount}`);
+        }
         totalFramesMissed++;
         return null;
       }
+      if (totalFramesDrawn < 3) {
+        diag(`getFrame HIT ts=${targetTimestamp.toFixed(4)} frameTs=${frame.timestamp.toFixed(4)}`);
+      }
 
       totalFramesDrawn++;
-      state.lastConsumedTimestamp = targetTimestamp;
 
-      // Prune old frames that we've passed
-      state.buffer.consumeUpTo(targetTimestamp);
+      // Prune old frames and send backpressure acks for consumed frames
+      const pruned = state.buffer.pruneOld(targetTimestamp);
+      const toAck = Math.min(state.undrawnCount, pruned + 1);
+      state.undrawnCount = Math.max(0, state.undrawnCount - toAck);
+      ackDrawnFrames(src, toAck);
 
       return frame.bitmap;
     },
@@ -382,6 +542,8 @@ export function createStreamingPlayback(): StreamingPlayback {
     },
 
     dispose(): void {
+      disposed = true;
+      stopIdleSweep();
       for (const [, state] of streams) {
         state.buffer.clear();
       }

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -458,16 +458,18 @@ export function createStreamingPlayback(): StreamingPlayback {
     getFrame(src: string, targetTimestamp: number, mediaId?: string): ImageBitmap | null {
       if (disposed) return null;
 
-      // Resolve the active URL via mediaId. The renderer may pass a stale
-      // blob URL from a previous render cycle (e.g. after forceFastScrubOverlay flip).
+      // Look up stream by the src the renderer provides (usually the proxy URL),
+      // then fall back to the blobUrlManager URL (original). Pre-warm starts
+      // streams with proxy URLs, so checking src first avoids a miss.
       let activeSrc = src;
-      if (mediaId) {
+      let state = streams.get(src) ?? null;
+      if (!state && mediaId) {
         const currentUrl = blobUrlManager.get(mediaId);
-        if (currentUrl) activeSrc = currentUrl;
+        if (currentUrl) {
+          activeSrc = currentUrl;
+          state = streams.get(currentUrl) ?? null;
+        }
       }
-
-      // Look up stream by active URL first, then stale URL
-      let state = streams.get(activeSrc) ?? streams.get(src);
 
       // Lazy auto-start: first time we see a source, start streaming
       if (!state || (!state.streaming && !state.autoStartPending)) {

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -35,8 +35,10 @@ const log = createLogger('StreamingPlayback');
 const IDLE_TIMEOUT_MS = 3000;
 /** How often to run the idle cleanup sweep. */
 const IDLE_SWEEP_INTERVAL_MS = 1000;
-/** Maximum frames buffered per source. */
-const MAX_BUFFER_SIZE = 30;
+/** Maximum frames buffered per source. Must be larger than
+ *  MAX_DECODE_AHEAD_SECONDS * max_fps to avoid evicting frames the
+ *  worker just decoded. 90 frames covers 3s@30fps or 1.5s@60fps. */
+const MAX_BUFFER_SIZE = 90;
 /** Source time tolerance for frame lookup (seconds). */
 const FRAME_TOLERANCE_SECONDS = 0.15;
 
@@ -500,6 +502,9 @@ export function createStreamingPlayback(): StreamingPlayback {
       }
 
       state.lastAccessMs = performance.now();
+
+      // Tell the worker where playback is so it throttles decode-ahead
+      worker?.postMessage({ type: 'playback_position', src: activeSrc, position: targetTimestamp });
 
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -328,18 +328,14 @@ export function createStreamingPlayback(): StreamingPlayback {
     return undefined;
   }
 
-  function postStartMessage(src: string, startTimestamp: number, mediaId?: string): void {
-    // Resolve the active blob URL via blobUrlManager when the passed src might be stale.
-    // During re-renders (e.g. forceFastScrubOverlay flip), blob URLs get revoked and
-    // recreated. The mediaId lets us find the current active URL and its blob.
-    let activeSrc = src;
-    if (mediaId) {
-      const currentUrl = blobUrlManager.get(mediaId);
-      if (currentUrl && currentUrl !== src) activeSrc = currentUrl;
-    }
+  function postStartMessage(src: string, startTimestamp: number): void {
+    // The caller is responsible for resolving the correct URL (proxy or original).
+    // We no longer override via blobUrlManager here — that would replace proxy URLs
+    // with original URLs, defeating the proxy resolution in collectPrewarmTargets.
+    const activeSrc = src;
 
     const sourceMetadata = getObjectUrlDirectFileMetadata(activeSrc) ?? undefined;
-    const keyframeTimestamps = getKeyframeTimestamps(activeSrc) ?? getKeyframeTimestamps(src);
+    const keyframeTimestamps = getKeyframeTimestamps(activeSrc);
     const w = ensureWorker();
 
     const doPost = (blob?: Blob) => {
@@ -479,7 +475,7 @@ export function createStreamingPlayback(): StreamingPlayback {
         state.lastAccessMs = performance.now();
         state.streaming = true;
         state.autoStartPending = false;
-        postStartMessage(activeSrc, targetTimestamp, mediaId);
+        postStartMessage(activeSrc, targetTimestamp);
 
         totalFramesMissed++;
         return null;

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -1,0 +1,412 @@
+/**
+ * Main-thread coordinator for WebCodecs streaming playback.
+ *
+ * Manages streaming decode workers and provides decoded ImageBitmaps
+ * to the render pipeline as a drop-in replacement for DOM video elements.
+ *
+ * Usage:
+ *   const playback = createStreamingPlayback();
+ *   playback.startStream('blob:...', 0.5);  // start decoding from 0.5s
+ *   const frame = playback.getFrame('blob:...', 1.2);  // get frame at 1.2s
+ *   playback.stopStream('blob:...');
+ *   playback.dispose();
+ */
+
+import { createLogger } from '@/shared/logging/logger';
+import {
+  getObjectUrlBlob,
+  getObjectUrlDirectFileMetadata,
+} from '@/infrastructure/browser/object-url-registry';
+import { getKeyframeTimestamps } from '@/shared/utils/keyframe-index-registry';
+
+const log = createLogger('StreamingPlayback');
+
+// ---------------------------------------------------------------------------
+// Frame buffer
+// ---------------------------------------------------------------------------
+
+interface BufferedFrame {
+  timestamp: number;
+  bitmap: ImageBitmap;
+}
+
+/** Per-source ring buffer of decoded frames. */
+class FrameBuffer {
+  private frames: BufferedFrame[] = [];
+  private readonly maxSize: number;
+
+  constructor(maxSize = 30) {
+    this.maxSize = maxSize;
+  }
+
+  /** Insert a frame, evicting the oldest if at capacity. */
+  push(timestamp: number, bitmap: ImageBitmap): void {
+    // Evict oldest if full
+    if (this.frames.length >= this.maxSize) {
+      const evicted = this.frames.shift();
+      evicted?.bitmap.close();
+    }
+    this.frames.push({ timestamp, bitmap });
+  }
+
+  /**
+   * Find the best frame for a target timestamp.
+   * Returns the closest frame at or before the target, or the closest overall.
+   */
+  getFrame(targetTimestamp: number, toleranceSeconds = 0.1): BufferedFrame | null {
+    if (this.frames.length === 0) return null;
+
+    let bestBefore: BufferedFrame | null = null;
+    let bestBeforeDist = Infinity;
+
+    for (const frame of this.frames) {
+      const dist = targetTimestamp - frame.timestamp;
+      // Prefer frames at or just before target (within tolerance)
+      if (dist >= -1e-4 && dist < bestBeforeDist) {
+        bestBeforeDist = dist;
+        bestBefore = frame;
+      }
+    }
+
+    if (bestBefore && bestBeforeDist <= toleranceSeconds) {
+      return bestBefore;
+    }
+
+    // Fallback: closest frame within tolerance
+    let bestAny: BufferedFrame | null = null;
+    let bestAnyDist = Infinity;
+    for (const frame of this.frames) {
+      const dist = Math.abs(frame.timestamp - targetTimestamp);
+      if (dist < bestAnyDist) {
+        bestAnyDist = dist;
+        bestAny = frame;
+      }
+    }
+
+    return bestAny && bestAnyDist <= toleranceSeconds ? bestAny : null;
+  }
+
+  /** Remove all frames at or before the given timestamp. */
+  consumeUpTo(timestamp: number): void {
+    // Keep frames near/after timestamp, close old ones
+    const cutoff = timestamp - 0.2; // keep a small lookback buffer
+    const kept: BufferedFrame[] = [];
+    for (const frame of this.frames) {
+      if (frame.timestamp < cutoff) {
+        frame.bitmap.close();
+      } else {
+        kept.push(frame);
+      }
+    }
+    this.frames = kept;
+  }
+
+  /** Flush all frames. */
+  clear(): void {
+    for (const frame of this.frames) {
+      frame.bitmap.close();
+    }
+    this.frames = [];
+  }
+
+  get size(): number {
+    return this.frames.length;
+  }
+
+  get oldestTimestamp(): number | null {
+    return this.frames.length > 0 ? this.frames[0]!.timestamp : null;
+  }
+
+  get newestTimestamp(): number | null {
+    return this.frames.length > 0 ? this.frames[this.frames.length - 1]!.timestamp : null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source state
+// ---------------------------------------------------------------------------
+
+interface SourceInfo {
+  width: number;
+  height: number;
+  duration: number;
+}
+
+interface StreamState {
+  buffer: FrameBuffer;
+  info: SourceInfo | null;
+  streaming: boolean;
+  lastConsumedTimestamp: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming playback coordinator
+// ---------------------------------------------------------------------------
+
+export interface StreamingPlayback {
+  /** Start streaming decode for a source from a given timestamp. */
+  startStream(src: string, startTimestamp: number): void;
+  /** Seek an active stream to a new timestamp. */
+  seekStream(src: string, timestamp: number): void;
+  /** Stop streaming for a source. */
+  stopStream(src: string): void;
+  /** Stop all active streams. */
+  stopAll(): void;
+  /** Get the best decoded frame for a source at a target timestamp. Returns null if no frame available. */
+  getFrame(src: string, targetTimestamp: number): ImageBitmap | null;
+  /** Get source info (dimensions, duration) if available. */
+  getSourceInfo(src: string): SourceInfo | null;
+  /** Whether a source is actively streaming. */
+  isStreaming(src: string): boolean;
+  /** Dispose all resources. */
+  dispose(): void;
+
+  /** Metrics for debugging. */
+  getMetrics(): StreamingPlaybackMetrics;
+}
+
+export interface StreamingPlaybackMetrics {
+  activeStreams: number;
+  totalFramesReceived: number;
+  totalFramesDrawn: number;
+  totalFramesMissed: number;
+  bufferSizes: Map<string, number>;
+}
+
+export function createStreamingPlayback(): StreamingPlayback {
+  let worker: Worker | null = null;
+  let workerReady = false;
+  const streams = new Map<string, StreamState>();
+  const pendingStarts: Array<() => void> = [];
+
+  // Metrics
+  let totalFramesReceived = 0;
+  let totalFramesDrawn = 0;
+  let totalFramesMissed = 0;
+
+  // Blob cache (same pattern as decoder-prewarm.ts)
+  const blobByUrl = new Map<string, Blob>();
+
+  function ensureWorker(): Worker {
+    if (worker) return worker;
+
+    worker = new Worker(
+      new URL('../workers/streaming-decode-worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+
+    worker.onmessage = handleWorkerMessage;
+    worker.onerror = (error) => {
+      log.warn('Streaming decode worker error', { message: error.message });
+    };
+    worker.postMessage({ type: 'warmup' });
+
+    return worker;
+  }
+
+  function handleWorkerMessage(event: MessageEvent): void {
+    const msg = event.data;
+
+    if (msg.type === 'ready') {
+      workerReady = true;
+      // Flush pending starts
+      for (const fn of pendingStarts) fn();
+      pendingStarts.length = 0;
+      return;
+    }
+
+    if (msg.type === 'source_ready') {
+      const state = streams.get(msg.src);
+      if (state) {
+        state.info = {
+          width: msg.width,
+          height: msg.height,
+          duration: msg.duration,
+        };
+      }
+      return;
+    }
+
+    if (msg.type === 'frame') {
+      const state = streams.get(msg.src);
+      if (!state) return;
+
+      totalFramesReceived++;
+
+      if (msg.bitmap instanceof ImageBitmap) {
+        state.buffer.push(msg.timestamp, msg.bitmap);
+      }
+
+      // Acknowledge consumption for backpressure
+      worker?.postMessage({ type: 'frame_consumed', src: msg.src });
+      return;
+    }
+
+    if (msg.type === 'stream_ended') {
+      const state = streams.get(msg.src);
+      if (state) {
+        state.streaming = false;
+      }
+      return;
+    }
+
+    if (msg.type === 'keyframes_extracted') {
+      // Could forward to main-thread registry if needed
+      return;
+    }
+
+    if (msg.type === 'error') {
+      log.warn('Streaming decode error', { src: msg.src, message: msg.message });
+      return;
+    }
+  }
+
+  function getOrCreateState(src: string): StreamState {
+    const existing = streams.get(src);
+    if (existing) return existing;
+    const state: StreamState = {
+      buffer: new FrameBuffer(30),
+      info: null,
+      streaming: false,
+      lastConsumedTimestamp: null,
+    };
+    streams.set(src, state);
+    return state;
+  }
+
+  function resolveBlobForWorker(src: string): Blob | undefined {
+    const cached = blobByUrl.get(src);
+    if (cached) return cached;
+
+    const registered = getObjectUrlBlob(src);
+    if (registered) {
+      blobByUrl.set(src, registered);
+      return registered;
+    }
+
+    return undefined;
+  }
+
+  function buildStartMessage(src: string, startTimestamp: number) {
+    const sourceMetadata = getObjectUrlDirectFileMetadata(src) ?? undefined;
+    const blob = sourceMetadata ? undefined : resolveBlobForWorker(src);
+    const keyframeTimestamps = getKeyframeTimestamps(src);
+
+    return {
+      type: 'stream_start' as const,
+      src,
+      startTimestamp,
+      blob,
+      sourceMetadata,
+      keyframeTimestamps,
+    };
+  }
+
+  return {
+    startStream(src: string, startTimestamp: number): void {
+      const state = getOrCreateState(src);
+      state.buffer.clear();
+      state.streaming = true;
+      state.lastConsumedTimestamp = null;
+
+      const w = ensureWorker();
+      const msg = buildStartMessage(src, startTimestamp);
+
+      if (workerReady) {
+        w.postMessage(msg);
+      } else {
+        pendingStarts.push(() => w.postMessage(msg));
+      }
+    },
+
+    seekStream(src: string, timestamp: number): void {
+      const state = streams.get(src);
+      if (!state) return;
+
+      state.buffer.clear();
+      state.streaming = true;
+      state.lastConsumedTimestamp = null;
+
+      worker?.postMessage({
+        type: 'stream_seek',
+        src,
+        timestamp,
+      });
+    },
+
+    stopStream(src: string): void {
+      const state = streams.get(src);
+      if (!state) return;
+
+      state.streaming = false;
+      worker?.postMessage({ type: 'stream_stop', src });
+    },
+
+    stopAll(): void {
+      for (const [src, state] of streams) {
+        if (state.streaming) {
+          state.streaming = false;
+          worker?.postMessage({ type: 'stream_stop', src });
+        }
+      }
+    },
+
+    getFrame(src: string, targetTimestamp: number): ImageBitmap | null {
+      const state = streams.get(src);
+      if (!state) {
+        totalFramesMissed++;
+        return null;
+      }
+
+      const frame = state.buffer.getFrame(targetTimestamp);
+      if (!frame) {
+        totalFramesMissed++;
+        return null;
+      }
+
+      totalFramesDrawn++;
+      state.lastConsumedTimestamp = targetTimestamp;
+
+      // Prune old frames that we've passed
+      state.buffer.consumeUpTo(targetTimestamp);
+
+      return frame.bitmap;
+    },
+
+    getSourceInfo(src: string): SourceInfo | null {
+      return streams.get(src)?.info ?? null;
+    },
+
+    isStreaming(src: string): boolean {
+      return streams.get(src)?.streaming ?? false;
+    },
+
+    dispose(): void {
+      for (const [, state] of streams) {
+        state.buffer.clear();
+      }
+      streams.clear();
+      blobByUrl.clear();
+
+      if (worker) {
+        worker.terminate();
+        worker = null;
+        workerReady = false;
+      }
+    },
+
+    getMetrics(): StreamingPlaybackMetrics {
+      const bufferSizes = new Map<string, number>();
+      for (const [src, state] of streams) {
+        bufferSizes.set(src, state.buffer.size);
+      }
+      return {
+        activeStreams: [...streams.values()].filter((s) => s.streaming).length,
+        totalFramesReceived,
+        totalFramesDrawn,
+        totalFramesMissed,
+        bufferSizes,
+      };
+    },
+  };
+}

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -454,14 +454,17 @@ export function createStreamingPlayback(): StreamingPlayback {
     getFrame(src: string, targetTimestamp: number, mediaId?: string): ImageBitmap | null {
       if (disposed) return null;
 
-      // Look up stream by the src the renderer provides (usually the proxy URL),
-      // then fall back to the blobUrlManager URL (original). Pre-warm starts
-      // streams with proxy URLs, so checking src first avoids a miss.
+      // Look up stream by the src the renderer provides, then fall back to
+      // the blobUrlManager URL. Track which URL matched so playback_position
+      // is sent with the correct key (the renderer may have a stale proxy URL
+      // after a mid-playback proxy toggle, but the stream uses the original).
+      let streamSrc = src;
       let state = streams.get(src) ?? null;
       if (!state && mediaId) {
         const fallbackUrl = blobUrlManager.get(mediaId);
         if (fallbackUrl) {
           state = streams.get(fallbackUrl) ?? null;
+          if (state) streamSrc = fallbackUrl;
         }
       }
 
@@ -481,8 +484,10 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       state.lastAccessMs = performance.now();
 
-      // Tell the worker where playback is so it throttles decode-ahead
-      worker?.postMessage({ type: 'playback_position', src, position: targetTimestamp });
+      // Tell the worker where playback is so it throttles decode-ahead.
+      // Use streamSrc (the key the stream was found by), not src (which may
+      // be a stale proxy URL from an un-rebuilt renderer composition).
+      worker?.postMessage({ type: 'playback_position', src: streamSrc, position: targetTimestamp });
 
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -457,25 +457,23 @@ export function createStreamingPlayback(): StreamingPlayback {
       // Look up stream by the src the renderer provides (usually the proxy URL),
       // then fall back to the blobUrlManager URL (original). Pre-warm starts
       // streams with proxy URLs, so checking src first avoids a miss.
-      let activeSrc = src;
       let state = streams.get(src) ?? null;
       if (!state && mediaId) {
-        const currentUrl = blobUrlManager.get(mediaId);
-        if (currentUrl) {
-          activeSrc = currentUrl;
-          state = streams.get(currentUrl) ?? null;
+        const fallbackUrl = blobUrlManager.get(mediaId);
+        if (fallbackUrl) {
+          state = streams.get(fallbackUrl) ?? null;
         }
       }
 
-      // Lazy auto-start: first time we see a source, start streaming
+      // Lazy auto-start: use the renderer's src (proxy or original) — not the
+      // blobUrlManager URL which always returns the original.
       if (!state || (!state.streaming && !state.autoStartPending)) {
-        state = getOrCreateState(activeSrc);
-        if (activeSrc !== src) streams.set(src, state);
+        state = getOrCreateState(src);
         state.autoStartPending = true;
         state.lastAccessMs = performance.now();
         state.streaming = true;
         state.autoStartPending = false;
-        postStartMessage(activeSrc, targetTimestamp);
+        postStartMessage(src, targetTimestamp);
 
         totalFramesMissed++;
         return null;
@@ -484,7 +482,7 @@ export function createStreamingPlayback(): StreamingPlayback {
       state.lastAccessMs = performance.now();
 
       // Tell the worker where playback is so it throttles decode-ahead
-      worker?.postMessage({ type: 'playback_position', src: activeSrc, position: targetTimestamp });
+      worker?.postMessage({ type: 'playback_position', src, position: targetTimestamp });
 
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -174,6 +174,9 @@ export interface StreamingPlayback {
   getSourceInfo(src: string): SourceInfo | null;
   /** Whether a source is actively streaming. */
   isStreaming(src: string): boolean;
+  /** Enable idle cleanup sweep. Call when playback starts.
+   *  Disabled by default so pre-warm streams aren't killed while paused. */
+  enableIdleSweep(): void;
   /** Dispose all resources. */
   dispose(): void;
   /** Metrics for debugging. */
@@ -425,7 +428,6 @@ export function createStreamingPlayback(): StreamingPlayback {
       state.autoStartPending = false;
 
       postStartMessage(src, startTimestamp);
-      startIdleSweep();
     },
 
     seekStream(src: string, timestamp: number): void {
@@ -476,7 +478,6 @@ export function createStreamingPlayback(): StreamingPlayback {
         state.streaming = true;
         state.autoStartPending = false;
         postStartMessage(activeSrc, targetTimestamp, mediaId);
-        startIdleSweep();
 
         totalFramesMissed++;
         return null;
@@ -507,6 +508,10 @@ export function createStreamingPlayback(): StreamingPlayback {
 
     isStreaming(src: string): boolean {
       return streams.get(src)?.streaming ?? false;
+    },
+
+    enableIdleSweep(): void {
+      startIdleSweep();
     },
 
     dispose(): void {

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -143,8 +143,6 @@ interface StreamState {
   buffer: FrameBuffer;
   info: SourceInfo | null;
   streaming: boolean;
-  /** Frames received from worker but not yet drawn. Used for backpressure. */
-  undrawnCount: number;
   /** Timestamp (ms) of the last getFrame() call. Used for idle cleanup. */
   lastAccessMs: number;
   /** Whether a lazy auto-start is already in flight. */
@@ -225,20 +223,11 @@ export function createStreamingPlayback(): StreamingPlayback {
 
   function handleWorkerMessage(event: MessageEvent): void {
     const msg = event.data;
-    // eslint-disable-next-line no-console
-    console.log('[StreamingPlayback:msg]', msg?.type, msg?.type === 'frame' ? { ts: msg.timestamp, hasBitmap: msg.bitmap instanceof ImageBitmap } : msg);
-
     if (msg.type === 'ready') {
       diag('worker ready');
       workerReady = true;
       for (const fn of pendingStarts) fn();
       pendingStarts.length = 0;
-      return;
-    }
-
-    if (msg.type === 'debug') {
-      // eslint-disable-next-line no-console
-      console.log('[StreamingPlayback:worker-debug]', msg);
       return;
     }
 
@@ -256,21 +245,33 @@ export function createStreamingPlayback(): StreamingPlayback {
 
     if (msg.type === 'frame') {
       const state = streams.get(msg.src);
-      if (!state) return;
+      if (!state) {
+        // No stream for this source — close the frame to avoid leak
+        if (msg.videoFrame instanceof VideoFrame) msg.videoFrame.close();
+        return;
+      }
 
       totalFramesReceived++;
-      if (totalFramesReceived <= 5) {
-        diag(`frame recv #${totalFramesReceived} ts=${msg.timestamp?.toFixed(4)} hasBitmap=${msg.bitmap instanceof ImageBitmap} src=${msg.src?.slice(0, 40)}`);
+
+      // Worker sends VideoFrame (zero-copy transfer). Convert to ImageBitmap
+      // on the main thread so the VideoFrame can be closed immediately.
+      // createImageBitmap(VideoFrame) is ~0.3ms — much faster than the worker
+      // doing drawImage + transferToImageBitmap (~2-5ms).
+      const videoFrame: VideoFrame | null = msg.videoFrame instanceof VideoFrame ? msg.videoFrame : null;
+      if (videoFrame) {
+        createImageBitmap(videoFrame).then((bitmap) => {
+          videoFrame.close();
+          state.buffer.push(msg.timestamp, bitmap);
+        }).catch(() => {
+          videoFrame.close();
+        });
+        return;
       }
 
+      // Fallback: ImageBitmap from older worker version
       if (msg.bitmap instanceof ImageBitmap) {
         state.buffer.push(msg.timestamp, msg.bitmap);
-        state.undrawnCount++;
       }
-      // NOTE: We do NOT send frame_consumed here.
-      // Backpressure signals are sent in getFrame() when the render pipeline
-      // actually draws a frame. This prevents the worker from racing ahead
-      // indefinitely while the main thread is busy.
       return;
     }
 
@@ -303,7 +304,6 @@ export function createStreamingPlayback(): StreamingPlayback {
       buffer: new FrameBuffer(MAX_BUFFER_SIZE),
       info: null,
       streaming: false,
-      undrawnCount: 0,
       lastAccessMs: performance.now(),
       autoStartPending: false,
     };
@@ -390,14 +390,6 @@ export function createStreamingPlayback(): StreamingPlayback {
     }
   }
 
-  /** Send backpressure acknowledgments for drawn frames. */
-  function ackDrawnFrames(src: string, count: number): void {
-    if (!worker || count <= 0) return;
-    for (let i = 0; i < count; i++) {
-      worker.postMessage({ type: 'frame_consumed', src });
-    }
-  }
-
   /** Stop and clean up a single source. */
   function stopSource(src: string): void {
     const state = streams.get(src);
@@ -408,7 +400,6 @@ export function createStreamingPlayback(): StreamingPlayback {
     state.streaming = false;
     state.autoStartPending = false;
     state.buffer.clear();
-    state.undrawnCount = 0;
   }
 
   /** Run idle cleanup: stop sources not accessed recently. */
@@ -445,7 +436,7 @@ export function createStreamingPlayback(): StreamingPlayback {
       const state = getOrCreateState(src);
       state.buffer.clear();
       state.streaming = true;
-      state.undrawnCount = 0;
+
       state.lastAccessMs = performance.now();
       state.autoStartPending = false;
 
@@ -460,7 +451,7 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       state.buffer.clear();
       state.streaming = true;
-      state.undrawnCount = 0;
+
       state.lastAccessMs = performance.now();
 
       worker?.postMessage({ type: 'stream_seek', src, timestamp });
@@ -513,7 +504,7 @@ export function createStreamingPlayback(): StreamingPlayback {
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {
         if (totalFramesMissed < 5 || totalFramesMissed % 30 === 0) {
-          diag(`getFrame MISS ts=${targetTimestamp.toFixed(4)} bufSize=${state.buffer.size} undrawn=${state.undrawnCount}`);
+          diag(`getFrame MISS ts=${targetTimestamp.toFixed(4)} bufSize=${state.buffer.size}`);
         }
         totalFramesMissed++;
         return null;
@@ -524,11 +515,8 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       totalFramesDrawn++;
 
-      // Prune old frames and send backpressure acks for consumed frames
-      const pruned = state.buffer.pruneOld(targetTimestamp);
-      const toAck = Math.min(state.undrawnCount, pruned + 1);
-      state.undrawnCount = Math.max(0, state.undrawnCount - toAck);
-      ackDrawnFrames(src, toAck);
+      // Prune old frames behind the playback position
+      state.buffer.pruneOld(targetTimestamp);
 
       return frame.bitmap;
     },

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -142,8 +142,10 @@ interface StreamState {
   streaming: boolean;
   /** Timestamp (ms) of the last getFrame() call. Used for idle cleanup. */
   lastAccessMs: number;
-  /** Whether a lazy auto-start is already in flight. */
-  autoStartPending: boolean;
+  /** Monotonic counter bumped on every start/stop — used to detect stale
+   *  async callbacks (e.g. blob fetch) that resolve after the stream was
+   *  stopped or restarted. */
+  generation: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -208,7 +210,8 @@ export function createStreamingPlayback(): StreamingPlayback {
   // Idle sweep timer
   let idleSweepTimer: ReturnType<typeof setInterval> | null = null;
 
-  function ensureWorker(): Worker {
+  function ensureWorker(): Worker | null {
+    if (typeof Worker === 'undefined') return null;
     if (worker) return worker;
 
     worker = new Worker(
@@ -264,7 +267,13 @@ export function createStreamingPlayback(): StreamingPlayback {
       if (videoFrame) {
         createImageBitmap(videoFrame).then((bitmap) => {
           videoFrame.close();
-          state.buffer.push(msg.timestamp, bitmap);
+          // Guard: state may have been removed from `streams` by stopAll()
+          // while this createImageBitmap was in-flight.
+          if (streams.has(msg.src)) {
+            state.buffer.push(msg.timestamp, bitmap);
+          } else {
+            bitmap.close();
+          }
         }).catch(() => {
           videoFrame.close();
         });
@@ -292,10 +301,6 @@ export function createStreamingPlayback(): StreamingPlayback {
 
     if (msg.type === 'error') {
       log.warn('Streaming decode error', { src: msg.src, message: msg.message });
-      const state = streams.get(msg.src);
-      if (state) {
-        state.autoStartPending = false;
-      }
       return;
     }
   }
@@ -308,7 +313,7 @@ export function createStreamingPlayback(): StreamingPlayback {
       info: null,
       streaming: false,
       lastAccessMs: performance.now(),
-      autoStartPending: false,
+      generation: 0,
     };
     streams.set(src, state);
     return state;
@@ -336,6 +341,7 @@ export function createStreamingPlayback(): StreamingPlayback {
     const sourceMetadata = getObjectUrlDirectFileMetadata(activeSrc) ?? undefined;
     const keyframeTimestamps = getKeyframeTimestamps(activeSrc);
     const w = ensureWorker();
+    if (!w) return;
 
     const doPost = (blob?: Blob) => {
       const msg = {
@@ -360,7 +366,11 @@ export function createStreamingPlayback(): StreamingPlayback {
       if (knownBlob) {
         doPost(knownBlob);
       } else if (activeSrc.startsWith('blob:')) {
+        // Capture generation so we can detect stop/restart during the async fetch.
+        const gen = streams.get(activeSrc)?.generation ?? -1;
         fetch(activeSrc).then((res) => res.blob()).then((blob) => {
+          const current = streams.get(activeSrc);
+          if (!current || current.generation !== gen) return;
           blobByUrl.set(activeSrc, blob);
           doPost(blob);
         }).catch(() => {
@@ -376,11 +386,11 @@ export function createStreamingPlayback(): StreamingPlayback {
   function stopSource(src: string): void {
     const state = streams.get(src);
     if (!state) return;
+    state.generation++;
     if (state.streaming) {
       worker?.postMessage({ type: 'stream_stop', src });
     }
     state.streaming = false;
-    state.autoStartPending = false;
     state.buffer.clear();
   }
 
@@ -396,6 +406,7 @@ export function createStreamingPlayback(): StreamingPlayback {
     for (const src of toStop) {
       log.debug('Stopping idle stream', { src: src.slice(0, 30) });
       stopSource(src);
+      worker?.postMessage({ type: 'dispose_source', src });
       streams.delete(src);
     }
   }
@@ -416,11 +427,10 @@ export function createStreamingPlayback(): StreamingPlayback {
     startStream(src: string, startTimestamp: number): void {
       if (disposed) return;
       const state = getOrCreateState(src);
+      state.generation++;
       state.buffer.clear();
       state.streaming = true;
-
       state.lastAccessMs = performance.now();
-      state.autoStartPending = false;
 
       postStartMessage(src, startTimestamp);
     },
@@ -432,10 +442,14 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       state.buffer.clear();
       state.streaming = true;
-
       state.lastAccessMs = performance.now();
 
-      worker?.postMessage({ type: 'stream_seek', src, timestamp });
+      const doSeek = () => worker?.postMessage({ type: 'stream_seek', src, timestamp });
+      if (workerReady) {
+        doSeek();
+      } else {
+        pendingStarts.push(doSeek);
+      }
     },
 
     stopStream(src: string): void {
@@ -445,6 +459,7 @@ export function createStreamingPlayback(): StreamingPlayback {
     stopAll(): void {
       for (const [src] of streams) {
         stopSource(src);
+        worker?.postMessage({ type: 'dispose_source', src });
       }
       streams.clear();
       stopIdleSweep();
@@ -469,12 +484,11 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       // Lazy auto-start: use the renderer's src (proxy or original) — not the
       // blobUrlManager URL which always returns the original.
-      if (!state || (!state.streaming && !state.autoStartPending)) {
+      if (!state || !state.streaming) {
         state = getOrCreateState(src);
-        state.autoStartPending = true;
+        state.generation++;
         state.lastAccessMs = performance.now();
         state.streaming = true;
-        state.autoStartPending = false;
         postStartMessage(src, targetTimestamp);
 
         totalFramesMissed++;

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -6,7 +6,7 @@
  *
  * Key behaviors:
  * - Lazy auto-start: getFrame() for an unknown source triggers async stream init
- * - Backpressure: frame_consumed signals are sent on draw, not receive
+ * - Position-aware throttle: worker stays within 1.5s ahead of playback position
  * - Idle cleanup: sources not requested for IDLE_TIMEOUT_MS are stopped
  *
  * Usage:
@@ -226,7 +226,6 @@ export function createStreamingPlayback(): StreamingPlayback {
   function handleWorkerMessage(event: MessageEvent): void {
     const msg = event.data;
     if (msg.type === 'ready') {
-      diag('worker ready');
       workerReady = true;
       for (const fn of pendingStarts) fn();
       pendingStarts.length = 0;
@@ -326,16 +325,6 @@ export function createStreamingPlayback(): StreamingPlayback {
     return undefined;
   }
 
-  // Dev diagnostics — stash breadcrumbs on window for inspection
-  const diagLog: string[] = [];
-  if (import.meta.env.DEV) {
-    (self as unknown as Record<string, unknown>).__STREAM_LOG__ = diagLog;
-  }
-  function diag(msg: string): void {
-    diagLog.push(`${Date.now()}: ${msg}`);
-    if (diagLog.length > 100) diagLog.shift();
-  }
-
   function postStartMessage(src: string, startTimestamp: number, mediaId?: string): void {
     // Resolve the active blob URL via blobUrlManager when the passed src might be stale.
     // During re-renders (e.g. forceFastScrubOverlay flip), blob URLs get revoked and
@@ -343,19 +332,14 @@ export function createStreamingPlayback(): StreamingPlayback {
     let activeSrc = src;
     if (mediaId) {
       const currentUrl = blobUrlManager.get(mediaId);
-      if (currentUrl && currentUrl !== src) {
-        diag(`resolved stale URL via mediaId=${mediaId}: ${src.slice(0, 30)} → ${currentUrl.slice(0, 30)}`);
-        activeSrc = currentUrl;
-      }
+      if (currentUrl && currentUrl !== src) activeSrc = currentUrl;
     }
 
-    diag(`postStartMessage src=${activeSrc.slice(0, 50)} ts=${startTimestamp} workerReady=${workerReady}`);
     const sourceMetadata = getObjectUrlDirectFileMetadata(activeSrc) ?? undefined;
     const keyframeTimestamps = getKeyframeTimestamps(activeSrc) ?? getKeyframeTimestamps(src);
     const w = ensureWorker();
 
     const doPost = (blob?: Blob) => {
-      diag(`doPost hasBlob=${!!blob} hasMetadata=${!!sourceMetadata} workerReady=${workerReady}`);
       const msg = {
         type: 'stream_start' as const,
         src: activeSrc,
@@ -378,13 +362,11 @@ export function createStreamingPlayback(): StreamingPlayback {
       if (knownBlob) {
         doPost(knownBlob);
       } else if (activeSrc.startsWith('blob:')) {
-        diag(`fetching blob for ${activeSrc.slice(0, 40)}`);
         fetch(activeSrc).then((res) => res.blob()).then((blob) => {
-          diag(`blob fetched size=${blob.size}`);
           blobByUrl.set(activeSrc, blob);
           doPost(blob);
-        }).catch((err) => {
-          diag(`blob fetch FAILED: ${err}`);
+        }).catch(() => {
+          // Blob URL may have been revoked — source can't be decoded
         });
       } else {
         doPost();
@@ -487,7 +469,6 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       // Lazy auto-start: first time we see a source, start streaming
       if (!state || (!state.streaming && !state.autoStartPending)) {
-        diag(`getFrame auto-start src=${activeSrc.slice(0, 50)} mediaId=${mediaId} ts=${targetTimestamp.toFixed(3)}`);
         state = getOrCreateState(activeSrc);
         if (activeSrc !== src) streams.set(src, state);
         state.autoStartPending = true;
@@ -508,14 +489,8 @@ export function createStreamingPlayback(): StreamingPlayback {
 
       const frame = state.buffer.getFrame(targetTimestamp);
       if (!frame) {
-        if (totalFramesMissed < 5 || totalFramesMissed % 30 === 0) {
-          diag(`getFrame MISS ts=${targetTimestamp.toFixed(4)} bufSize=${state.buffer.size}`);
-        }
         totalFramesMissed++;
         return null;
-      }
-      if (totalFramesDrawn < 3) {
-        diag(`getFrame HIT ts=${targetTimestamp.toFixed(4)} frameTs=${frame.timestamp.toFixed(4)}`);
       }
 
       totalFramesDrawn++;

--- a/src/features/preview/utils/streaming-playback.ts
+++ b/src/features/preview/utils/streaming-playback.ts
@@ -92,14 +92,9 @@ class FrameBuffer {
       return bestBefore;
     }
 
-    // When the worker is behind (decode startup), show the newest frame we have
-    // rather than nothing. A slightly stale frame is better than a blank canvas.
-    if (bestBefore) {
-      return bestBefore;
-    }
-
-    // Fallback: closest frame overall (handles slightly-ahead frames during seek)
-    return this.frames[this.frames.length - 1] ?? null;
+    // Reject stale frames — return null so the renderer falls through to
+    // DOM video instead of showing a frozen frame from seconds ago.
+    return null;
   }
 
   /** Remove frames well behind the playback position. */
@@ -174,6 +169,10 @@ export interface StreamingPlayback {
   getSourceInfo(src: string): SourceInfo | null;
   /** Whether a source is actively streaming. */
   isStreaming(src: string): boolean;
+  /** Update the worker's playback position for a source without reading a frame.
+   *  Keeps the decode-ahead throttle advancing during DOM video playback
+   *  so the buffer is warm when the canvas overlay activates. */
+  updatePosition(src: string, position: number): void;
   /** Enable idle cleanup sweep. Call when playback starts.
    *  Disabled by default so pre-warm streams aren't killed while paused. */
   enableIdleSweep(): void;
@@ -509,6 +508,13 @@ export function createStreamingPlayback(): StreamingPlayback {
 
     isStreaming(src: string): boolean {
       return streams.get(src)?.streaming ?? false;
+    },
+
+    updatePosition(src: string, position: number): void {
+      const state = streams.get(src);
+      if (!state) return;
+      state.lastAccessMs = performance.now();
+      worker?.postMessage({ type: 'playback_position', src, position });
     },
 
     enableIdleSweep(): void {

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -259,7 +259,9 @@ async function runStreamLoop(src: string, state: SourceState, startTimestamp: nu
   state.paused = false;
 
   const streamStart = getStreamStart(src, startTimestamp);
+  self.postMessage({ type: 'debug', step: 'stream_loop_starting', src: src.slice(0, 50), streamStart, startTimestamp });
   const iterator = state.sink.samples(streamStart, Infinity) as AsyncGenerator<MBSample, void, unknown>;
+  let frameCount = 0;
 
   try {
     for await (const sample of iterator) {
@@ -289,6 +291,10 @@ async function runStreamLoop(src: string, state: SourceState, startTimestamp: nu
 
       // Post frame to main thread (bitmap is in data AND transfer list for zero-copy)
       state.inflightCount++;
+      frameCount++;
+      if (frameCount <= 3) {
+        self.postMessage({ type: 'debug', step: 'posting_frame', frameCount, timestamp, bitmapWidth: bitmap.width, bitmapHeight: bitmap.height });
+      }
       self.postMessage(
         {
           type: 'frame',
@@ -357,12 +363,14 @@ self.onmessage = async (event: MessageEvent) => {
 
   if (msg.type === 'stream_start') {
     const { src, startTimestamp, blob, sourceMetadata } = msg;
+    self.postMessage({ type: 'debug', step: 'stream_start_received', src: src?.slice(0, 50), hasBlob: !!blob, hasMetadata: !!sourceMetadata, startTimestamp });
     try {
       const state = await getOrInitSource(src, { blob, sourceMetadata });
       if (!state) {
-        self.postMessage({ type: 'error', src, message: 'Failed to init source' });
+        self.postMessage({ type: 'error', src, message: 'Failed to init source — getOrInitSource returned null' });
         return;
       }
+      self.postMessage({ type: 'debug', step: 'source_initialized', src: src?.slice(0, 50), width: state.width, height: state.height });
       // Bump generation to abort any existing stream loop
       state.generation++;
       if (state.resumeResolve) {
@@ -375,7 +383,7 @@ self.onmessage = async (event: MessageEvent) => {
       self.postMessage({
         type: 'error',
         src,
-        message: error instanceof Error ? error.message : String(error),
+        message: `stream_start failed: ${error instanceof Error ? error.message : String(error)}`,
       });
     }
     return;

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -19,9 +19,9 @@ import type { ObjectUrlSourceMetadata } from '@/infrastructure/browser/object-ur
 const TIMESTAMP_EPSILON = 1e-4;
 const STREAM_BACKTRACK_SECONDS = 1.0;
 /** Max seconds the worker may decode ahead of the last known playback position.
- *  Must be less than the main thread's ring buffer capacity in seconds
- *  (90 frames / 30fps = 3s) to prevent buffer eviction of undisplayed frames. */
-const MAX_DECODE_AHEAD_SECONDS = 1.5;
+ *  Matches the main thread's ring buffer capacity (90 frames / 30fps = 3s)
+ *  so the full transition window can be pre-buffered. */
+const MAX_DECODE_AHEAD_SECONDS = 2.5;
 /** How long to sleep when throttled before checking again. */
 const THROTTLE_SLEEP_MS = 50;
 

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -18,6 +18,12 @@ import type { ObjectUrlSourceMetadata } from '@/infrastructure/browser/object-ur
 
 const TIMESTAMP_EPSILON = 1e-4;
 const STREAM_BACKTRACK_SECONDS = 1.0;
+/** Max seconds the worker may decode ahead of the last known playback position.
+ *  Must be less than the main thread's ring buffer capacity in seconds
+ *  (90 frames / 30fps = 3s) to prevent buffer eviction of undisplayed frames. */
+const MAX_DECODE_AHEAD_SECONDS = 1.5;
+/** How long to sleep when throttled before checking again. */
+const THROTTLE_SLEEP_MS = 50;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,6 +43,9 @@ interface SourceState {
   streaming: boolean;
   /** Incremented on every seek/stop to abort stale stream loops. */
   generation: number;
+  /** Last known playback position (seconds). Updated by main thread.
+   *  Worker throttles decode to stay within MAX_DECODE_AHEAD_SECONDS of this. */
+  playbackPosition: number;
 }
 
 const keyframeIndexBySrc = new Map<string, number[]>();
@@ -149,6 +158,7 @@ async function getOrInitSource(src: string, options?: InitSourceOptions): Promis
         duration,
         streaming: false,
         generation: 0,
+        playbackPosition: 0,
       };
       sources.set(src, state);
 
@@ -268,10 +278,16 @@ async function runStreamLoop(src: string, state: SourceState, startTimestamp: nu
         { transfer: [extracted.frame] },
       );
 
-      // No backpressure — the main thread ring buffer handles overflow.
-      // At ~1ms/frame decode, the worker fills 30 frames in 30ms then
-      // the async generator naturally yields to the event loop, allowing
-      // seek/stop messages to be processed.
+      // Position-aware throttle: don't decode more than MAX_DECODE_AHEAD_SECONDS
+      // ahead of where playback currently is. Without this, the worker races
+      // far ahead during pre-warm, overflowing the main thread's ring buffer
+      // and causing the renderer to show frames from the distant future.
+      while (
+        state.generation === gen
+        && timestamp > state.playbackPosition + MAX_DECODE_AHEAD_SECONDS
+      ) {
+        await new Promise<void>((r) => setTimeout(r, THROTTLE_SLEEP_MS));
+      }
     }
   } catch (error) {
     if (state.generation === gen) {
@@ -311,6 +327,13 @@ self.onmessage = async (event: MessageEvent) => {
     return;
   }
 
+  if (msg.type === 'playback_position') {
+    const { src, position } = msg;
+    const state = sources.get(src);
+    if (state) state.playbackPosition = position;
+    return;
+  }
+
   if (msg.type === 'stream_start') {
     const { src, startTimestamp, blob, sourceMetadata } = msg;
     try {
@@ -320,6 +343,7 @@ self.onmessage = async (event: MessageEvent) => {
         return;
       }
       state.generation++;
+      state.playbackPosition = startTimestamp;
       void runStreamLoop(src, state, startTimestamp);
     } catch (error) {
       self.postMessage({

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -1,0 +1,438 @@
+/**
+ * Streaming video decode worker for WebCodecs-based playback.
+ *
+ * Runs mediabunny's forward `samples()` generator continuously, decoding
+ * frames ahead of playback and transferring ImageBitmaps to the main thread.
+ * This replaces the HTML5 <video> element playback path with frame-perfect,
+ * worker-decoded frames that feed directly into the canvas/GPU render pipeline.
+ *
+ * Key difference from decoder-prewarm-worker: this worker runs a continuous
+ * forward decode stream (not individual frame requests), maintaining decode
+ * pipeline state across frames for ~1ms/frame sequential throughput.
+ */
+
+import { createMediabunnyInputSource } from '@/infrastructure/browser/mediabunny-input-source';
+import type { ObjectUrlSourceMetadata } from '@/infrastructure/browser/object-url-registry';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max frames to buffer ahead before pausing decode. */
+const MAX_BUFFER_AHEAD = 15;
+/** Resume decode when buffer drops to this count. */
+const RESUME_THRESHOLD = 8;
+/** Epsilon for timestamp comparison. */
+const TIMESTAMP_EPSILON = 1e-4;
+/** Fixed backtrack from target when no keyframe index is available. */
+const STREAM_BACKTRACK_SECONDS = 1.0;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MBSample = any;
+
+interface SourceState {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sink: any;
+  canvas: OffscreenCanvas;
+  ctx: OffscreenCanvasRenderingContext2D;
+  width: number;
+  height: number;
+  duration: number;
+  /** Whether a forward stream loop is currently running. */
+  streaming: boolean;
+  /** Incremented on every seek/stop to abort stale stream loops. */
+  generation: number;
+  /** Timestamps of frames currently buffered on the main thread (unacknowledged). */
+  inflightCount: number;
+  /** Whether decode is paused due to buffer pressure. */
+  paused: boolean;
+  /** Resolve function to wake up a paused decode loop. */
+  resumeResolve: (() => void) | null;
+}
+
+/** Per-source keyframe index received from main thread. */
+const keyframeIndexBySrc = new Map<string, number[]>();
+
+// ---------------------------------------------------------------------------
+// Mediabunny lazy load
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mb: any = null;
+async function getMediabunny() {
+  if (!mb) mb = await import('mediabunny');
+  return mb;
+}
+
+// ---------------------------------------------------------------------------
+// Source management
+// ---------------------------------------------------------------------------
+
+const sources = new Map<string, SourceState>();
+const initPromises = new Map<string, Promise<SourceState | null>>();
+
+function nearestKeyframeBefore(timestamps: number[], target: number): number | null {
+  if (timestamps.length === 0 || timestamps[0]! > target) return null;
+  let lo = 0;
+  let hi = timestamps.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (timestamps[mid]! <= target) lo = mid;
+    else hi = mid - 1;
+  }
+  return timestamps[lo]!;
+}
+
+function getStreamStart(src: string, targetTimestamp: number): number {
+  const timestamps = keyframeIndexBySrc.get(src);
+  if (timestamps && timestamps.length > 0) {
+    const kf = nearestKeyframeBefore(timestamps, targetTimestamp);
+    if (kf !== null) return Math.max(0, kf - 0.05);
+  }
+  return Math.max(0, targetTimestamp - STREAM_BACKTRACK_SECONDS);
+}
+
+interface InitSourceOptions {
+  blob?: Blob;
+  sourceMetadata?: ObjectUrlSourceMetadata;
+}
+
+async function getOrInitSource(src: string, options?: InitSourceOptions): Promise<SourceState | null> {
+  const existing = sources.get(src);
+  if (existing) return existing;
+
+  const inflight = initPromises.get(src);
+  if (inflight) return inflight;
+
+  const promise = (async (): Promise<SourceState | null> => {
+    const mediabunny = await getMediabunny();
+    const source = createMediabunnyInputSource(mediabunny, src, {
+      metadata: options?.sourceMetadata,
+      fallbackBlob: options?.blob,
+    });
+    const input = new mediabunny.Input({
+      formats: mediabunny.ALL_FORMATS,
+      source,
+    });
+
+    try {
+      const videoTrack = await input.getPrimaryVideoTrack();
+      if (!videoTrack) {
+        input.dispose?.();
+        return null;
+      }
+
+      if (typeof videoTrack.canDecode === 'function' && !(await videoTrack.canDecode())) {
+        input.dispose?.();
+        return null;
+      }
+
+      // Extract keyframe index if not already available
+      if (!keyframeIndexBySrc.has(src)) {
+        try {
+          const eps = new mediabunny.EncodedPacketSink(videoTrack);
+          const kfTimestamps: number[] = [];
+          const metadataOpts = { metadataOnly: true } as const;
+          let pkt = await eps.getFirstKeyPacket(metadataOpts);
+          while (pkt) {
+            kfTimestamps.push(pkt.timestamp);
+            pkt = await eps.getNextKeyPacket(pkt, metadataOpts);
+          }
+          eps.dispose?.();
+          if (kfTimestamps.length > 0) {
+            keyframeIndexBySrc.set(src, kfTimestamps);
+            self.postMessage({ type: 'keyframes_extracted', src, keyframeTimestamps: kfTimestamps });
+          }
+        } catch {
+          // Non-fatal
+        }
+      }
+
+      const sink = new mediabunny.VideoSampleSink(videoTrack);
+      const width = videoTrack.displayWidth || 1920;
+      const height = videoTrack.displayHeight || 1080;
+      const duration = videoTrack.duration || 0;
+      const canvas = new OffscreenCanvas(width, height);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        input.dispose?.();
+        return null;
+      }
+
+      const state: SourceState = {
+        input,
+        sink,
+        canvas,
+        ctx,
+        width,
+        height,
+        duration,
+        streaming: false,
+        generation: 0,
+        inflightCount: 0,
+        paused: false,
+        resumeResolve: null,
+      };
+      sources.set(src, state);
+
+      self.postMessage({
+        type: 'source_ready',
+        src,
+        width,
+        height,
+        duration,
+      });
+
+      return state;
+    } catch (error) {
+      input.dispose?.();
+      throw error;
+    }
+  })();
+
+  initPromises.set(src, promise);
+  try {
+    return await promise;
+  } finally {
+    initPromises.delete(src);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Frame rendering
+// ---------------------------------------------------------------------------
+
+function renderSampleToBitmap(state: SourceState, sample: MBSample): ImageBitmap | null {
+  let videoFrame: VideoFrame | null = null;
+  try {
+    videoFrame = typeof sample.toVideoFrame === 'function'
+      ? sample.toVideoFrame()
+      : (sample.frame ?? null);
+    if (!videoFrame) return null;
+
+    const visibleRect = (videoFrame as VideoFrame & {
+      visibleRect?: { x: number; y: number; width: number; height: number };
+    }).visibleRect;
+
+    const width = visibleRect?.width && visibleRect.width > 0
+      ? visibleRect.width : videoFrame.displayWidth;
+    const height = visibleRect?.height && visibleRect.height > 0
+      ? visibleRect.height : videoFrame.displayHeight;
+    if (width < 1 || height < 1) return null;
+
+    // Resize canvas if dimensions changed
+    if (state.canvas.width !== width || state.canvas.height !== height) {
+      state.canvas.width = width;
+      state.canvas.height = height;
+    }
+
+    if (visibleRect && visibleRect.width > 0 && visibleRect.height > 0) {
+      state.ctx.drawImage(
+        videoFrame,
+        visibleRect.x, visibleRect.y, visibleRect.width, visibleRect.height,
+        0, 0, width, height,
+      );
+    } else {
+      state.ctx.drawImage(videoFrame, 0, 0, width, height);
+    }
+
+    return state.canvas.transferToImageBitmap();
+  } finally {
+    videoFrame?.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming decode loop
+// ---------------------------------------------------------------------------
+
+async function runStreamLoop(src: string, state: SourceState, startTimestamp: number): Promise<void> {
+  const gen = state.generation;
+  state.streaming = true;
+  state.inflightCount = 0;
+  state.paused = false;
+
+  const streamStart = getStreamStart(src, startTimestamp);
+  const iterator = state.sink.samples(streamStart, Infinity) as AsyncGenerator<MBSample, void, unknown>;
+
+  try {
+    for await (const sample of iterator) {
+      // Abort if generation changed (seek or stop happened)
+      if (state.generation !== gen) {
+        sample.close?.();
+        break;
+      }
+
+      const timestamp: number = sample.timestamp ?? 0;
+
+      // Skip samples before our target (we started from a keyframe before target)
+      if (timestamp + TIMESTAMP_EPSILON < startTimestamp) {
+        sample.close?.();
+        continue;
+      }
+
+      // Render to bitmap
+      const bitmap = renderSampleToBitmap(state, sample);
+      sample.close?.();
+
+      if (!bitmap) continue;
+      if (state.generation !== gen) {
+        bitmap.close();
+        break;
+      }
+
+      // Post frame to main thread (bitmap is in data AND transfer list for zero-copy)
+      state.inflightCount++;
+      self.postMessage(
+        {
+          type: 'frame',
+          src,
+          timestamp,
+          bitmap,
+        },
+        { transfer: [bitmap] },
+      );
+
+      // Backpressure: pause if too many frames unacknowledged
+      if (state.inflightCount >= MAX_BUFFER_AHEAD) {
+        state.paused = true;
+        await new Promise<void>((resolve) => {
+          state.resumeResolve = resolve;
+          // Safety: auto-resume after 500ms to prevent deadlock
+          setTimeout(() => {
+            if (state.resumeResolve === resolve) {
+              state.paused = false;
+              state.resumeResolve = null;
+              resolve();
+            }
+          }, 500);
+        });
+        // Check generation after waking up
+        if (state.generation !== gen) break;
+      }
+    }
+  } catch (error) {
+    if (state.generation === gen) {
+      self.postMessage({
+        type: 'error',
+        src,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  } finally {
+    void iterator.return?.();
+    if (state.generation === gen) {
+      state.streaming = false;
+      self.postMessage({ type: 'stream_ended', src });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message handler
+// ---------------------------------------------------------------------------
+
+self.postMessage({ type: 'ready' });
+
+self.onmessage = async (event: MessageEvent) => {
+  const msg = event.data;
+
+  if (msg.type === 'warmup') {
+    void getMediabunny();
+    return;
+  }
+
+  if (msg.type === 'set_keyframes') {
+    if (msg.src && Array.isArray(msg.keyframeTimestamps)) {
+      keyframeIndexBySrc.set(msg.src, msg.keyframeTimestamps);
+    }
+    return;
+  }
+
+  if (msg.type === 'stream_start') {
+    const { src, startTimestamp, blob, sourceMetadata } = msg;
+    try {
+      const state = await getOrInitSource(src, { blob, sourceMetadata });
+      if (!state) {
+        self.postMessage({ type: 'error', src, message: 'Failed to init source' });
+        return;
+      }
+      // Bump generation to abort any existing stream loop
+      state.generation++;
+      if (state.resumeResolve) {
+        state.resumeResolve();
+        state.resumeResolve = null;
+      }
+      // Start new stream
+      void runStreamLoop(src, state, startTimestamp);
+    } catch (error) {
+      self.postMessage({
+        type: 'error',
+        src,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return;
+  }
+
+  if (msg.type === 'stream_seek') {
+    const { src, timestamp } = msg;
+    const state = sources.get(src);
+    if (!state) return;
+    // Bump generation to abort current loop, start new one
+    state.generation++;
+    if (state.resumeResolve) {
+      state.resumeResolve();
+      state.resumeResolve = null;
+    }
+    void runStreamLoop(src, state, timestamp);
+    return;
+  }
+
+  if (msg.type === 'stream_stop') {
+    const { src } = msg;
+    const state = sources.get(src);
+    if (!state) return;
+    state.generation++;
+    if (state.resumeResolve) {
+      state.resumeResolve();
+      state.resumeResolve = null;
+    }
+    return;
+  }
+
+  if (msg.type === 'frame_consumed') {
+    const { src } = msg;
+    const state = sources.get(src);
+    if (!state) return;
+    state.inflightCount = Math.max(0, state.inflightCount - 1);
+    // Resume decode if we dropped below threshold
+    if (state.paused && state.inflightCount <= RESUME_THRESHOLD && state.resumeResolve) {
+      state.paused = false;
+      const resolve = state.resumeResolve;
+      state.resumeResolve = null;
+      resolve();
+    }
+    return;
+  }
+
+  if (msg.type === 'dispose_source') {
+    const { src } = msg;
+    const state = sources.get(src);
+    if (!state) return;
+    state.generation++;
+    if (state.resumeResolve) {
+      state.resumeResolve();
+      state.resumeResolve = null;
+    }
+    state.input.dispose?.();
+    sources.delete(src);
+    return;
+  }
+};

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -67,6 +67,10 @@ async function getMediabunny() {
 
 const sources = new Map<string, SourceState>();
 const initPromises = new Map<string, Promise<SourceState | null>>();
+/** Sources disposed while an init was in-flight — prevents resurrection. */
+const disposedSources = new Set<string>();
+/** Queued seek targets for sources still initializing. */
+const pendingSeeks = new Map<string, number>();
 
 function nearestKeyframeBefore(timestamps: number[], target: number): number | null {
   if (timestamps.length === 0 || timestamps[0]! > target) return null;
@@ -149,6 +153,12 @@ async function getOrInitSource(src: string, options?: InitSourceOptions): Promis
       const width = videoTrack.displayWidth || 1920;
       const height = videoTrack.displayHeight || 1080;
       const duration = videoTrack.duration || 0;
+
+      // Guard: source may have been disposed while init was in-flight
+      if (disposedSources.has(src)) {
+        input.dispose?.();
+        return null;
+      }
 
       const state: SourceState = {
         input,
@@ -336,15 +346,20 @@ self.onmessage = async (event: MessageEvent) => {
 
   if (msg.type === 'stream_start') {
     const { src, startTimestamp, blob, sourceMetadata } = msg;
+    disposedSources.delete(src);
     try {
       const state = await getOrInitSource(src, { blob, sourceMetadata });
       if (!state) {
         self.postMessage({ type: 'error', src, message: 'Failed to init source' });
         return;
       }
+      // Apply any seek that arrived while the source was initializing
+      const pendingSeek = pendingSeeks.get(src);
+      pendingSeeks.delete(src);
+      const effectiveStart = pendingSeek ?? startTimestamp;
       state.generation++;
-      state.playbackPosition = startTimestamp;
-      void runStreamLoop(src, state, startTimestamp);
+      state.playbackPosition = effectiveStart;
+      void runStreamLoop(src, state, effectiveStart);
     } catch (error) {
       self.postMessage({
         type: 'error',
@@ -358,7 +373,13 @@ self.onmessage = async (event: MessageEvent) => {
   if (msg.type === 'stream_seek') {
     const { src, timestamp } = msg;
     const state = sources.get(src);
-    if (!state) return;
+    if (!state) {
+      // Source still initializing — queue the seek for when init completes
+      if (initPromises.has(src)) {
+        pendingSeeks.set(src, timestamp);
+      }
+      return;
+    }
     state.generation++;
     state.playbackPosition = timestamp;
     void runStreamLoop(src, state, timestamp);
@@ -375,6 +396,9 @@ self.onmessage = async (event: MessageEvent) => {
 
   if (msg.type === 'dispose_source') {
     const { src } = msg;
+    disposedSources.add(src);
+    keyframeIndexBySrc.delete(src);
+    pendingSeeks.delete(src);
     const state = sources.get(src);
     if (!state) return;
     state.generation++;

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -360,6 +360,7 @@ self.onmessage = async (event: MessageEvent) => {
     const state = sources.get(src);
     if (!state) return;
     state.generation++;
+    state.playbackPosition = timestamp;
     void runStreamLoop(src, state, timestamp);
     return;
   }

--- a/src/features/preview/workers/streaming-decode-worker.ts
+++ b/src/features/preview/workers/streaming-decode-worker.ts
@@ -1,14 +1,12 @@
 /**
  * Streaming video decode worker for WebCodecs-based playback.
  *
- * Runs mediabunny's forward `samples()` generator continuously, decoding
- * frames ahead of playback and transferring ImageBitmaps to the main thread.
- * This replaces the HTML5 <video> element playback path with frame-perfect,
- * worker-decoded frames that feed directly into the canvas/GPU render pipeline.
+ * Runs mediabunny's forward `samples()` generator continuously, transferring
+ * decoded VideoFrames directly to the main thread (zero intermediate copies).
+ * The main thread ring buffer handles overflow — no backpressure needed.
  *
- * Key difference from decoder-prewarm-worker: this worker runs a continuous
- * forward decode stream (not individual frame requests), maintaining decode
- * pipeline state across frames for ~1ms/frame sequential throughput.
+ * Decode throughput: ~1ms/frame for forward sequential access once warmed.
+ * Initial keyframe seek: 200-600ms (one-time cost per stream start).
  */
 
 import { createMediabunnyInputSource } from '@/infrastructure/browser/mediabunny-input-source';
@@ -18,13 +16,7 @@ import type { ObjectUrlSourceMetadata } from '@/infrastructure/browser/object-ur
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Max frames to buffer ahead before pausing decode. */
-const MAX_BUFFER_AHEAD = 15;
-/** Resume decode when buffer drops to this count. */
-const RESUME_THRESHOLD = 8;
-/** Epsilon for timestamp comparison. */
 const TIMESTAMP_EPSILON = 1e-4;
-/** Fixed backtrack from target when no keyframe index is available. */
 const STREAM_BACKTRACK_SECONDS = 1.0;
 
 // ---------------------------------------------------------------------------
@@ -39,24 +31,14 @@ interface SourceState {
   input: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sink: any;
-  canvas: OffscreenCanvas;
-  ctx: OffscreenCanvasRenderingContext2D;
   width: number;
   height: number;
   duration: number;
-  /** Whether a forward stream loop is currently running. */
   streaming: boolean;
   /** Incremented on every seek/stop to abort stale stream loops. */
   generation: number;
-  /** Timestamps of frames currently buffered on the main thread (unacknowledged). */
-  inflightCount: number;
-  /** Whether decode is paused due to buffer pressure. */
-  paused: boolean;
-  /** Resolve function to wake up a paused decode loop. */
-  resumeResolve: (() => void) | null;
 }
 
-/** Per-source keyframe index received from main thread. */
 const keyframeIndexBySrc = new Map<string, number[]>();
 
 // ---------------------------------------------------------------------------
@@ -158,37 +140,19 @@ async function getOrInitSource(src: string, options?: InitSourceOptions): Promis
       const width = videoTrack.displayWidth || 1920;
       const height = videoTrack.displayHeight || 1080;
       const duration = videoTrack.duration || 0;
-      const canvas = new OffscreenCanvas(width, height);
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        input.dispose?.();
-        return null;
-      }
 
       const state: SourceState = {
         input,
         sink,
-        canvas,
-        ctx,
         width,
         height,
         duration,
         streaming: false,
         generation: 0,
-        inflightCount: 0,
-        paused: false,
-        resumeResolve: null,
       };
       sources.set(src, state);
 
-      self.postMessage({
-        type: 'source_ready',
-        src,
-        width,
-        height,
-        duration,
-      });
-
+      self.postMessage({ type: 'source_ready', src, width, height, duration });
       return state;
     } catch (error) {
       input.dispose?.();
@@ -205,47 +169,54 @@ async function getOrInitSource(src: string, options?: InitSourceOptions): Promis
 }
 
 // ---------------------------------------------------------------------------
-// Frame rendering
+// Frame extraction — transfer VideoFrame directly (zero copy)
 // ---------------------------------------------------------------------------
 
-function renderSampleToBitmap(state: SourceState, sample: MBSample): ImageBitmap | null {
-  let videoFrame: VideoFrame | null = null;
-  try {
-    videoFrame = typeof sample.toVideoFrame === 'function'
-      ? sample.toVideoFrame()
-      : (sample.frame ?? null);
-    if (!videoFrame) return null;
+/**
+ * Extract a VideoFrame from a mediabunny sample and compute its visible dimensions.
+ * Returns null if the sample can't produce a valid frame.
+ * Caller must close the returned VideoFrame when done.
+ */
+function extractVideoFrame(sample: MBSample): { frame: VideoFrame; width: number; height: number } | null {
+  const videoFrame: VideoFrame | null = typeof sample.toVideoFrame === 'function'
+    ? sample.toVideoFrame()
+    : (sample.frame ?? null);
+  if (!videoFrame) return null;
 
-    const visibleRect = (videoFrame as VideoFrame & {
-      visibleRect?: { x: number; y: number; width: number; height: number };
-    }).visibleRect;
+  const visibleRect = (videoFrame as VideoFrame & {
+    visibleRect?: { x: number; y: number; width: number; height: number };
+  }).visibleRect;
 
-    const width = visibleRect?.width && visibleRect.width > 0
-      ? visibleRect.width : videoFrame.displayWidth;
-    const height = visibleRect?.height && visibleRect.height > 0
-      ? visibleRect.height : videoFrame.displayHeight;
-    if (width < 1 || height < 1) return null;
+  const width = visibleRect?.width && visibleRect.width > 0
+    ? visibleRect.width : videoFrame.displayWidth;
+  const height = visibleRect?.height && visibleRect.height > 0
+    ? visibleRect.height : videoFrame.displayHeight;
 
-    // Resize canvas if dimensions changed
-    if (state.canvas.width !== width || state.canvas.height !== height) {
-      state.canvas.width = width;
-      state.canvas.height = height;
-    }
-
-    if (visibleRect && visibleRect.width > 0 && visibleRect.height > 0) {
-      state.ctx.drawImage(
-        videoFrame,
-        visibleRect.x, visibleRect.y, visibleRect.width, visibleRect.height,
-        0, 0, width, height,
-      );
-    } else {
-      state.ctx.drawImage(videoFrame, 0, 0, width, height);
-    }
-
-    return state.canvas.transferToImageBitmap();
-  } finally {
-    videoFrame?.close();
+  if (width < 1 || height < 1) {
+    videoFrame.close();
+    return null;
   }
+
+  // If visibleRect is a strict subset (codec padding), create a cropped copy
+  // so the main thread draws the correct region without needing to know the offset.
+  if (
+    visibleRect
+    && (visibleRect.x > 0 || visibleRect.y > 0
+      || visibleRect.width < videoFrame.codedWidth
+      || visibleRect.height < videoFrame.codedHeight)
+  ) {
+    try {
+      const cropped = new VideoFrame(videoFrame, {
+        visibleRect: { x: visibleRect.x, y: visibleRect.y, width, height },
+      });
+      videoFrame.close();
+      return { frame: cropped, width, height };
+    } catch {
+      // Cropping unsupported — fall through and send the full frame
+    }
+  }
+
+  return { frame: videoFrame, width, height };
 }
 
 // ---------------------------------------------------------------------------
@@ -255,17 +226,12 @@ function renderSampleToBitmap(state: SourceState, sample: MBSample): ImageBitmap
 async function runStreamLoop(src: string, state: SourceState, startTimestamp: number): Promise<void> {
   const gen = state.generation;
   state.streaming = true;
-  state.inflightCount = 0;
-  state.paused = false;
 
   const streamStart = getStreamStart(src, startTimestamp);
-  self.postMessage({ type: 'debug', step: 'stream_loop_starting', src: src.slice(0, 50), streamStart, startTimestamp });
   const iterator = state.sink.samples(streamStart, Infinity) as AsyncGenerator<MBSample, void, unknown>;
-  let frameCount = 0;
 
   try {
     for await (const sample of iterator) {
-      // Abort if generation changed (seek or stop happened)
       if (state.generation !== gen) {
         sample.close?.();
         break;
@@ -273,55 +239,39 @@ async function runStreamLoop(src: string, state: SourceState, startTimestamp: nu
 
       const timestamp: number = sample.timestamp ?? 0;
 
-      // Skip samples before our target (we started from a keyframe before target)
+      // Skip samples before our target (decode started from a keyframe before target)
       if (timestamp + TIMESTAMP_EPSILON < startTimestamp) {
         sample.close?.();
         continue;
       }
 
-      // Render to bitmap
-      const bitmap = renderSampleToBitmap(state, sample);
+      // Extract VideoFrame directly (no intermediate canvas copy)
+      const extracted = extractVideoFrame(sample);
       sample.close?.();
 
-      if (!bitmap) continue;
+      if (!extracted) continue;
       if (state.generation !== gen) {
-        bitmap.close();
+        extracted.frame.close();
         break;
       }
 
-      // Post frame to main thread (bitmap is in data AND transfer list for zero-copy)
-      state.inflightCount++;
-      frameCount++;
-      if (frameCount <= 3) {
-        self.postMessage({ type: 'debug', step: 'posting_frame', frameCount, timestamp, bitmapWidth: bitmap.width, bitmapHeight: bitmap.height });
-      }
+      // Transfer VideoFrame to main thread (zero-copy via transferable)
       self.postMessage(
         {
           type: 'frame',
           src,
           timestamp,
-          bitmap,
+          videoFrame: extracted.frame,
+          width: extracted.width,
+          height: extracted.height,
         },
-        { transfer: [bitmap] },
+        { transfer: [extracted.frame] },
       );
 
-      // Backpressure: pause if too many frames unacknowledged
-      if (state.inflightCount >= MAX_BUFFER_AHEAD) {
-        state.paused = true;
-        await new Promise<void>((resolve) => {
-          state.resumeResolve = resolve;
-          // Safety: auto-resume after 500ms to prevent deadlock
-          setTimeout(() => {
-            if (state.resumeResolve === resolve) {
-              state.paused = false;
-              state.resumeResolve = null;
-              resolve();
-            }
-          }, 500);
-        });
-        // Check generation after waking up
-        if (state.generation !== gen) break;
-      }
+      // No backpressure — the main thread ring buffer handles overflow.
+      // At ~1ms/frame decode, the worker fills 30 frames in 30ms then
+      // the async generator naturally yields to the event loop, allowing
+      // seek/stop messages to be processed.
     }
   } catch (error) {
     if (state.generation === gen) {
@@ -363,27 +313,19 @@ self.onmessage = async (event: MessageEvent) => {
 
   if (msg.type === 'stream_start') {
     const { src, startTimestamp, blob, sourceMetadata } = msg;
-    self.postMessage({ type: 'debug', step: 'stream_start_received', src: src?.slice(0, 50), hasBlob: !!blob, hasMetadata: !!sourceMetadata, startTimestamp });
     try {
       const state = await getOrInitSource(src, { blob, sourceMetadata });
       if (!state) {
-        self.postMessage({ type: 'error', src, message: 'Failed to init source — getOrInitSource returned null' });
+        self.postMessage({ type: 'error', src, message: 'Failed to init source' });
         return;
       }
-      self.postMessage({ type: 'debug', step: 'source_initialized', src: src?.slice(0, 50), width: state.width, height: state.height });
-      // Bump generation to abort any existing stream loop
       state.generation++;
-      if (state.resumeResolve) {
-        state.resumeResolve();
-        state.resumeResolve = null;
-      }
-      // Start new stream
       void runStreamLoop(src, state, startTimestamp);
     } catch (error) {
       self.postMessage({
         type: 'error',
         src,
-        message: `stream_start failed: ${error instanceof Error ? error.message : String(error)}`,
+        message: error instanceof Error ? error.message : String(error),
       });
     }
     return;
@@ -393,12 +335,7 @@ self.onmessage = async (event: MessageEvent) => {
     const { src, timestamp } = msg;
     const state = sources.get(src);
     if (!state) return;
-    // Bump generation to abort current loop, start new one
     state.generation++;
-    if (state.resumeResolve) {
-      state.resumeResolve();
-      state.resumeResolve = null;
-    }
     void runStreamLoop(src, state, timestamp);
     return;
   }
@@ -408,25 +345,6 @@ self.onmessage = async (event: MessageEvent) => {
     const state = sources.get(src);
     if (!state) return;
     state.generation++;
-    if (state.resumeResolve) {
-      state.resumeResolve();
-      state.resumeResolve = null;
-    }
-    return;
-  }
-
-  if (msg.type === 'frame_consumed') {
-    const { src } = msg;
-    const state = sources.get(src);
-    if (!state) return;
-    state.inflightCount = Math.max(0, state.inflightCount - 1);
-    // Resume decode if we dropped below threshold
-    if (state.paused && state.inflightCount <= RESUME_THRESHOLD && state.resumeResolve) {
-      state.paused = false;
-      const resolve = state.resumeResolve;
-      state.resumeResolve = null;
-      resolve();
-    }
     return;
   }
 
@@ -435,10 +353,6 @@ self.onmessage = async (event: MessageEvent) => {
     const state = sources.get(src);
     if (!state) return;
     state.generation++;
-    if (state.resumeResolve) {
-      state.resumeResolve();
-      state.resumeResolve = null;
-    }
     state.input.dispose?.();
     sources.delete(src);
     return;


### PR DESCRIPTION
## Summary

- Add WebCodecs-based streaming video decode via mediabunny's forward `samples()` generator in a Web Worker
- Streaming is scoped to **transitions only** — regular playback uses DOM `<video>` elements (zero overhead, native audio/timing)
- Pre-warms both transition clips 3s before the transition starts, buffering decoded ImageBitmaps via a ring buffer
- Transition session renderer reads pre-decoded frames, falling through to DOM video on miss
- Position-aware decode throttle keeps the worker within 2.5s of playback, preventing buffer overflow
- Respects proxy toggle — streams use proxy URLs when enabled, restarts on toggle
- Debug: `window.__DEBUG__.setStreamingPlayback(true)` forces all-clip streaming

### Key files
- `streaming-decode-worker.ts` — Web Worker running mediabunny decode loop with throttle
- `streaming-playback.ts` — Main-thread coordinator: frame buffer, idle sweep, stream lifecycle
- `use-streaming-playback-controller.ts` — React hook: transition-scoped pre-warm, lookahead, proxy awareness
- `canvas-item-renderer.ts` — Streaming frame check before DOM video fallback
- `use-preview-transition-session-controller.ts` — Wires streaming provider into transition renderer

## Test plan
- [ ] Play through a transition — both clips should render smoothly
- [ ] Regular playback (no transition nearby) — no streaming overhead, DOM video handles everything
- [ ] Toggle proxy during playback — resolution switches without stuck frames
- [ ] Pause near transition, wait 3s, play — pre-warm buffers should be filled
- [ ] `window.__DEBUG__.streamingPlaybackMetrics()` shows active streams near transitions
- [ ] `window.__DEBUG__.setStreamingPlayback(true)` enables all-clip streaming for testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental WebCodecs-based streaming playback for preview and transition rendering.
  * New streaming frame provider hook / setter to allow external frame sources to be used by the renderer.

* **Chores**
  * Added a streaming playback controller and background decode worker to manage decoded frame delivery and lifecycle across preview and export paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->