### PR TITLE
feat: weekly changelog, What's New dialog, and auto-append pipeline

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173,
+      "autoPort": true
+    },
+    {
+      "name": "test",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test"],
+      "port": 0
+    },
+    {
+      "name": "preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4173
+    }
+  ]
+}

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: changelog
+description: Maintain FreeCut's weekly changelog with a rolling current entry. Use when (1) backfilling historical weeks into CHANGELOG.md and src/data/changelog.json (backfill mode), (2) adding new bullets to the rolling current entry as commits land (append mode), or (3) closing the week and promoting current into a tagged weekly release (rollup mode). Handles commit curation, deduplication, version assignment, tag creation, and keeping both markdown and JSON artifacts in sync.
+---
+
+# Changelog skill
+
+FreeCut's changelog lives in two synchronized files:
+
+- **`CHANGELOG.md`** — human-facing, Keep-a-Changelog style, read on GitHub
+- **`src/data/changelog.json`** — typed, imported by the "What's New" dialog UI
+
+Both are generated from the same data. Always update both or neither.
+
+## Structure: weekly releases + one rolling current entry
+
+The changelog has two tiers:
+
+1. **`current`** — a single rolling entry for the in-progress week. It accumulates bullets as commits land, dedupes when the same feature is touched multiple times, and is shown in the UI as a "This Week" card. **Not tagged, not versioned with a final version number.**
+2. **`releases`** — one entry per completed week, newest first. Each has a version, a date, and a git tag.
+
+### Versioning: CalVer, Monday-start weeks
+
+- Format: `YYYY.MM.DD` where the date is the **Monday** that opens the week (Mon–Sun).
+- Tag: `v2026.04.13` (leading `v`, always).
+- A week "closes" on Monday morning of the following week. Rollup is **manually triggered**.
+- If a mid-week hotfix needs its own release, add `.N` suffix (`2026.04.13.2`). Rare.
+- `package.json` `version` field mirrors the most recent released version.
+
+Separate packages (future CLI/API) get their own semver and their own changelog under their package directory. This file is for the web app only.
+
+## Modes
+
+### Backfill mode
+
+Given a git range, produce historical weekly entries.
+
+**Process**:
+1. Walk PR merges in chronological order: `git log --merges --first-parent main --pretty=format:"%H|%ad|%s" --date=short <range>`.
+2. Group commits by week (Monday-start). For each week, union all non-merge commits across all PRs that landed that week.
+3. Apply curation rules (below), dedup features revisited within the week.
+4. Emit one weekly entry per week that has at least one user-visible change. Skip empty weeks.
+
+Pre-PR era (if any): collapse the entire foundation into a single initial release entry, dated the Monday of the week before first-PR week.
+
+### Append mode
+
+Triggered ad-hoc to update `current` as new commits land.
+
+**Input**: commits since last read of `current` (or `git log v<lastTag>..HEAD` if current is empty).
+
+**Process**:
+1. Walk new commits, applying curation rules.
+2. Merge with existing `current.groups` — **dedupe by title**. If a new commit refines or walks back a bullet already in current, edit the existing bullet rather than adding a duplicate.
+3. Update `current.date` to today.
+4. Do not create tags. Do not update `package.json`.
+
+### Rollup mode
+
+Triggered manually on Monday to close the previous week.
+
+**Input**: none (reads `current` and today's date).
+
+**Process**:
+1. Determine last week's Monday date → new version `vYYYY.MM.DD`.
+2. Move `current` into `releases` with that version and the Monday date.
+3. Empty `current` (or seed with any commits landed since Monday).
+4. Bump `package.json` `version` to the new release.
+5. Create annotated tag locally: `git tag -a v<version> <mergeCommitSha> -m "<version> — <highlights>"`. The tag should point at the last PR merge commit of the closed week, not today's HEAD (since dev continues on develop).
+6. **Do not `git push --tags`** — print the plan and wait for user confirmation.
+
+## Curation rules
+
+### Drop
+
+- Merge commits (`Merge pull request`, `Merge branch`)
+- `chore(...)` — including `chore(release)`
+- `ci(...)`
+- `test(...)` unless it documents notable test infra changes
+- `refactor(...)` when the scope is internal (stores, types, utils, deps adapters, chunk splits)
+- `deps` / `deps-dev` bumps unless major-version bumps with user-visible impact
+- **Follow-up fixes** — commits whose message matches `/address.*(review|PR|findings|feedback)|code review|follow-?up|fix.*(lint|typecheck|build|pre-existing)/i` AND land in the same week as a parent feature. Roll them into the parent bullet silently.
+- Reverts paired with a subsequent re-fix in the same week — skip both the revert and the offending commit; keep only the final correct implementation.
+- "Update src/..." auto-subject merges (GitHub web-edit artifacts)
+- Revisits: if the same feature is improved multiple times in one week, dedupe to one bullet describing the final state. Never list the same feature twice in one week.
+
+### Keep and rewrite
+
+- `feat(...)` — always, one bullet per distinct user-visible feature
+- `fix(...)` — if the bug was user-observable (rendering, playback, data loss, crash). Skip fixes for code that never shipped or was shipped and reverted in the same week.
+- `perf(...)` — if the impact is noticeable (measurable time saved, dropped frames recovered)
+
+### Rewrite style
+
+Commit messages are dev-speak. The changelog is user-facing. Rewrite:
+
+| Commit subject | Changelog bullet |
+|---|---|
+| `feat(timeline): add Alt+C as alternate split-at-playhead shortcut` | Split clips at playhead with Alt+C |
+| `perf(filmstrip): fill zoom gaps with cover frame background and full-set fallback` | Smoother filmstrip rendering when zooming the timeline |
+| `fix(preview): retry video with fresh blob URL on stale-blob load errors` | Preview no longer fails when media blobs expire |
+| `feat(storage): migrate to workspace folder via File System Access API` | Projects now live on disk in a folder you choose, not hidden browser storage |
+
+Rules of thumb:
+- Lead with the verb of the user experience, not the code change.
+- Drop internal names (stores, modules, workers) unless the user knows them.
+- If a bullet is only meaningful to developers, drop it.
+- Aim for ≤12 words per bullet.
+- For weekly entries, prefer thematic phrasing over commit-level phrasing ("Trim tools with smart zone detection" rather than listing each tool variant).
+
+### Grouping
+
+Within each weekly entry, group into:
+- **Added** — new features
+- **Fixed** — user-visible bug fixes
+- **Improved** — performance, polish, noticeable refactors
+
+Skip any group with zero entries.
+
+### Highlights
+
+Each weekly entry picks 1–3 highlights — the bullets a user would brag about. These appear at the top of the UI card. Skip highlights for weeks that are purely fixes.
+
+## File formats
+
+### `src/data/changelog.json`
+
+Matches types in `src/data/changelog-types.ts`:
+
+```ts
+export type ChangelogGroup = 'added' | 'fixed' | 'improved';
+
+export type ChangelogItem = {
+  title: string;           // ≤12 words, user-facing
+  scope?: string;          // optional, e.g. "timeline"
+};
+
+export type ChangelogEntry = {
+  version: string;         // "2026.04.13" for releases, "current" for rolling
+  date: string;            // ISO date — Monday for releases, today for current
+  highlights?: string[];   // 1-3 bullets
+  groups: Partial<Record<ChangelogGroup, ChangelogItem[]>>;
+};
+
+export type ChangelogFile = {
+  current: ChangelogEntry | null;   // in-progress week
+  releases: ChangelogEntry[];       // completed weeks, newest first
+};
+```
+
+### `CHANGELOG.md`
+
+```markdown
+# Changelog
+
+All notable changes to FreeCut. Versioning follows weekly CalVer: `YYYY.MM.DD` = the Monday of the release week.
+
+## [Current] — week of 2026-04-13
+...
+## [2026.04.06] — week of 2026-04-06 to 2026-04-12
+...
+```
+
+Do **not** include PR links in weekly entries. Weekly entries aggregate many PRs; PR links add noise. Optionally link the GitHub compare view at the bottom of each entry:
+
+```markdown
+[Compare](https://github.com/walterlow/freecut/compare/v2026.03.30...v2026.04.06)
+```
+
+## Git tag discipline
+
+- Always annotated (`git tag -a`), never lightweight.
+- Tag message = version + 1-line summary of highlights.
+- Tag points at the **last PR merge commit of that week** on `main`, not develop HEAD.
+- Print the plan (tag → sha → date) before creating tags; never push without the user asking.
+
+## When in doubt
+
+- Fewer bullets > more bullets. A wall of text is worse than missing a tiny fix.
+- If a week is 100 commits but they all revisit the same 3 features, produce 3 bullets.
+- If a commit scope is new and you don't know if it's user-visible, check what files it touches. UI components and public APIs = user-visible; stores/utils/tests = usually not.
+- A "current" entry that has grown past ~15 bullets is a sign you need a rollup.

--- a/.github/workflows/changelog-append.yml
+++ b/.github/workflows/changelog-append.yml
@@ -8,19 +8,25 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Serialize runs on the same ref so two pushes in quick succession can't
+  # race each other when committing back to main.
+  group: changelog-append-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   append:
     # Skip the commits we push ourselves from this workflow.
     if: |
       !contains(github.event.head_commit.message, '[skip changelog]') &&
-      !contains(github.event.head_commit.message, 'chore(changelog)')
+      !startsWith(github.event.head_commit.message, 'chore(changelog)')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Full history so HEAD~1..HEAD can walk side-branch commits
-          # brought in by merge commits from staging.
+          # Full history so github.event.before..HEAD can walk side-branch
+          # commits brought in by merge commits from staging.
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,9 +36,13 @@ jobs:
           # github.event.before is main's tip *before* this push. Walk
           # everything from that point to HEAD so we capture all commits
           # that actually arrived, regardless of merge/fast-forward shape.
+          # Fall back to HEAD~1..HEAD when before is missing (branch
+          # creation) or not in local history (force-push).
           BEFORE="${{ github.event.before }}"
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            # First push / branch creation; just process HEAD.
+            echo "range=HEAD~1..HEAD" >> "$GITHUB_OUTPUT"
+          elif ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "Warning: before-sha $BEFORE not in history; falling back to HEAD~1..HEAD"
             echo "range=HEAD~1..HEAD" >> "$GITHUB_OUTPUT"
           else
             echo "range=$BEFORE..HEAD" >> "$GITHUB_OUTPUT"
@@ -44,9 +54,9 @@ jobs:
           node-version: 22
 
       - name: Run append script
-        run: node scripts/changelog-append.mjs ${{ steps.range.outputs.range }}
+        run: node scripts/changelog-append.mjs "${{ steps.range.outputs.range }}"
 
-      - name: Commit updated changelog
+      - name: Commit and push updated changelog
         run: |
           if git diff --quiet src/data/changelog.json; then
             echo "No changelog updates."
@@ -54,6 +64,27 @@ jobs:
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          COMMIT_MSG="chore(changelog): append bullets from $(git rev-parse --short HEAD^) [skip ci]"
           git add src/data/changelog.json
-          git commit -m "chore(changelog): append bullets from $(git rev-parse --short HEAD^) [skip ci]"
-          git push
+          git commit -m "$COMMIT_MSG"
+
+          # Rebase-and-retry: if another push lands between our checkout and
+          # our push, rebase onto the new tip and retry. Give up after 5
+          # attempts.
+          BRANCH="${GITHUB_REF_NAME}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:$BRANCH"; then
+              echo "Pushed on attempt $attempt."
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; rebasing onto origin/$BRANCH and retrying."
+            git fetch origin "$BRANCH"
+            git rebase "origin/$BRANCH" || {
+              echo "Rebase conflict; aborting."
+              git rebase --abort || true
+              exit 1
+            }
+          done
+          echo "Exhausted push retries."
+          exit 1

--- a/.github/workflows/changelog-append.yml
+++ b/.github/workflows/changelog-append.yml
@@ -1,0 +1,43 @@
+name: Changelog append
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  append:
+    # Skip the commits we push ourselves from this workflow.
+    if: |
+      !contains(github.event.head_commit.message, '[skip changelog]') &&
+      !contains(github.event.head_commit.message, 'chore(changelog)')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run append script
+        run: node scripts/changelog-append.mjs HEAD~1..HEAD
+
+      - name: Commit updated changelog
+        run: |
+          if git diff --quiet src/data/changelog.json; then
+            echo "No changelog updates."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/data/changelog.json
+          git commit -m "chore(changelog): append bullets from $(git rev-parse --short HEAD^) [skip ci]"
+          git push

--- a/.github/workflows/changelog-append.yml
+++ b/.github/workflows/changelog-append.yml
@@ -19,8 +19,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # Full history so HEAD~1..HEAD can walk side-branch commits
+          # brought in by merge commits from staging.
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute range
+        id: range
+        run: |
+          # github.event.before is main's tip *before* this push. Walk
+          # everything from that point to HEAD so we capture all commits
+          # that actually arrived, regardless of merge/fast-forward shape.
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            # First push / branch creation; just process HEAD.
+            echo "range=HEAD~1..HEAD" >> "$GITHUB_OUTPUT"
+          else
+            echo "range=$BEFORE..HEAD" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -28,7 +44,7 @@ jobs:
           node-version: 22
 
       - name: Run append script
-        run: node scripts/changelog-append.mjs HEAD~1..HEAD
+        run: node scripts/changelog-append.mjs ${{ steps.range.outputs.range }}
 
       - name: Commit updated changelog
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ coverage
 # TanStack Router auto-generated files
 # Note: Some teams commit this, uncomment if you prefer to commit
 # src/routeTree.gen.ts
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 
 .vercel
 .env*.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,300 @@
+# Changelog
+
+All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the release week (Mon–Sun).
+
+<!-- Entries below are generated via the `changelog` skill. Newest first. -->
+
+## [Current] — week of 2026-04-13
+
+**Highlights**
+- Projects now live on disk in a workspace folder you choose
+- Per-clip pitch shift in semitones and cents
+- Floating six-band clip EQ panels
+
+### Added
+- Projects now live on disk in a workspace folder you choose
+- Multi-workspace support with waveform mirroring
+- Multi-select projects with marquee and bulk delete
+- Trash section with soft-delete, undo, and permanent delete
+- Legacy browser-storage migration progress banner
+- Per-clip pitch shift in semitones and cents
+- Compact DaVinci-style six-band clip EQ with floating panel
+- Mixer tuck handle to slide channel strips behind the bus
+- Separate project master bus from per-device monitor volume
+
+### Fixed
+- Preview no longer fails when media blobs expire
+- Disabled tracks remain editable and styled after reload
+- Pen mask tracks are now visible in classic timelines
+- Transitions stay aligned to source time across splits
+- Pen paths default to shapes with 5-second duration
+- UI accessibility, transition alpha, and viewport clamp fixes
+
+### Improved
+- Compact clip shell for narrow clips with short-circuited fades
+- Smoother filmstrip rendering when zooming the timeline
+- Smaller 960×540 proxy resolution with worker-side loading
+
+## [2026.04.06] — week of 2026-04-06 to 2026-04-12
+
+**Highlights**
+- Unified clip EQ across preview, export, and editor
+- AI-powered captioning, text-to-speech music, and scene detection
+- Alt+C as alternate split-at-playhead shortcut
+
+### Added
+- Clip EQ with five-band presets across preview and export
+- SoundTouch-based preview audio replaces WAV path
+- Alt+C as alternate split-at-playhead shortcut
+- AI-powered media captioning with LFM vision model
+- Local MusicGen music generation with presets and cancellation
+- Gemma-4 scene cut verification and LFM 2.5 VL alternative
+- Fast histogram-based scene detection
+- Local model cache management in settings
+- Source monitor patch destination pickers
+- Delete shortcut routes to keyframe editor when active
+
+### Fixed
+- Split linked items together without sync drift
+- Glitch transition shader no longer paints black regions
+- Context menu submenu clicks no longer deselect items
+- Same-origin transition exit no longer pops a frame
+- Vorbis audio and nested media play through proxies
+- Stale timeline in/out points are clamped
+
+### Improved
+- Filmstrip rewritten: no edge gap, pop, or zoom-driven re-renders
+- Reduced drag, marquee, and scroll-driven re-renders
+- Editor dialogs now lazy-load
+- Frame-accurate source time snapping prevents skipped frames
+
+## [2026.03.30] — week of 2026-03-30 to 2026-04-05
+
+**Highlights**
+- Nested compound clips with cycle detection
+- Local AI Text-to-Speech panel
+- AV1 codec export support
+
+### Added
+- Nested compound clips with cycle detection and deep-nested rename/delete
+- Crop-aware media layout with soft-edge feathering
+- SVG import, image filmstrips, and draggable text/shape templates
+- Renamed Composition to Compound Clip across UI
+- AI Text-to-Speech panel with local WebGPU inference
+- AV1 codec support in export with runtime capability checks
+- Media library hover-skim preview in program monitor
+- Audio preview play button on media cards
+- Mixer fader and mute on the bus master channel
+- Edge halo system for trim handles with constraint feedback
+- Track push/pull handle for multi-track gap adjustment
+- Full-column toggle for properties and media sidebars
+- Per-card info popover replaces bottom info panel
+- Video fade in/out handles applied in preview and export
+- Single disable toggle unifies track visibility and mute
+- Default FPS, snap, preview quality, and export defaults in settings
+- Smart ripple behavior on rate-stretch tool
+- Auto-match project canvas and FPS to first dropped video
+- Alt+scroll to resize tracks from headers
+
+### Fixed
+- GPU transition effect renders when paused on a transition frame
+- Sub-pixel seam gone from uncropped edges
+- Masks apply in composition space with stable refs
+- Clip volume edits persist with stereo waveform channels
+- Per-track meter preview during fader drag
+- Slide and linked-clip clamping respects transitions and limits
+- Duplicate slide limit boxes on neighbor counterparts removed
+- Overlapping items on the same track now detected and prevented
+
+## [2026.03.23] — week of 2026-03-23 to 2026-03-29
+
+**Highlights**
+- Full editing toolset: trim, ripple, rolling, slip, slide
+- Linked audio-video compound clips replace track groups
+- Floating mixer with stereo LED meters and real-time fader metering
+
+### Added
+- Trim, ripple, rolling, slip, and slide tools with live previews
+- Smart zone detection and constraint feedback while editing
+- Tool operation overlay with compact limit edges
+- Linked audio-video items replace track groups
+- Compound wrappers: speed, transitions, trim, slip/slide, linked audio
+- Split and join compound wrappers with crossfade playback
+- Cut-centered handle-based transitions replace overlap model
+- Transition drag tooltip and drop ghost polish
+- Audio fade curves with power-curve model and edge snapping
+- Media drop zones and track drop preview
+- Content-based track drag lane moves
+- Track-kind-aware item placement
+- Drag-and-drop effects onto clips and draggable adjustment layers
+- Floating dockable mixer with stereo LED meters and track colors
+- Real-time volume and meter levels during fader drag
+- Dopesheet with property accordion groups and marquee selection
+- Bezier tangent mirroring, multi-curve overlay, and compact navigator
+- Full-height media sidebar with in-panel keyframe editor
+- Transition selector dropdown replaces large grid
+- Compact source and program monitor toolbars
+- Source patch controls moved into the source monitor
+
+### Fixed
+- Track resize now feels anchored, Resolve-style
+- Transition audio doubling eliminated
+- Prewarm worker initialization and transition cold decode stalls
+
+### Improved
+- Mixer fader decoupled from store writes for smooth dragging
+- Adaptive seek backtracking via keyframe index
+- Batch preseek and faster keyframe extraction
+- Eager WASM warmup and batch prearm for transitions
+- Narrow render-critical store subscriptions
+
+## [2026.03.16] — week of 2026-03-16 to 2026-03-22
+
+**Highlights**
+- Pen mode with canvas drop and mask editing
+- Audio transcription
+- GPU transitions migrated to WebGPU shaders
+
+### Added
+- Pen mode with canvas drop, scopes, and interaction lock
+- Mask editing with in-panel keyframe editor
+- Audio transcription
+- Explicit auto-keyframe arming via dopesheet toggle
+- GPU shader migration for all transitions with export parity
+
+### Fixed
+- Transition playback jitter and scrub stability
+- Waveform now renders on initial media drop
+- Properties sidebar scrollbar
+
+### Improved
+- Export blits GPU composite directly to canvas (no readback)
+- Cold-start playback stalls eliminated
+- Timeline scroll and zoom rendering optimizations
+
+## [2026.03.09] — week of 2026-03-09 to 2026-03-15
+
+**Highlights**
+- New distort and stylize effects with color parameters
+
+### Added
+- Distort and stylize effect family with color parameters
+- Structured wide-event logging across core features
+
+## [2026.02.23] — week of 2026-02-23 to 2026-03-01
+
+**Highlights**
+- Timeline and preview performance overhaul
+- Export packet remux fast path
+
+### Fixed
+- No more infinite retry storms on failed video source init
+- Audio clicks and spurious video warnings eliminated during playback
+- Keyframed transforms apply on ruler frame seeks
+- Stale fast-scrub renders no longer flash after scrub exit
+- Gizmo and keyframe scrub stay in sync with the preview frame
+- Hidden adjustment tracks now respected in canvas renderer
+
+### Improved
+- Indexed stores, streaming proxies, and cost-aware resolution
+- Memory-aware filmstrip cache with batch optimizations
+- Export: packet remux fast path and streaming source
+- Strict-decode video frames in edit 2-up overlay with legacy fallback
+- Chunked window optimizations for export, timeline, and waveforms
+
+## [2026.02.16] — week of 2026-02-16 to 2026-02-22
+
+**Highlights**
+- Ripple, rolling, slip, and slide editing tools with 2-up previews
+- Font picker with searchable catalog and live preview
+- NLE-style waveforms and FCP-style transition bridge
+
+### Added
+- Ripple edit tool with downstream clip shifting
+- Rolling edit with 2-up frame comparison overlay
+- Slip and slide editing with live filmstrip preview
+- Font picker with searchable catalog and live preview
+- Proxy playback toggle and proxy management UI
+- Option to delete local files when deleting a project
+- Single-page new project with inline template picker
+- Undo history depth setting
+- AC-3/E-AC-3 codec support
+- Streaming partial audio decode with wavesurfer-style rendering
+- Sub-composition audio extraction in export
+- Animated WebP support and transparent GIF rendering
+- Per-track Close Gaps button replaces magnetic mode
+- 3-row clip layout with dedicated label row
+- Project-scoped cache, thumbnail, and proxy controls
+- NLE-style continuous filled-path waveform rendering
+- FCP-style transition bridge with live ripple preview
+- Shift+Z to zoom to 100% at cursor or playhead
+- Interactive razor mode with tool-aware playhead colors
+- Brave browser support guidance in media library
+
+### Fixed
+- Stale properties panel on clip selection
+- Audio stable across split boundaries during playback
+- Playback and proxy seek no longer hang
+- Clock frozen while tab is hidden prevents reseek stutter
+- Recovery from stale blob URLs after tab inactivity
+- 1px gaps from clip edge rounding eliminated
+- Block split and razor cuts inside transition overlap zones
+- Stale asset errors now show a save prompt
+
+### Improved
+- Video source pooling reduces transition flicker
+
+## [2026.02.09] — week of 2026-02-09 to 2026-02-15
+
+**Highlights**
+- Pre-compositions with 1-level nesting
+- Track groups with gate behavior
+- Animatable volume and gain keyframes
+
+### Added
+- Track groups with collapse, drag, and gate behavior
+- Source monitor with In/Out points and Insert/Overwrite editing
+- Animatable volume and gain via keyframes
+- Pre-compositions: group clips into nested sequences
+- Reverse clip, freeze frame, and magnetic timeline mode
+- Bento layout presets with interactive drag-to-swap canvas
+- Inline preview player in the export complete view
+- On-demand 720p proxy video generation
+- Drag-to-resize sidebars with persisted widths
+- Source monitor with split layout and slide-up media info
+- Hover-based keyboard shortcuts for source monitor
+
+### Fixed
+- Transition system overhaul: split-clip stutter and flip flash gone
+- Export corner radius and audio quality now match preview
+- Correct source-FPS conversion for clip trim points
+- Toggling track visibility no longer leaves stale opacity
+- Segments and transitions can move on hidden tracks
+- Prevent dropping items onto group tracks
+- Export shortcut (Ctrl+E) overrides Chrome default
+
+### Improved
+- App-wide error boundaries and toast notifications
+- Frame callback drift correction and smoother resume playback
+- Filmstrip extraction throttled for lower CPU load
+
+## [2026.02.02] — initial release
+
+**Highlights**
+- First public beta — multi-track video editor in the browser
+- Custom playback engine with WebGPU acceleration
+- Export via WebCodecs with client and server render modes
+
+### Added
+- Multi-track timeline: drag, drop, trim, razor, zoom, snap
+- Media library with import, metadata, thumbnails, and waveforms
+- Live preview with resizable layout
+- Transition library with 24+ effects
+- Keyframe animation with Bezier easing and graph editor
+- GPU effects and blend modes
+- Video export with MP3 audio and animated GIF support
+- Project save/load with schema versioning and migrations
+- Project bundle (ZIP) export and import
+- Customizable keyboard shortcuts
+- In/out points for selective timeline exports
+- Hover playhead preview with video seeking

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freecut",
   "private": true,
-  "version": "0.0.0",
+  "version": "2026.04.06",
   "type": "module",
   "scripts": {
     "dev": "vite --host",
@@ -28,6 +28,8 @@
     "test:preview-sync": "vitest run src/features/preview/components/video-preview.sync.test.tsx",
     "test:preview-sync:stress": "node scripts/preview-sync-stress.mjs --runs 20",
     "test:coverage": "vitest run --coverage",
+    "changelog:append": "node scripts/changelog-append.mjs",
+    "changelog:rollup": "node scripts/changelog-rollup.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/changelog-append.mjs
+++ b/scripts/changelog-append.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Append user-visible commits to the `current` entry of src/data/changelog.json.
+//
+// Usage:
+//   node scripts/changelog-append.mjs            # process HEAD only
+//   node scripts/changelog-append.mjs <range>    # e.g. HEAD~5..HEAD or <sha>..HEAD
+//
+// Intended to run in CI on every push to main. Writes changelog.json in place
+// and exits 0 whether or not changes were made. The workflow file decides
+// whether to commit.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHANGELOG_PATH = resolve(__dirname, '..', 'src', 'data', 'changelog.json');
+
+const DROP_SUBJECT_PATTERNS = [
+  /^merge /i,
+  /^revert /i,
+  /address.*(review|pr|findings|feedback)/i,
+  /code review/i,
+  /follow-?up/i,
+  /fix.*(lint|typecheck|build|pre-existing)/i,
+];
+
+const DROP_TYPES = new Set(['chore', 'ci', 'test', 'refactor', 'docs', 'style', 'build']);
+const KEEP_TYPES = new Set(['feat', 'fix', 'perf']);
+
+const GROUP_FOR_TYPE = {
+  feat: 'added',
+  fix: 'fixed',
+  perf: 'improved',
+};
+
+function parseSubject(subject) {
+  // type(scope): title   OR   type: title
+  const match = subject.match(/^([a-z]+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+  if (!match) return null;
+  const [, type, scope, , title] = match;
+  return { type: type.toLowerCase(), scope: scope ?? undefined, title: title.trim() };
+}
+
+function shouldDrop(subject) {
+  return DROP_SUBJECT_PATTERNS.some((re) => re.test(subject));
+}
+
+function todayIso() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getCommitSubjects(range) {
+  const spec = range ?? 'HEAD~1..HEAD';
+  const out = execSync(`git log --no-merges --pretty=format:%s ${spec}`, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return out.split('\n').filter(Boolean);
+}
+
+function loadChangelog() {
+  const raw = readFileSync(CHANGELOG_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function saveChangelog(data) {
+  writeFileSync(CHANGELOG_PATH, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function ensureCurrent(data) {
+  if (data.current) {
+    data.current.date = todayIso();
+    data.current.groups = data.current.groups ?? {};
+    return data.current;
+  }
+  data.current = {
+    version: 'current',
+    date: todayIso(),
+    groups: {},
+  };
+  return data.current;
+}
+
+function addBulletDedup(groupArr, item) {
+  const key = `${item.scope ?? ''}::${item.title.toLowerCase()}`;
+  const exists = groupArr.some(
+    (b) => `${b.scope ?? ''}::${b.title.toLowerCase()}` === key,
+  );
+  if (!exists) groupArr.push(item);
+}
+
+function main() {
+  const range = process.argv[2];
+  const subjects = getCommitSubjects(range);
+  if (subjects.length === 0) {
+    console.log('No commits in range; nothing to append.');
+    return;
+  }
+
+  const data = loadChangelog();
+  const current = ensureCurrent(data);
+
+  let added = 0;
+  for (const subject of subjects) {
+    if (shouldDrop(subject)) continue;
+    const parsed = parseSubject(subject);
+    if (!parsed) continue;
+    if (DROP_TYPES.has(parsed.type)) continue;
+    if (!KEEP_TYPES.has(parsed.type)) continue;
+
+    const groupKey = GROUP_FOR_TYPE[parsed.type];
+    current.groups[groupKey] = current.groups[groupKey] ?? [];
+    addBulletDedup(current.groups[groupKey], {
+      title: parsed.title,
+      ...(parsed.scope ? { scope: parsed.scope } : {}),
+    });
+    added += 1;
+  }
+
+  if (added === 0) {
+    console.log(`Scanned ${subjects.length} commit(s); nothing user-visible to append.`);
+    return;
+  }
+
+  saveChangelog(data);
+  console.log(`Appended ${added} bullet(s) to current (${current.date}).`);
+}
+
+main();

--- a/scripts/changelog-rollup.mjs
+++ b/scripts/changelog-rollup.mjs
@@ -18,7 +18,7 @@
 //   git push && git push --tags
 
 import { readFileSync, writeFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -49,11 +49,13 @@ function parseArgs() {
 
 function lastMondayIso(today = new Date()) {
   const d = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
-  // Monday-start: day 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+  // Monday-start: getUTCDay() → 0 = Sunday, 1 = Monday, ..., 6 = Saturday.
+  // We want the Monday of the most recent *completed* calendar week (Mon–Sun).
+  //   - Mon → 7 days back (last week's Monday)
+  //   - Tue → 8, Wed → 9, ..., Sat → 12
+  //   - Sun → 13 days back (previous week's Monday; the current Mon–Sun
+  //     week is still in progress until the next Monday).
   const dayOfWeek = d.getUTCDay();
-  // We want the Monday of the previous calendar week (the week that just closed).
-  // If today is Monday, last week's Monday is 7 days ago.
-  // If today is Sunday, last week's Monday is 6 days ago.
   const daysBack = ((dayOfWeek + 6) % 7) + 7;
   d.setUTCDate(d.getUTCDate() - daysBack);
   return d.toISOString().slice(0, 10);
@@ -126,10 +128,6 @@ function latestMainMergeSha() {
   return out;
 }
 
-function run(cmd) {
-  execSync(cmd, { stdio: 'inherit' });
-}
-
 function main() {
   const { sha: shaArg, dateOverride } = parseArgs();
   const mondayIso = dateOverride ?? lastMondayIso();
@@ -170,7 +168,11 @@ function main() {
   const tagMessage = `${tagName} — ${highlightLine}`;
 
   console.log(`\nTagging ${tagName} at ${sha.slice(0, 8)}`);
-  run(`git tag -a ${tagName} ${sha} -m "${tagMessage.replaceAll('"', '\\"')}"`);
+  // Pass args as an array and bypass the shell so backticks, $(), or other
+  // metacharacters inside tagMessage can't be interpreted.
+  execFileSync('git', ['tag', '-a', tagName, sha, '-m', tagMessage], {
+    stdio: 'inherit',
+  });
 
   console.log(`
 Rollup complete.

--- a/scripts/changelog-rollup.mjs
+++ b/scripts/changelog-rollup.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// Close the current week and promote `current` into a tagged weekly release.
+//
+// Usage:
+//   node scripts/changelog-rollup.mjs             # tag at latest main merge commit
+//   node scripts/changelog-rollup.mjs <sha>       # tag at explicit commit
+//   node scripts/changelog-rollup.mjs --date YYYY-MM-DD
+//
+// Steps:
+//   1. Compute the Monday-of-last-week (or --date override) -> new version.
+//   2. Move `current` into `releases` with that version and date.
+//   3. Update CHANGELOG.md with the new entry.
+//   4. Bump package.json version.
+//   5. Create an annotated git tag locally.
+//
+// Does NOT commit, push, or publish tags. Operator runs:
+//   git add . && git commit -m "chore(release): v<version>"
+//   git push && git push --tags
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const CHANGELOG_JSON = resolve(REPO_ROOT, 'src', 'data', 'changelog.json');
+const CHANGELOG_MD = resolve(REPO_ROOT, 'CHANGELOG.md');
+const PACKAGE_JSON = resolve(REPO_ROOT, 'package.json');
+
+const GROUP_ORDER = ['added', 'fixed', 'improved'];
+const GROUP_LABEL = { added: 'Added', fixed: 'Fixed', improved: 'Improved' };
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let sha;
+  let dateOverride;
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--date') {
+      dateOverride = args[i + 1];
+      i += 1;
+    } else if (!a.startsWith('--')) {
+      sha = a;
+    }
+  }
+  return { sha, dateOverride };
+}
+
+function lastMondayIso(today = new Date()) {
+  const d = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  // Monday-start: day 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+  const dayOfWeek = d.getUTCDay();
+  // We want the Monday of the previous calendar week (the week that just closed).
+  // If today is Monday, last week's Monday is 7 days ago.
+  // If today is Sunday, last week's Monday is 6 days ago.
+  const daysBack = ((dayOfWeek + 6) % 7) + 7;
+  d.setUTCDate(d.getUTCDate() - daysBack);
+  return d.toISOString().slice(0, 10);
+}
+
+function formatWeekRange(mondayIso) {
+  const monday = new Date(`${mondayIso}T00:00:00Z`);
+  const sunday = new Date(monday.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const fmt = (d) =>
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  return `${fmt(monday)} to ${fmt(sunday)}`;
+}
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function bulletLine(item) {
+  const scope = item.scope ? `**${item.scope}**: ` : '';
+  return `- ${scope}${item.title}`;
+}
+
+function renderMarkdownEntry(entry, mondayIso) {
+  const lines = [];
+  lines.push(`## [${entry.version}] — week of ${mondayIso} to ${toSundayIso(mondayIso)}`);
+  lines.push('');
+  if (entry.highlights?.length) {
+    lines.push('**Highlights**');
+    for (const h of entry.highlights) lines.push(`- ${h}`);
+    lines.push('');
+  }
+  for (const groupKey of GROUP_ORDER) {
+    const items = entry.groups?.[groupKey];
+    if (!items?.length) continue;
+    lines.push(`### ${GROUP_LABEL[groupKey]}`);
+    for (const item of items) lines.push(bulletLine(item));
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function toSundayIso(mondayIso) {
+  const m = new Date(`${mondayIso}T00:00:00Z`);
+  m.setUTCDate(m.getUTCDate() + 6);
+  return m.toISOString().slice(0, 10);
+}
+
+function insertIntoMarkdown(newEntryMd) {
+  const md = readFileSync(CHANGELOG_MD, 'utf8');
+  const marker = '## ';
+  const insertIdx = md.indexOf(marker);
+  if (insertIdx === -1) {
+    writeFileSync(CHANGELOG_MD, `${md.trimEnd()}\n\n${newEntryMd}\n`);
+    return;
+  }
+  const before = md.slice(0, insertIdx);
+  const after = md.slice(insertIdx);
+  writeFileSync(CHANGELOG_MD, `${before}${newEntryMd}\n${after}`);
+}
+
+function latestMainMergeSha() {
+  const out = execSync(
+    'git log --first-parent main -1 --pretty=format:%H',
+    { encoding: 'utf8' },
+  ).trim();
+  return out;
+}
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+function main() {
+  const { sha: shaArg, dateOverride } = parseArgs();
+  const mondayIso = dateOverride ?? lastMondayIso();
+  const version = mondayIso.replaceAll('-', '.');
+  const tagName = `v${version}`;
+
+  const data = loadJson(CHANGELOG_JSON);
+  if (!data.current || Object.keys(data.current.groups ?? {}).length === 0) {
+    console.error('No bullets in current entry; nothing to roll up.');
+    process.exit(1);
+  }
+
+  if (data.releases.some((r) => r.version === version)) {
+    console.error(`Release ${version} already exists.`);
+    process.exit(1);
+  }
+
+  const releaseEntry = {
+    version,
+    date: mondayIso,
+    ...(data.current.highlights?.length ? { highlights: data.current.highlights } : {}),
+    groups: data.current.groups,
+  };
+
+  data.releases.unshift(releaseEntry);
+  data.current = null;
+  writeJson(CHANGELOG_JSON, data);
+
+  const newEntryMd = renderMarkdownEntry(releaseEntry, mondayIso);
+  insertIntoMarkdown(newEntryMd);
+
+  const pkg = loadJson(PACKAGE_JSON);
+  pkg.version = version;
+  writeJson(PACKAGE_JSON, pkg);
+
+  const sha = shaArg ?? latestMainMergeSha();
+  const highlightLine = releaseEntry.highlights?.[0] ?? `Week of ${formatWeekRange(mondayIso)}`;
+  const tagMessage = `${tagName} — ${highlightLine}`;
+
+  console.log(`\nTagging ${tagName} at ${sha.slice(0, 8)}`);
+  run(`git tag -a ${tagName} ${sha} -m "${tagMessage.replaceAll('"', '\\"')}"`);
+
+  console.log(`
+Rollup complete.
+  Version:   ${version}
+  Tag:       ${tagName} at ${sha.slice(0, 12)}
+  Files:     src/data/changelog.json, CHANGELOG.md, package.json
+
+Next steps (run manually when ready):
+  git add src/data/changelog.json CHANGELOG.md package.json
+  git commit -m "chore(release): ${tagName}"
+  git push
+  git push origin ${tagName}
+`);
+}
+
+main();

--- a/src/data/changelog-types.ts
+++ b/src/data/changelog-types.ts
@@ -8,6 +8,7 @@ export type ChangelogItem = {
 export type ChangelogEntry = {
   version: string;
   date: string;
+  subtitle?: string;
   highlights?: string[];
   groups: Partial<Record<ChangelogGroup, ChangelogItem[]>>;
 };

--- a/src/data/changelog-types.ts
+++ b/src/data/changelog-types.ts
@@ -1,0 +1,18 @@
+export type ChangelogGroup = 'added' | 'fixed' | 'improved';
+
+export type ChangelogItem = {
+  title: string;
+  scope?: string;
+};
+
+export type ChangelogEntry = {
+  version: string;
+  date: string;
+  highlights?: string[];
+  groups: Partial<Record<ChangelogGroup, ChangelogItem[]>>;
+};
+
+export type ChangelogFile = {
+  current: ChangelogEntry | null;
+  releases: ChangelogEntry[];
+};

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -817,6 +817,7 @@
     {
       "version": "2026.02.02",
       "date": "2026-02-02",
+      "subtitle": "Initial release",
       "highlights": [
         "First public beta — multi-track video editor in the browser",
         "Custom playback engine with WebGPU acceleration",

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,0 +1,867 @@
+{
+  "current": {
+    "version": "current",
+    "date": "2026-04-17",
+    "highlights": [
+      "Projects now live on disk in a workspace folder you choose",
+      "Per-clip pitch shift in semitones and cents",
+      "Floating six-band clip EQ panels"
+    ],
+    "groups": {
+      "added": [
+        {
+          "title": "Projects now live on disk in a workspace folder you choose",
+          "scope": "storage"
+        },
+        {
+          "title": "Multi-workspace support with waveform mirroring",
+          "scope": "storage"
+        },
+        {
+          "title": "Multi-select projects with marquee and bulk delete",
+          "scope": "projects"
+        },
+        {
+          "title": "Trash section with soft-delete, undo, and permanent delete",
+          "scope": "projects"
+        },
+        {
+          "title": "Legacy browser-storage migration progress banner",
+          "scope": "storage"
+        },
+        {
+          "title": "Per-clip pitch shift in semitones and cents",
+          "scope": "audio"
+        },
+        {
+          "title": "Compact DaVinci-style six-band clip EQ with floating panel",
+          "scope": "audio"
+        },
+        {
+          "title": "Mixer tuck handle to slide channel strips behind the bus",
+          "scope": "mixer"
+        },
+        {
+          "title": "Separate project master bus from per-device monitor volume",
+          "scope": "audio"
+        }
+      ],
+      "fixed": [
+        {
+          "title": "Preview no longer fails when media blobs expire",
+          "scope": "preview"
+        },
+        {
+          "title": "Disabled tracks remain editable and styled after reload",
+          "scope": "timeline"
+        },
+        {
+          "title": "Pen mask tracks are now visible in classic timelines",
+          "scope": "timeline"
+        },
+        {
+          "title": "Transitions stay aligned to source time across splits",
+          "scope": "transitions"
+        },
+        {
+          "title": "Pen paths default to shapes with 5-second duration",
+          "scope": "timeline"
+        },
+        {
+          "title": "UI accessibility, transition alpha, and viewport clamp fixes",
+          "scope": "editor"
+        }
+      ],
+      "improved": [
+        {
+          "title": "Compact clip shell for narrow clips with short-circuited fades",
+          "scope": "timeline"
+        },
+        {
+          "title": "Smoother filmstrip rendering when zooming the timeline",
+          "scope": "timeline"
+        },
+        {
+          "title": "Smaller 960×540 proxy resolution with worker-side loading",
+          "scope": "preview"
+        }
+      ]
+    }
+  },
+  "releases": [
+    {
+      "version": "2026.04.06",
+      "date": "2026-04-06",
+      "highlights": [
+        "Unified clip EQ across preview, export, and editor",
+        "AI-powered captioning, text-to-speech music, and scene detection",
+        "Alt+C as alternate split-at-playhead shortcut"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Clip EQ with five-band presets across preview and export",
+            "scope": "audio"
+          },
+          {
+            "title": "SoundTouch-based preview audio replaces WAV path",
+            "scope": "audio"
+          },
+          {
+            "title": "Alt+C as alternate split-at-playhead shortcut",
+            "scope": "timeline"
+          },
+          {
+            "title": "AI-powered media captioning with LFM vision model",
+            "scope": "media-library"
+          },
+          {
+            "title": "Local MusicGen music generation with presets and cancellation",
+            "scope": "editor"
+          },
+          {
+            "title": "Gemma-4 scene cut verification and LFM 2.5 VL alternative",
+            "scope": "analysis"
+          },
+          {
+            "title": "Fast histogram-based scene detection",
+            "scope": "analysis"
+          },
+          {
+            "title": "Local model cache management in settings",
+            "scope": "settings"
+          },
+          {
+            "title": "Source monitor patch destination pickers",
+            "scope": "preview"
+          },
+          {
+            "title": "Delete shortcut routes to keyframe editor when active",
+            "scope": "keyframes"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Split linked items together without sync drift",
+            "scope": "timeline"
+          },
+          {
+            "title": "Glitch transition shader no longer paints black regions",
+            "scope": "transitions"
+          },
+          {
+            "title": "Context menu submenu clicks no longer deselect items",
+            "scope": "timeline"
+          },
+          {
+            "title": "Same-origin transition exit no longer pops a frame",
+            "scope": "preview"
+          },
+          {
+            "title": "Vorbis audio and nested media play through proxies",
+            "scope": "preview"
+          },
+          {
+            "title": "Stale timeline in/out points are clamped",
+            "scope": "timeline"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Filmstrip rewritten: no edge gap, pop, or zoom-driven re-renders",
+            "scope": "timeline"
+          },
+          {
+            "title": "Reduced drag, marquee, and scroll-driven re-renders",
+            "scope": "timeline"
+          },
+          {
+            "title": "Editor dialogs now lazy-load",
+            "scope": "editor"
+          },
+          {
+            "title": "Frame-accurate source time snapping prevents skipped frames",
+            "scope": "preview"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.03.30",
+      "date": "2026-03-30",
+      "highlights": [
+        "Nested compound clips with cycle detection",
+        "Local AI Text-to-Speech panel",
+        "AV1 codec export support"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Nested compound clips with cycle detection and deep-nested rename/delete",
+            "scope": "compositions"
+          },
+          {
+            "title": "Crop-aware media layout with soft-edge feathering",
+            "scope": "editor"
+          },
+          {
+            "title": "SVG import, image filmstrips, and draggable text/shape templates",
+            "scope": "editor"
+          },
+          {
+            "title": "Renamed Composition to Compound Clip across UI",
+            "scope": "editor"
+          },
+          {
+            "title": "AI Text-to-Speech panel with local WebGPU inference",
+            "scope": "editor"
+          },
+          {
+            "title": "AV1 codec support in export with runtime capability checks",
+            "scope": "export"
+          },
+          {
+            "title": "Media library hover-skim preview in program monitor",
+            "scope": "preview"
+          },
+          {
+            "title": "Audio preview play button on media cards",
+            "scope": "media-library"
+          },
+          {
+            "title": "Mixer fader and mute on the bus master channel",
+            "scope": "mixer"
+          },
+          {
+            "title": "Edge halo system for trim handles with constraint feedback",
+            "scope": "timeline"
+          },
+          {
+            "title": "Track push/pull handle for multi-track gap adjustment",
+            "scope": "timeline"
+          },
+          {
+            "title": "Full-column toggle for properties and media sidebars",
+            "scope": "editor"
+          },
+          {
+            "title": "Per-card info popover replaces bottom info panel",
+            "scope": "media-library"
+          },
+          {
+            "title": "Video fade in/out handles applied in preview and export",
+            "scope": "timeline"
+          },
+          {
+            "title": "Single disable toggle unifies track visibility and mute",
+            "scope": "timeline"
+          },
+          {
+            "title": "Default FPS, snap, preview quality, and export defaults in settings",
+            "scope": "settings"
+          },
+          {
+            "title": "Smart ripple behavior on rate-stretch tool",
+            "scope": "timeline"
+          },
+          {
+            "title": "Auto-match project canvas and FPS to first dropped video",
+            "scope": "editor"
+          },
+          {
+            "title": "Alt+scroll to resize tracks from headers",
+            "scope": "timeline"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "GPU transition effect renders when paused on a transition frame",
+            "scope": "transitions"
+          },
+          {
+            "title": "Sub-pixel seam gone from uncropped edges",
+            "scope": "editor"
+          },
+          {
+            "title": "Masks apply in composition space with stable refs",
+            "scope": "preview"
+          },
+          {
+            "title": "Clip volume edits persist with stereo waveform channels",
+            "scope": "audio"
+          },
+          {
+            "title": "Per-track meter preview during fader drag",
+            "scope": "mixer"
+          },
+          {
+            "title": "Slide and linked-clip clamping respects transitions and limits",
+            "scope": "timeline"
+          },
+          {
+            "title": "Duplicate slide limit boxes on neighbor counterparts removed",
+            "scope": "timeline"
+          },
+          {
+            "title": "Overlapping items on the same track now detected and prevented",
+            "scope": "timeline"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.03.23",
+      "date": "2026-03-23",
+      "highlights": [
+        "Full editing toolset: trim, ripple, rolling, slip, slide",
+        "Linked audio-video compound clips replace track groups",
+        "Floating mixer with stereo LED meters and real-time fader metering"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Trim, ripple, rolling, slip, and slide tools with live previews",
+            "scope": "timeline"
+          },
+          {
+            "title": "Smart zone detection and constraint feedback while editing",
+            "scope": "timeline"
+          },
+          {
+            "title": "Tool operation overlay with compact limit edges",
+            "scope": "timeline"
+          },
+          {
+            "title": "Linked audio-video items replace track groups",
+            "scope": "timeline"
+          },
+          {
+            "title": "Compound wrappers: speed, transitions, trim, slip/slide, linked audio",
+            "scope": "timeline"
+          },
+          {
+            "title": "Split and join compound wrappers with crossfade playback",
+            "scope": "timeline"
+          },
+          {
+            "title": "Cut-centered handle-based transitions replace overlap model",
+            "scope": "transitions"
+          },
+          {
+            "title": "Transition drag tooltip and drop ghost polish",
+            "scope": "transitions"
+          },
+          {
+            "title": "Audio fade curves with power-curve model and edge snapping",
+            "scope": "audio"
+          },
+          {
+            "title": "Media drop zones and track drop preview",
+            "scope": "timeline"
+          },
+          {
+            "title": "Content-based track drag lane moves",
+            "scope": "timeline"
+          },
+          {
+            "title": "Track-kind-aware item placement",
+            "scope": "timeline"
+          },
+          {
+            "title": "Drag-and-drop effects onto clips and draggable adjustment layers",
+            "scope": "editor"
+          },
+          {
+            "title": "Floating dockable mixer with stereo LED meters and track colors",
+            "scope": "mixer"
+          },
+          {
+            "title": "Real-time volume and meter levels during fader drag",
+            "scope": "mixer"
+          },
+          {
+            "title": "Dopesheet with property accordion groups and marquee selection",
+            "scope": "keyframes"
+          },
+          {
+            "title": "Bezier tangent mirroring, multi-curve overlay, and compact navigator",
+            "scope": "keyframes"
+          },
+          {
+            "title": "Full-height media sidebar with in-panel keyframe editor",
+            "scope": "editor"
+          },
+          {
+            "title": "Transition selector dropdown replaces large grid",
+            "scope": "editor"
+          },
+          {
+            "title": "Compact source and program monitor toolbars",
+            "scope": "preview"
+          },
+          {
+            "title": "Source patch controls moved into the source monitor",
+            "scope": "preview"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Track resize now feels anchored, Resolve-style",
+            "scope": "timeline"
+          },
+          {
+            "title": "Transition audio doubling eliminated",
+            "scope": "audio"
+          },
+          {
+            "title": "Prewarm worker initialization and transition cold decode stalls",
+            "scope": "preview"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Mixer fader decoupled from store writes for smooth dragging",
+            "scope": "mixer"
+          },
+          {
+            "title": "Adaptive seek backtracking via keyframe index",
+            "scope": "preview"
+          },
+          {
+            "title": "Batch preseek and faster keyframe extraction",
+            "scope": "preview"
+          },
+          {
+            "title": "Eager WASM warmup and batch prearm for transitions",
+            "scope": "preview"
+          },
+          {
+            "title": "Narrow render-critical store subscriptions",
+            "scope": "timeline"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.03.16",
+      "date": "2026-03-16",
+      "highlights": [
+        "Pen mode with canvas drop and mask editing",
+        "Audio transcription",
+        "GPU transitions migrated to WebGPU shaders"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Pen mode with canvas drop, scopes, and interaction lock",
+            "scope": "editor"
+          },
+          {
+            "title": "Mask editing with in-panel keyframe editor",
+            "scope": "editor"
+          },
+          {
+            "title": "Audio transcription",
+            "scope": "editor"
+          },
+          {
+            "title": "Explicit auto-keyframe arming via dopesheet toggle",
+            "scope": "keyframes"
+          },
+          {
+            "title": "GPU shader migration for all transitions with export parity",
+            "scope": "transitions"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Transition playback jitter and scrub stability",
+            "scope": "preview"
+          },
+          {
+            "title": "Waveform now renders on initial media drop",
+            "scope": "timeline"
+          },
+          {
+            "title": "Properties sidebar scrollbar",
+            "scope": "editor"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Export blits GPU composite directly to canvas (no readback)",
+            "scope": "export"
+          },
+          {
+            "title": "Cold-start playback stalls eliminated",
+            "scope": "preview"
+          },
+          {
+            "title": "Timeline scroll and zoom rendering optimizations",
+            "scope": "timeline"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.03.09",
+      "date": "2026-03-09",
+      "highlights": [
+        "New distort and stylize effects with color parameters"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Distort and stylize effect family with color parameters",
+            "scope": "effects"
+          },
+          {
+            "title": "Structured wide-event logging across core features",
+            "scope": "editor"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.02.23",
+      "date": "2026-02-23",
+      "highlights": [
+        "Timeline and preview performance overhaul",
+        "Export packet remux fast path"
+      ],
+      "groups": {
+        "fixed": [
+          {
+            "title": "No more infinite retry storms on failed video source init",
+            "scope": "preview"
+          },
+          {
+            "title": "Audio clicks and spurious video warnings eliminated during playback",
+            "scope": "preview"
+          },
+          {
+            "title": "Keyframed transforms apply on ruler frame seeks",
+            "scope": "preview"
+          },
+          {
+            "title": "Stale fast-scrub renders no longer flash after scrub exit",
+            "scope": "preview"
+          },
+          {
+            "title": "Gizmo and keyframe scrub stay in sync with the preview frame",
+            "scope": "preview"
+          },
+          {
+            "title": "Hidden adjustment tracks now respected in canvas renderer",
+            "scope": "preview"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Indexed stores, streaming proxies, and cost-aware resolution",
+            "scope": "timeline"
+          },
+          {
+            "title": "Memory-aware filmstrip cache with batch optimizations",
+            "scope": "timeline"
+          },
+          {
+            "title": "Export: packet remux fast path and streaming source",
+            "scope": "export"
+          },
+          {
+            "title": "Strict-decode video frames in edit 2-up overlay with legacy fallback",
+            "scope": "preview"
+          },
+          {
+            "title": "Chunked window optimizations for export, timeline, and waveforms",
+            "scope": "editor"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.02.16",
+      "date": "2026-02-16",
+      "highlights": [
+        "Ripple, rolling, slip, and slide editing tools with 2-up previews",
+        "Font picker with searchable catalog and live preview",
+        "NLE-style waveforms and FCP-style transition bridge"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Ripple edit tool with downstream clip shifting",
+            "scope": "timeline"
+          },
+          {
+            "title": "Rolling edit with 2-up frame comparison overlay",
+            "scope": "timeline"
+          },
+          {
+            "title": "Slip and slide editing with live filmstrip preview",
+            "scope": "timeline"
+          },
+          {
+            "title": "Font picker with searchable catalog and live preview",
+            "scope": "editor"
+          },
+          {
+            "title": "Proxy playback toggle and proxy management UI",
+            "scope": "preview"
+          },
+          {
+            "title": "Option to delete local files when deleting a project",
+            "scope": "projects"
+          },
+          {
+            "title": "Single-page new project with inline template picker",
+            "scope": "projects"
+          },
+          {
+            "title": "Undo history depth setting",
+            "scope": "settings"
+          },
+          {
+            "title": "AC-3/E-AC-3 codec support",
+            "scope": "audio"
+          },
+          {
+            "title": "Streaming partial audio decode with wavesurfer-style rendering",
+            "scope": "audio"
+          },
+          {
+            "title": "Sub-composition audio extraction in export",
+            "scope": "export"
+          },
+          {
+            "title": "Animated WebP support and transparent GIF rendering",
+            "scope": "timeline"
+          },
+          {
+            "title": "Per-track Close Gaps button replaces magnetic mode",
+            "scope": "timeline"
+          },
+          {
+            "title": "3-row clip layout with dedicated label row",
+            "scope": "timeline"
+          },
+          {
+            "title": "Project-scoped cache, thumbnail, and proxy controls",
+            "scope": "settings"
+          },
+          {
+            "title": "NLE-style continuous filled-path waveform rendering",
+            "scope": "timeline"
+          },
+          {
+            "title": "FCP-style transition bridge with live ripple preview",
+            "scope": "transitions"
+          },
+          {
+            "title": "Shift+Z to zoom to 100% at cursor or playhead",
+            "scope": "timeline"
+          },
+          {
+            "title": "Interactive razor mode with tool-aware playhead colors",
+            "scope": "timeline"
+          },
+          {
+            "title": "Brave browser support guidance in media library",
+            "scope": "media-library"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Stale properties panel on clip selection",
+            "scope": "editor"
+          },
+          {
+            "title": "Audio stable across split boundaries during playback",
+            "scope": "player"
+          },
+          {
+            "title": "Playback and proxy seek no longer hang",
+            "scope": "player"
+          },
+          {
+            "title": "Clock frozen while tab is hidden prevents reseek stutter",
+            "scope": "player"
+          },
+          {
+            "title": "Recovery from stale blob URLs after tab inactivity",
+            "scope": "preview"
+          },
+          {
+            "title": "1px gaps from clip edge rounding eliminated",
+            "scope": "timeline"
+          },
+          {
+            "title": "Block split and razor cuts inside transition overlap zones",
+            "scope": "timeline"
+          },
+          {
+            "title": "Stale asset errors now show a save prompt",
+            "scope": "editor"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Video source pooling reduces transition flicker",
+            "scope": "preview"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.02.09",
+      "date": "2026-02-09",
+      "highlights": [
+        "Pre-compositions with 1-level nesting",
+        "Track groups with gate behavior",
+        "Animatable volume and gain keyframes"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Track groups with collapse, drag, and gate behavior",
+            "scope": "timeline"
+          },
+          {
+            "title": "Source monitor with In/Out points and Insert/Overwrite editing",
+            "scope": "preview"
+          },
+          {
+            "title": "Animatable volume and gain via keyframes",
+            "scope": "keyframes"
+          },
+          {
+            "title": "Pre-compositions: group clips into nested sequences",
+            "scope": "timeline"
+          },
+          {
+            "title": "Reverse clip, freeze frame, and magnetic timeline mode",
+            "scope": "timeline"
+          },
+          {
+            "title": "Bento layout presets with interactive drag-to-swap canvas",
+            "scope": "timeline"
+          },
+          {
+            "title": "Inline preview player in the export complete view",
+            "scope": "export"
+          },
+          {
+            "title": "On-demand 720p proxy video generation",
+            "scope": "preview"
+          },
+          {
+            "title": "Drag-to-resize sidebars with persisted widths",
+            "scope": "editor"
+          },
+          {
+            "title": "Source monitor with split layout and slide-up media info",
+            "scope": "preview"
+          },
+          {
+            "title": "Hover-based keyboard shortcuts for source monitor",
+            "scope": "preview"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Transition system overhaul: split-clip stutter and flip flash gone",
+            "scope": "transitions"
+          },
+          {
+            "title": "Export corner radius and audio quality now match preview",
+            "scope": "export"
+          },
+          {
+            "title": "Correct source-FPS conversion for clip trim points",
+            "scope": "timeline"
+          },
+          {
+            "title": "Toggling track visibility no longer leaves stale opacity",
+            "scope": "timeline"
+          },
+          {
+            "title": "Segments and transitions can move on hidden tracks",
+            "scope": "timeline"
+          },
+          {
+            "title": "Prevent dropping items onto group tracks",
+            "scope": "timeline"
+          },
+          {
+            "title": "Export shortcut (Ctrl+E) overrides Chrome default",
+            "scope": "export"
+          }
+        ],
+        "improved": [
+          {
+            "title": "App-wide error boundaries and toast notifications",
+            "scope": "editor"
+          },
+          {
+            "title": "Frame callback drift correction and smoother resume playback",
+            "scope": "player"
+          },
+          {
+            "title": "Filmstrip extraction throttled for lower CPU load",
+            "scope": "timeline"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.02.02",
+      "date": "2026-02-02",
+      "highlights": [
+        "First public beta — multi-track video editor in the browser",
+        "Custom playback engine with WebGPU acceleration",
+        "Export via WebCodecs with client and server render modes"
+      ],
+      "groups": {
+        "added": [
+          {
+            "title": "Multi-track timeline: drag, drop, trim, razor, zoom, snap"
+          },
+          {
+            "title": "Media library with import, metadata, thumbnails, and waveforms"
+          },
+          {
+            "title": "Live preview with resizable layout"
+          },
+          {
+            "title": "Transition library with 24+ effects"
+          },
+          {
+            "title": "Keyframe animation with Bezier easing and graph editor"
+          },
+          {
+            "title": "GPU effects and blend modes"
+          },
+          {
+            "title": "Video export with MP3 audio and animated GIF support"
+          },
+          {
+            "title": "Project save/load with schema versioning and migrations"
+          },
+          {
+            "title": "Project bundle (ZIP) export and import"
+          },
+          {
+            "title": "Customizable keyboard shortcuts"
+          },
+          {
+            "title": "In/out points for selective timeline exports"
+          },
+          {
+            "title": "Hover playhead preview with video seeking"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/features/editor/components/toolbar.tsx
+++ b/src/features/editor/components/toolbar.tsx
@@ -67,10 +67,10 @@ export const Toolbar = memo(function Toolbar({
     setHasUnseenWhatsNew(hasUnseenChangelog());
   }, []);
 
-  useEffect(() => {
-    if (!showWhatsNewDialog) return;
+  const openWhatsNew = () => {
     setHasUnseenWhatsNew(false);
-  }, [showWhatsNewDialog]);
+    setShowWhatsNewDialog(true);
+  };
 
   const handleBackClick = () => {
     if (isDirty) {
@@ -152,7 +152,7 @@ export const Toolbar = memo(function Toolbar({
           variant="outline"
           size="icon"
           className="h-7 w-7 relative"
-          onClick={() => setShowWhatsNewDialog(true)}
+          onClick={openWhatsNew}
           data-tooltip="What's New"
           data-tooltip-side="bottom"
           aria-label="What's new"

--- a/src/features/editor/components/toolbar.tsx
+++ b/src/features/editor/components/toolbar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import {
   ArrowLeft,
@@ -10,6 +10,7 @@ import {
   Keyboard,
   Save,
   Settings,
+  Sparkles,
   Video,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -26,6 +27,8 @@ import { ProjectDebugPanel } from './project-debug-panel';
 import { SettingsDialog } from './settings-dialog';
 import { ShortcutsDialog } from './shortcuts-dialog';
 import { UnsavedChangesDialog } from './unsaved-changes-dialog';
+import { WhatsNewDialog } from './whats-new-dialog';
+import { hasUnseenChangelog } from './whats-new-seen';
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/app/editor-layout';
 import { cn } from '@/shared/ui/cn';
 import { useDebugStore } from '@/features/editor/stores/debug-store';
@@ -57,6 +60,17 @@ export const Toolbar = memo(function Toolbar({
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [showShortcutsDialog, setShowShortcutsDialog] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
+  const [showWhatsNewDialog, setShowWhatsNewDialog] = useState(false);
+  const [hasUnseenWhatsNew, setHasUnseenWhatsNew] = useState(false);
+
+  useEffect(() => {
+    setHasUnseenWhatsNew(hasUnseenChangelog());
+  }, []);
+
+  useEffect(() => {
+    if (!showWhatsNewDialog) return;
+    setHasUnseenWhatsNew(false);
+  }, [showWhatsNewDialog]);
 
   const handleBackClick = () => {
     if (isDirty) {
@@ -125,10 +139,32 @@ export const Toolbar = memo(function Toolbar({
         onOpenChange={setShowSettingsDialog}
       />
 
+      <WhatsNewDialog
+        open={showWhatsNewDialog}
+        onOpenChange={setShowWhatsNewDialog}
+      />
+
       <div className="flex items-center gap-1.5">
         {import.meta.env.DEV && import.meta.env.VITE_SHOW_DEBUG_PANEL !== 'false' && (
           <DebugPopover projectId={projectId} />
         )}
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7 relative"
+          onClick={() => setShowWhatsNewDialog(true)}
+          data-tooltip="What's New"
+          data-tooltip-side="bottom"
+          aria-label="What's new"
+        >
+          <Sparkles className="h-4 w-4" />
+          {hasUnseenWhatsNew && (
+            <span
+              className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-primary"
+              aria-hidden="true"
+            />
+          )}
+        </Button>
         <Button
           variant="outline"
           size="icon"

--- a/src/features/editor/components/whats-new-dialog.tsx
+++ b/src/features/editor/components/whats-new-dialog.tsx
@@ -46,8 +46,8 @@ function formatWeekRange(mondayIso: string): string {
 }
 
 function formatEntrySubtitle(entry: ChangelogEntry): string {
+  if (entry.subtitle) return entry.subtitle;
   if (entry.version === 'current') return `As of ${formatSingleDate(entry.date)}`;
-  if (entry.version.startsWith('2026.02.02')) return 'Initial release';
   return `Week of ${formatWeekRange(entry.date)}`;
 }
 

--- a/src/features/editor/components/whats-new-dialog.tsx
+++ b/src/features/editor/components/whats-new-dialog.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState, type ComponentType } from 'react';
+import { Sparkles, Bug, Zap, ExternalLink } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/shared/ui/cn';
+import changelogData from '@/data/changelog.json';
+import type {
+  ChangelogEntry,
+  ChangelogFile,
+  ChangelogGroup,
+} from '@/data/changelog-types';
+import { markChangelogSeen } from './whats-new-seen';
+
+const data = changelogData as ChangelogFile;
+const GITHUB_REPO_URL = 'https://github.com/walterlow/freecut';
+
+const GROUP_CONFIG: Record<
+  ChangelogGroup,
+  { label: string; icon: ComponentType<{ className?: string }> }
+> = {
+  added: { label: 'Added', icon: Sparkles },
+  fixed: { label: 'Fixed', icon: Bug },
+  improved: { label: 'Improved', icon: Zap },
+};
+
+const GROUP_ORDER: ChangelogGroup[] = ['added', 'fixed', 'improved'];
+
+function formatEntryLabel(entry: ChangelogEntry): string {
+  return entry.version === 'current' ? 'This Week' : entry.version;
+}
+
+function formatWeekRange(mondayIso: string): string {
+  const monday = new Date(`${mondayIso}T00:00:00Z`);
+  const sunday = new Date(monday.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const fmt = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  return `${fmt.format(monday)} — ${fmt.format(sunday)}`;
+}
+
+function formatEntrySubtitle(entry: ChangelogEntry): string {
+  if (entry.version === 'current') return `As of ${formatSingleDate(entry.date)}`;
+  if (entry.version.startsWith('2026.02.02')) return 'Initial release';
+  return `Week of ${formatWeekRange(entry.date)}`;
+}
+
+function formatSingleDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(d);
+}
+
+interface WhatsNewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function WhatsNewDialog({ open, onOpenChange }: WhatsNewDialogProps) {
+  const entries = useMemo<ChangelogEntry[]>(
+    () => (data.current ? [data.current, ...data.releases] : data.releases),
+    [],
+  );
+
+  const [selectedVersion, setSelectedVersion] = useState<string>(
+    () => entries[0]?.version ?? '',
+  );
+
+  useEffect(() => {
+    if (open) markChangelogSeen();
+  }, [open]);
+
+  const selected = entries.find((e) => e.version === selectedVersion) ?? entries[0];
+  const latestReleaseVersion = data.releases[0]?.version;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl h-[72vh] p-0 flex flex-col overflow-hidden gap-0">
+        <DialogHeader className="px-6 pt-5 pb-3">
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            What's New
+          </DialogTitle>
+        </DialogHeader>
+        <Separator />
+        <div className="flex flex-1 overflow-hidden min-h-0">
+          <nav className="w-56 border-r shrink-0 bg-muted/20">
+            <ScrollArea className="h-full">
+              <ul className="p-2 space-y-0.5">
+                {entries.map((entry) => {
+                  const isCurrent = entry.version === 'current';
+                  const isSelected = selectedVersion === entry.version;
+                  return (
+                    <li key={entry.version}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedVersion(entry.version)}
+                        className={cn(
+                          'w-full text-left px-3 py-2 rounded-md text-sm transition-colors',
+                          isSelected ? 'bg-accent' : 'hover:bg-accent/50',
+                        )}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium truncate">
+                            {formatEntryLabel(entry)}
+                          </span>
+                          {isCurrent && (
+                            <span className="text-[10px] uppercase tracking-wide text-primary bg-primary/10 px-1.5 py-0.5 rounded shrink-0">
+                              New
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5 truncate">
+                          {formatEntrySubtitle(entry)}
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </ScrollArea>
+          </nav>
+          <ScrollArea className="flex-1 min-w-0">
+            {selected && <ChangelogEntryView entry={selected} />}
+          </ScrollArea>
+        </div>
+        <Separator />
+        <div className="px-6 py-3 flex justify-between items-center text-xs text-muted-foreground">
+          <span>{latestReleaseVersion ? `Released: v${latestReleaseVersion}` : 'Pre-release'}</span>
+          <a
+            href={`${GITHUB_REPO_URL}/blob/main/CHANGELOG.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:text-foreground hover:underline"
+          >
+            Full changelog
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChangelogEntryView({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <div className="px-6 py-5 space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">{formatEntryLabel(entry)}</h2>
+        <p className="text-sm text-muted-foreground">{formatEntrySubtitle(entry)}</p>
+      </header>
+
+      {entry.highlights && entry.highlights.length > 0 && (
+        <section className="rounded-lg border bg-primary/5 p-4 space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-primary">
+            Highlights
+          </h3>
+          <ul className="space-y-1.5">
+            {entry.highlights.map((highlight, i) => (
+              <li key={i} className="flex gap-2 text-sm">
+                <Sparkles className="h-4 w-4 text-primary shrink-0 mt-0.5" />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {GROUP_ORDER.map((groupKey) => {
+        const items = entry.groups[groupKey];
+        if (!items || items.length === 0) return null;
+        const { label, icon: Icon } = GROUP_CONFIG[groupKey];
+        return (
+          <section key={groupKey} className="space-y-2">
+            <h3 className="flex items-center gap-2 text-sm font-semibold">
+              <Icon className="h-4 w-4 text-muted-foreground" />
+              {label}
+            </h3>
+            <ul className="space-y-1.5 pl-6">
+              {items.map((item, i) => (
+                <li key={i} className="text-sm flex gap-2">
+                  <span className="text-muted-foreground shrink-0">•</span>
+                  <span>
+                    {item.scope && (
+                      <span className="text-xs text-muted-foreground font-mono mr-1.5">
+                        {item.scope}
+                      </span>
+                    )}
+                    {item.title}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/editor/components/whats-new-seen.ts
+++ b/src/features/editor/components/whats-new-seen.ts
@@ -1,0 +1,30 @@
+import changelogData from '@/data/changelog.json';
+import type { ChangelogFile } from '@/data/changelog-types';
+
+const data = changelogData as ChangelogFile;
+const LAST_SEEN_KEY = 'freecut:whatsNewLastSeen';
+
+export function getLatestIdentifier(): string {
+  if (data.current) return `current:${data.current.date}`;
+  return data.releases[0]?.version ?? '';
+}
+
+export function hasUnseenChangelog(): boolean {
+  if (typeof window === 'undefined') return false;
+  const latest = getLatestIdentifier();
+  if (!latest) return false;
+  try {
+    return window.localStorage.getItem(LAST_SEEN_KEY) !== latest;
+  } catch {
+    return false;
+  }
+}
+
+export function markChangelogSeen(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LAST_SEEN_KEY, getLatestIdentifier());
+  } catch {
+    // storage unavailable; ignore
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces a weekly CalVer changelog (`YYYY.MM.DD` = Monday of the week) with a rolling `current` entry that accumulates bullets across the week
- Backfills 9 historical weekly releases covering Feb–Apr 2026 from 1172 commits, with matching local git tags
- Adds a **What's New** dialog (Sparkles button in the toolbar, left of Settings) with an unseen-version indicator
- Automates append on every push to `main` via GitHub Action; weekly rollup via `npm run changelog:rollup`

## Architecture
- `src/data/changelog.json` — typed source of truth (`{ current, releases[] }`); imported by UI
- `CHANGELOG.md` — human-facing mirror
- `.claude/skills/changelog/SKILL.md` — skill for curation/rollup work (backfill/append/rollup modes)
- `scripts/changelog-append.mjs` — parses `feat`/`fix`/`perf` subjects, appends deduped bullets to `current`
- `scripts/changelog-rollup.mjs` — promotes `current` → tagged weekly release, bumps `package.json`, creates annotated tag
- `.github/workflows/changelog-append.yml` — runs append on push-to-main with `github.event.before..HEAD` range and full-depth checkout so merge-commit side branches are walkable

## Tags (local only, 9 total)
`v2026.02.02` `v2026.02.09` `v2026.02.16` `v2026.02.23` `v2026.03.09` `v2026.03.16` `v2026.03.23` `v2026.03.30` `v2026.04.06`

Push with `git push origin --tags` after this lands on main.

## Test plan
- [ ] Reload dev and click the new Sparkles button — dialog renders with weekly versions in the sidebar and `This Week` card at top
- [ ] Click through several weekly versions — highlights, added/fixed/improved groups render correctly
- [ ] Close and reopen — no unseen-dot after first open (localStorage writes `freecut:whatsNewLastSeen`)
- [ ] After this merges to main, check that the Action appends bullets to `current` (will include 2 meta-bullets for the changelog feature itself unless the merge message carries `[skip changelog]`)
- [ ] Dry-run `npm run changelog:rollup -- --date 2026-04-13` after the current week closes to verify rollup output

## Caveats
- Action uses `GITHUB_TOKEN`; self-pushes don't trigger further runs (belt-and-suspenders `if:` guard also filters on commit message)
- Append script produces raw dev-speak bullets; polish via the `changelog` skill before rollup
- `.claude/` is now partially tracked: `settings.local.json` and `worktrees/` stay ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "What's New" dialog in-app to browse recent release notes with highlights, grouped change lists, a notification dot for unseen updates, and a link to the full changelog.

* **Documentation**
  * Introduced a formal, versioned weekly changelog (CalVer weeks) with structured entries for Highlights, Added, Fixed, and Improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->