### PR TITLE
refactor(changelog): drop git tags from rollup flow

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -16,16 +16,17 @@ Both are generated from the same data. Always update both or neither.
 
 The changelog has two tiers:
 
-1. **`current`** — a single rolling entry for the in-progress week. It accumulates bullets as commits land, dedupes when the same feature is touched multiple times, and is shown in the UI as a "This Week" card. **Not tagged, not versioned with a final version number.**
-2. **`releases`** — one entry per completed week, newest first. Each has a version, a date, and a git tag.
+1. **`current`** — a single rolling entry for the in-progress week. It accumulates bullets as commits land, dedupes when the same feature is touched multiple times, and is shown in the UI as a "This Week" card.
+2. **`releases`** — one entry per completed week, newest first. Each has a version and a date.
 
 ### Versioning: CalVer, Monday-start weeks
 
 - Format: `YYYY.MM.DD` where the date is the **Monday** that opens the week (Mon–Sun).
-- Tag: `v2026.04.13` (leading `v`, always).
 - A week "closes" on Monday morning of the following week. Rollup is **manually triggered**.
 - If a mid-week hotfix needs its own release, add `.N` suffix (`2026.04.13.2`). Rare.
-- `package.json` `version` field mirrors the most recent released version.
+- `package.json` `version` field is the authoritative version — mirrors the most recent released week.
+
+**No git tags.** The web app ships continuously via Vercel; tags add maintenance overhead without buying anything. `changelog.json` + `package.json` are the source of truth. If GitHub Releases pages are wanted later, tag from `package.json` history at that point.
 
 Separate packages (future CLI/API) get their own semver and their own changelog under their package directory. This file is for the web app only.
 
@@ -62,12 +63,12 @@ Triggered manually on Monday to close the previous week.
 **Input**: none (reads `current` and today's date).
 
 **Process**:
-1. Determine last week's Monday date → new version `vYYYY.MM.DD`.
+1. Determine last week's Monday date → new version `YYYY.MM.DD`.
 2. Move `current` into `releases` with that version and the Monday date.
 3. Empty `current` (or seed with any commits landed since Monday).
 4. Bump `package.json` `version` to the new release.
-5. Create annotated tag locally: `git tag -a v<version> <mergeCommitSha> -m "<version> — <highlights>"`. The tag should point at the last PR merge commit of the closed week, not today's HEAD (since dev continues on develop).
-6. **Do not `git push --tags`** — print the plan and wait for user confirmation.
+5. Update `CHANGELOG.md` with the new entry at the top.
+6. Print the commit/push commands for the operator to run manually.
 
 ## Curation rules
 
@@ -161,18 +162,7 @@ All notable changes to FreeCut. Versioning follows weekly CalVer: `YYYY.MM.DD` =
 ...
 ```
 
-Do **not** include PR links in weekly entries. Weekly entries aggregate many PRs; PR links add noise. Optionally link the GitHub compare view at the bottom of each entry:
-
-```markdown
-[Compare](https://github.com/walterlow/freecut/compare/v2026.03.30...v2026.04.06)
-```
-
-## Git tag discipline
-
-- Always annotated (`git tag -a`), never lightweight.
-- Tag message = version + 1-line summary of highlights.
-- Tag points at the **last PR merge commit of that week** on `main`, not develop HEAD.
-- Print the plan (tag → sha → date) before creating tags; never push without the user asking.
+Do **not** include PR links in weekly entries. Weekly entries aggregate many PRs; PR links add noise.
 
 ## When in doubt
 

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog
-description: Maintain FreeCut's weekly changelog with a rolling current entry. Use when (1) backfilling historical weeks into CHANGELOG.md and src/data/changelog.json (backfill mode), (2) adding new bullets to the rolling current entry as commits land (append mode), or (3) closing the week and promoting current into a tagged weekly release (rollup mode). Handles commit curation, deduplication, version assignment, tag creation, and keeping both markdown and JSON artifacts in sync.
+description: Maintain FreeCut's weekly changelog with a rolling current entry. Use when (1) backfilling historical weeks into CHANGELOG.md and src/data/changelog.json (backfill mode), (2) adding new bullets to the rolling current entry as commits land (append mode), or (3) closing the week and promoting current into a weekly release (rollup mode). Handles commit curation, deduplication, version assignment, and keeping both markdown and JSON artifacts in sync.
 ---
 
 # Changelog skill
@@ -48,7 +48,7 @@ Pre-PR era (if any): collapse the entire foundation into a single initial releas
 
 Triggered ad-hoc to update `current` as new commits land.
 
-**Input**: commits since last read of `current` (or `git log v<lastTag>..HEAD` if current is empty).
+**Input**: commits since last read of `current`. When `current` is empty (just after a rollup), walk from the most recent `chore(release):` commit on `main` to HEAD.
 
 **Process**:
 1. Walk new commits, applying curation rules.

--- a/scripts/changelog-rollup.mjs
+++ b/scripts/changelog-rollup.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// Close the current week and promote `current` into a tagged weekly release.
+// Close the current week and promote `current` into a weekly release.
 //
 // Usage:
-//   node scripts/changelog-rollup.mjs             # tag at latest main merge commit
-//   node scripts/changelog-rollup.mjs <sha>       # tag at explicit commit
+//   node scripts/changelog-rollup.mjs
 //   node scripts/changelog-rollup.mjs --date YYYY-MM-DD
 //
 // Steps:
@@ -11,14 +10,13 @@
 //   2. Move `current` into `releases` with that version and date.
 //   3. Update CHANGELOG.md with the new entry.
 //   4. Bump package.json version.
-//   5. Create an annotated git tag locally.
 //
-// Does NOT commit, push, or publish tags. Operator runs:
-//   git add . && git commit -m "chore(release): v<version>"
-//   git push && git push --tags
+// Does NOT commit or push. Operator runs:
+//   git add src/data/changelog.json CHANGELOG.md package.json
+//   git commit -m "chore(release): v<version>"
+//   git push
 
 import { readFileSync, writeFileSync } from 'node:fs';
-import { execFileSync, execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -33,18 +31,15 @@ const GROUP_LABEL = { added: 'Added', fixed: 'Fixed', improved: 'Improved' };
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  let sha;
   let dateOverride;
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     if (a === '--date') {
       dateOverride = args[i + 1];
       i += 1;
-    } else if (!a.startsWith('--')) {
-      sha = a;
     }
   }
-  return { sha, dateOverride };
+  return { dateOverride };
 }
 
 function lastMondayIso(today = new Date()) {
@@ -59,14 +54,6 @@ function lastMondayIso(today = new Date()) {
   const daysBack = ((dayOfWeek + 6) % 7) + 7;
   d.setUTCDate(d.getUTCDate() - daysBack);
   return d.toISOString().slice(0, 10);
-}
-
-function formatWeekRange(mondayIso) {
-  const monday = new Date(`${mondayIso}T00:00:00Z`);
-  const sunday = new Date(monday.getTime() + 6 * 24 * 60 * 60 * 1000);
-  const fmt = (d) =>
-    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-  return `${fmt(monday)} to ${fmt(sunday)}`;
 }
 
 function loadJson(path) {
@@ -120,19 +107,10 @@ function insertIntoMarkdown(newEntryMd) {
   writeFileSync(CHANGELOG_MD, `${before}${newEntryMd}\n${after}`);
 }
 
-function latestMainMergeSha() {
-  const out = execSync(
-    'git log --first-parent main -1 --pretty=format:%H',
-    { encoding: 'utf8' },
-  ).trim();
-  return out;
-}
-
 function main() {
-  const { sha: shaArg, dateOverride } = parseArgs();
+  const { dateOverride } = parseArgs();
   const mondayIso = dateOverride ?? lastMondayIso();
   const version = mondayIso.replaceAll('-', '.');
-  const tagName = `v${version}`;
 
   const data = loadJson(CHANGELOG_JSON);
   if (!data.current || Object.keys(data.current.groups ?? {}).length === 0) {
@@ -163,28 +141,15 @@ function main() {
   pkg.version = version;
   writeJson(PACKAGE_JSON, pkg);
 
-  const sha = shaArg ?? latestMainMergeSha();
-  const highlightLine = releaseEntry.highlights?.[0] ?? `Week of ${formatWeekRange(mondayIso)}`;
-  const tagMessage = `${tagName} — ${highlightLine}`;
-
-  console.log(`\nTagging ${tagName} at ${sha.slice(0, 8)}`);
-  // Pass args as an array and bypass the shell so backticks, $(), or other
-  // metacharacters inside tagMessage can't be interpreted.
-  execFileSync('git', ['tag', '-a', tagName, sha, '-m', tagMessage], {
-    stdio: 'inherit',
-  });
-
   console.log(`
 Rollup complete.
   Version:   ${version}
-  Tag:       ${tagName} at ${sha.slice(0, 12)}
   Files:     src/data/changelog.json, CHANGELOG.md, package.json
 
 Next steps (run manually when ready):
   git add src/data/changelog.json CHANGELOG.md package.json
-  git commit -m "chore(release): ${tagName}"
+  git commit -m "chore(release): v${version}"
   git push
-  git push origin ${tagName}
 `);
 }
 

--- a/scripts/changelog-rollup.mjs
+++ b/scripts/changelog-rollup.mjs
@@ -13,7 +13,7 @@
 //
 // Does NOT commit or push. Operator runs:
 //   git add src/data/changelog.json CHANGELOG.md package.json
-//   git commit -m "chore(release): v<version>"
+//   git commit -m "chore(release): <version>"
 //   git push
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -148,7 +148,7 @@ Rollup complete.
 
 Next steps (run manually when ready):
   git add src/data/changelog.json CHANGELOG.md package.json
-  git commit -m "chore(release): v${version}"
+  git commit -m "chore(release): ${version}"
   git push
 `);
 }

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -44,6 +44,14 @@
         {
           "title": "Separate project master bus from per-device monitor volume",
           "scope": "audio"
+        },
+        {
+          "title": "add What's New dialog with weekly changelog viewer",
+          "scope": "editor"
+        },
+        {
+          "title": "weekly CalVer changelog with auto-append and rollup",
+          "scope": "changelog"
         }
       ],
       "fixed": [
@@ -70,6 +78,10 @@
         {
           "title": "UI accessibility, transition alpha, and viewport clamp fixes",
           "scope": "editor"
+        },
+        {
+          "title": "use github.event.before for range and full fetch depth",
+          "scope": "changelog"
         }
       ],
       "improved": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -46,12 +46,8 @@
           "scope": "audio"
         },
         {
-          "title": "add What's New dialog with weekly changelog viewer",
+          "title": "What's New dialog shows weekly changelog",
           "scope": "editor"
-        },
-        {
-          "title": "weekly CalVer changelog with auto-append and rollup",
-          "scope": "changelog"
         }
       ],
       "fixed": [
@@ -78,10 +74,6 @@
         {
           "title": "UI accessibility, transition alpha, and viewport clamp fixes",
           "scope": "editor"
-        },
-        {
-          "title": "use github.event.before for range and full fetch depth",
-          "scope": "changelog"
         }
       ],
       "improved": [


### PR DESCRIPTION
## Summary
- Removes git tag creation from the rollup script and skill doc
- Deletes the 9 local weekly tags (never pushed; no remote cleanup needed)
- Makes `package.json` version the authoritative source for released state

## Why
The web app ships continuously via Vercel. Git tags don't gate deploys, don't pin consumers, and aren't used by the "What's New" dialog (which reads `changelog.json`). They were ceremony without payoff. `changelog.json` + `package.json` is enough.

If GitHub Releases landing pages are wanted later, we can tag from `package.json` history at that point.

## Changes
- `scripts/changelog-rollup.mjs`: removed `git tag -a` call, the `--sha` arg, `latestMainMergeSha()`, `formatWeekRange()`, `execFileSync` import
- `.claude/skills/changelog/SKILL.md`: dropped "Git tag discipline" section; clarified `package.json` is authoritative

## Test plan
- [ ] Run `npm run changelog:rollup -- --date 2099-01-05` in a dirty branch to verify the rollup still produces `changelog.json`, `CHANGELOG.md`, `package.json` updates and prints the commit/push hint
- [ ] Confirm no stray tag is created (`git tag -l` shows none afterward)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly "What's New" dialog to view recent changelog updates directly in the editor.

* **Improvements**
  * Updated changelog handling and rollup workflow for clearer, manual release steps.

* **Documentation**
  * Simplified versioning guidance to use YYYY.MM.DD (no "v" prefix) and removed automated git-tag instructions and optional compare-link guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->