### PR TITLE
Media library, preview, and workspace-fs v2 improvements

### DIFF
--- a/src/components/marquee-overlay.tsx
+++ b/src/components/marquee-overlay.tsx
@@ -1,8 +1,9 @@
-import { getMarqueeRect, type MarqueeState } from '@/hooks/use-marquee-selection';
+import { useSyncExternalStore } from 'react';
+import { getMarqueeRect, type MarqueeController } from '@/hooks/use-marquee-selection';
 
 interface MarqueeOverlayProps {
-  /** Current marquee state */
-  marqueeState: MarqueeState;
+  /** Subscription-based controller returned from `useMarqueeSelection` */
+  marquee: MarqueeController;
 
   /** Custom className for styling */
   className?: string;
@@ -12,29 +13,16 @@ interface MarqueeOverlayProps {
  * Visual overlay for marquee selection rectangle
  *
  * Renders a draggable selection box that appears when the user
- * click-drags to select multiple items.
- *
- * @example
- * ```tsx
- * const { marqueeState } = useMarqueeSelection({ ... });
- *
- * return (
- *   <div className="relative">
- *     <MarqueeOverlay marqueeState={marqueeState} />
- *     {items.map(item => <Item key={item.id} />)}
- *   </div>
- * );
- * ```
+ * click-drags to select multiple items. Subscribes directly to the
+ * marquee controller so only this component re-renders per pointer move —
+ * the tree above stays quiet.
  */
-export function MarqueeOverlay({ marqueeState, className }: MarqueeOverlayProps) {
-  if (!marqueeState.active) return null;
+export function MarqueeOverlay({ marquee, className }: MarqueeOverlayProps) {
+  const state = useSyncExternalStore(marquee.subscribe, marquee.getSnapshot, marquee.getSnapshot);
 
-  const rect = getMarqueeRect(
-    marqueeState.startX,
-    marqueeState.startY,
-    marqueeState.currentX,
-    marqueeState.currentY
-  );
+  if (!state.active) return null;
+
+  const rect = getMarqueeRect(state.startX, state.startY, state.currentX, state.currentY);
 
   return (
     <div

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -83,6 +83,24 @@ const ContextMenuItem = React.forwardRef<
 ))
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
 
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName
+
 const ContextMenuSeparator = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
@@ -116,6 +134,7 @@ export {
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuShortcut,
   ContextMenuSub,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/features/composition-runtime/utils/preview-audio-conform.ts
+++ b/src/features/composition-runtime/utils/preview-audio-conform.ts
@@ -151,7 +151,7 @@ export async function deletePreviewAudioConform(
   pendingPreviewAudioConformPersists.delete(mediaId);
   blobUrlManager.invalidate(getPreviewAudioConformCacheKey(mediaId));
 
-  void removeWorkspaceCacheEntry(previewAudioPath(mediaId));
+  await removeWorkspaceCacheEntry(previewAudioPath(mediaId));
 
   if (media?.previewAudioOpfsPath) {
     const legacyPath = media.previewAudioOpfsPath;

--- a/src/features/composition-runtime/utils/preview-audio-conform.ts
+++ b/src/features/composition-runtime/utils/preview-audio-conform.ts
@@ -14,17 +14,10 @@ import { audioBufferToWavBlob } from './audio-buffer-wav';
 
 const log = createLogger('PreviewAudioConform');
 
-const PREVIEW_AUDIO_CONFORM_DIR = 'preview-audio';
 const PREVIEW_AUDIO_CONFORM_MIME_TYPE = 'audio/wav';
 
 const pendingPreviewAudioConformLoads = new Map<string, Promise<string | null>>();
 const pendingPreviewAudioConformPersists = new Map<string, Promise<void>>();
-
-function buildPreviewAudioConformPath(mediaId: string): string {
-  const shard1 = mediaId.slice(0, 2) || '00';
-  const shard2 = mediaId.slice(2, 4) || '00';
-  return `${PREVIEW_AUDIO_CONFORM_DIR}/${shard1}/${shard2}/${mediaId}.wav`;
-}
 
 export function getPreviewAudioConformCacheKey(mediaId: string): string {
   return `preview-audio:${mediaId}`;
@@ -49,13 +42,12 @@ export async function resolvePreviewAudioConformUrl(mediaId: string): Promise<st
   const promise = (async () => {
     try {
       const media = await getMedia(mediaId);
-      if (!media?.previewAudioOpfsPath) {
+      if (!media?.previewAudioConformedAt && !media?.previewAudioOpfsPath) {
         return null;
       }
-      const persistedPath = media.previewAudioOpfsPath;
       const mimeType = media.previewAudioMimeType || PREVIEW_AUDIO_CONFORM_MIME_TYPE;
 
-      const workspaceBlob = await readWorkspaceBlob(previewAudioPath(persistedPath));
+      const workspaceBlob = await readWorkspaceBlob(previewAudioPath(mediaId));
       if (workspaceBlob) {
         return blobUrlManager.acquire(
           cacheKey,
@@ -63,13 +55,18 @@ export async function resolvePreviewAudioConformUrl(mediaId: string): Promise<st
         );
       }
 
-      // Legacy fallback: older sessions wrote only to OPFS. If found there,
-      // hydrate the workspace copy so subsequent reads stay workspace-first.
+      // Legacy fallback: older sessions wrote only to OPFS under a sharded
+      // path recorded in `previewAudioOpfsPath`. If found there, hydrate the
+      // workspace v2 copy so subsequent reads stay workspace-first.
+      const legacyPath = media.previewAudioOpfsPath;
+      if (!legacyPath) {
+        return null;
+      }
       try {
-        const bytes = await opfsService.getFile(persistedPath);
+        const bytes = await opfsService.getFile(legacyPath);
         await writeBlob(
           requireWorkspaceRoot(),
-          previewAudioPath(persistedPath),
+          previewAudioPath(mediaId),
           new Uint8Array(bytes),
         );
         return blobUrlManager.acquire(
@@ -79,7 +76,7 @@ export async function resolvePreviewAudioConformUrl(mediaId: string): Promise<st
       } catch (err) {
         log.warn('Failed to resolve preview audio conform asset from legacy OPFS', {
           mediaId,
-          path: persistedPath,
+          path: legacyPath,
           err,
         });
         return null;
@@ -120,16 +117,14 @@ export async function persistPreviewAudioConform(
     }
 
     const nextBlob = wavBlob ?? audioBufferToWavBlob(buffer);
-    const persistedPath = media.previewAudioOpfsPath ?? buildPreviewAudioConformPath(mediaId);
     const bytes = await nextBlob.arrayBuffer();
     await writeBlob(
       requireWorkspaceRoot(),
-      previewAudioPath(persistedPath),
+      previewAudioPath(mediaId),
       new Uint8Array(bytes),
     );
 
     await updateMedia(mediaId, {
-      previewAudioOpfsPath: persistedPath,
       previewAudioMimeType: PREVIEW_AUDIO_CONFORM_MIME_TYPE,
       previewAudioConformedAt: Date.now(),
     });
@@ -156,25 +151,22 @@ export async function deletePreviewAudioConform(
   pendingPreviewAudioConformPersists.delete(mediaId);
   blobUrlManager.invalidate(getPreviewAudioConformCacheKey(mediaId));
 
-  if (!media) {
-    return;
-  }
+  void removeWorkspaceCacheEntry(previewAudioPath(mediaId));
 
-  if (media.previewAudioOpfsPath) {
-    const persistedPath = media.previewAudioOpfsPath;
+  if (media?.previewAudioOpfsPath) {
+    const legacyPath = media.previewAudioOpfsPath;
     try {
-      await opfsService.deleteFile(persistedPath);
+      await opfsService.deleteFile(legacyPath);
     } catch (err) {
       log.debug('Legacy OPFS preview audio conform asset was already absent or unreadable', {
         mediaId,
-        path: persistedPath,
+        path: legacyPath,
         err,
       });
     }
-    void removeWorkspaceCacheEntry(previewAudioPath(persistedPath));
   }
 
-  if (options?.clearMetadata) {
+  if (options?.clearMetadata && media) {
     try {
       await updateMedia(mediaId, {
         previewAudioOpfsPath: undefined,

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -32,6 +32,7 @@ import { useEditorStore } from '@/app/state/editor';
 import { clearPreviewAudioCache } from '@/features/editor/deps/composition-runtime';
 import { useProjectStore } from '@/features/editor/deps/projects';
 import { importExportDialog } from '@/features/editor/deps/export-contract';
+import { prewarmEffectPreviews } from '@/features/editor/deps/effects-contract';
 import { getEditorLayout, getEditorLayoutCssVars } from '@/app/editor-layout';
 import { createProjectUpgradeBackup, formatProjectUpgradeBackupName } from '@/features/editor/deps/projects';
 import { ProjectUpgradeDialog } from './project-upgrade-dialog';
@@ -237,6 +238,13 @@ export const LoadedEditor = memo(function LoadedEditor({
       preloadExportDialog();
       preloadBundleExportDialog();
     });
+    return () => cancelIdleCallback(id);
+  }, []);
+
+  // Prewarm effect preview thumbnails so the Add Effect picker has no
+  // placeholder → image flash on first open.
+  useEffect(() => {
+    const id = requestIdleCallback(() => prewarmEffectPreviews());
     return () => cancelIdleCallback(id);
   }, []);
 

--- a/src/features/editor/deps/effects-contract.ts
+++ b/src/features/editor/deps/effects-contract.ts
@@ -4,5 +4,5 @@
  */
 
 export { EffectsSection } from '@/features/effects/components/effects-section';
-export { useEffectPreviews } from '@/features/effects/hooks/use-effect-previews';
+export { useEffectPreviews, prewarmEffectPreviews } from '@/features/effects/hooks/use-effect-previews';
 export type { EffectPreviewEntry } from '@/features/effects/hooks/use-effect-previews';

--- a/src/features/effects/components/effects-section.tsx
+++ b/src/features/effects/components/effects-section.tsx
@@ -246,6 +246,18 @@ export const EffectsSection = memo(function EffectsSection({ items }: EffectsSec
   const openPicker = useCallback(() => {
     triggerPreviews();
     setSearchQuery('');
+    // Measure the trigger synchronously so the portal mounts already
+    // positioned — otherwise the first render flashes a full-width,
+    // unconstrained panel before the positioning effect runs.
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPanelStyle({
+        position: 'fixed',
+        top: `${rect.bottom + 4}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`,
+      });
+    }
     setPickerOpen(true);
   }, [triggerPreviews]);
 
@@ -255,17 +267,9 @@ export const EffectsSection = memo(function EffectsSection({ items }: EffectsSec
     triggerRef.current?.blur();
   }, []);
 
-  // Position panel when opened
+  // Focus the search input after the panel mounts.
   useEffect(() => {
-    if (!pickerOpen || !triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setPanelStyle({
-      position: 'fixed',
-      top: `${rect.bottom + 4}px`,
-      left: `${rect.left}px`,
-      width: `${rect.width}px`,
-    });
-    // Focus search input after render
+    if (!pickerOpen) return;
     requestAnimationFrame(() => searchInputRef.current?.focus());
   }, [pickerOpen]);
 

--- a/src/features/effects/hooks/use-effect-previews.ts
+++ b/src/features/effects/hooks/use-effect-previews.ts
@@ -10,8 +10,8 @@
  * only need to be generated once per session.
  */
 
-import { useState, useCallback, useRef } from 'react';
-import { EffectsPipeline } from '@/infrastructure/gpu/effects';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { EffectsPipeline, getGpuCategoriesWithEffects } from '@/infrastructure/gpu/effects';
 import type { GpuEffectInstance, GpuEffectDefinition } from '@/infrastructure/gpu/effects';
 import { EFFECT_PRESETS } from '@/types/effects';
 
@@ -22,6 +22,10 @@ const PREVIEW_HEIGHT = 45;
 const previewCache = new Map<string, string>();
 let pipelineInstance: EffectsPipeline | null = null;
 let pipelinePromise: Promise<EffectsPipeline | null> | null = null;
+// Shared generation guard — both `trigger()` and `prewarmEffectPreviews()`
+// route through this so the render loop runs at most once per session.
+let generationPromise: Promise<void> | null = null;
+const generationListeners = new Set<() => void>();
 
 async function getOrCreatePipeline(): Promise<EffectsPipeline | null> {
   if (pipelineInstance) return pipelineInstance;
@@ -164,6 +168,72 @@ export interface EffectPreviewEntry {
 }
 
 /**
+ * Generate blob URLs for every registered GPU effect + preset into the
+ * module-level cache. Idempotent — concurrent callers share one promise,
+ * and subsequent calls after completion no-op. Failures (no GPU, etc.) are
+ * swallowed so callers can treat this as fire-and-forget.
+ */
+function generateAllPreviews(): Promise<void> {
+  if (generationPromise) return generationPromise;
+
+  generationPromise = (async () => {
+    const pipeline = await getOrCreatePipeline();
+    if (!pipeline) return;
+
+    const source = createSampleCanvas();
+
+    for (const { effects } of getGpuCategoriesWithEffects()) {
+      for (const def of effects) {
+        if (previewCache.has(def.id)) continue;
+        const url = await renderEffectPreview(pipeline, source, def.id, def);
+        if (url) {
+          previewCache.set(def.id, url);
+          generationListeners.forEach((fn) => fn());
+        }
+      }
+    }
+
+    for (const preset of EFFECT_PRESETS) {
+      const cacheKey = `preset:${preset.id}`;
+      if (previewCache.has(cacheKey)) continue;
+      const url = await renderPresetPreview(pipeline, source, preset.id);
+      if (url) {
+        previewCache.set(cacheKey, url);
+        generationListeners.forEach((fn) => fn());
+      }
+    }
+  })();
+
+  return generationPromise;
+}
+
+/**
+ * Kick off GPU-rendering of all effect preview thumbnails into the shared
+ * cache. Safe to call on editor mount (via `requestIdleCallback`) so that
+ * by the time the user opens the Add Effect picker, the cache is warm and
+ * no placeholder → thumbnail flash occurs.
+ */
+export function prewarmEffectPreviews(): void {
+  void generateAllPreviews();
+}
+
+function buildPreviewsMap(
+  effects: EffectPreviewEntry[],
+  presetIds: string[],
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const { id } of effects) {
+    const url = previewCache.get(id);
+    if (url) result.set(id, url);
+  }
+  for (const id of presetIds) {
+    const url = previewCache.get(`preset:${id}`);
+    if (url) result.set(`preset:${id}`, url);
+  }
+  return result;
+}
+
+/**
  * Hook that generates GPU-rendered preview thumbnails for effects.
  *
  * Returns a Map of effect/preset ID → blob URL, plus a trigger function.
@@ -174,63 +244,34 @@ export function useEffectPreviews(
   effects: EffectPreviewEntry[],
   presetIds: string[],
 ): { previews: Map<string, string>; trigger: () => void } {
-  const [previews, setPreviews] = useState<Map<string, string>>(() => {
-    // Populate from module-level cache on mount
-    const cached = new Map<string, string>();
-    for (const { id } of effects) {
-      const url = previewCache.get(id);
-      if (url) cached.set(id, url);
-    }
-    for (const id of presetIds) {
-      const url = previewCache.get(`preset:${id}`);
-      if (url) cached.set(`preset:${id}`, url);
-    }
-    return cached;
-  });
+  const [previews, setPreviews] = useState<Map<string, string>>(() =>
+    buildPreviewsMap(effects, presetIds),
+  );
 
-  const generatingRef = useRef(false);
+  // Keep latest args in refs so the listener always sees current inputs
+  // without re-subscribing every render.
+  const effectsRef = useRef(effects);
+  const presetIdsRef = useRef(presetIds);
+  effectsRef.current = effects;
+  presetIdsRef.current = presetIds;
+
+  // Subscribe to cache updates from concurrent prewarm/trigger calls so the
+  // UI reflects entries as they stream in, not only at the end.
+  useEffect(() => {
+    const listener = () => {
+      setPreviews(buildPreviewsMap(effectsRef.current, presetIdsRef.current));
+    };
+    generationListeners.add(listener);
+    // Sync once on mount in case generation finished before subscribing.
+    listener();
+    return () => {
+      generationListeners.delete(listener);
+    };
+  }, []);
 
   const trigger = useCallback(() => {
-    const allIds = [
-      ...effects.map(({ id }) => id),
-      ...presetIds.map((id) => `preset:${id}`),
-    ];
-    const missing = allIds.filter((id) => !previewCache.has(id));
-    if (missing.length === 0 || generatingRef.current) return;
-
-    generatingRef.current = true;
-
-    (async () => {
-      const pipeline = await getOrCreatePipeline();
-      if (!pipeline) {
-        generatingRef.current = false;
-        return;
-      }
-
-      const source = createSampleCanvas();
-
-      for (const { id, def } of effects) {
-        if (previewCache.has(id)) continue;
-        const url = await renderEffectPreview(pipeline, source, id, def);
-        if (url) previewCache.set(id, url);
-      }
-
-      for (const presetId of presetIds) {
-        const cacheKey = `preset:${presetId}`;
-        if (previewCache.has(cacheKey)) continue;
-        const url = await renderPresetPreview(pipeline, source, presetId);
-        if (url) previewCache.set(cacheKey, url);
-      }
-
-      const result = new Map<string, string>();
-      for (const id of allIds) {
-        const url = previewCache.get(id);
-        if (url) result.set(id, url);
-      }
-      setPreviews(result);
-      generatingRef.current = false;
-    })();
-  }, [effects, presetIds]);
+    void generateAllPreviews();
+  }, []);
 
   return { previews, trigger };
 }

--- a/src/features/export/deps/timeline-contract.ts
+++ b/src/features/export/deps/timeline-contract.ts
@@ -5,6 +5,7 @@
 
 export { useTimelineStore } from '@/features/timeline/stores/timeline-store';
 export { useCompositionsStore } from '@/features/timeline/stores/compositions-store';
+export type { SubComposition } from '@/features/timeline/stores/compositions-store';
 export { resolveEffectiveTrackStates } from '@/features/timeline/utils/group-utils';
 export {
   timelineToSourceFrames,

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -188,6 +188,8 @@ export interface SubCompRenderData {
   }>;
   /** O(1) keyframe lookup by item ID */
   keyframesMap: Map<string, ItemKeyframes>;
+  /** Adjustment layers from visible tracks, with their track orders */
+  adjustmentLayers?: AdjustmentLayerWithTrackOrder[];
 }
 
 export interface TransitionParticipantRenderState<TItem extends TimelineItem = TimelineItem> {
@@ -1446,6 +1448,8 @@ async function renderCompositionItem(
       }
     }
 
+    const subAdjustmentLayers = subData.adjustmentLayers ?? [];
+
     let renderedSubItems = 0;
     for (const track of subData.sortedTracks) {
       if (!track.visible) continue;
@@ -1477,15 +1481,56 @@ async function renderCompositionItem(
           });
         }
 
-        if (applicableMasks.length === 0) {
+        const itemEffects = (
+          rctx.renderMode === 'preview'
+            ? rctx.getPreviewEffectsOverride?.(subItem.id)
+            : undefined
+        ) ?? subItem.effects;
+        const adjEffects = getAdjustmentLayerEffects(
+          track.order,
+          subAdjustmentLayers,
+          localFrame,
+          rctx.renderMode === 'preview' ? rctx.getPreviewEffectsOverride : undefined,
+          rctx.renderMode === 'preview' ? rctx.getLiveItemSnapshotById : undefined,
+        );
+        const combinedEffects = combineEffects(itemEffects, adjEffects);
+        const hasEffects = combinedEffects.length > 0;
+
+        if (!hasEffects && applicableMasks.length === 0) {
           await renderItem(subContentCtx, subItem, subItemTransform, localFrame, subRctx);
-        } else {
+        } else if (!hasEffects) {
           const { canvas: maskedItemCanvas, ctx: maskedItemCtx } = rctx.canvasPool.acquire();
           try {
+            maskedItemCanvas.width = item.compositionWidth;
+            maskedItemCanvas.height = item.compositionHeight;
+            maskedItemCtx.clearRect(0, 0, maskedItemCanvas.width, maskedItemCanvas.height);
             await renderItem(maskedItemCtx, subItem, subItemTransform, localFrame, subRctx);
             applyMasks(subContentCtx, maskedItemCanvas, applicableMasks, subMaskSettings);
           } finally {
             rctx.canvasPool.release(maskedItemCanvas);
+          }
+        } else {
+          const { canvas: itemCanvas, ctx: itemCtx } = rctx.canvasPool.acquire();
+          itemCanvas.width = item.compositionWidth;
+          itemCanvas.height = item.compositionHeight;
+          itemCtx.clearRect(0, 0, itemCanvas.width, itemCanvas.height);
+          try {
+            await renderItem(itemCtx, subItem, subItemTransform, localFrame, subRctx);
+            const { source, poolCanvases } = await renderEffectsFromMaskedSource(
+              rctx.canvasPool,
+              itemCanvas,
+              combinedEffects,
+              applicableMasks,
+              localFrame,
+              subMaskSettings,
+              rctx.gpuPipeline,
+            );
+            subContentCtx.drawImage(source, 0, 0);
+            for (const poolCanvas of poolCanvases) {
+              rctx.canvasPool.release(poolCanvas);
+            }
+          } finally {
+            rctx.canvasPool.release(itemCanvas);
           }
         }
         renderedSubItems++;

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -1464,6 +1464,11 @@ async function renderCompositionItem(
         if (subItem.type === 'shape' && subItem.isMask) {
           continue;
         }
+        // Adjustment layers are applied via getAdjustmentLayerEffects; they
+        // are not renderable visible content themselves.
+        if (subItem.type === 'adjustment') {
+          continue;
+        }
 
         const subItemKeyframes = subData.keyframesMap.get(subItem.id);
         const subItemTransform = getAnimatedTransform(subItem, subItemKeyframes, localFrame, subCanvasSettings);

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -710,7 +710,11 @@ export async function createCompositionRenderer(
   };
 
   return {
-    async preload(options: { priorityFrame?: number; priorityWindowFrames?: number } = {}) {
+    async preload(options: {
+      priorityFrame?: number;
+      priorityWindowFrames?: number;
+      onPriorityMediaReady?: () => void;
+    } = {}) {
       // Composition items require the compositions store which only exists on main thread.
       // Workers get a fresh, empty Zustand store, so sub-comp data can never be resolved.
       // Bail early to trigger the main-thread fallback path.
@@ -958,6 +962,18 @@ export async function createCompositionRenderer(
         if (prioritizedSubVideoItemIds.length > 0) {
           await initializeMediabunnyForItems(prioritizedSubVideoItemIds);
         }
+
+        // Signal that priority media for the current frame is ready. The
+        // preview controller uses this to trigger a re-render before the
+        // rest of preload (remaining videos, sub images, GIF/WebP frames)
+        // finishes — so the user sees the correct frame faster after
+        // exiting a sub-composition.
+        try {
+          options.onPriorityMediaReady?.();
+        } catch (err) {
+          getLog().warn('onPriorityMediaReady callback threw', { error: err });
+        }
+
         const remainingSubVideoItemIds = subVideoItemIds.filter(
           (itemId) => !prioritySubCompVideoItemIds.has(itemId)
         );

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -58,7 +58,7 @@ import { isGifUrl, isWebpUrl } from '@/shared/utils/media-utils';
 import { CanvasPool, TextMeasurementCache } from './canvas-pool';
 import { SharedVideoExtractorPool, type VideoFrameSource } from './shared-video-extractor';
 import { getCompositeOperation } from '@/types/blend-mode-css';
-import { useCompositionsStore } from '@/features/export/deps/timeline';
+import { useCompositionsStore, type SubComposition } from '@/features/export/deps/timeline';
 import { doesMaskAffectTrack } from '@/shared/utils/mask-scope';
 import type { FrameInvalidationRequest } from '@/shared/utils/frame-invalidation';
 import { collectReachableCompositionIdsFromItems, collectReachableCompositionIdsFromTracks } from '@/features/export/deps/timeline';
@@ -480,8 +480,44 @@ export async function createCompositionRenderer(
   const inFlightInitByItem = new Map<string, Promise<boolean>>();
   let isDisposed = false;
 
-  // Pre-computed sub-composition render data (populated during preload)
+  // Pre-computed sub-composition render data. Populated synchronously at
+  // renderer creation (so the first renderFrame sees compound-clip structure
+  // even before preload finishes) and refreshed during preload.
   const subCompRenderData = new Map<string, SubCompRenderData>();
+
+  const buildSubCompRenderDataEntry = (subComp: SubComposition): SubCompRenderData => {
+    const sorted = [...subComp.tracks].sort(
+      (a, b) => (b.order ?? 0) - (a.order ?? 0)
+    );
+    const sortedWithItems = sorted.map((t) => ({
+      order: t.order ?? 0,
+      visible: t.visible !== false,
+      items: subComp.items.filter(
+        (i) => i.trackId === t.id && i.type !== 'audio' && i.type !== 'adjustment'
+      ),
+    }));
+    const subKfMap = new Map<string, ItemKeyframes>();
+    for (const kf of subComp.keyframes ?? []) {
+      subKfMap.set(kf.itemId, kf);
+    }
+    const subAdjustmentLayers: AdjustmentLayerWithTrackOrder[] = [];
+    for (const t of subComp.tracks) {
+      if (t.visible === false) continue;
+      const trackOrder = t.order ?? 0;
+      for (const i of subComp.items) {
+        if (i.trackId === t.id && i.type === 'adjustment') {
+          subAdjustmentLayers.push({ layer: i, trackOrder });
+        }
+      }
+    }
+    return {
+      fps: subComp.fps,
+      durationInFrames: subComp.durationInFrames,
+      sortedTracks: sortedWithItems,
+      keyframesMap: subKfMap,
+      adjustmentLayers: subAdjustmentLayers,
+    };
+  };
   const PREWARM_DECODE_MAX_ITEMS = 6;
   let prewarmCanvas: OffscreenCanvas | HTMLCanvasElement | null = null;
   let prewarmCtx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null = null;
@@ -516,6 +552,24 @@ export async function createCompositionRenderer(
     gpuTransitionPipeline: null,
     domVideoElementProvider,
   };
+
+  // Synchronously populate sub-comp render data from the current compositions
+  // store. Without this, the first renderFrame after creation would fall into
+  // the `if (!subData) return;` path in renderCompositionItem and skip all
+  // compound clips — producing a black frame until preload() finishes.
+  {
+    const initialCompositionById = useCompositionsStore.getState().compositionById;
+    const initialReachableIds = collectReachableCompositionIdsFromTracks(
+      tracks,
+      initialCompositionById,
+    );
+    for (const compositionId of initialReachableIds) {
+      const subComp = initialCompositionById[compositionId];
+      if (!subComp) continue;
+      if (subCompRenderData.has(compositionId)) continue;
+      subCompRenderData.set(compositionId, buildSubCompRenderDataEntry(subComp));
+    }
+  }
 
   const getPrewarmContext = (): OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null => {
     if (prewarmAttempted) return prewarmCtx;
@@ -851,41 +905,7 @@ export async function createCompositionRenderer(
         }
 
         if (!subCompRenderData.has(compositionId)) {
-          const sorted = [...subComp.tracks].sort(
-            (a, b) => (b.order ?? 0) - (a.order ?? 0)
-          );
-          const sortedWithItems = sorted.map((t) => ({
-            order: t.order ?? 0,
-            visible: t.visible !== false,
-            items: subComp.items.filter(
-              (i) => i.trackId === t.id && i.type !== 'audio' && i.type !== 'adjustment'
-            ),
-          }));
-          const subKfMap = new Map<string, ItemKeyframes>();
-          for (const kf of subComp.keyframes ?? []) {
-            subKfMap.set(kf.itemId, kf);
-          }
-
-          // Collect adjustment layers from VISIBLE tracks so their effects apply
-          // to items below them inside the sub-composition (parity with main timeline).
-          const subAdjustmentLayers: AdjustmentLayerWithTrackOrder[] = [];
-          for (const t of subComp.tracks) {
-            if (t.visible === false) continue;
-            const trackOrder = t.order ?? 0;
-            for (const i of subComp.items) {
-              if (i.trackId === t.id && i.type === 'adjustment') {
-                subAdjustmentLayers.push({ layer: i, trackOrder });
-              }
-            }
-          }
-
-          subCompRenderData.set(compositionId, {
-            fps: subComp.fps,
-            durationInFrames: subComp.durationInFrames,
-            sortedTracks: sortedWithItems,
-            keyframesMap: subKfMap,
-            adjustmentLayers: subAdjustmentLayers,
-          });
+          subCompRenderData.set(compositionId, buildSubCompRenderDataEntry(subComp));
         }
 
         for (const subItem of subComp.items) {

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -553,23 +553,28 @@ export async function createCompositionRenderer(
     domVideoElementProvider,
   };
 
+  // Track the SubComposition identity we last built each entry from so we only
+  // rebuild when the Zustand store produced a new reference (effects added,
+  // items changed, etc.). Using reference equality keeps the per-frame cost
+  // near-zero when nothing edited the sub-comp.
+  const subCompRenderDataSource = new Map<string, SubComposition>();
+
+  const refreshSubCompRenderData = (compositionById: Record<string, SubComposition>) => {
+    const reachableIds = collectReachableCompositionIdsFromTracks(tracks, compositionById);
+    for (const compositionId of reachableIds) {
+      const subComp = compositionById[compositionId];
+      if (!subComp) continue;
+      if (subCompRenderDataSource.get(compositionId) === subComp) continue;
+      subCompRenderData.set(compositionId, buildSubCompRenderDataEntry(subComp));
+      subCompRenderDataSource.set(compositionId, subComp);
+    }
+  };
+
   // Synchronously populate sub-comp render data from the current compositions
   // store. Without this, the first renderFrame after creation would fall into
   // the `if (!subData) return;` path in renderCompositionItem and skip all
   // compound clips — producing a black frame until preload() finishes.
-  {
-    const initialCompositionById = useCompositionsStore.getState().compositionById;
-    const initialReachableIds = collectReachableCompositionIdsFromTracks(
-      tracks,
-      initialCompositionById,
-    );
-    for (const compositionId of initialReachableIds) {
-      const subComp = initialCompositionById[compositionId];
-      if (!subComp) continue;
-      if (subCompRenderData.has(compositionId)) continue;
-      subCompRenderData.set(compositionId, buildSubCompRenderDataEntry(subComp));
-    }
-  }
+  refreshSubCompRenderData(useCompositionsStore.getState().compositionById);
 
   const getPrewarmContext = (): OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null => {
     if (prewarmAttempted) return prewarmCtx;
@@ -908,8 +913,9 @@ export async function createCompositionRenderer(
           continue;
         }
 
-        if (!subCompRenderData.has(compositionId)) {
+        if (subCompRenderDataSource.get(compositionId) !== subComp) {
           subCompRenderData.set(compositionId, buildSubCompRenderDataEntry(subComp));
+          subCompRenderDataSource.set(compositionId, subComp);
         }
 
         for (const subItem of subComp.items) {
@@ -1142,6 +1148,16 @@ export async function createCompositionRenderer(
           ctx.drawImage(cached, 0, 0);
           return;
         }
+      }
+
+      // Refresh sub-comp render data so edits inside compound clips (effects,
+      // items, keyframes) show up during playback. Reference-equality keeps
+      // unchanged compositions at ~zero cost; only mutated entries rebuild.
+      // This matters for nested compounds where `renderCompositionItem` reads
+      // sub-item effects directly from the cached snapshot — without this
+      // refresh, effects added after renderer creation stay invisible.
+      if (renderMode === 'preview') {
+        refreshSubCompRenderData(useCompositionsStore.getState().compositionById);
       }
 
       // Clear canvas
@@ -1977,6 +1993,7 @@ export async function createCompositionRenderer(
       imageElements.clear();
       gifFramesMap.clear(); // Clear GIF frame references (actual frames are managed by gifFrameCache)
       subCompRenderData.clear(); // Release sub-composition render data references
+      subCompRenderDataSource.clear();
       prewarmCtx = null;
       prewarmCanvas = null;
       prewarmAttempted = false;

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -866,11 +866,25 @@ export async function createCompositionRenderer(
             subKfMap.set(kf.itemId, kf);
           }
 
+          // Collect adjustment layers from VISIBLE tracks so their effects apply
+          // to items below them inside the sub-composition (parity with main timeline).
+          const subAdjustmentLayers: AdjustmentLayerWithTrackOrder[] = [];
+          for (const t of subComp.tracks) {
+            if (t.visible === false) continue;
+            const trackOrder = t.order ?? 0;
+            for (const i of subComp.items) {
+              if (i.trackId === t.id && i.type === 'adjustment') {
+                subAdjustmentLayers.push({ layer: i, trackOrder });
+              }
+            }
+          }
+
           subCompRenderData.set(compositionId, {
             fps: subComp.fps,
             durationInFrames: subComp.durationInFrames,
             sortedTracks: sortedWithItems,
             keyframesMap: subKfMap,
+            adjustmentLayers: subAdjustmentLayers,
           });
         }
 
@@ -1135,15 +1149,34 @@ export async function createCompositionRenderer(
         });
       }
 
+      const hasGpuEffects = (effects: TimelineItem['effects']): boolean =>
+        effects?.some((e) => e.enabled && e.effect.type === 'gpu-effect') ?? false;
       let hasAnyGpuEffects = false;
       for (const track of sortedTracks) {
         if (!visibleTrackIds.has(track.id)) continue;
         for (const baseItem of track.items ?? []) {
           const item = getCurrentItem(baseItem);
           if (frame < item.from || frame >= item.from + item.durationInFrames) continue;
-          if (item.effects?.some((e) => e.enabled && e.effect.type === 'gpu-effect')) {
+          if (hasGpuEffects(item.effects)) {
             hasAnyGpuEffects = true;
             break;
+          }
+          // Compound clips: also check GPU effects on sub-comp items and
+          // adjustment layers so the pipeline is initialized before
+          // renderCompositionItem needs it.
+          if (item.type === 'composition') {
+            const subData = subCompRenderData.get(item.compositionId);
+            if (!subData) continue;
+            const trackItemWithGpu = subData.sortedTracks.some((t) =>
+              t.items.some((subItem) => hasGpuEffects(subItem.effects)),
+            );
+            const adjustmentWithGpu = (subData.adjustmentLayers ?? []).some((entry) =>
+              hasGpuEffects(entry.layer.effects),
+            );
+            if (trackItemWithGpu || adjustmentWithGpu) {
+              hasAnyGpuEffects = true;
+              break;
+            }
           }
         }
         if (hasAnyGpuEffects) break;

--- a/src/features/media-library/components/media-card.test.tsx
+++ b/src/features/media-library/components/media-card.test.tsx
@@ -73,11 +73,11 @@ const sourcePlayerStoreState = vi.hoisted(() => ({
   setPendingSeekFrame: vi.fn(),
 }));
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({
+vi.mock('@/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContextMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({
     children,
     onClick,
     disabled,
@@ -86,18 +86,8 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
     disabled?: boolean;
   }) => <button disabled={disabled} onClick={onClick}>{children}</button>,
-}));
-
-vi.mock('@/components/ui/button', () => ({
-  Button: ({
-    children,
-    onClick,
-    disabled,
-  }: {
-    children: ReactNode;
-    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-    disabled?: boolean;
-  }) => <button disabled={disabled} onClick={onClick}>{children}</button>,
+  ContextMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContextMenuSeparator: () => <hr />,
 }));
 
 vi.mock('./transcribe-dialog', () => ({
@@ -400,7 +390,7 @@ describe('MediaCard', () => {
 
     render(<MediaCard media={makeMedia()} viewMode="list" />);
 
-    fireEvent.click(screen.getByText('Cancel Proxy Generation'));
+    fireEvent.click(screen.getByText('Cancel Generation'));
 
     expect(proxyServiceMocks.cancelProxy).toHaveBeenCalledWith('media-1', 'proxy-media-1');
   });

--- a/src/features/media-library/components/media-card.test.tsx
+++ b/src/features/media-library/components/media-card.test.tsx
@@ -327,7 +327,7 @@ describe('MediaCard', () => {
     expect(screen.getByText('Delete Transcript')).toBeInTheDocument();
   });
 
-  it('shows transcript progress bars while transcribing', () => {
+  it('shows the inline transcript progress bar while transcribing', () => {
     mediaStoreState.transcriptStatus = new Map([['media-1', 'queued']]);
     mediaStoreState.transcriptProgress = new Map([
       ['media-1', { stage: 'queued', progress: 0 }],
@@ -335,25 +335,8 @@ describe('MediaCard', () => {
 
     render(<MediaCard media={makeMedia()} viewMode="list" />);
 
-    expect(screen.getByText('Queued (0%)')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Transcript menu progress' }))
-      .toHaveAttribute('aria-valuenow', '0');
     expect(screen.getByRole('progressbar', { name: 'Transcript progress' }))
       .toHaveAttribute('aria-valuenow', '0');
-    expect(screen.getByText('Cancel Transcript')).toBeInTheDocument();
-  });
-
-  it('cancels transcript generation from the action menu', () => {
-    mediaStoreState.transcriptStatus = new Map([['media-1', 'queued']]);
-    mediaStoreState.transcriptProgress = new Map([
-      ['media-1', { stage: 'queued', progress: 0 }],
-    ]);
-
-    render(<MediaCard media={makeMedia()} viewMode="list" />);
-
-    fireEvent.click(screen.getByText('Cancel Transcript'));
-
-    expect(mediaTranscriptionServiceMocks.cancelTranscription).toHaveBeenCalledWith('media-1');
   });
 
   it('deletes a transcript from the media action menu', async () => {
@@ -382,17 +365,6 @@ describe('MediaCard', () => {
     fireEvent.click(screen.getByText('Relink File...'));
 
     expect(onRelink).toHaveBeenCalledTimes(1);
-  });
-
-  it('allows cancelling proxy generation from the action menu', () => {
-    mediaStoreState.proxyStatus = new Map([['media-1', 'generating']]);
-    mediaStoreState.proxyProgress = new Map([['media-1', 0.42]]);
-
-    render(<MediaCard media={makeMedia()} viewMode="list" />);
-
-    fireEvent.click(screen.getByText('Cancel Generation'));
-
-    expect(proxyServiceMocks.cancelProxy).toHaveBeenCalledWith('media-1', 'proxy-media-1');
   });
 
   it('shows an active AI analysis badge in list view while analysis is running', () => {

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -40,7 +40,7 @@ interface MediaCardProps {
   isBroken?: boolean;
   onSelect?: (event: React.MouseEvent) => void;
   onDoubleClick?: () => void;
-  onDelete?: () => void;
+  onDelete?: (mediaIds: string[]) => void;
   onRelink?: () => void;
   viewMode?: 'grid' | 'list';
 }
@@ -51,19 +51,14 @@ interface MediaCardActionMenuProps {
   canGenerateProxy: boolean;
   hasProxy: boolean;
   proxyStatus?: 'generating' | 'ready' | 'error';
-  proxyProgress?: number;
   isTranscribable: boolean;
   isTranscribing: boolean;
   hasTranscript: boolean;
-  transcriptProgressPercent: number | null;
-  transcriptBusyLabel: string;
   isTaggable: boolean;
   isTagging: boolean;
   onGenerateProxy: (event: React.MouseEvent) => void | Promise<void>;
-  onCancelProxy: (event: React.MouseEvent) => void | Promise<void>;
   onDeleteProxy: (event: React.MouseEvent) => Promise<void>;
   onGenerateTranscript: (event: React.MouseEvent) => void | Promise<void>;
-  onCancelTranscript: (event: React.MouseEvent) => void;
   onDeleteTranscript: (event: React.MouseEvent) => Promise<void>;
   onAnalyzeWithAI: (event: React.MouseEvent) => void;
   onDelete: (event: React.MouseEvent) => void;
@@ -77,33 +72,25 @@ function MediaCardActionMenuItems({
   canGenerateProxy,
   hasProxy,
   proxyStatus,
-  proxyProgress,
   isTranscribable,
   isTranscribing,
   hasTranscript,
-  transcriptProgressPercent,
-  transcriptBusyLabel,
   isTaggable,
   isTagging,
   onGenerateProxy,
-  onCancelProxy,
   onDeleteProxy,
   onGenerateTranscript,
-  onCancelTranscript,
   onDeleteTranscript,
   onAnalyzeWithAI,
   onDelete,
 }: MediaCardActionMenuProps) {
   const hasBrokenGroup = isBroken && !!onRelink;
-  const showProxyGroup =
-    !isBroken
-    && (
-      (canGenerateProxy && !hasProxy && proxyStatus !== 'generating')
-      || proxyStatus === 'generating'
-      || hasProxy
-    );
-  const showTranscriptGroup = isTranscribable && !isBroken;
-  const showAiGroup = isTaggable && !isBroken;
+  const canShowGenerateProxy = canGenerateProxy && !hasProxy && proxyStatus !== 'generating';
+  const showProxyGroup = !isBroken && (canShowGenerateProxy || hasProxy);
+  const canShowGenerateTranscript = isTranscribable && !isBroken && !isTranscribing;
+  const canShowDeleteTranscript = isTranscribable && !isBroken && hasTranscript && !isTranscribing;
+  const showTranscriptGroup = canShowGenerateTranscript || canShowDeleteTranscript;
+  const showAiGroup = isTaggable && !isBroken && !isTagging;
 
   const groups: ReactNode[] = [];
 
@@ -126,23 +113,11 @@ function MediaCardActionMenuItems({
     groups.push(
       <Fragment key="proxy">
         <ContextMenuLabel>Proxy</ContextMenuLabel>
-        {canGenerateProxy && !hasProxy && proxyStatus !== 'generating' && (
+        {canShowGenerateProxy && (
           <ContextMenuItem onClick={onGenerateProxy}>
             <Zap className="w-3 h-3 mr-2" />
             Generate Proxy
           </ContextMenuItem>
-        )}
-        {proxyStatus === 'generating' && (
-          <>
-            <ContextMenuItem disabled>
-              <Loader2 className="w-3 h-3 mr-2 animate-spin" />
-              Generating{proxyProgress != null ? ` (${Math.round(proxyProgress * 100)}%)` : '...'}
-            </ContextMenuItem>
-            <ContextMenuItem onClick={onCancelProxy}>
-              <Square className="w-3 h-3 mr-2" />
-              Cancel Generation
-            </ContextMenuItem>
-          </>
         )}
         {hasProxy && (
           <ContextMenuItem onClick={onDeleteProxy} className="text-destructive focus:text-destructive">
@@ -158,46 +133,13 @@ function MediaCardActionMenuItems({
     groups.push(
       <Fragment key="transcript">
         <ContextMenuLabel>Transcript</ContextMenuLabel>
-        {!isTranscribing && (
+        {canShowGenerateTranscript && (
           <ContextMenuItem onClick={onGenerateTranscript}>
             <FileText className="w-3 h-3 mr-2" />
             {hasTranscript ? 'Refresh Transcript' : 'Generate Transcript'}
           </ContextMenuItem>
         )}
-        {isTranscribing && (
-          <>
-            <ContextMenuItem disabled>
-              <div className="flex w-full min-w-48 flex-col gap-1.5">
-                <div className="flex items-center gap-2">
-                  <Loader2 className="w-3 h-3 animate-spin flex-shrink-0" />
-                  <span className="min-w-0 truncate">
-                    {transcriptBusyLabel}
-                  </span>
-                </div>
-                {transcriptProgressPercent !== null && (
-                  <div
-                    role="progressbar"
-                    aria-label="Transcript menu progress"
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-valuenow={transcriptProgressPercent}
-                    className="h-1 overflow-hidden rounded-full bg-secondary"
-                  >
-                    <div
-                      className="h-full rounded-full bg-blue-500 transition-all duration-300"
-                      style={{ width: `${transcriptProgressPercent}%` }}
-                    />
-                  </div>
-                )}
-              </div>
-            </ContextMenuItem>
-            <ContextMenuItem onClick={onCancelTranscript}>
-              <Square className="w-3 h-3 mr-2" />
-              Cancel Transcript
-            </ContextMenuItem>
-          </>
-        )}
-        {hasTranscript && !isTranscribing && (
+        {canShowDeleteTranscript && (
           <ContextMenuItem onClick={onDeleteTranscript} className="text-destructive focus:text-destructive">
             <Trash2 className="w-3 h-3 mr-2" />
             Delete Transcript
@@ -211,17 +153,10 @@ function MediaCardActionMenuItems({
     groups.push(
       <Fragment key="ai">
         <ContextMenuLabel>AI</ContextMenuLabel>
-        {!isTagging ? (
-          <ContextMenuItem onClick={onAnalyzeWithAI}>
-            <Sparkles className="w-3 h-3 mr-2" />
-            Analyze with AI
-          </ContextMenuItem>
-        ) : (
-          <ContextMenuItem disabled>
-            <Loader2 className="w-3 h-3 mr-2 animate-spin" />
-            Analyzing...
-          </ContextMenuItem>
-        )}
+        <ContextMenuItem onClick={onAnalyzeWithAI}>
+          <Sparkles className="w-3 h-3 mr-2" />
+          Analyze with AI
+        </ContextMenuItem>
       </Fragment>
     );
   }
@@ -264,7 +199,6 @@ export const MediaCard = memo(function MediaCard({
   );
 
   const proxyStatus = useMediaLibraryStore((s) => s.proxyStatus.get(media.id));
-  const proxyProgress = useMediaLibraryStore((s) => s.proxyProgress.get(media.id));
   const transcriptStatus = useMediaLibraryStore((s) => s.transcriptStatus.get(media.id) ?? 'idle');
   const transcriptProgress = useMediaLibraryStore((s) => s.transcriptProgress.get(media.id));
 
@@ -313,59 +247,82 @@ export const MediaCard = memo(function MediaCard({
     };
   }, [media.id, media.thumbnailId]);
 
+  const getTargetMediaItems = useCallback((): MediaMetadata[] => {
+    const store = useMediaLibraryStore.getState();
+    const selectedIds = store.selectedMediaIds;
+    if (selectedIds.length > 1 && selectedIds.includes(media.id)) {
+      return selectedIds
+        .map((id) => store.mediaItems.find((m) => m.id === id))
+        .filter((m): m is MediaMetadata => m !== undefined);
+    }
+    return [media];
+  }, [media]);
+
+  const handleContextMenuOpenChange = useCallback((open: boolean) => {
+    if (!open) return;
+    const store = useMediaLibraryStore.getState();
+    if (!store.selectedMediaIds.includes(media.id)) {
+      store.setSelection({ mediaIds: [media.id], compositionIds: [] });
+    }
+  }, [media.id]);
+
   const handleDelete = (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
-    onDelete?.();
+    const targets = getTargetMediaItems();
+    onDelete?.(targets.map((m) => m.id));
   };
 
   const handleGenerateProxy = (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
-    try {
-      const proxyKey = getSharedProxyKey(media);
-      proxyService.setProxyKey(media.id, proxyKey);
-      proxyService.generateProxy(
-        media.id,
-        media.storageType === 'opfs' && media.opfsPath
-          ? { kind: 'opfs', path: media.opfsPath, mimeType: media.mimeType }
-          : () => mediaLibraryService.getMediaFile(media.id),
-        media.width,
-        media.height,
-        proxyKey
-      );
-    } catch {
-      useMediaLibraryStore.getState().setProxyStatus(media.id, 'error');
+    const store = useMediaLibraryStore.getState();
+    const targets = getTargetMediaItems().filter((m) =>
+      proxyService.canGenerateProxy(m.mimeType)
+      && store.proxyStatus.get(m.id) !== 'ready'
+      && store.proxyStatus.get(m.id) !== 'generating'
+    );
+    for (const item of targets) {
+      try {
+        const proxyKey = getSharedProxyKey(item);
+        proxyService.setProxyKey(item.id, proxyKey);
+        proxyService.generateProxy(
+          item.id,
+          item.storageType === 'opfs' && item.opfsPath
+            ? { kind: 'opfs', path: item.opfsPath, mimeType: item.mimeType }
+            : () => mediaLibraryService.getMediaFile(item.id),
+          item.width,
+          item.height,
+          proxyKey
+        );
+      } catch {
+        useMediaLibraryStore.getState().setProxyStatus(item.id, 'error');
+      }
     }
   };
 
   const handleDeleteProxy = async (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
-    try {
-      const sharedProxyKey = getSharedProxyKey(media);
-      await proxyService.deleteProxy(media.id, sharedProxyKey);
+    const targets = getTargetMediaItems().filter(
+      (m) => useMediaLibraryStore.getState().proxyStatus.get(m.id) === 'ready'
+    );
+    for (const item of targets) {
+      try {
+        const sharedProxyKey = getSharedProxyKey(item);
+        await proxyService.deleteProxy(item.id, sharedProxyKey);
 
-      const store = useMediaLibraryStore.getState();
-      for (const item of store.mediaItems) {
-        if (item.mimeType.startsWith('video/') && getSharedProxyKey(item) === sharedProxyKey) {
-          store.clearProxyStatus(item.id);
-          proxyService.clearProxyKey(item.id);
+        const store = useMediaLibraryStore.getState();
+        for (const other of store.mediaItems) {
+          if (other.mimeType.startsWith('video/') && getSharedProxyKey(other) === sharedProxyKey) {
+            store.clearProxyStatus(other.id);
+            proxyService.clearProxyKey(other.id);
+          }
         }
+      } catch {
+        useMediaLibraryStore.getState().setProxyStatus(item.id, 'error');
       }
-    } catch {
-      useMediaLibraryStore.getState().setProxyStatus(media.id, 'error');
     }
   };
 
-  const handleCancelProxy = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    proxyService.cancelProxy(media.id, getSharedProxyKey(media));
-  };
-
   const handleOpenTranscribeDialog = (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
     setTranscribeErrorMessage(null);
     setTranscribeDialogOpen(true);
@@ -434,36 +391,65 @@ export const MediaCard = memo(function MediaCard({
   const handleCancelTranscript = (e?: React.MouseEvent) => {
     e?.preventDefault();
     e?.stopPropagation();
-    mediaTranscriptionService.cancelTranscription(media.id);
+    const store = useMediaLibraryStore.getState();
+    const targets = getTargetMediaItems().filter((m) => {
+      const status = store.transcriptStatus.get(m.id);
+      return status === 'queued' || status === 'transcribing';
+    });
+    for (const item of targets) {
+      mediaTranscriptionService.cancelTranscription(item.id);
+    }
   };
 
   const handleDeleteTranscript = async (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
 
     const store = useMediaLibraryStore.getState();
+    const targets = getTargetMediaItems().filter(
+      (m) => store.transcriptStatus.get(m.id) === 'ready'
+    );
 
-    try {
-      await mediaTranscriptionService.deleteTranscript(media.id);
-      store.setTranscriptStatus(media.id, 'idle');
-      store.clearTranscriptProgress(media.id);
+    let failures = 0;
+    for (const item of targets) {
+      try {
+        await mediaTranscriptionService.deleteTranscript(item.id);
+        store.setTranscriptStatus(item.id, 'idle');
+        store.clearTranscriptProgress(item.id);
+      } catch {
+        failures += 1;
+      }
+    }
+
+    if (targets.length === 1 && failures === 0) {
+      const [only] = targets;
       store.showNotification({
         type: 'success',
-        message: `Transcript deleted for "${media.fileName}"`,
+        message: `Transcript deleted for "${only!.fileName}"`,
       });
-    } catch (error) {
+    } else if (targets.length > 1 && failures === 0) {
+      store.showNotification({
+        type: 'success',
+        message: `Deleted ${targets.length} transcripts`,
+      });
+    } else if (failures > 0) {
       store.showNotification({
         type: 'error',
-        message: error instanceof Error ? error.message : 'Failed to delete transcript',
+        message: failures === targets.length
+          ? 'Failed to delete transcript'
+          : `Failed to delete ${failures} of ${targets.length} transcripts`,
       });
     }
   };
 
   const handleAnalyzeWithAI = useCallback(async (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
-    await mediaAnalysisService.analyzeMedia(media);
-  }, [media]);
+    const targets = getTargetMediaItems();
+    if (targets.length > 1) {
+      await mediaAnalysisService.analyzeBatch({ mediaIds: targets.map((m) => m.id) });
+    } else {
+      await mediaAnalysisService.analyzeMedia(media);
+    }
+  }, [media, getTargetMediaItems]);
 
   const handleDragStart = useCallback((e: React.DragEvent) => {
     // Set drag data for timeline drop
@@ -716,9 +702,6 @@ export const MediaCard = memo(function MediaCard({
   const transcriptProgressLabel = transcriptProgress
     ? `${getTranscriptionStageLabel(transcriptProgress.stage)} (${transcriptProgressPercent}%)`
     : 'Transcribing...';
-  const transcriptBusyLabel = hasTranscript
-    ? `Refreshing Transcript (${transcriptProgressLabel})`
-    : transcriptProgressLabel;
 
   const transcribeDialog = (
     <TranscribeDialog
@@ -745,19 +728,14 @@ export const MediaCard = memo(function MediaCard({
       canGenerateProxy={canGenerateProxy}
       hasProxy={hasProxy}
       proxyStatus={proxyStatus}
-      proxyProgress={proxyProgress}
       isTranscribable={isTranscribable}
       isTranscribing={isTranscribing}
       hasTranscript={hasTranscript}
-      transcriptProgressPercent={transcriptProgressPercent}
-      transcriptBusyLabel={transcriptBusyLabel}
       isTaggable={isTaggable}
       isTagging={isTagging}
       onGenerateProxy={handleGenerateProxy}
-      onCancelProxy={handleCancelProxy}
       onDeleteProxy={handleDeleteProxy}
       onGenerateTranscript={handleOpenTranscribeDialog}
-      onCancelTranscript={handleCancelTranscript}
       onDeleteTranscript={handleDeleteTranscript}
       onAnalyzeWithAI={handleAnalyzeWithAI}
       onDelete={handleDelete}
@@ -782,7 +760,7 @@ export const MediaCard = memo(function MediaCard({
     return (
       <>
       {transcribeDialog}
-      <ContextMenu>
+      <ContextMenu onOpenChange={handleContextMenuOpenChange}>
       <ContextMenuTrigger asChild disabled={isImporting}>
       <div
         style={CARD_PERF_STYLE}
@@ -938,7 +916,7 @@ export const MediaCard = memo(function MediaCard({
   return (
     <>
     {transcribeDialog}
-    <ContextMenu>
+    <ContextMenu onOpenChange={handleContextMenuOpenChange}>
     <ContextMenuTrigger asChild disabled={isImporting}>
     <div
       style={CARD_PERF_STYLE}

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -1,12 +1,13 @@
-import { memo, useState, useEffect, useRef, useCallback } from 'react';
-import { Video, FileAudio, Image as ImageIcon, MoreVertical, Trash2, Loader2, Link2Off, RefreshCw, Zap, FileText, Play, Square, Sparkles } from 'lucide-react';
+import { Fragment, memo, useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
+import { Video, FileAudio, Image as ImageIcon, Trash2, Loader2, Link2Off, RefreshCw, Zap, FileText, Play, Square, Sparkles } from 'lucide-react';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Button } from '@/components/ui/button';
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
 import type { MediaMetadata } from '@/types/storage';
 import { mediaLibraryService } from '../services/media-library-service';
 import { mediaAnalysisService } from '../services/media-analysis-service';
@@ -58,7 +59,6 @@ interface MediaCardActionMenuProps {
   transcriptBusyLabel: string;
   isTaggable: boolean;
   isTagging: boolean;
-  hasTags: boolean;
   onGenerateProxy: (event: React.MouseEvent) => void | Promise<void>;
   onCancelProxy: (event: React.MouseEvent) => void | Promise<void>;
   onDeleteProxy: (event: React.MouseEvent) => Promise<void>;
@@ -85,7 +85,6 @@ function MediaCardActionMenuItems({
   transcriptBusyLabel,
   isTaggable,
   isTagging,
-  hasTags,
   onGenerateProxy,
   onCancelProxy,
   onDeleteProxy,
@@ -95,99 +94,155 @@ function MediaCardActionMenuItems({
   onAnalyzeWithAI,
   onDelete,
 }: MediaCardActionMenuProps) {
-  return (
-    <>
-      {isBroken && onRelink && (
-        <DropdownMenuItem onClick={(event) => { event.stopPropagation(); onRelink(); }} className="text-primary focus:text-primary">
+  const hasBrokenGroup = isBroken && !!onRelink;
+  const showProxyGroup =
+    !isBroken
+    && (
+      (canGenerateProxy && !hasProxy && proxyStatus !== 'generating')
+      || proxyStatus === 'generating'
+      || hasProxy
+    );
+  const showTranscriptGroup = isTranscribable && !isBroken;
+  const showAiGroup = isTaggable && !isBroken;
+
+  const groups: ReactNode[] = [];
+
+  if (hasBrokenGroup) {
+    groups.push(
+      <Fragment key="broken">
+        <ContextMenuLabel>File</ContextMenuLabel>
+        <ContextMenuItem
+          onClick={(event) => { event.stopPropagation(); onRelink!(); }}
+          className="text-primary focus:text-primary"
+        >
           <RefreshCw className="w-3 h-3 mr-2" />
           Relink File...
-        </DropdownMenuItem>
-      )}
-      {canGenerateProxy && !hasProxy && proxyStatus !== 'generating' && (
-        <DropdownMenuItem onClick={onGenerateProxy}>
-          <Zap className="w-3 h-3 mr-2" />
-          Generate Proxy
-        </DropdownMenuItem>
-      )}
-      {isTranscribable && !isBroken && !isTranscribing && (
-        <DropdownMenuItem onClick={onGenerateTranscript}>
-          <FileText className="w-3 h-3 mr-2" />
-          {hasTranscript ? 'Refresh Transcript' : 'Generate Transcript'}
-        </DropdownMenuItem>
-      )}
-      {isTranscribable && !isBroken && hasTranscript && !isTranscribing && (
-        <DropdownMenuItem onClick={onDeleteTranscript} className="text-destructive focus:text-destructive">
-          <Trash2 className="w-3 h-3 mr-2" />
-          Delete Transcript
-        </DropdownMenuItem>
-      )}
-      {isTranscribable && !isBroken && isTranscribing && (
-        <DropdownMenuItem disabled>
-          <div className="flex w-full min-w-48 flex-col gap-1.5">
-            <div className="flex items-center gap-2">
-              <Loader2 className="w-3 h-3 animate-spin flex-shrink-0" />
-              <span className="min-w-0 truncate">
-                {transcriptBusyLabel}
-              </span>
-            </div>
-            {transcriptProgressPercent !== null && (
-              <div
-                role="progressbar"
-                aria-label="Transcript menu progress"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={transcriptProgressPercent}
-                className="h-1 overflow-hidden rounded-full bg-secondary"
-              >
-                <div
-                  className="h-full rounded-full bg-blue-500 transition-all duration-300"
-                  style={{ width: `${transcriptProgressPercent}%` }}
-                />
+        </ContextMenuItem>
+      </Fragment>
+    );
+  }
+
+  if (showProxyGroup) {
+    groups.push(
+      <Fragment key="proxy">
+        <ContextMenuLabel>Proxy</ContextMenuLabel>
+        {canGenerateProxy && !hasProxy && proxyStatus !== 'generating' && (
+          <ContextMenuItem onClick={onGenerateProxy}>
+            <Zap className="w-3 h-3 mr-2" />
+            Generate Proxy
+          </ContextMenuItem>
+        )}
+        {proxyStatus === 'generating' && (
+          <>
+            <ContextMenuItem disabled>
+              <Loader2 className="w-3 h-3 mr-2 animate-spin" />
+              Generating{proxyProgress != null ? ` (${Math.round(proxyProgress * 100)}%)` : '...'}
+            </ContextMenuItem>
+            <ContextMenuItem onClick={onCancelProxy}>
+              <Square className="w-3 h-3 mr-2" />
+              Cancel Generation
+            </ContextMenuItem>
+          </>
+        )}
+        {hasProxy && (
+          <ContextMenuItem onClick={onDeleteProxy} className="text-destructive focus:text-destructive">
+            <Trash2 className="w-3 h-3 mr-2" />
+            Delete Proxy
+          </ContextMenuItem>
+        )}
+      </Fragment>
+    );
+  }
+
+  if (showTranscriptGroup) {
+    groups.push(
+      <Fragment key="transcript">
+        <ContextMenuLabel>Transcript</ContextMenuLabel>
+        {!isTranscribing && (
+          <ContextMenuItem onClick={onGenerateTranscript}>
+            <FileText className="w-3 h-3 mr-2" />
+            {hasTranscript ? 'Refresh Transcript' : 'Generate Transcript'}
+          </ContextMenuItem>
+        )}
+        {isTranscribing && (
+          <>
+            <ContextMenuItem disabled>
+              <div className="flex w-full min-w-48 flex-col gap-1.5">
+                <div className="flex items-center gap-2">
+                  <Loader2 className="w-3 h-3 animate-spin flex-shrink-0" />
+                  <span className="min-w-0 truncate">
+                    {transcriptBusyLabel}
+                  </span>
+                </div>
+                {transcriptProgressPercent !== null && (
+                  <div
+                    role="progressbar"
+                    aria-label="Transcript menu progress"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={transcriptProgressPercent}
+                    className="h-1 overflow-hidden rounded-full bg-secondary"
+                  >
+                    <div
+                      className="h-full rounded-full bg-blue-500 transition-all duration-300"
+                      style={{ width: `${transcriptProgressPercent}%` }}
+                    />
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-        </DropdownMenuItem>
-      )}
-      {isTranscribable && !isBroken && isTranscribing && (
-        <DropdownMenuItem onClick={onCancelTranscript}>
-          <Square className="w-3 h-3 mr-2" />
-          Cancel Transcript
-        </DropdownMenuItem>
-      )}
-      {proxyStatus === 'generating' && (
-        <>
-          <DropdownMenuItem disabled>
+            </ContextMenuItem>
+            <ContextMenuItem onClick={onCancelTranscript}>
+              <Square className="w-3 h-3 mr-2" />
+              Cancel Transcript
+            </ContextMenuItem>
+          </>
+        )}
+        {hasTranscript && !isTranscribing && (
+          <ContextMenuItem onClick={onDeleteTranscript} className="text-destructive focus:text-destructive">
+            <Trash2 className="w-3 h-3 mr-2" />
+            Delete Transcript
+          </ContextMenuItem>
+        )}
+      </Fragment>
+    );
+  }
+
+  if (showAiGroup) {
+    groups.push(
+      <Fragment key="ai">
+        <ContextMenuLabel>AI</ContextMenuLabel>
+        {!isTagging ? (
+          <ContextMenuItem onClick={onAnalyzeWithAI}>
+            <Sparkles className="w-3 h-3 mr-2" />
+            Analyze with AI
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem disabled>
             <Loader2 className="w-3 h-3 mr-2 animate-spin" />
-            Generating Proxy{proxyProgress != null ? ` (${Math.round(proxyProgress * 100)}%)` : '...'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onCancelProxy}>
-            <Square className="w-3 h-3 mr-2" />
-            Cancel Proxy Generation
-          </DropdownMenuItem>
-        </>
-      )}
-      {hasProxy && (
-        <DropdownMenuItem onClick={onDeleteProxy} className="text-destructive focus:text-destructive">
-          <Trash2 className="w-3 h-3 mr-2" />
-          Delete Proxy
-        </DropdownMenuItem>
-      )}
-      {isTaggable && !isBroken && !isTagging && (
-        <DropdownMenuItem onClick={onAnalyzeWithAI}>
-          <Sparkles className="w-3 h-3 mr-2" />
-          {hasTags ? 'Re-analyze with AI' : 'Analyze with AI'}
-        </DropdownMenuItem>
-      )}
-      {isTaggable && !isBroken && isTagging && (
-        <DropdownMenuItem disabled>
-          <Loader2 className="w-3 h-3 mr-2 animate-spin" />
-          Analyzing...
-        </DropdownMenuItem>
-      )}
-      <DropdownMenuItem onClick={onDelete} className="text-destructive focus:text-destructive">
+            Analyzing...
+          </ContextMenuItem>
+        )}
+      </Fragment>
+    );
+  }
+
+  groups.push(
+    <Fragment key="destructive">
+      <ContextMenuItem onClick={onDelete} className="text-destructive focus:text-destructive">
         <Trash2 className="w-3 h-3 mr-2" />
         Delete
-      </DropdownMenuItem>
+      </ContextMenuItem>
+    </Fragment>
+  );
+
+  return (
+    <>
+      {groups.map((group, index) => (
+        <Fragment key={index}>
+          {index > 0 && <ContextMenuSeparator />}
+          {group}
+        </Fragment>
+      ))}
     </>
   );
 }
@@ -698,7 +753,6 @@ export const MediaCard = memo(function MediaCard({
       transcriptBusyLabel={transcriptBusyLabel}
       isTaggable={isTaggable}
       isTagging={isTagging}
-      hasTags={hasCaptions}
       onGenerateProxy={handleGenerateProxy}
       onCancelProxy={handleCancelProxy}
       onDeleteProxy={handleDeleteProxy}
@@ -728,6 +782,8 @@ export const MediaCard = memo(function MediaCard({
     return (
       <>
       {transcribeDialog}
+      <ContextMenu>
+      <ContextMenuTrigger asChild disabled={isImporting}>
       <div
         style={CARD_PERF_STYLE}
         className={`
@@ -866,23 +922,14 @@ export const MediaCard = memo(function MediaCard({
               triggerClassName="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-colors"
               onSeekToCaption={handleSeekToCaption}
             />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
-                >
-                  <MoreVertical className="w-3 h-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                {actionMenuItems}
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
         )}
       </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent onClick={(e) => e.stopPropagation()}>
+        {actionMenuItems}
+      </ContextMenuContent>
+      </ContextMenu>
       </>
     );
   }
@@ -891,6 +938,8 @@ export const MediaCard = memo(function MediaCard({
   return (
     <>
     {transcribeDialog}
+    <ContextMenu>
+    <ContextMenuTrigger asChild disabled={isImporting}>
     <div
       style={CARD_PERF_STYLE}
       className={`
@@ -1052,24 +1101,6 @@ export const MediaCard = memo(function MediaCard({
               {media.fileName}
             </h3>
           </div>
-
-          {/* Actions dropdown - hidden during upload */}
-          {!isImporting && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
-                >
-                  <MoreVertical className="w-2.5 h-2.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                {actionMenuItems}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
         </div>
       </div>
 
@@ -1077,6 +1108,11 @@ export const MediaCard = memo(function MediaCard({
       <div className="absolute left-0 top-0 bottom-0 w-[2px] bg-gradient-to-b from-border via-muted to-border opacity-50" />
       <div className="absolute right-0 top-0 bottom-0 w-[2px] bg-gradient-to-b from-border via-muted to-border opacity-50" />
     </div>
+    </ContextMenuTrigger>
+    <ContextMenuContent onClick={(e) => e.stopPropagation()}>
+      {actionMenuItems}
+    </ContextMenuContent>
+    </ContextMenu>
     </>
   );
 });

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -304,10 +304,14 @@ export const MediaCard = memo(function MediaCard({
     const targets = getTargetMediaItems().filter(
       (m) => useMediaLibraryStore.getState().proxyStatus.get(m.id) === 'ready'
     );
+    const uniqueKeys = new Map<string, MediaMetadata>();
     for (const item of targets) {
+      const key = getSharedProxyKey(item);
+      if (!uniqueKeys.has(key)) uniqueKeys.set(key, item);
+    }
+    for (const [sharedProxyKey, representative] of uniqueKeys) {
       try {
-        const sharedProxyKey = getSharedProxyKey(item);
-        await proxyService.deleteProxy(item.id, sharedProxyKey);
+        await proxyService.deleteProxy(representative.id, sharedProxyKey);
 
         const store = useMediaLibraryStore.getState();
         for (const other of store.mediaItems) {
@@ -317,7 +321,12 @@ export const MediaCard = memo(function MediaCard({
           }
         }
       } catch {
-        useMediaLibraryStore.getState().setProxyStatus(item.id, 'error');
+        const store = useMediaLibraryStore.getState();
+        for (const other of store.mediaItems) {
+          if (other.mimeType.startsWith('video/') && getSharedProxyKey(other) === sharedProxyKey) {
+            store.setProxyStatus(other.id, 'error');
+          }
+        }
       }
     }
   };
@@ -330,63 +339,90 @@ export const MediaCard = memo(function MediaCard({
 
   const handleStartTranscription = useCallback((values: TranscribeDialogValues) => {
     const store = useMediaLibraryStore.getState();
-    const previousStatus = store.transcriptStatus.get(media.id) ?? 'idle';
+    const targets = getTargetMediaItems();
+    const previousStatusById = new Map<string, ReturnType<typeof store.transcriptStatus.get>>(
+      targets.map((t) => [t.id, store.transcriptStatus.get(t.id) ?? 'idle']),
+    );
 
     setTranscribeErrorMessage(null);
-    store.setTranscriptStatus(media.id, 'queued');
-    store.setTranscriptProgress(media.id, { stage: 'queued', progress: 0 });
+    for (const t of targets) {
+      store.setTranscriptStatus(t.id, 'queued');
+      store.setTranscriptProgress(t.id, { stage: 'queued', progress: 0 });
+    }
 
     scheduleAfterPaint(() => {
       void (async () => {
-        try {
-          await mediaTranscriptionService.transcribeMedia(media.id, {
-            model: values.model,
-            quantization: values.quantization,
-            language: values.language || undefined,
-            onQueueStatusChange: (state) => {
-              if (state === 'queued') {
-                store.setTranscriptStatus(media.id, 'queued');
-                store.setTranscriptProgress(media.id, { stage: 'queued', progress: 0 });
-                return;
-              }
+        let succeeded = 0;
+        let failed = 0;
+        let lastErrorMessage: string | null = null;
 
-              store.setTranscriptStatus(media.id, 'transcribing');
-              store.setTranscriptProgress(media.id, { stage: 'loading', progress: 0 });
-            },
-            onProgress: (progress) => {
-              store.setTranscriptProgress(media.id, progress);
-            },
-          });
-          store.setTranscriptStatus(media.id, 'ready');
-          store.clearTranscriptProgress(media.id);
-          store.showNotification({
-            type: 'success',
-            message: `Transcript ready for "${media.fileName}"`,
-          });
-          setTranscribeDialogOpen(false);
-        } catch (error) {
-          if (isTranscriptionCancellationError(error)) {
-            store.setTranscriptStatus(media.id, previousStatus);
-            store.clearTranscriptProgress(media.id);
-            return;
+        for (const target of targets) {
+          const previousStatus = previousStatusById.get(target.id) ?? 'idle';
+          try {
+            await mediaTranscriptionService.transcribeMedia(target.id, {
+              model: values.model,
+              quantization: values.quantization,
+              language: values.language || undefined,
+              onQueueStatusChange: (state) => {
+                if (state === 'queued') {
+                  store.setTranscriptStatus(target.id, 'queued');
+                  store.setTranscriptProgress(target.id, { stage: 'queued', progress: 0 });
+                  return;
+                }
+                store.setTranscriptStatus(target.id, 'transcribing');
+                store.setTranscriptProgress(target.id, { stage: 'loading', progress: 0 });
+              },
+              onProgress: (progress) => {
+                store.setTranscriptProgress(target.id, progress);
+              },
+            });
+            store.setTranscriptStatus(target.id, 'ready');
+            store.clearTranscriptProgress(target.id);
+            succeeded += 1;
+          } catch (error) {
+            if (isTranscriptionCancellationError(error)) {
+              store.setTranscriptStatus(target.id, previousStatus);
+              store.clearTranscriptProgress(target.id);
+              continue;
+            }
+
+            store.setTranscriptStatus(target.id, previousStatus === 'ready' ? 'ready' : 'error');
+            store.clearTranscriptProgress(target.id);
+
+            const baseMessage = error instanceof Error ? error.message : 'Failed to transcribe media';
+            lastErrorMessage = isTranscriptionOutOfMemoryError(error) ? TRANSCRIPTION_OOM_HINT : baseMessage;
+            failed += 1;
           }
+        }
 
-          store.setTranscriptStatus(media.id, previousStatus === 'ready' ? 'ready' : 'error');
-          store.clearTranscriptProgress(media.id);
-
-          const baseMessage = error instanceof Error ? error.message : 'Failed to transcribe media';
-          const dialogMessage = isTranscriptionOutOfMemoryError(error)
-            ? TRANSCRIPTION_OOM_HINT
-            : baseMessage;
-          setTranscribeErrorMessage(dialogMessage);
+        if (failed === 0 && succeeded > 0) {
+          if (targets.length === 1) {
+            store.showNotification({
+              type: 'success',
+              message: `Transcript ready for "${targets[0]!.fileName}"`,
+            });
+          } else {
+            store.showNotification({
+              type: 'success',
+              message: `Transcripts ready for ${succeeded} media files`,
+            });
+          }
+          setTranscribeDialogOpen(false);
+        } else if (failed > 0) {
+          const msg = lastErrorMessage ?? 'Failed to transcribe media';
+          setTranscribeErrorMessage(msg);
           store.showNotification({
             type: 'error',
-            message: dialogMessage,
+            message: targets.length === 1
+              ? msg
+              : `Transcription failed for ${failed} of ${targets.length} media files`,
           });
+        } else {
+          setTranscribeDialogOpen(false);
         }
       })();
     });
-  }, [media.id, media.fileName]);
+  }, [getTargetMediaItems]);
 
   const handleCancelTranscript = (e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -443,11 +479,23 @@ export const MediaCard = memo(function MediaCard({
 
   const handleAnalyzeWithAI = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
-    const targets = getTargetMediaItems();
-    if (targets.length > 1) {
-      await mediaAnalysisService.analyzeBatch({ mediaIds: targets.map((m) => m.id) });
+    const store = useMediaLibraryStore.getState();
+    const analyzable = getTargetMediaItems().filter((m) => {
+      const type = getMediaType(m.mimeType);
+      if (type !== 'video' && type !== 'image') return false;
+      if (store.brokenMediaIds?.includes(m.id)) return false;
+      if (store.importingIds?.includes(m.id)) return false;
+      return true;
+    });
+    if (analyzable.length > 1) {
+      await mediaAnalysisService.analyzeBatch({ mediaIds: analyzable.map((m) => m.id) });
+    } else if (analyzable.length === 1) {
+      await mediaAnalysisService.analyzeMedia(analyzable[0]!);
     } else {
-      await mediaAnalysisService.analyzeMedia(media);
+      const type = getMediaType(media.mimeType);
+      if (type === 'video' || type === 'image') {
+        await mediaAnalysisService.analyzeMedia(media);
+      }
     }
   }, [media, getTargetMediaItems]);
 

--- a/src/features/media-library/components/media-grid.tsx
+++ b/src/features/media-library/components/media-grid.tsx
@@ -36,7 +36,7 @@ interface MediaGridProps {
 
 export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'grid', itemSize = 3, items }: MediaGridProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [mediaIdToDelete, setMediaIdToDelete] = useState<string | null>(null);
+  const [mediaIdsToDelete, setMediaIdsToDelete] = useState<string[]>([]);
   const lastSelectedIdRef = useRef<string | null>(null);
 
   const allFilteredItems = useFilteredMediaItems();
@@ -46,6 +46,7 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
   const selectedMediaIds = useMediaLibraryStore((s) => s.selectedMediaIds);
   const brokenMediaIds = useMediaLibraryStore((s) => s.brokenMediaIds);
   const deleteMedia = useMediaLibraryStore((s) => s.deleteMedia);
+  const deleteMediaBatch = useMediaLibraryStore((s) => s.deleteMediaBatch);
   const relinkMedia = useMediaLibraryStore((s) => s.relinkMedia);
   const importMedia = useMediaLibraryStore((s) => s.importMedia);
   const setSourcePreviewMediaId = useEditorStore((s) => s.setSourcePreviewMediaId);
@@ -57,10 +58,10 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
   }, [filteredItems]);
 
   const affectedMediaImpact = useMemo(() => (
-    mediaIdToDelete
-      ? getMediaDeletionImpact([mediaIdToDelete])
+    mediaIdsToDelete.length > 0
+      ? getMediaDeletionImpact(mediaIdsToDelete)
       : { itemIds: [], rootReferenceCount: 0, nestedReferenceCount: 0, totalReferenceCount: 0 }
-  ), [mediaIdToDelete]);
+  ), [mediaIdsToDelete]);
 
   const handleCardSelect = useCallback((mediaId: string, event?: React.MouseEvent) => {
     const currentFilteredItems = filteredItemsRef.current;
@@ -98,14 +99,15 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
   }, [onMediaSelect]);
 
   // Show delete confirmation dialog (called from MediaCard)
-  const handleCardDelete = useCallback((mediaId: string) => {
-    setMediaIdToDelete(mediaId);
+  const handleCardDelete = useCallback((mediaIds: string[]) => {
+    if (mediaIds.length === 0) return;
+    setMediaIdsToDelete(mediaIds);
     setShowDeleteDialog(true);
   }, []);
 
   // Actually delete after confirmation
   const handleConfirmDelete = async () => {
-    if (!mediaIdToDelete) return;
+    if (mediaIdsToDelete.length === 0) return;
 
     setShowDeleteDialog(false);
     try {
@@ -115,18 +117,22 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
       }
 
       // Then delete the media from the library
-      await deleteMedia(mediaIdToDelete);
+      if (mediaIdsToDelete.length === 1) {
+        await deleteMedia(mediaIdsToDelete[0]!);
+      } else {
+        await deleteMediaBatch(mediaIdsToDelete);
+      }
     } catch (error) {
       logger.error('Failed to delete media:', error);
       // Error is already set in store
     } finally {
-      setMediaIdToDelete(null);
+      setMediaIdsToDelete([]);
     }
   };
 
   const handleCancelDelete = useCallback(() => {
     setShowDeleteDialog(false);
-    setMediaIdToDelete(null);
+    setMediaIdsToDelete([]);
   }, []);
 
   // Handle relinking a broken media file
@@ -159,7 +165,7 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
     filteredItems.map((media) => [media.id, {
       onSelect: (event: React.MouseEvent) => handleCardSelect(media.id, event),
       onDoubleClick: () => setSourcePreviewMediaId(media.id),
-      onDelete: () => handleCardDelete(media.id),
+      onDelete: (mediaIds: string[]) => handleCardDelete(mediaIds),
       onRelink: () => {
         void handleRelink(media.id);
       },
@@ -237,12 +243,18 @@ export const MediaGrid = memo(function MediaGrid({ onMediaSelect, viewMode = 'gr
       <AlertDialog open={showDeleteDialog} onOpenChange={(open) => !open && handleCancelDelete()}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete media file?</AlertDialogTitle>
+            <AlertDialogTitle>
+              {mediaIdsToDelete.length > 1
+                ? `Delete ${mediaIdsToDelete.length} media files?`
+                : 'Delete media file?'}
+            </AlertDialogTitle>
             <AlertDialogDescription asChild>
               <div className="space-y-3">
                 <p>
-                  Are you sure you want to delete "{filteredItems.find(m => m.id === mediaIdToDelete)?.fileName}"?
-                  This action cannot be undone.
+                  {mediaIdsToDelete.length > 1
+                    ? `Are you sure you want to delete ${mediaIdsToDelete.length} selected media files? This action cannot be undone.`
+                    : `Are you sure you want to delete "${filteredItems.find(m => m.id === mediaIdsToDelete[0])?.fileName}"? This action cannot be undone.`
+                  }
                 </p>
                 {affectedMediaImpact.totalReferenceCount > 0 && (
                   <div className="flex items-start gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-md">

--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -188,7 +188,8 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
   const viewMode = useMediaLibraryStore((s) => s.viewMode);
   const setViewMode = useMediaLibraryStore((s) => s.setViewMode);
   const sceneBrowserOpen = useSceneBrowserStore((s) => s.open);
-  const toggleSceneBrowser = useSceneBrowserStore((s) => s.toggleBrowser);
+  const openSceneBrowser = useSceneBrowserStore((s) => s.openBrowser);
+  const closeSceneBrowser = useSceneBrowserStore((s) => s.closeBrowser);
   const mediaItemSize = useMediaLibraryStore((s) => s.mediaItemSize);
   const setMediaItemSize = useMediaLibraryStore((s) => s.setMediaItemSize);
   const selectedMediaIds = useMediaLibraryStore((s) => s.selectedMediaIds);
@@ -712,26 +713,6 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
               </button>
             </HeaderActionTooltip>
 
-            {/* Scene browser view toggle — lives here with Import (not in
-                the filter row) because it switches the whole panel between
-                media-library and scene-captioner views; the search/filter
-                bar below only scopes whichever view is mounted. */}
-            <HeaderActionTooltip label="Search scenes (Ctrl+Shift+F)">
-              <button
-                onClick={toggleSceneBrowser}
-                className={cn(
-                  'flex items-center gap-1.5 h-7 px-2.5 rounded-md shrink-0 border transition-colors duration-150',
-                  sceneBrowserOpen
-                    ? 'bg-primary/10 border-primary/40 text-primary'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground hover:bg-foreground/5',
-                )}
-                aria-pressed={sceneBrowserOpen}
-              >
-                <ScanSearch className="w-3.5 h-3.5" />
-                <span className="hidden @[340px]:inline">Scenes</span>
-              </button>
-            </HeaderActionTooltip>
-
             {/* Missing media indicator */}
             {currentProjectBrokenMediaIds.length > 0 && (
               <HeaderActionTooltip label={`View ${currentProjectBrokenMediaIds.length} missing media file${currentProjectBrokenMediaIds.length === 1 ? '' : 's'}`}>
@@ -872,28 +853,77 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
         </div>
       )}
 
-      {/* Search and filters — hidden in Scene mode since they only scope
-          the media library grid; the scene browser has its own search. */}
-      {!sceneBrowserOpen && (
+      {/* Search + view toggle always render so the toggle stays reachable
+          in Scene mode. The search input and the filter row below only scope
+          the media-library grid, so they're hidden when the Scene browser is
+          mounted (it has its own search). */}
       <div className="px-4 pt-3 pb-2 space-y-2 flex-shrink-0">
-        {/* Search */}
-        <div className="relative group">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground group-focus-within:text-primary transition-colors" />
-          <Input
-            placeholder="Search media..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-8 h-7 bg-secondary border border-border focus:border-primary text-foreground placeholder:text-muted-foreground text-xs"
-          />
-          {searchQuery && (
-            <button
-              onClick={() => setSearchQuery('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors"
-            >
-              <X className="w-3 h-3" />
-            </button>
+        {/* Search + Media/Scenes toggle group */}
+        <div className="@container flex items-center gap-2">
+          {!sceneBrowserOpen && (
+            <div className="relative group flex-1 min-w-0">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground group-focus-within:text-primary transition-colors" />
+              <Input
+                placeholder="Search media..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-8 h-7 bg-secondary border border-border focus:border-primary text-foreground placeholder:text-muted-foreground text-xs"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
           )}
+          {sceneBrowserOpen && <div className="flex-1 min-w-0" aria-hidden />}
+          <div
+            role="group"
+            aria-label="Library view"
+            className="inline-flex items-center h-7 rounded-md border border-border bg-secondary p-0.5 shrink-0"
+          >
+            <HeaderActionTooltip label="Show media library">
+              <button
+                onClick={() => {
+                  if (sceneBrowserOpen) closeSceneBrowser();
+                }}
+                aria-pressed={!sceneBrowserOpen}
+                className={cn(
+                  'flex items-center gap-1 h-6 px-1.5 @[280px]:px-2 rounded-[3px] text-[11px] transition-colors duration-150',
+                  !sceneBrowserOpen
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <Film className="w-3 h-3" />
+                <span className="hidden @[280px]:inline">Media</span>
+              </button>
+            </HeaderActionTooltip>
+            <HeaderActionTooltip label="Search scenes (Ctrl+Shift+F)">
+              <button
+                onClick={() => {
+                  if (!sceneBrowserOpen) openSceneBrowser();
+                }}
+                aria-pressed={sceneBrowserOpen}
+                className={cn(
+                  'flex items-center gap-1 h-6 px-1.5 @[280px]:px-2 rounded-[3px] text-[11px] transition-colors duration-150',
+                  sceneBrowserOpen
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <ScanSearch className="w-3 h-3" />
+                <span className="hidden @[280px]:inline">Scenes</span>
+              </button>
+            </HeaderActionTooltip>
+          </div>
         </div>
+
+        {!sceneBrowserOpen && (<>
+
 
         {/* Filters and sort */}
         <div className="@container flex items-center gap-1.5 min-w-0">
@@ -1024,8 +1054,8 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
             </div>
           </div>
         </div>
+        </>)}
       </div>
-      )}
 
       {/* Composition navigation banner — shown when inside a sub-composition */}
       {activeCompositionId !== null && activeCompLabel && (

--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -346,7 +346,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
     [compositions, filteredMediaItems]
   );
 
-  const { marqueeState } = useMarqueeSelection({
+  const { marquee } = useMarqueeSelection({
     containerRef: scrollContainerRef as React.RefObject<HTMLElement>,
     items: marqueeItems,
     enabled: marqueeItems.length > 0,
@@ -369,30 +369,20 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
     },
   });
 
-  // Track focus and clear selection when clicking outside the media library
+  // Track focus scope for the Delete hotkey. Selection itself is only cleared
+  // by explicit user action (empty-area click or marquee), never by focus
+  // changes — otherwise selection leaks away when the user clicks the timeline
+  // or another panel.
   useEffect(() => {
     const handleMouseDown = (event: MouseEvent) => {
-      const isInside = containerRef.current?.contains(event.target as Node);
-
-      if (isInside) {
-        // Clicked inside - mark as focused
-        isFocusedRef.current = true;
-      } else {
-        // Clicked outside - clear focus and selection
-        isFocusedRef.current = false;
-        if (selectedAssetCount > 0) {
-          clearSelection();
-        }
-      }
+      isFocusedRef.current = !!containerRef.current?.contains(event.target as Node);
     };
 
-    // Use capture phase to catch events before they're stopped by other handlers
     document.addEventListener('mousedown', handleMouseDown, true);
-
     return () => {
       document.removeEventListener('mousedown', handleMouseDown, true);
     };
-  }, [selectedAssetCount, clearSelection]);
+  }, []);
 
   // Handle Delete key to delete selected items
   useEffect(() => {
@@ -783,11 +773,12 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                   <HeaderActionTooltip label={`Generate proxies for ${selectedProxyEligibleCount} selected item${selectedProxyEligibleCount === 1 ? '' : 's'}`}>
                     <button
                       onClick={handleGenerateSelectedProxies}
-                      className="flex items-center gap-1 h-7 px-2 rounded-md shrink-0
-                        text-muted-foreground hover:text-primary hover:bg-primary/10
+                      className="flex items-center gap-1.5 h-7 px-2.5 rounded-md shrink-0 border
+                        bg-secondary border-border text-muted-foreground
+                        hover:text-primary hover:bg-primary/10 hover:border-primary/40
                         transition-colors duration-150"
                     >
-                      <Zap className="w-3 h-3" />
+                      <Zap className="w-3.5 h-3.5" />
                       <span className="hidden @[320px]:inline">Proxy ({selectedProxyEligibleCount})</span>
                     </button>
                   </HeaderActionTooltip>
@@ -797,11 +788,12 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                 <HeaderActionTooltip label="Delete selected assets">
                   <button
                     onClick={handleDeleteSelected}
-                    className="flex items-center gap-1 h-7 px-2 rounded-md shrink-0
-                      text-destructive/80 hover:text-destructive hover:bg-destructive/10
+                    className="flex items-center gap-1.5 h-7 px-2.5 rounded-md shrink-0
+                      bg-destructive/10 border border-destructive/25 text-destructive
+                      hover:bg-destructive/20 hover:border-destructive/40
                       transition-colors duration-150"
                   >
-                    <Trash2 className="w-3 h-3" />
+                    <Trash2 className="w-3.5 h-3.5" />
                     <span className="hidden @[280px]:inline">Delete</span>
                   </button>
                 </HeaderActionTooltip>
@@ -1065,7 +1057,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          <MarqueeOverlay marqueeState={marqueeState} />
+          <MarqueeOverlay marquee={marquee} />
 
           {/* Compositions section — collapsible, auto-hidden when empty */}
           <CompositionsSection />

--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -695,7 +695,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
       {/* Header toolbar */}
       <div className="@container px-3 py-2 border-b border-border flex-shrink-0">
         <TooltipProvider>
-          <div className="flex flex-wrap items-center gap-2 text-xs min-w-0">
+          <div className="flex flex-nowrap items-center gap-2 text-xs min-w-0 overflow-hidden">
             {/* Import action */}
             <HeaderActionTooltip label="Import media files">
               <button
@@ -708,7 +708,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                   transition-colors duration-150"
               >
                 <FolderOpen className="w-3.5 h-3.5" />
-                <span className="hidden @[220px]:inline">Import</span>
+                <span className="hidden @[260px]:inline">Import</span>
               </button>
             </HeaderActionTooltip>
 
@@ -728,7 +728,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                 aria-pressed={sceneBrowserOpen}
               >
                 <ScanSearch className="w-3.5 h-3.5" />
-                <span className="hidden @[260px]:inline">Scenes</span>
+                <span className="hidden @[340px]:inline">Scenes</span>
               </button>
             </HeaderActionTooltip>
 
@@ -743,7 +743,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                     transition-colors duration-150"
                 >
                   <Link2Off className="w-3.5 h-3.5" />
-                  <span className="hidden @[250px]:inline">{currentProjectBrokenMediaIds.length} Missing</span>
+                  <span className="hidden @[340px]:inline">{currentProjectBrokenMediaIds.length} Missing</span>
                 </button>
               </HeaderActionTooltip>
             )}
@@ -752,12 +752,12 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
             {/* Selection indicator & actions */}
             {selectedAssetCount > 0 && (
               <>
-                <div className="h-4 w-px bg-border hidden @[240px]:block" />
+                <div className="h-4 w-px bg-border hidden @[300px]:block" />
 
                 {/* Selection badge */}
                 <div className="flex items-center gap-1 h-7 pl-2 pr-1 rounded-md bg-accent/50 border border-border min-w-0 max-w-full">
                   <span className="tabular-nums shrink-0">{selectedAssetCount}</span>
-                  <span className="text-muted-foreground hidden @[260px]:inline">selected</span>
+                  <span className="text-muted-foreground hidden @[360px]:inline">selected</span>
                   <HeaderActionTooltip label="Clear selection">
                     <button
                       onClick={clearSelection}
@@ -779,7 +779,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                         transition-colors duration-150"
                     >
                       <Zap className="w-3.5 h-3.5" />
-                      <span className="hidden @[320px]:inline">Proxy ({selectedProxyEligibleCount})</span>
+                      <span className="hidden @[440px]:inline">Proxy ({selectedProxyEligibleCount})</span>
                     </button>
                   </HeaderActionTooltip>
                 )}
@@ -794,7 +794,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                       transition-colors duration-150"
                   >
                     <Trash2 className="w-3.5 h-3.5" />
-                    <span className="hidden @[280px]:inline">Delete</span>
+                    <span className="hidden @[400px]:inline">Delete</span>
                   </button>
                 </HeaderActionTooltip>
               </>

--- a/src/features/media-library/services/media-analysis-service.test.ts
+++ b/src/features/media-library/services/media-analysis-service.test.ts
@@ -165,6 +165,7 @@ describe('mediaAnalysisService.analyzeMedia', () => {
     expect(deleteCaptionThumbnailsMock).not.toHaveBeenCalled();
     expect(deleteCaptionEmbeddingsMock).not.toHaveBeenCalled();
     expect(updateMediaCaptionsMock).not.toHaveBeenCalled();
+    expect(invalidateMediaCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
   });
 
   it('clears caption metadata and old assets when a rerun finds no scenes', async () => {
@@ -183,6 +184,7 @@ describe('mediaAnalysisService.analyzeMedia', () => {
     expect(storeState.updateMediaCaptions).toHaveBeenCalledWith(media.id, []);
     expect(deleteCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
     expect(deleteCaptionEmbeddingsMock).toHaveBeenCalledWith(media.id);
+    expect(invalidateMediaCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
   });
 
   it('short-circuits when the content-addressable cache already has captions for the same source', async () => {
@@ -217,9 +219,11 @@ describe('mediaAnalysisService.analyzeMedia', () => {
 
     expect(captionImageMock).not.toHaveBeenCalled();
     expect(captionVideoMock).not.toHaveBeenCalled();
-    expect(adoptCaptionsFromCacheMock).toHaveBeenCalledWith(media.id, 'hash-abc');
+    expect(getCaptionsByContentHashMock).toHaveBeenCalledWith('hash-abc', 3);
+    expect(adoptCaptionsFromCacheMock).toHaveBeenCalledWith(media.id, 'hash-abc', 3);
     expect(storeState.updateMediaCaptions).toHaveBeenCalledWith(media.id, cachedCaptions);
     expect(updateMediaDBMock).toHaveBeenCalledWith(media.id, { aiCaptions: cachedCaptions });
+    expect(invalidateMediaCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
   });
 
   it('falls through to full analysis when the cached captions were generated at a different sample interval', async () => {
@@ -242,5 +246,6 @@ describe('mediaAnalysisService.analyzeMedia', () => {
 
     expect(adoptCaptionsFromCacheMock).not.toHaveBeenCalled();
     expect(captionImageMock).toHaveBeenCalled();
+    expect(invalidateMediaCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
   });
 });

--- a/src/features/media-library/services/media-analysis-service.test.ts
+++ b/src/features/media-library/services/media-analysis-service.test.ts
@@ -43,6 +43,11 @@ vi.mock('../deps/settings-contract', () => ({
   resolveCaptioningIntervalSec: resolveCaptioningIntervalSecMock,
 }));
 
+const getCaptionsByContentHashMock = vi.fn();
+const adoptCaptionsFromCacheMock = vi.fn();
+const updateMediaDBMock = vi.fn();
+const getMediaFileMock = vi.fn();
+
 vi.mock('@/infrastructure/storage', () => ({
   saveCaptionThumbnail: saveCaptionThumbnailMock,
   deleteCaptionThumbnails: deleteCaptionThumbnailsMock,
@@ -50,6 +55,13 @@ vi.mock('@/infrastructure/storage', () => ({
   saveCaptionEmbeddings: vi.fn(),
   saveCaptionImageEmbeddings: vi.fn(),
   getTranscript: vi.fn(),
+  getCaptionsByContentHash: getCaptionsByContentHashMock,
+  adoptCaptionsFromCache: adoptCaptionsFromCacheMock,
+  updateMedia: updateMediaDBMock,
+}));
+
+vi.mock('../utils/content-hash', () => ({
+  computeContentHashFromBuffer: vi.fn(async () => 'hash-abc'),
 }));
 
 vi.mock('../deps/scene-browser', () => ({
@@ -66,6 +78,7 @@ vi.mock('./media-library-service', () => ({
   mediaLibraryService: {
     getMediaBlobUrl: getMediaBlobUrlMock,
     updateMediaCaptions: updateMediaCaptionsMock,
+    getMediaFile: getMediaFileMock,
   },
 }));
 
@@ -129,6 +142,11 @@ describe('mediaAnalysisService.analyzeMedia', () => {
     captionVideoMock.mockReset();
     captionImageMock.mockReset();
     resolveCaptioningIntervalSecMock.mockReturnValue(3);
+    // By default the captions cache miss — each test opts into a hit.
+    getCaptionsByContentHashMock.mockResolvedValue(undefined);
+    adoptCaptionsFromCacheMock.mockResolvedValue(undefined);
+    getMediaFileMock.mockResolvedValue(null);
+    updateMediaDBMock.mockResolvedValue(undefined);
     vi.stubGlobal('fetch', vi.fn(async () => new Response(new Blob(['image-bytes'], { type: 'image/png' }))));
     Object.defineProperty(URL, 'revokeObjectURL', {
       configurable: true,
@@ -157,11 +175,72 @@ describe('mediaAnalysisService.analyzeMedia', () => {
 
     await expect(mediaAnalysisService.analyzeMedia(media)).resolves.toBe(true);
 
-    expect(updateMediaCaptionsMock).toHaveBeenCalledWith(media.id, [], {
-      sampleIntervalSec: 3,
-    });
+    expect(updateMediaCaptionsMock).toHaveBeenCalledWith(
+      media.id,
+      [],
+      expect.objectContaining({ sampleIntervalSec: 3 }),
+    );
     expect(storeState.updateMediaCaptions).toHaveBeenCalledWith(media.id, []);
     expect(deleteCaptionThumbnailsMock).toHaveBeenCalledWith(media.id);
     expect(deleteCaptionEmbeddingsMock).toHaveBeenCalledWith(media.id);
+  });
+
+  it('short-circuits when the content-addressable cache already has captions for the same source', async () => {
+    const media = makeMedia({ contentHash: 'hash-abc' });
+    const cachedCaptions = [
+      { timeSec: 0, text: 'Cached caption', thumbRelPath: 'content/ha/hash-abc/ai/captions-thumbs/0.jpg' },
+    ];
+    getCaptionsByContentHashMock.mockResolvedValue({
+      schemaVersion: 1,
+      kind: 'captions',
+      mediaId: 'other-media',
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      params: { sampleIntervalSec: 3 },
+      createdAt: 1,
+      updatedAt: 1,
+      data: { captions: cachedCaptions, contentHash: 'hash-abc' },
+    });
+    adoptCaptionsFromCacheMock.mockResolvedValue({
+      schemaVersion: 1,
+      kind: 'captions',
+      mediaId: media.id,
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      params: { sampleIntervalSec: 3 },
+      createdAt: 1,
+      updatedAt: 2,
+      data: { captions: cachedCaptions, contentHash: 'hash-abc' },
+    });
+
+    await expect(mediaAnalysisService.analyzeMedia(media)).resolves.toBe(true);
+
+    expect(captionImageMock).not.toHaveBeenCalled();
+    expect(captionVideoMock).not.toHaveBeenCalled();
+    expect(adoptCaptionsFromCacheMock).toHaveBeenCalledWith(media.id, 'hash-abc');
+    expect(storeState.updateMediaCaptions).toHaveBeenCalledWith(media.id, cachedCaptions);
+    expect(updateMediaDBMock).toHaveBeenCalledWith(media.id, { aiCaptions: cachedCaptions });
+  });
+
+  it('falls through to full analysis when the cached captions were generated at a different sample interval', async () => {
+    const media = makeMedia({ contentHash: 'hash-abc' });
+    captionImageMock.mockResolvedValue([]);
+    getCaptionsByContentHashMock.mockResolvedValue({
+      schemaVersion: 1,
+      kind: 'captions',
+      mediaId: 'other-media',
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      // Sample interval differs from the test's configured 3s → cache miss.
+      params: { sampleIntervalSec: 10 },
+      createdAt: 1,
+      updatedAt: 1,
+      data: { captions: [], contentHash: 'hash-abc' },
+    });
+
+    await expect(mediaAnalysisService.analyzeMedia(media)).resolves.toBe(true);
+
+    expect(adoptCaptionsFromCacheMock).not.toHaveBeenCalled();
+    expect(captionImageMock).toHaveBeenCalled();
   });
 });

--- a/src/features/media-library/services/media-analysis-service.ts
+++ b/src/features/media-library/services/media-analysis-service.ts
@@ -34,7 +34,11 @@ import {
   saveCaptionEmbeddings,
   saveCaptionImageEmbeddings,
   getTranscript,
+  getCaptionsByContentHash,
+  adoptCaptionsFromCache,
 } from '@/infrastructure/storage';
+import { computeContentHashFromBuffer } from '../utils/content-hash';
+import { updateMedia as updateMediaDB } from '@/infrastructure/storage';
 import { invalidateMediaCaptionThumbnails } from '../deps/scene-browser';
 import { useMediaLibraryStore } from '../stores/media-library-store';
 import { mediaLibraryService } from './media-library-service';
@@ -108,6 +112,36 @@ class MediaAnalysisService {
     store.setTaggingMedia(media.id, true);
 
     try {
+      // Content-addressable cache lookup: if another media item with the
+      // same source bytes already produced captions, reuse them instead of
+      // re-running the VLM. We resolve the hash once here and thread it
+      // through every save* call so the shared bins/thumbs land in the
+      // content tree (or so the adoptCaptionsFromCache fast-path can run).
+      const contentHash = await this.resolveContentHash(media);
+
+      if (contentHash) {
+        const cached = await getCaptionsByContentHash(contentHash).catch(() => undefined);
+        if (cached && this.isCacheCompatible(cached, sampleIntervalSec)) {
+          const adopted = await adoptCaptionsFromCache(media.id, contentHash);
+          if (adopted) {
+            const captions = adopted.data.captions;
+            store.updateMediaCaptions(media.id, captions);
+            try {
+              await updateMediaDB(media.id, { aiCaptions: captions });
+            } catch (error) {
+              logger.warn('Failed to mirror cached captions to media DB', { mediaId: media.id, error });
+            }
+            store.showNotification({
+              type: 'success',
+              message: captions.length === 0
+                ? `Reused cached analysis for "${media.fileName}" (no scenes)`
+                : `Reused cached analysis: ${captions.length} scene caption${captions.length === 1 ? '' : 's'} for "${media.fileName}"`,
+            });
+            return true;
+          }
+        }
+      }
+
       // Drop every in-memory thumbnail URL and semantic cache entry tied to
       // this media before re-analysis starts. If the rerun fails, the old
       // on-disk assets still exist and can be rehydrated on demand; if it
@@ -198,7 +232,7 @@ class MediaAnalysisService {
 
           const vectors = await embeddingsProvider.embedBatch(texts);
           if (vectors.length === captions.length) {
-            await saveCaptionEmbeddings(media.id, vectors, EMBEDDING_MODEL_DIM);
+            await saveCaptionEmbeddings(media.id, vectors, EMBEDDING_MODEL_DIM, { contentHash });
             embeddingModel = EMBEDDING_MODEL_ID;
             embeddingDim = EMBEDDING_MODEL_DIM;
             captionsWithEmbeddings = captionsWithEmbeddings.map((caption, i) => ({
@@ -220,7 +254,7 @@ class MediaAnalysisService {
             await clipProvider.ensureReady();
             const imageVectors = await clipProvider.embedImages(validBlobs);
             if (imageVectors.length === captions.length) {
-              await saveCaptionImageEmbeddings(media.id, imageVectors, CLIP_EMBEDDING_DIM);
+              await saveCaptionImageEmbeddings(media.id, imageVectors, CLIP_EMBEDDING_DIM, { contentHash });
               imageEmbeddingModel = CLIP_MODEL_ID;
               imageEmbeddingDim = CLIP_EMBEDDING_DIM;
             }
@@ -235,7 +269,7 @@ class MediaAnalysisService {
               const blob = stagedThumbnailBlobs.get(index);
               if (!blob) return caption;
               try {
-                const thumbRelPath = await saveCaptionThumbnail(media.id, index, blob);
+                const thumbRelPath = await saveCaptionThumbnail(media.id, index, blob, { contentHash });
                 return { ...caption, thumbRelPath };
               } catch {
                 return caption;
@@ -250,6 +284,7 @@ class MediaAnalysisService {
           embeddingDim,
           imageEmbeddingModel,
           imageEmbeddingDim,
+          contentHash,
         });
         store.updateMediaCaptions(media.id, captionsWithEmbeddings);
 
@@ -261,6 +296,7 @@ class MediaAnalysisService {
       } else {
         await mediaLibraryService.updateMediaCaptions(media.id, [], {
           sampleIntervalSec,
+          contentHash,
         });
         store.updateMediaCaptions(media.id, []);
         await deleteCaptionThumbnails(media.id);
@@ -375,6 +411,54 @@ class MediaAnalysisService {
 
   isBatchInFlight(): boolean {
     return this.batchInFlight;
+  }
+
+  /**
+   * Resolve the SHA-256 content hash for a media item. Prefers the cached
+   * value on `MediaMetadata.contentHash` when present; otherwise reads the
+   * source blob once, hashes, and persists the result so future analyze
+   * runs (and the shared-cache check) skip the hashing step.
+   *
+   * Returns `undefined` only when the source blob can't be loaded — the
+   * cache lookup is skipped in that case and analysis proceeds as usual.
+   */
+  private async resolveContentHash(media: MediaMetadata): Promise<string | undefined> {
+    if (media.contentHash) return media.contentHash;
+    try {
+      const file = await mediaLibraryService.getMediaFile(media.id);
+      if (!file) return undefined;
+      const buffer = await file.arrayBuffer();
+      const hash = await computeContentHashFromBuffer(buffer);
+      try {
+        await updateMediaDB(media.id, { contentHash: hash });
+      } catch (error) {
+        logger.warn('Failed to persist contentHash on media metadata', { mediaId: media.id, error });
+      }
+      return hash;
+    } catch (error) {
+      logger.warn('Failed to compute contentHash; skipping caption cache lookup', {
+        mediaId: media.id,
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  /**
+   * Cache-hit acceptance check. Today we only gate on sampleIntervalSec
+   * since that's the one user-visible param that changes output cardinality.
+   * When the captioner or embedding model versions bump, callers should flush
+   * the shared cache rather than relying on a version check here — shared
+   * cache GC is cheap via the ai-refs file.
+   */
+  private isCacheCompatible(
+    envelope: Awaited<ReturnType<typeof getCaptionsByContentHash>>,
+    sampleIntervalSec: number,
+  ): boolean {
+    if (!envelope) return false;
+    const envInterval = (envelope.params as { sampleIntervalSec?: number }).sampleIntervalSec;
+    if (envInterval === undefined) return true;
+    return Math.abs(envInterval - sampleIntervalSec) < 0.01;
   }
 }
 

--- a/src/features/media-library/services/media-analysis-service.ts
+++ b/src/features/media-library/services/media-analysis-service.ts
@@ -119,10 +119,16 @@ class MediaAnalysisService {
       // content tree (or so the adoptCaptionsFromCache fast-path can run).
       const contentHash = await this.resolveContentHash(media);
 
+      // Drop every in-memory thumbnail URL and semantic cache entry tied to
+      // this media before either adopting cached captions or writing fresh
+      // outputs. Otherwise a re-analyze can keep serving stale per-media
+      // blobs/embeddings until the next reload.
+      invalidateMediaCaptionThumbnails(media.id);
+
       if (contentHash) {
-        const cached = await getCaptionsByContentHash(contentHash).catch(() => undefined);
+        const cached = await getCaptionsByContentHash(contentHash, sampleIntervalSec).catch(() => undefined);
         if (cached && this.isCacheCompatible(cached, sampleIntervalSec)) {
-          const adopted = await adoptCaptionsFromCache(media.id, contentHash);
+          const adopted = await adoptCaptionsFromCache(media.id, contentHash, sampleIntervalSec);
           if (adopted) {
             const captions = adopted.data.captions;
             store.updateMediaCaptions(media.id, captions);
@@ -141,12 +147,6 @@ class MediaAnalysisService {
           }
         }
       }
-
-      // Drop every in-memory thumbnail URL and semantic cache entry tied to
-      // this media before re-analysis starts. If the rerun fails, the old
-      // on-disk assets still exist and can be rehydrated on demand; if it
-      // succeeds, fresh thumbs/embeddings repopulate the caches below.
-      invalidateMediaCaptionThumbnails(media.id);
 
       let captions: MediaCaption[];
       const stagedThumbnailBlobs = new Map<number, Blob>();
@@ -232,7 +232,10 @@ class MediaAnalysisService {
 
           const vectors = await embeddingsProvider.embedBatch(texts);
           if (vectors.length === captions.length) {
-            await saveCaptionEmbeddings(media.id, vectors, EMBEDDING_MODEL_DIM, { contentHash });
+            await saveCaptionEmbeddings(media.id, vectors, EMBEDDING_MODEL_DIM, {
+              contentHash,
+              sampleIntervalSec,
+            });
             embeddingModel = EMBEDDING_MODEL_ID;
             embeddingDim = EMBEDDING_MODEL_DIM;
             captionsWithEmbeddings = captionsWithEmbeddings.map((caption, i) => ({
@@ -254,7 +257,10 @@ class MediaAnalysisService {
             await clipProvider.ensureReady();
             const imageVectors = await clipProvider.embedImages(validBlobs);
             if (imageVectors.length === captions.length) {
-              await saveCaptionImageEmbeddings(media.id, imageVectors, CLIP_EMBEDDING_DIM, { contentHash });
+              await saveCaptionImageEmbeddings(media.id, imageVectors, CLIP_EMBEDDING_DIM, {
+                contentHash,
+                sampleIntervalSec,
+              });
               imageEmbeddingModel = CLIP_MODEL_ID;
               imageEmbeddingDim = CLIP_EMBEDDING_DIM;
             }
@@ -269,7 +275,10 @@ class MediaAnalysisService {
               const blob = stagedThumbnailBlobs.get(index);
               if (!blob) return caption;
               try {
-                const thumbRelPath = await saveCaptionThumbnail(media.id, index, blob, { contentHash });
+                const thumbRelPath = await saveCaptionThumbnail(media.id, index, blob, {
+                  contentHash,
+                  sampleIntervalSec,
+                });
                 return { ...caption, thumbRelPath };
               } catch {
                 return caption;

--- a/src/features/media-library/services/media-analysis-service.ts
+++ b/src/features/media-library/services/media-analysis-service.ts
@@ -128,7 +128,18 @@ class MediaAnalysisService {
       if (contentHash) {
         const cached = await getCaptionsByContentHash(contentHash, sampleIntervalSec).catch(() => undefined);
         if (cached && this.isCacheCompatible(cached, sampleIntervalSec)) {
-          const adopted = await adoptCaptionsFromCache(media.id, contentHash, sampleIntervalSec);
+          // Treat an adopt failure as a cache miss and fall through to a full
+          // run rather than aborting the whole analysis.
+          let adopted: Awaited<ReturnType<typeof adoptCaptionsFromCache>> | undefined;
+          try {
+            adopted = await adoptCaptionsFromCache(media.id, contentHash, sampleIntervalSec);
+          } catch (error) {
+            logger.warn('adoptCaptionsFromCache threw — falling through to full analysis', {
+              mediaId: media.id,
+              error,
+            });
+            adopted = undefined;
+          }
           if (adopted) {
             const captions = adopted.data.captions;
             store.updateMediaCaptions(media.id, captions);
@@ -466,7 +477,14 @@ class MediaAnalysisService {
   ): boolean {
     if (!envelope) return false;
     const envInterval = (envelope.params as { sampleIntervalSec?: number }).sampleIntervalSec;
-    if (envInterval === undefined) return true;
+    if (envInterval === undefined) {
+      // Legacy cache (pre-versioning): fall back to the interval recorded in
+      // `data` so users who changed their interval get a fresh analysis
+      // instead of silently reusing the old density.
+      const dataInterval = (envelope.data as { sampleIntervalSec?: number }).sampleIntervalSec;
+      if (dataInterval === undefined) return true;
+      return Math.abs(dataInterval - sampleIntervalSec) < 0.01;
+    }
     return Math.abs(envInterval - sampleIntervalSec) < 0.01;
   }
 }

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -18,6 +18,12 @@ const indexedDbMocks = vi.hoisted(() => ({
   getProjectsUsingMedia: vi.fn(),
   getMediaForProject: vi.fn(),
   deleteTranscript: vi.fn(),
+  readAiOutput: vi.fn(),
+}));
+
+const captionsStorageMocks = vi.hoisted(() => ({
+  saveCaptions: vi.fn(async () => []),
+  deleteCaptions: vi.fn(async () => undefined),
 }));
 
 const opfsMocks = vi.hoisted(() => ({
@@ -72,6 +78,8 @@ const backgroundMediaWorkMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/infrastructure/storage', () => indexedDbMocks);
+
+vi.mock('@/infrastructure/storage/workspace-fs/captions', () => captionsStorageMocks);
 
 vi.mock('./opfs-service', () => ({
   opfsService: opfsMocks,
@@ -144,6 +152,7 @@ describe('MediaLibraryService', () => {
     compositionRuntimeMocks.needsCustomAudioDecoder.mockReturnValue(false);
     compositionRuntimeMocks.startPreviewAudioStartupWarm.mockResolvedValue(undefined);
     filmstripCacheMocks.prewarmPriorityWindow.mockResolvedValue(undefined);
+    indexedDbMocks.readAiOutput.mockResolvedValue(undefined);
   });
 
   describe('getAllMedia', () => {
@@ -199,6 +208,7 @@ describe('MediaLibraryService', () => {
         thumbnail: new Blob(['thumb'], { type: 'image/webp' }),
       });
       mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false });
+      indexedDbMocks.getAllMedia.mockResolvedValue([]);
       indexedDbMocks.getMediaForProject.mockResolvedValue([]);
 
       const result = await mediaLibraryService.importMediaWithHandle(mockHandle, 'project-1');
@@ -231,6 +241,7 @@ describe('MediaLibraryService', () => {
         fileName: 'video.mp4',
         fileSize: 4,
       });
+      indexedDbMocks.getAllMedia.mockResolvedValue([]);
       indexedDbMocks.getMediaForProject.mockResolvedValue([existingMedia]);
 
       const mockFile = new File(['data'], 'video.mp4', { type: 'video/mp4' });
@@ -246,6 +257,46 @@ describe('MediaLibraryService', () => {
       expect(result.isDuplicate).toBe(true);
       expect(result.id).toBe('existing-1');
       expect(indexedDbMocks.createMedia).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the stored handle when reusing a workspace duplicate', async () => {
+      const existingMedia = makeMediaMetadata({
+        id: 'existing-1',
+        fileName: 'video.mp4',
+        fileSize: 4,
+        fileLastModified: 1234,
+        storageType: 'handle',
+      });
+      const refreshedMedia = {
+        ...existingMedia,
+        fileHandle: {} as FileSystemFileHandle,
+      };
+      indexedDbMocks.getAllMedia.mockResolvedValue([existingMedia]);
+      indexedDbMocks.getProjectMediaIds.mockResolvedValue([]);
+      indexedDbMocks.updateMedia.mockResolvedValue(refreshedMedia);
+
+      const mockFile = new File(['data'], 'video.mp4', {
+        type: 'video/mp4',
+        lastModified: 1234,
+      });
+      const mockHandle = {
+        name: 'video.mp4',
+        getFile: vi.fn().mockResolvedValue(mockFile),
+        queryPermission: vi.fn().mockResolvedValue('granted'),
+        requestPermission: vi.fn().mockResolvedValue('granted'),
+      } as unknown as FileSystemFileHandle;
+
+      const result = await mediaLibraryService.importMediaWithHandle(mockHandle, 'project-2');
+
+      expect(indexedDbMocks.updateMedia).toHaveBeenCalledWith('existing-1', expect.objectContaining({
+        fileHandle: mockHandle,
+        fileName: 'video.mp4',
+        fileSize: 4,
+        fileLastModified: 1234,
+      }));
+      expect(indexedDbMocks.associateMediaWithProject).toHaveBeenCalledWith('project-2', 'existing-1');
+      expect(result.id).toBe('existing-1');
+      expect(result.isDuplicate).toBe(false);
     });
 
     it('starts preview audio conform in background for custom-decoded imports', async () => {
@@ -271,6 +322,7 @@ describe('MediaLibraryService', () => {
         },
       });
       mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false });
+      indexedDbMocks.getAllMedia.mockResolvedValue([]);
       indexedDbMocks.getMediaForProject.mockResolvedValue([]);
       compositionRuntimeMocks.needsCustomAudioDecoder.mockReturnValue(true);
 
@@ -475,6 +527,47 @@ describe('MediaLibraryService', () => {
       await expect(
         mediaLibraryService.copyMediaToProject('nonexistent', 'project-2')
       ).rejects.toThrow('Media not found');
+    });
+  });
+
+  describe('updateMediaCaptions', () => {
+    it('preserves existing analysis metadata on partial caption rewrites', async () => {
+      const media = makeMediaMetadata({ id: 'm1' });
+      indexedDbMocks.readAiOutput.mockResolvedValue({
+        service: 'lfm-captioning',
+        model: 'lfm-2.5-vl',
+        params: { sampleIntervalSec: 3 },
+        data: {
+          sampleIntervalSec: 3,
+          embeddingModel: 'embed-old',
+          embeddingDim: 384,
+          imageEmbeddingModel: 'clip-old',
+          imageEmbeddingDim: 512,
+          contentHash: 'hash-abc',
+          captions: [{ timeSec: 0, text: 'old' }],
+        },
+      });
+      indexedDbMocks.updateMedia.mockResolvedValue({
+        ...media,
+        aiCaptions: [{ timeSec: 0, text: 'new' }],
+      });
+
+      await mediaLibraryService.updateMediaCaptions('m1', [{ timeSec: 0, text: 'new' }]);
+
+      expect(captionsStorageMocks.saveCaptions).toHaveBeenCalledWith(expect.objectContaining({
+        mediaId: 'm1',
+        sampleIntervalSec: 3,
+        embeddingModel: 'embed-old',
+        embeddingDim: 384,
+        imageEmbeddingModel: 'clip-old',
+        imageEmbeddingDim: 512,
+        contentHash: 'hash-abc',
+        service: 'lfm-captioning',
+        model: 'lfm-2.5-vl',
+      }));
+      expect(indexedDbMocks.updateMedia).toHaveBeenCalledWith('m1', {
+        aiCaptions: [{ timeSec: 0, text: 'new' }],
+      });
     });
   });
 

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -55,6 +55,7 @@ import {
   getProjectsUsingMedia,
   getMediaForProject as getMediaForProjectDB,
   deleteTranscript,
+  readAiOutput,
 } from '@/infrastructure/storage';
 import { saveCaptions, deleteCaptions } from '@/infrastructure/storage/workspace-fs/captions';
 import { deleteScenes } from '@/infrastructure/storage/workspace-fs/scenes';
@@ -308,12 +309,23 @@ class MediaLibraryService {
         && m.fileLastModified === file.lastModified,
     );
     if (workspaceDuplicate) {
-      const projectMediaIds = await getProjectMediaIds(projectId).catch(() => [] as string[]);
-      const alreadyInThisProject = projectMediaIds.includes(workspaceDuplicate.id);
-      if (!alreadyInThisProject) {
-        await associateMediaWithProject(projectId, workspaceDuplicate.id);
+      let resolvedDuplicate = workspaceDuplicate;
+      if (workspaceDuplicate.storageType === 'handle') {
+        resolvedDuplicate = await updateMediaDB(workspaceDuplicate.id, {
+          fileHandle: handle,
+          fileName: file.name,
+          fileSize: file.size,
+          fileLastModified: file.lastModified,
+          updatedAt: Date.now(),
+        });
       }
-      return { ...workspaceDuplicate, isDuplicate: alreadyInThisProject };
+      mirrorSourceToWorkspaceInBackground(resolvedDuplicate.id, file, file.name);
+      const projectMediaIds = await getProjectMediaIds(projectId).catch(() => [] as string[]);
+      const alreadyInThisProject = projectMediaIds.includes(resolvedDuplicate.id);
+      if (!alreadyInThisProject) {
+        await associateMediaWithProject(projectId, resolvedDuplicate.id);
+      }
+      return { ...resolvedDuplicate, isDuplicate: alreadyInThisProject };
     }
 
     // Stage 3b: Project-scoped name+size fallback for legacy records missing
@@ -1090,18 +1102,37 @@ class MediaLibraryService {
       contentHash?: string;
     },
   ): Promise<MediaMetadata> {
+    const existingEnvelope = await readAiOutput(mediaId, 'captions').catch(() => undefined);
+    const existingSampleInterval = (() => {
+      const fromData = existingEnvelope?.data.sampleIntervalSec;
+      if (typeof fromData === 'number') return fromData;
+      const fromParams = (existingEnvelope?.params as { sampleIntervalSec?: unknown } | undefined)?.sampleIntervalSec;
+      return typeof fromParams === 'number' ? fromParams : undefined;
+    })();
+
+    const resolvedOptions = {
+      service: options?.service ?? existingEnvelope?.service ?? 'lfm-captioning',
+      model: options?.model ?? existingEnvelope?.model ?? 'lfm-2.5-vl',
+      sampleIntervalSec: options?.sampleIntervalSec ?? existingSampleInterval,
+      embeddingModel: options?.embeddingModel ?? existingEnvelope?.data.embeddingModel,
+      embeddingDim: options?.embeddingDim ?? existingEnvelope?.data.embeddingDim,
+      imageEmbeddingModel: options?.imageEmbeddingModel ?? existingEnvelope?.data.imageEmbeddingModel,
+      imageEmbeddingDim: options?.imageEmbeddingDim ?? existingEnvelope?.data.imageEmbeddingDim,
+      contentHash: options?.contentHash ?? existingEnvelope?.data.contentHash,
+    };
+
     try {
       await saveCaptions({
         mediaId,
         captions,
-        service: options?.service ?? 'lfm-captioning',
-        model: options?.model ?? 'lfm-2.5-vl',
-        sampleIntervalSec: options?.sampleIntervalSec,
-        embeddingModel: options?.embeddingModel,
-        embeddingDim: options?.embeddingDim,
-        imageEmbeddingModel: options?.imageEmbeddingModel,
-        imageEmbeddingDim: options?.imageEmbeddingDim,
-        contentHash: options?.contentHash,
+        service: resolvedOptions.service,
+        model: resolvedOptions.model,
+        sampleIntervalSec: resolvedOptions.sampleIntervalSec,
+        embeddingModel: resolvedOptions.embeddingModel,
+        embeddingDim: resolvedOptions.embeddingDim,
+        imageEmbeddingModel: resolvedOptions.imageEmbeddingModel,
+        imageEmbeddingDim: resolvedOptions.imageEmbeddingDim,
+        contentHash: resolvedOptions.contentHash,
       });
     } catch (error) {
       logger.warn(`Failed to persist captions for ${mediaId}; metadata mirror will still update`, error);

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -334,7 +334,13 @@ class MediaLibraryService {
     // reuse is covered by 3a.
     const projectMedia = await getMediaForProjectDB(projectId);
     const existingMedia = projectMedia.find(
-      (m) => m.fileName === file.name && m.fileSize === file.size,
+      (m) =>
+        m.fileName === file.name
+        && m.fileSize === file.size
+        // Only consider legacy records that lack `fileLastModified` — current
+        // records with a different mtime must not be collapsed onto the new
+        // file since they describe different bytes.
+        && (m.fileLastModified === null || m.fileLastModified === undefined),
     );
     if (existingMedia) {
       return { ...existingMedia, isDuplicate: true };

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -284,15 +284,47 @@ class MediaLibraryService {
       throw new Error(validationResult.error);
     }
 
-    // Stage 3: Check for duplicates (by fileName + fileSize)
-    const projectMedia = await getMediaForProjectDB(projectId);
-
-    const existingMedia = projectMedia.find(
-      (m) => m.fileName === file.name && m.fileSize === file.size
+    // Stage 3a: Cross-workspace dedup by (fileName + fileSize + lastModified).
+    // A File's triple-tuple is effectively unique: the same bytes re-saved
+    // bumps lastModified, and two different files sharing name + exact byte
+    // size + exact mtime is a practical non-occurrence. Zero file I/O — all
+    // three fields come from File metadata — so unique imports pay nothing.
+    // A match reuses the existing media record across projects instead of
+    // re-mirroring the bytes into a fresh `media/{id}/` directory.
+    //
+    // `isDuplicate` is only set when the matched media is already in THIS
+    // project. Cross-project reuse (new project importing the same file) is
+    // a successful import from the UI's perspective — the media just happens
+    // to already live in the workspace, so we associate and return it as a
+    // regular import result. `getAllMedia` includes media whose only project
+    // is trashed; re-associating into the new project effectively brings
+    // those records forward, and the trash sweep's ref-counted delete still
+    // keeps the bytes alive because the new project now references them.
+    const workspaceMedia = await getAllMediaDB();
+    const workspaceDuplicate = workspaceMedia.find(
+      (m) =>
+        m.fileName === file.name
+        && m.fileSize === file.size
+        && m.fileLastModified === file.lastModified,
     );
+    if (workspaceDuplicate) {
+      const projectMediaIds = await getProjectMediaIds(projectId).catch(() => [] as string[]);
+      const alreadyInThisProject = projectMediaIds.includes(workspaceDuplicate.id);
+      if (!alreadyInThisProject) {
+        await associateMediaWithProject(projectId, workspaceDuplicate.id);
+      }
+      return { ...workspaceDuplicate, isDuplicate: alreadyInThisProject };
+    }
 
+    // Stage 3b: Project-scoped name+size fallback for legacy records missing
+    // `fileLastModified` (imported before that field was persisted). Only
+    // fires for records already in the current project — cross-project
+    // reuse is covered by 3a.
+    const projectMedia = await getMediaForProjectDB(projectId);
+    const existingMedia = projectMedia.find(
+      (m) => m.fileName === file.name && m.fileSize === file.size,
+    );
     if (existingMedia) {
-      // File already exists in project - return existing with duplicate flag
       return { ...existingMedia, isDuplicate: true };
     }
 
@@ -1050,6 +1082,12 @@ class MediaLibraryService {
       embeddingDim?: number;
       imageEmbeddingModel?: string;
       imageEmbeddingDim?: number;
+      /**
+       * When provided, the captions envelope and heavy assets are mirrored
+       * into the shared content-addressable cache so other mediaIds with the
+       * same source bytes skip re-analysis.
+       */
+      contentHash?: string;
     },
   ): Promise<MediaMetadata> {
     try {
@@ -1063,6 +1101,7 @@ class MediaLibraryService {
         embeddingDim: options?.embeddingDim,
         imageEmbeddingModel: options?.imageEmbeddingModel,
         imageEmbeddingDim: options?.imageEmbeddingDim,
+        contentHash: options?.contentHash,
       });
     } catch (error) {
       logger.warn(`Failed to persist captions for ${mediaId}; metadata mirror will still update`, error);

--- a/src/features/media-library/services/proxy-service.ts
+++ b/src/features/media-library/services/proxy-service.ts
@@ -25,7 +25,7 @@ import {
   readWorkspaceBlob,
   removeWorkspaceCacheEntry,
 } from '@/infrastructure/storage/workspace-fs/cache-mirror';
-import { proxyFilePath, proxyMetaPath, WORKSPACE_PROXIES_DIR } from '@/infrastructure/storage/workspace-fs/paths';
+import { proxyDir, proxyFilePath, proxyMetaPath } from '@/infrastructure/storage/workspace-fs/paths';
 import { PROXY_DIR, PROXY_SCHEMA_VERSION } from '../proxy-constants';
 import type {
   ProxyWorkerRequest,
@@ -347,7 +347,7 @@ class ProxyService {
     }
 
     // Mirror deletion to workspace cache before reporting completion.
-    await removeWorkspaceCacheEntry([WORKSPACE_PROXIES_DIR, resolvedProxyKey], {
+    await removeWorkspaceCacheEntry(proxyDir(resolvedProxyKey), {
       recursive: true,
     });
   }

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -77,7 +77,6 @@ async function initializeProxyState(mediaItems: MediaMetadata[]): Promise<void> 
 type MediaLibraryStoreApi = UseBoundStore<StoreApi<MediaLibraryState & MediaLibraryActions>>;
 
 declare global {
-  // eslint-disable-next-line no-var
   var __FREECUT_MEDIA_LIBRARY_STORE__: MediaLibraryStoreApi | undefined;
 }
 

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -23,6 +23,15 @@ const logger = createLogger('MediaLibraryStore');
 /** Tracked timeout for notification auto-clear */
 let notificationTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
+function sameStringList(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 function buildMediaById(mediaItems: MediaMetadata[]): Record<string, MediaMetadata> {
   const mediaById: Record<string, MediaMetadata> = {};
   for (const item of mediaItems) {
@@ -215,14 +224,30 @@ const newStore: MediaLibraryStoreApi = hotStore ?? create<
       ...createRelinkingActions(set, get),
 
       // Selection management
-      setSelection: ({ mediaIds, compositionIds }) => set({
-        selectedMediaIds: mediaIds,
-        selectedCompositionIds: compositionIds,
-      }),
+      setSelection: ({ mediaIds, compositionIds }) => {
+        const state = get();
+        const mediaUnchanged = sameStringList(state.selectedMediaIds, mediaIds);
+        const compUnchanged = sameStringList(state.selectedCompositionIds, compositionIds);
+        // Marquee live-commits fire at ~15fps even when the intersecting set
+        // hasn't changed — skip the write so subscribers don't thrash.
+        if (mediaUnchanged && compUnchanged) return;
+        set({
+          selectedMediaIds: mediaUnchanged ? state.selectedMediaIds : mediaIds,
+          selectedCompositionIds: compUnchanged ? state.selectedCompositionIds : compositionIds,
+        });
+      },
 
-      selectMedia: (ids) => set({ selectedMediaIds: ids }),
+      selectMedia: (ids) => {
+        const state = get();
+        if (sameStringList(state.selectedMediaIds, ids)) return;
+        set({ selectedMediaIds: ids });
+      },
 
-      selectCompositions: (ids) => set({ selectedCompositionIds: ids }),
+      selectCompositions: (ids) => {
+        const state = get();
+        if (sameStringList(state.selectedCompositionIds, ids)) return;
+        set({ selectedCompositionIds: ids });
+      },
 
       toggleMediaSelection: (id) =>
         set((state) => ({
@@ -238,7 +263,11 @@ const newStore: MediaLibraryStoreApi = hotStore ?? create<
             : [...state.selectedCompositionIds, id],
         })),
 
-      clearSelection: () => set({ selectedMediaIds: [], selectedCompositionIds: [] }),
+      clearSelection: () => {
+        const state = get();
+        if (state.selectedMediaIds.length === 0 && state.selectedCompositionIds.length === 0) return;
+        set({ selectedMediaIds: [], selectedCompositionIds: [] });
+      },
 
       // Filters and search
       setSearchQuery: (query) => set({ searchQuery: query }),

--- a/src/features/media-library/utils/proxy-key.ts
+++ b/src/features/media-library/utils/proxy-key.ts
@@ -26,17 +26,22 @@ function fnv1a32(input: string): string {
 /**
  * Build a stable proxy identity key for shared proxy files.
  * Uses strongest source identity available:
- * 1) content hash
- * 2) OPFS path (content-addressable)
+ * 1) content hash (SHA-256 hex, 64 chars)
+ * 2) OPFS path hash + size
  * 3) file fingerprint fallback for handle-based media
+ *
+ * The three formats are distinguishable by shape (hex-length vs dashed
+ * fingerprint), so no source-type tag is needed in the key. Keeping the
+ * key tag-free means on-disk folder names under `content/proxies/` read
+ * as the underlying fingerprint rather than `f-…` / `h-…` / `o-…`.
  */
 export function getSharedProxyKey(media: ProxyKeyMedia): string {
   if (media.contentHash) {
-    return `h-${media.contentHash}`;
+    return media.contentHash;
   }
 
   if (media.storageType === 'opfs' && media.opfsPath) {
-    return `o-${fnv1a32(media.opfsPath)}-${media.fileSize}`;
+    return `${fnv1a32(media.opfsPath)}-${media.fileSize}`;
   }
 
   const fingerprint = [
@@ -48,5 +53,5 @@ export function getSharedProxyKey(media: ProxyKeyMedia): string {
     media.height,
   ].join('|');
 
-  return `f-${fnv1a32(fingerprint)}-${media.fileSize}-${media.fileLastModified ?? 0}`;
+  return `${fnv1a32(fingerprint)}-${media.fileSize}-${media.fileLastModified ?? 0}`;
 }

--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -53,6 +53,14 @@ export function GizmoOverlay({
   overlayPadding = 100,
 }: GizmoOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Track the marquee portal target (the full preview background) in state so
+  // React re-renders once the parent's ref is populated. Refs alone don't
+  // trigger re-renders.
+  const [marqueePortalTarget, setMarqueePortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setMarqueePortalTarget(hitAreaRef?.current ?? null);
+  }, [hitAreaRef]);
   const getResolvedFrameForPlaybackState = useCallback(
     (
       playbackState: ReturnType<typeof usePlaybackStore.getState>,
@@ -310,10 +318,13 @@ export function GizmoOverlay({
   }, [visibleItems, coordParams, containerRect, visualTransformsMap]);
 
   // Marquee selection hook
-  // Use hitAreaRef for bounds checking (fills container), overlayRef for coordinate display
+  // Use the full preview background as both the hit area and the coordinate
+  // space so drag-started-outside-the-player positions don't get clipped to a
+  // smaller overlay, which previously produced a phantom marquee pinned to the
+  // overlay's edge.
+  const marqueeContainerRef = (hitAreaRef ?? overlayRef) as React.RefObject<HTMLElement>;
   const { marquee } = useMarqueeSelection({
-    containerRef: overlayRef as React.RefObject<HTMLElement>,
-    hitAreaRef: hitAreaRef as React.RefObject<HTMLElement> | undefined,
+    containerRef: marqueeContainerRef,
     items: marqueeItems,
     onSelectionChange: useCallback(
       (ids: string[]) => {
@@ -640,8 +651,11 @@ export function GizmoOverlay({
       }}
       onDoubleClick={(e) => e.stopPropagation()}
     >
-      {/* Marquee selection rectangle - hidden during corner pin / mask editing */}
-      {!isCornerPinEditing && !isMaskEditing && <MarqueeOverlay marquee={marquee} />}
+      {/* Marquee selection rectangle — portaled into the preview background so
+          it renders in the same coordinate space the marquee hook tracks.
+          Hidden during corner pin / mask editing. */}
+      {!isCornerPinEditing && !isMaskEditing && marqueePortalTarget &&
+        createPortal(<MarqueeOverlay marquee={marquee} />, marqueePortalTarget)}
 
       {/* Player area - receives clicks for deselection and contains gizmos */}
       {/* Disabled entirely during corner pin / mask editing so the overlay gets exclusive input */}

--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -311,7 +311,7 @@ export function GizmoOverlay({
 
   // Marquee selection hook
   // Use hitAreaRef for bounds checking (fills container), overlayRef for coordinate display
-  const { marqueeState } = useMarqueeSelection({
+  const { marquee } = useMarqueeSelection({
     containerRef: overlayRef as React.RefObject<HTMLElement>,
     hitAreaRef: hitAreaRef as React.RefObject<HTMLElement> | undefined,
     items: marqueeItems,
@@ -641,7 +641,7 @@ export function GizmoOverlay({
       onDoubleClick={(e) => e.stopPropagation()}
     >
       {/* Marquee selection rectangle - hidden during corner pin / mask editing */}
-      {!isCornerPinEditing && !isMaskEditing && <MarqueeOverlay marqueeState={marqueeState} />}
+      {!isCornerPinEditing && !isMaskEditing && <MarqueeOverlay marquee={marquee} />}
 
       {/* Player area - receives clicks for deselection and contains gizmos */}
       {/* Disabled entirely during corner pin / mask editing so the overlay gets exclusive input */}

--- a/src/features/preview/deps/timeline-store.ts
+++ b/src/features/preview/deps/timeline-store.ts
@@ -3,7 +3,7 @@
  * Preview modules should import timeline stores/types from here.
  */
 
-export type { TimelineState } from './timeline-contract';
+export type { SubComposition, TimelineState } from './timeline-contract';
 export {
   useTimelineStore,
   useItemsStore,
@@ -13,4 +13,5 @@ export {
   useTimelineViewportStore,
   useMediaDependencyStore,
   useCompositionsStore,
+  useCompositionNavigationStore,
 } from './timeline-contract';

--- a/src/features/preview/deps/timeline-store.ts
+++ b/src/features/preview/deps/timeline-store.ts
@@ -12,4 +12,5 @@ export {
   useTimelineSettingsStore,
   useTimelineViewportStore,
   useMediaDependencyStore,
+  useCompositionsStore,
 } from './timeline-contract';

--- a/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { shouldForceContinuousPreviewOverlay } from './use-gpu-effects-overlay';
 import type { TimelineItem } from '@/types/timeline';
-import type { SubComposition } from '@/features/timeline/stores/compositions-store';
+import type { SubComposition } from '@/features/preview/deps/timeline-store';
 
 function createVideoItem(overrides: Partial<TimelineItem> = {}): TimelineItem {
   return {

--- a/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { shouldForceContinuousPreviewOverlay } from './use-gpu-effects-overlay';
 import type { TimelineItem } from '@/types/timeline';
+import type { SubComposition } from '@/features/timeline/stores/compositions-store';
 
 function createVideoItem(overrides: Partial<TimelineItem> = {}): TimelineItem {
   return {
@@ -70,6 +71,149 @@ describe('shouldForceContinuousPreviewOverlay', () => {
     });
 
     expect(shouldForceContinuousPreviewOverlay([blendedItem], 0, 120)).toBe(false);
+  });
+
+  it('forces continuous overlay when an active compound clip has gpu effects on sub-items', () => {
+    const compItem: TimelineItem = {
+      id: 'comp-1',
+      type: 'composition',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 120,
+      label: 'Comp',
+      compositionId: 'sub-1',
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+    } as TimelineItem;
+
+    const subComp: SubComposition = {
+      id: 'sub-1',
+      name: 'Sub',
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 120,
+      tracks: [],
+      transitions: [],
+      keyframes: [],
+      items: [
+        {
+          id: 'sub-item-1',
+          type: 'video',
+          trackId: 't',
+          from: 0,
+          durationInFrames: 120,
+          label: 'v',
+          src: 'blob:v',
+          effects: [
+            {
+              id: 'e',
+              enabled: true,
+              effect: { type: 'gpu-effect', gpuEffectType: 'gpu-blur', params: { amount: 0.5 } },
+            },
+          ],
+        } as TimelineItem,
+      ],
+    };
+
+    expect(
+      shouldForceContinuousPreviewOverlay([compItem], 0, 0, undefined, { 'sub-1': subComp }),
+    ).toBe(true);
+  });
+
+  it('forces continuous overlay when an active compound clip has adjustment-layer gpu effects', () => {
+    const compItem: TimelineItem = {
+      id: 'comp-1',
+      type: 'composition',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 120,
+      label: 'Comp',
+      compositionId: 'sub-1',
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+    } as TimelineItem;
+
+    const subComp: SubComposition = {
+      id: 'sub-1',
+      name: 'Sub',
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 120,
+      tracks: [],
+      transitions: [],
+      keyframes: [],
+      items: [
+        {
+          id: 'adj-1',
+          type: 'adjustment',
+          trackId: 't',
+          from: 0,
+          durationInFrames: 120,
+          label: 'adj',
+          effects: [
+            {
+              id: 'e',
+              enabled: true,
+              effect: { type: 'gpu-effect', gpuEffectType: 'gpu-blur', params: { amount: 0.5 } },
+            },
+          ],
+        } as TimelineItem,
+      ],
+    };
+
+    expect(
+      shouldForceContinuousPreviewOverlay([compItem], 0, 0, undefined, { 'sub-1': subComp }),
+    ).toBe(true);
+  });
+
+  it('does not force continuous overlay when compound clip is inactive', () => {
+    const compItem: TimelineItem = {
+      id: 'comp-1',
+      type: 'composition',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Comp',
+      compositionId: 'sub-1',
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+    } as TimelineItem;
+
+    const subComp: SubComposition = {
+      id: 'sub-1',
+      name: 'Sub',
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 60,
+      tracks: [],
+      transitions: [],
+      keyframes: [],
+      items: [
+        {
+          id: 'sub-item-1',
+          type: 'video',
+          trackId: 't',
+          from: 0,
+          durationInFrames: 60,
+          label: 'v',
+          src: 'blob:v',
+          effects: [
+            {
+              id: 'e',
+              enabled: true,
+              effect: { type: 'gpu-effect', gpuEffectType: 'gpu-blur', params: { amount: 0.5 } },
+            },
+          ],
+        } as TimelineItem,
+      ],
+    };
+
+    expect(
+      shouldForceContinuousPreviewOverlay([compItem], 0, 120, undefined, { 'sub-1': subComp }),
+    ).toBe(false);
   });
 
   it('forces continuous overlay for preview-only gpu effects on the active frame', () => {

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -3,12 +3,12 @@ import {
   useCompositionsStore,
   useItemsStore,
   useTransitionsStore,
+  type SubComposition,
 } from '@/features/preview/deps/timeline-store';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useGizmoStore } from '@/features/preview/stores/gizmo-store';
 import type { ItemEffect } from '@/types/effects';
 import type { TimelineItem } from '@/types/timeline';
-import type { SubComposition } from '@/features/timeline/stores/compositions-store';
 
 function hasEnabledGpuEffect(effects: ItemEffect[] | undefined): boolean {
   return effects?.some((e) => e.enabled && e.effect.type === 'gpu-effect') ?? false;

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -14,12 +14,24 @@ function hasEnabledGpuEffect(effects: ItemEffect[] | undefined): boolean {
   return effects?.some((e) => e.enabled && e.effect.type === 'gpu-effect') ?? false;
 }
 
-function subCompositionHasGpuEffectsOrBlend(subComp: SubComposition): boolean {
-  return subComp.items.some(
-    (subItem) =>
-      hasEnabledGpuEffect(subItem.effects)
-      || (subItem.blendMode !== undefined && subItem.blendMode !== 'normal'),
-  );
+function subCompositionHasGpuEffectsOrBlend(
+  subComp: SubComposition,
+  compositionById?: Record<string, SubComposition>,
+  visited: Set<string> = new Set(),
+): boolean {
+  if (visited.has(subComp.id)) return false;
+  visited.add(subComp.id);
+  return subComp.items.some((subItem) => {
+    if (hasEnabledGpuEffect(subItem.effects)) return true;
+    if (subItem.blendMode !== undefined && subItem.blendMode !== 'normal') return true;
+    if (subItem.type === 'composition' && compositionById) {
+      const nested = compositionById[subItem.compositionId];
+      if (nested && subCompositionHasGpuEffectsOrBlend(nested, compositionById, visited)) {
+        return true;
+      }
+    }
+    return false;
+  });
 }
 
 /**
@@ -53,7 +65,7 @@ export function shouldForceContinuousPreviewOverlay(
     if (item.blendMode && item.blendMode !== 'normal') return true;
     if (item.type === 'composition' && compositionById) {
       const subComp = compositionById[item.compositionId];
-      if (subComp && subCompositionHasGpuEffectsOrBlend(subComp)) return true;
+      if (subComp && subCompositionHasGpuEffectsOrBlend(subComp, compositionById)) return true;
     }
     return false;
   });

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -1,9 +1,26 @@
 import { useEffect, useState } from 'react';
-import { useItemsStore, useTransitionsStore } from '@/features/preview/deps/timeline-store';
+import {
+  useCompositionsStore,
+  useItemsStore,
+  useTransitionsStore,
+} from '@/features/preview/deps/timeline-store';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useGizmoStore } from '@/features/preview/stores/gizmo-store';
 import type { ItemEffect } from '@/types/effects';
 import type { TimelineItem } from '@/types/timeline';
+import type { SubComposition } from '@/features/timeline/stores/compositions-store';
+
+function hasEnabledGpuEffect(effects: ItemEffect[] | undefined): boolean {
+  return effects?.some((e) => e.enabled && e.effect.type === 'gpu-effect') ?? false;
+}
+
+function subCompositionHasGpuEffectsOrBlend(subComp: SubComposition): boolean {
+  return subComp.items.some(
+    (subItem) =>
+      hasEnabledGpuEffect(subItem.effects)
+      || (subItem.blendMode !== undefined && subItem.blendMode !== 'normal'),
+  );
+}
 
 /**
  * Detects whether the composition renderer overlay should stay active
@@ -12,30 +29,34 @@ import type { TimelineItem } from '@/types/timeline';
  * Returns true when any of these conditions exist:
  * - GPU effects enabled on any item
  * - Non-normal blend modes
+ * - An active compound clip whose sub-composition contains GPU effects,
+ *   adjustment-layer GPU effects, or non-normal blend modes
  */
 export function shouldForceContinuousPreviewOverlay(
   items: TimelineItem[],
   transitionCount: number,
   frame: number,
   previewEffectsByItemId?: ReadonlyMap<string, ItemEffect[]>,
+  compositionById?: Record<string, SubComposition>,
 ): boolean {
   void transitionCount;
   if (!Number.isFinite(frame)) {
     return false;
   }
 
-  return (
-    items.some((item) =>
-      frame >= item.from
-      && frame < (item.from + item.durationInFrames)
-      && (
-        (previewEffectsByItemId?.get(item.id) ?? item.effects)?.some(
-          (e) => e.enabled && e.effect.type === 'gpu-effect'
-        )
-        || (item.blendMode && item.blendMode !== 'normal')
-      )
-    )
-  );
+  return items.some((item) => {
+    if (frame < item.from || frame >= item.from + item.durationInFrames) {
+      return false;
+    }
+    const effectiveEffects = previewEffectsByItemId?.get(item.id) ?? item.effects;
+    if (hasEnabledGpuEffect(effectiveEffects)) return true;
+    if (item.blendMode && item.blendMode !== 'normal') return true;
+    if (item.type === 'composition' && compositionById) {
+      const subComp = compositionById[item.compositionId];
+      if (subComp && subCompositionHasGpuEffectsOrBlend(subComp)) return true;
+    }
+    return false;
+  });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -46,6 +67,7 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
     const check = () => {
       const items = useItemsStore.getState().items;
       const transitions = useTransitionsStore.getState().transitions;
+      const compositionById = useCompositionsStore.getState().compositionById;
       const playback = usePlaybackStore.getState();
       const frame = playback.previewFrame ?? playback.currentFrame;
       const preview = useGizmoStore.getState().preview;
@@ -63,6 +85,7 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
           transitions.length,
           frame,
           previewEffectsByItemId,
+          compositionById,
         );
         return prev === next ? prev : next;
       });
@@ -70,6 +93,7 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
     check();
     const unsubItems = useItemsStore.subscribe(check);
     const unsubTransitions = useTransitionsStore.subscribe(check);
+    const unsubCompositions = useCompositionsStore.subscribe(check);
     const unsubGizmo = useGizmoStore.subscribe((state, prev) => {
       if (state.preview === prev.preview) {
         return;
@@ -82,7 +106,13 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
       }
       check();
     });
-    return () => { unsubItems(); unsubTransitions(); unsubGizmo(); unsubPlayback(); };
+    return () => {
+      unsubItems();
+      unsubTransitions();
+      unsubCompositions();
+      unsubGizmo();
+      unsubPlayback();
+    };
   }, []);
 
   return needsOverlay;

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -371,9 +371,30 @@ export function usePreviewRendererController({
           isGizmoInteractingRef.current,
         );
         const preloadPriorityFrame = runtimeSnapshot.anchorFrame;
+        // Invalidate the current frame and re-request a render. Used both
+        // after priority media is ready (earlier, partial preload) and after
+        // full preload completes, so the real video + GPU effects appear
+        // without needing a manual scrub. Idempotent.
+        const kickRerender = () => {
+          if (scrubRendererRef.current !== renderer) return;
+          const playbackState = usePlaybackStore.getState();
+          const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
+          try {
+            renderer.invalidateFrameCache({ frames: [targetFrame] });
+          } catch {
+            return;
+          }
+          if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+            scrubOffscreenRenderedFrameRef.current = null;
+          }
+          scrubRequestedFrameRef.current = targetFrame;
+          void resumeScrubLoopRef.current();
+        };
+
         const preloadPromise = renderer.preload({
           priorityFrame: preloadPriorityFrame,
           priorityWindowFrames: Math.max(12, Math.round(fps * 4)),
+          onPriorityMediaReady: kickRerender,
         })
           .catch((error) => {
             logger.warn('Renderer preload failed:', error);
@@ -382,25 +403,7 @@ export function usePreviewRendererController({
             if (scrubPreloadPromiseRef.current === preloadPromise) {
               scrubPreloadPromiseRef.current = null;
             }
-            // First render after a fresh renderer (e.g. exit from sub-comp)
-            // often runs before sub-comp video extractors are initialized,
-            // so compound-clip videos render as empty. Invalidate the current
-            // frame and re-request a render once preload finishes so the
-            // real video and its GPU effects appear without needing a scrub.
-            if (scrubRendererRef.current !== renderer) return;
-            const playbackState = usePlaybackStore.getState();
-            const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
-            try {
-              renderer.invalidateFrameCache({ frames: [targetFrame] });
-            } catch {
-              // Renderer may have been disposed between the check and here.
-              return;
-            }
-            if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
-              scrubOffscreenRenderedFrameRef.current = null;
-            }
-            scrubRequestedFrameRef.current = targetFrame;
-            void resumeScrubLoopRef.current();
+            kickRerender();
           });
         scrubPreloadPromiseRef.current = preloadPromise;
         void Promise.race([

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -7,6 +7,7 @@ import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransform } from '@/types/transform';
 import type { CaptureOptions } from '@/shared/state/playback';
 import { usePlaybackStore } from '@/shared/state/playback';
+import { useCompositionsStore } from '@/features/preview/deps/timeline-store';
 import { usePreviewBridgeStore, type PostEditWarmRequest } from '@/shared/state/preview-bridge';
 import { createLogger } from '@/shared/logging/logger';
 import type { PreviewPathVerticesOverride } from '../deps/composition-runtime';
@@ -632,6 +633,61 @@ export function usePreviewRendererController({
     fastScrubRendererStructureKey,
     forceFastScrubOverlay,
     items,
+    resumeScrubLoopRef,
+    scrubOffscreenRenderedFrameRef,
+    scrubRendererRef,
+    scrubRendererStructureKeyRef,
+    scrubRequestedFrameRef,
+    showFastScrubOverlayRef,
+    showPlaybackTransitionOverlayRef,
+  ]);
+
+  useEffect(() => {
+    const invalidateCurrentFrame = () => {
+      const scrubRenderer = scrubRendererRef.current;
+      const bgRenderer = bgTransitionRendererRef.current;
+      const scrubRendererMatchesStructure = (
+        scrubRendererStructureKeyRef.current === fastScrubRendererStructureKey
+      );
+      const bgRendererMatchesStructure = (
+        bgTransitionRendererStructureKeyRef.current === fastScrubRendererStructureKey
+      );
+      if (!scrubRenderer && !bgRenderer) return;
+
+      const playbackState = usePlaybackStore.getState();
+      const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
+
+      if (scrubRenderer && scrubRendererMatchesStructure) {
+        scrubRenderer.invalidateFrameCache({ frames: [targetFrame] });
+      }
+      if (bgRenderer && bgRendererMatchesStructure) {
+        bgRenderer.invalidateFrameCache({ frames: [targetFrame] });
+      }
+      if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+        scrubOffscreenRenderedFrameRef.current = null;
+      }
+
+      const needsRenderedFrame = (
+        forceFastScrubOverlay
+        || playbackState.previewFrame !== null
+        || showFastScrubOverlayRef.current
+        || showPlaybackTransitionOverlayRef.current
+      );
+      if (!needsRenderedFrame) return;
+
+      scrubRequestedFrameRef.current = targetFrame;
+      void resumeScrubLoopRef.current();
+    };
+
+    return useCompositionsStore.subscribe((state, prev) => {
+      if (state.compositionById === prev.compositionById) return;
+      invalidateCurrentFrame();
+    });
+  }, [
+    bgTransitionRendererRef,
+    bgTransitionRendererStructureKeyRef,
+    fastScrubRendererStructureKey,
+    forceFastScrubOverlay,
     resumeScrubLoopRef,
     scrubOffscreenRenderedFrameRef,
     scrubRendererRef,

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -7,7 +7,12 @@ import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransform } from '@/types/transform';
 import type { CaptureOptions } from '@/shared/state/playback';
 import { usePlaybackStore } from '@/shared/state/playback';
-import { useCompositionsStore } from '@/features/preview/deps/timeline-store';
+import {
+  useCompositionNavigationStore,
+  useCompositionsStore,
+  useItemsStore,
+  type SubComposition,
+} from '@/features/preview/deps/timeline-store';
 import { usePreviewBridgeStore, type PostEditWarmRequest } from '@/shared/state/preview-bridge';
 import { createLogger } from '@/shared/logging/logger';
 import type { PreviewPathVerticesOverride } from '../deps/composition-runtime';
@@ -19,7 +24,12 @@ import {
 } from '../utils/preview-constants';
 import { setActivePreviewScrubbingCache } from '../utils/preview-scrubbing-cache-bridge';
 import { collectVisualInvalidationRanges } from '../utils/preview-frame-invalidation';
-import { isFrameInRanges } from '@/shared/utils/frame-invalidation';
+import {
+  isFrameInRanges,
+  normalizeFrameRanges,
+  type FrameInvalidationRequest,
+  type FrameRange,
+} from '@/shared/utils/frame-invalidation';
 import { usePreviewCaptureBridge } from './use-preview-capture-bridge';
 
 const logger = createLogger('VideoPreview');
@@ -372,6 +382,25 @@ export function usePreviewRendererController({
             if (scrubPreloadPromiseRef.current === preloadPromise) {
               scrubPreloadPromiseRef.current = null;
             }
+            // First render after a fresh renderer (e.g. exit from sub-comp)
+            // often runs before sub-comp video extractors are initialized,
+            // so compound-clip videos render as empty. Invalidate the current
+            // frame and re-request a render once preload finishes so the
+            // real video and its GPU effects appear without needing a scrub.
+            if (scrubRendererRef.current !== renderer) return;
+            const playbackState = usePlaybackStore.getState();
+            const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
+            try {
+              renderer.invalidateFrameCache({ frames: [targetFrame] });
+            } catch {
+              // Renderer may have been disposed between the check and here.
+              return;
+            }
+            if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+              scrubOffscreenRenderedFrameRef.current = null;
+            }
+            scrubRequestedFrameRef.current = targetFrame;
+            void resumeScrubLoopRef.current();
           });
         scrubPreloadPromiseRef.current = preloadPromise;
         void Promise.race([
@@ -454,8 +483,14 @@ export function usePreviewRendererController({
       || showFastScrubOverlayRef.current
       || showPlaybackTransitionOverlayRef.current
     ) {
-      scrubRequestedFrameRef.current = targetFrame;
-      void resumeScrubLoopRef.current();
+      // Defer the kick to a microtask so it fires after the render-pump
+      // useEffect has re-assigned resumeScrubLoopRef to the new closure.
+      // Without this, the cleanup order (pump cleanup sets ref to no-op
+      // before the new pump effect runs) silently drops the resume.
+      queueMicrotask(() => {
+        scrubRequestedFrameRef.current = targetFrame;
+        void resumeScrubLoopRef.current();
+      });
     }
   }, [
     bgTransitionRendererRef,
@@ -643,7 +678,21 @@ export function usePreviewRendererController({
   ]);
 
   useEffect(() => {
-    const invalidateCurrentFrame = () => {
+    const computeChangedCompositionIds = (
+      nextById: Record<string, SubComposition>,
+      prevById: Record<string, SubComposition>,
+    ): Set<string> => {
+      const changed = new Set<string>();
+      for (const id of Object.keys(nextById)) {
+        if (nextById[id] !== prevById[id]) changed.add(id);
+      }
+      for (const id of Object.keys(prevById)) {
+        if (!(id in nextById)) changed.add(id);
+      }
+      return changed;
+    };
+
+    const invalidateForChangedCompositions = (changedIds: Set<string>) => {
       const scrubRenderer = scrubRendererRef.current;
       const bgRenderer = bgTransitionRendererRef.current;
       const scrubRendererMatchesStructure = (
@@ -657,13 +706,40 @@ export function usePreviewRendererController({
       const playbackState = usePlaybackStore.getState();
       const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
 
+      // Read the latest items directly — when exitComposition fires, this
+      // subscription runs synchronously inside saveCurrentToComposition,
+      // before restoreTimeline updates the items store. Reading from the
+      // closure would see stale sub-comp items. The microtask defer below
+      // handles the ordering, but we still read live to be safe.
+      const currentItems = useItemsStore.getState().items;
+      const ranges: FrameRange[] = [];
+      for (const compItem of currentItems) {
+        if (compItem.type !== 'composition') continue;
+        if (!changedIds.has(compItem.compositionId)) continue;
+        ranges.push({
+          startFrame: compItem.from,
+          endFrame: compItem.from + compItem.durationInFrames,
+        });
+      }
+
+      const normalized = normalizeFrameRanges(ranges);
+      const request: FrameInvalidationRequest = normalized.length > 0
+        ? { ranges: normalized }
+        : { frames: [targetFrame] };
+
       if (scrubRenderer && scrubRendererMatchesStructure) {
-        scrubRenderer.invalidateFrameCache({ frames: [targetFrame] });
+        scrubRenderer.invalidateFrameCache(request);
       }
       if (bgRenderer && bgRendererMatchesStructure) {
-        bgRenderer.invalidateFrameCache({ frames: [targetFrame] });
+        bgRenderer.invalidateFrameCache(request);
       }
-      if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+
+      const currentFrameInvalidated = normalized.length === 0
+        || isFrameInRanges(targetFrame, normalized);
+      if (
+        currentFrameInvalidated
+        && scrubOffscreenRenderedFrameRef.current === targetFrame
+      ) {
         scrubOffscreenRenderedFrameRef.current = null;
       }
 
@@ -673,16 +749,78 @@ export function usePreviewRendererController({
         || showFastScrubOverlayRef.current
         || showPlaybackTransitionOverlayRef.current
       );
-      if (!needsRenderedFrame) return;
+      if (!needsRenderedFrame || !currentFrameInvalidated) return;
 
       scrubRequestedFrameRef.current = targetFrame;
       void resumeScrubLoopRef.current();
     };
 
-    return useCompositionsStore.subscribe((state, prev) => {
+    let pendingMicrotask = false;
+    const pendingChangedIds = new Set<string>();
+
+    const unsubCompositions = useCompositionsStore.subscribe((state, prev) => {
       if (state.compositionById === prev.compositionById) return;
-      invalidateCurrentFrame();
+      const changedIds = computeChangedCompositionIds(state.compositionById, prev.compositionById);
+      if (changedIds.size === 0) return;
+      for (const id of changedIds) pendingChangedIds.add(id);
+
+      if (pendingMicrotask) return;
+      pendingMicrotask = true;
+      queueMicrotask(() => {
+        pendingMicrotask = false;
+        const batchedIds = new Set(pendingChangedIds);
+        pendingChangedIds.clear();
+        if (batchedIds.size === 0) return;
+        invalidateForChangedCompositions(batchedIds);
+      });
     });
+
+    // On composition navigation (enter/exit/navigate), the tracks topology
+    // swaps wholesale. The dispose useEffect recreates the renderer on the
+    // structure-key change, but its render pump can race with Zustand's
+    // batched items/tracks updates. Queue an explicit invalidation in a
+    // microtask so the pump sees the fully restored timeline before it
+    // re-renders the current frame.
+    const unsubNav = useCompositionNavigationStore.subscribe((state, prev) => {
+      if (state.activeCompositionId === prev.activeCompositionId
+        && state.breadcrumbs === prev.breadcrumbs) {
+        return;
+      }
+      queueMicrotask(() => {
+        const scrubRenderer = scrubRendererRef.current;
+        const bgRenderer = bgTransitionRendererRef.current;
+        const playbackState = usePlaybackStore.getState();
+        const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame;
+
+        if (scrubRenderer
+          && scrubRendererStructureKeyRef.current === fastScrubRendererStructureKey) {
+          scrubRenderer.invalidateFrameCache({ frames: [targetFrame] });
+        }
+        if (bgRenderer
+          && bgTransitionRendererStructureKeyRef.current === fastScrubRendererStructureKey) {
+          bgRenderer.invalidateFrameCache({ frames: [targetFrame] });
+        }
+        if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+          scrubOffscreenRenderedFrameRef.current = null;
+        }
+
+        const needsRenderedFrame = (
+          forceFastScrubOverlay
+          || playbackState.previewFrame !== null
+          || showFastScrubOverlayRef.current
+          || showPlaybackTransitionOverlayRef.current
+        );
+        if (!needsRenderedFrame) return;
+
+        scrubRequestedFrameRef.current = targetFrame;
+        void resumeScrubLoopRef.current();
+      });
+    });
+
+    return () => {
+      unsubCompositions();
+      unsubNav();
+    };
   }, [
     bgTransitionRendererRef,
     bgTransitionRendererStructureKeyRef,

--- a/src/features/preview/hooks/use-preview-transition-model.ts
+++ b/src/features/preview/hooks/use-preview-transition-model.ts
@@ -4,6 +4,7 @@ import type { TimelineItem } from '@/types/timeline';
 import type { ResolvedTransitionWindow } from '@/core/timeline/transitions/transition-planner';
 import { resolveTransitionWindows } from '@/core/timeline/transitions/transition-planner';
 import { shouldForceContinuousPreviewOverlay } from '../hooks/use-gpu-effects-overlay';
+import { useCompositionsStore } from '@/features/preview/deps/timeline-store';
 
 interface UsePreviewTransitionModelParams {
   fps: number;
@@ -80,7 +81,14 @@ export function usePreviewTransitionModel({
     if (getTransitionWindowForFrame(frame) !== null) {
       return true;
     }
-    return shouldForceContinuousPreviewOverlay(fastScrubPreviewItems, (transitions ?? []).length, frame);
+    const compositionById = useCompositionsStore.getState().compositionById;
+    return shouldForceContinuousPreviewOverlay(
+      fastScrubPreviewItems,
+      (transitions ?? []).length,
+      frame,
+      undefined,
+      compositionById,
+    );
   }, [fastScrubPreviewItems, getTransitionWindowForFrame, transitions]);
 
   return {

--- a/src/features/project-bundle/services/bundle-export-service.ts
+++ b/src/features/project-bundle/services/bundle-export-service.ts
@@ -14,7 +14,7 @@ import {
   BUNDLE_VERSION,
   BUNDLE_EXTENSION,
 } from '../types/bundle';
-import { getProject, getProjectMediaIds, getThumbnail } from '@/infrastructure/storage';
+import { getProject, getProjectMediaIds, loadProjectThumbnail } from '@/infrastructure/storage';
 import {
   mediaLibraryService,
   computeContentHashFromBuffer,
@@ -169,9 +169,9 @@ export async function exportProjectBundle(
   // Step 7: Add project cover thumbnail if exists
   if (project.thumbnailId) {
     try {
-      const thumbnailData = await getThumbnail(project.thumbnailId);
-      if (thumbnailData?.blob) {
-        const thumbnailBuffer = await thumbnailData.blob.arrayBuffer();
+      const thumbnailBlob = await loadProjectThumbnail(project.id);
+      if (thumbnailBlob) {
+        const thumbnailBuffer = await thumbnailBlob.arrayBuffer();
         const thumbnailFile = new ZipPassThrough('cover.jpg');
         zip.add(thumbnailFile);
         thumbnailFile.push(new Uint8Array(thumbnailBuffer), true);
@@ -371,9 +371,9 @@ export async function exportProjectBundleStreaming(
     // Step 7: Add project cover thumbnail if exists
     if (project.thumbnailId) {
       try {
-        const thumbnailData = await getThumbnail(project.thumbnailId);
-        if (thumbnailData?.blob) {
-          const thumbnailBuffer = await thumbnailData.blob.arrayBuffer();
+        const thumbnailBlob = await loadProjectThumbnail(project.id);
+        if (thumbnailBlob) {
+          const thumbnailBuffer = await thumbnailBlob.arrayBuffer();
           const thumbnailFile = new ZipPassThrough('cover.jpg');
           zip.add(thumbnailFile);
           thumbnailFile.push(new Uint8Array(thumbnailBuffer), true);

--- a/src/features/project-bundle/services/bundle-import-service.ts
+++ b/src/features/project-bundle/services/bundle-import-service.ts
@@ -21,6 +21,7 @@ import {
   createProject,
   createMedia,
   saveThumbnail,
+  saveProjectThumbnail,
   associateMediaWithProject,
   updateProject,
 } from '@/infrastructure/storage';
@@ -208,17 +209,8 @@ export async function importProjectBundle(
     try {
       const blob = new Blob([new Uint8Array(coverData)], { type: 'image/jpeg' });
       const thumbnailId = `project:${newProjectId}:cover`;
-      await saveThumbnail({
-        id: thumbnailId,
-        mediaId: newProjectId, // Use project ID as mediaId for cover thumbnails
-        blob,
-        timestamp: Date.now(),
-        width: 320, // Default thumbnail dimensions
-        height: 180,
-      });
-      // Update project with thumbnailId
+      await saveProjectThumbnail(newProjectId, blob);
       project.thumbnailId = thumbnailId;
-      // Note: Project already created above, need to update it
       await updateProject(newProjectId, { thumbnailId });
     } catch (err) {
       // Thumbnail restoration is optional, continue without it

--- a/src/features/projects/hooks/use-project-thumbnail.ts
+++ b/src/features/projects/hooks/use-project-thumbnail.ts
@@ -1,5 +1,5 @@
 ﻿import { useState, useEffect } from 'react';
-import { getThumbnail } from '@/infrastructure/storage';
+import { loadProjectThumbnail } from '@/infrastructure/storage';
 import type { Project } from '@/types/project';
 import { createLogger } from '@/shared/logging/logger';
 
@@ -20,12 +20,12 @@ export function useProjectThumbnail(project: Project): string | undefined {
     let cancelled = false;
 
     async function loadThumbnail() {
-      // Try to load from thumbnailId first (workspace-backed blob storage)
+      // Try to load the workspace-backed project thumbnail blob.
       if (project.thumbnailId) {
         try {
-          const thumbnailData = await getThumbnail(project.thumbnailId);
-          if (thumbnailData && !cancelled) {
-            objectUrl = URL.createObjectURL(thumbnailData.blob);
+          const blob = await loadProjectThumbnail(project.id);
+          if (blob && !cancelled) {
+            objectUrl = URL.createObjectURL(blob);
             setThumbnailUrl(objectUrl);
             return;
           }

--- a/src/features/projects/services/project-upgrade-service.test.ts
+++ b/src/features/projects/services/project-upgrade-service.test.ts
@@ -6,9 +6,9 @@ const indexedDbMocks = vi.hoisted(() => ({
   deleteProject: vi.fn(),
   getProject: vi.fn(),
   getProjectMediaIds: vi.fn(),
-  getThumbnail: vi.fn(),
+  loadProjectThumbnail: vi.fn(),
   removeMediaFromProject: vi.fn(),
-  saveThumbnail: vi.fn(),
+  saveProjectThumbnail: vi.fn(),
   updateProject: vi.fn(),
 }));
 
@@ -35,14 +35,7 @@ describe('createProjectUpgradeBackup', () => {
       timeline: { tracks: [], items: [] },
     });
     indexedDbMocks.getProjectMediaIds.mockResolvedValue(['media-1', 'media-2']);
-    indexedDbMocks.getThumbnail.mockResolvedValue({
-      id: 'project:project-1:cover',
-      mediaId: 'project-1',
-      blob: new Blob(['thumb']),
-      timestamp: 10,
-      width: 320,
-      height: 180,
-    });
+    indexedDbMocks.loadProjectThumbnail.mockResolvedValue(new Blob(['thumb']));
 
     const backup = await createProjectUpgradeBackup('project-1', {
       fromVersion: 4,
@@ -58,12 +51,11 @@ describe('createProjectUpgradeBackup', () => {
     );
     expect(indexedDbMocks.associateMediaWithProject).toHaveBeenNthCalledWith(1, backup.id, 'media-1');
     expect(indexedDbMocks.associateMediaWithProject).toHaveBeenNthCalledWith(2, backup.id, 'media-2');
-    expect(indexedDbMocks.saveThumbnail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: `project:${backup.id}:cover`,
-        mediaId: backup.id,
-      })
+    expect(indexedDbMocks.saveProjectThumbnail).toHaveBeenCalledWith(
+      backup.id,
+      expect.any(Blob),
     );
+    expect(indexedDbMocks.loadProjectThumbnail).toHaveBeenCalledWith('project-1');
     expect(indexedDbMocks.updateProject).toHaveBeenCalledWith(backup.id, {
       thumbnailId: `project:${backup.id}:cover`,
       thumbnail: undefined,

--- a/src/features/projects/services/project-upgrade-service.ts
+++ b/src/features/projects/services/project-upgrade-service.ts
@@ -4,9 +4,9 @@ import {
   deleteProject,
   getProject,
   getProjectMediaIds,
-  getThumbnail,
+  loadProjectThumbnail,
   removeMediaFromProject,
-  saveThumbnail,
+  saveProjectThumbnail,
   updateProject,
 } from '@/infrastructure/storage';
 import { createLogger } from '@/shared/logging/logger';
@@ -76,18 +76,13 @@ export async function createProjectUpgradeBackup(
   }
 
   try {
-    const thumbnail = await getThumbnail(project.thumbnailId);
-    if (!thumbnail) {
+    const thumbnailBlob = await loadProjectThumbnail(project.id);
+    if (!thumbnailBlob) {
       return backup;
     }
 
     const backupThumbnailId = `project:${backup.id}:cover`;
-    await saveThumbnail({
-      ...thumbnail,
-      id: backupThumbnailId,
-      mediaId: backup.id,
-      timestamp: Date.now(),
-    });
+    await saveProjectThumbnail(backup.id, thumbnailBlob);
 
     await updateProject(backup.id, {
       thumbnailId: backupThumbnailId,

--- a/src/features/projects/services/project-upgrade-service.ts
+++ b/src/features/projects/services/project-upgrade-service.ts
@@ -71,11 +71,10 @@ export async function createProjectUpgradeBackup(
     throw error;
   }
 
-  if (!project.thumbnailId) {
-    return backup;
-  }
-
   try {
+    // `thumbnailId` is a presence sentinel, not a storage key — always try to
+    // load from the project-scoped thumbnail path and bail only if nothing is
+    // actually stored.
     const thumbnailBlob = await loadProjectThumbnail(project.id);
     if (!thumbnailBlob) {
       return backup;

--- a/src/features/projects/stores/project-store.ts
+++ b/src/features/projects/stores/project-store.ts
@@ -140,7 +140,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
         // Create a new project with optimistic update
         createProject: async (data: ProjectFormData) => {
-          set({ isLoading: true, error: null });
+          set({ error: null });
 
           const newProject = createProjectObject(data);
 
@@ -150,7 +150,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
           try {
             await createProjectDB(newProject);
-            set({ isLoading: false, currentProject: newProject });
+            set({ currentProject: newProject });
             return newProject;
           } catch (error) {
             // Rollback on error
@@ -158,14 +158,14 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
             const errorMessage =
               error instanceof Error ? error.message : 'Failed to create project';
-            set({ error: errorMessage, isLoading: false });
+            set({ error: errorMessage });
             throw error;
           }
         },
 
         // Update an existing project with optimistic update
         updateProject: async (id: string, data: Partial<ProjectFormData>) => {
-          set({ isLoading: true, error: null });
+          set({ error: null });
 
           const previousProjects = get().projects;
           const currentProject = get().currentProject;
@@ -180,7 +180,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
           }
 
           if (!existingProject) {
-            set({ error: `Project not found: ${id}`, isLoading: false });
+            set({ error: `Project not found: ${id}` });
             throw new Error(`Project not found: ${id}`);
           }
 
@@ -217,7 +217,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
               set({ currentProject: updated });
             }
 
-            set({ isLoading: false });
             return updated;
           } catch (error) {
             // Rollback on error
@@ -230,7 +229,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
             const errorMessage =
               error instanceof Error ? error.message : 'Failed to update project';
-            set({ error: errorMessage, isLoading: false });
+            set({ error: errorMessage });
             throw error;
           }
         },
@@ -238,7 +237,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
         // Delete a project with optimistic update
         // v3: Also deletes media associations (with reference counting)
         deleteProject: async (id: string, clearLocalFiles?: boolean) => {
-          set({ isLoading: true, error: null });
+          set({ error: null });
 
           const previousProjects = get().projects;
           const projectToDelete = previousProjects.find((p) => p.id === id);
@@ -257,7 +256,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
             fsPermissionGranted = permission === 'granted';
             if (!fsPermissionGranted) {
               logger.warn(`Permission denied to clear local files for project ${id}`);
-              set({ isLoading: false });
               throw new Error('Filesystem permission denied — project was not deleted. Please grant access and try again.');
             }
           }
@@ -317,7 +315,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
             // their TTL.
             const marker = await softDeleteProject(id);
 
-            set({ isLoading: false });
             return {
               localFilesDeleted,
               trashed: true as const,
@@ -330,7 +327,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
               const scope = localFilesDeleted ? 'All local files deleted' : 'Some local files deleted';
               const errorMessage = `${scope} but soft-delete failed — project may be inconsistent`;
               logger.error(errorMessage, error);
-              set({ error: errorMessage, isLoading: false });
+              set({ error: errorMessage });
               throw new Error(errorMessage, { cause: error });
             }
             // Rollback on error (safe — no local files were touched)
@@ -338,23 +335,23 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
             const errorMessage =
               error instanceof Error ? error.message : 'Failed to delete project';
-            set({ error: errorMessage, isLoading: false });
+            set({ error: errorMessage });
             throw error;
           }
         },
 
         restoreProject: async (id: string) => {
-          set({ isLoading: true, error: null });
+          set({ error: null });
           try {
             await restoreProjectDB(id);
             // Refresh the visible list so the restored project reappears.
             const projects = await getAllProjects();
-            set({ projects, isLoading: false });
+            set({ projects });
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : 'Failed to restore project';
             logger.error(`restoreProject(${id}) failed`, error);
-            set({ error: errorMessage, isLoading: false });
+            set({ error: errorMessage });
             throw error;
           }
         },
@@ -388,12 +385,12 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
         // Duplicate an existing project
         duplicateProject: async (id: string) => {
-          set({ isLoading: true, error: null });
+          set({ error: null });
 
           const originalProject = get().projects.find((p) => p.id === id);
 
           if (!originalProject) {
-            set({ error: `Project not found: ${id}`, isLoading: false });
+            set({ error: `Project not found: ${id}` });
             throw new Error(`Project not found: ${id}`);
           }
 
@@ -413,7 +410,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
               await associateMediaWithProject(newProject.id, mediaId);
             }
 
-            set({ isLoading: false });
             return newProject;
           } catch (error) {
             // Rollback on error
@@ -421,7 +417,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
 
             const errorMessage =
               error instanceof Error ? error.message : 'Failed to duplicate project';
-            set({ error: errorMessage, isLoading: false });
+            set({ error: errorMessage });
             throw error;
           }
         },

--- a/src/features/scene-browser/components/library-palette-grid.tsx
+++ b/src/features/scene-browser/components/library-palette-grid.tsx
@@ -4,7 +4,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { cn } from '@/shared/ui/cn';
 import { useLibraryPalette } from '../hooks/use-library-palette';
 import { useSceneBrowserStore } from '../stores/scene-browser-store';
-import { labToRgb } from './scene-palette-swatches';
+import { labToRgb } from '../utils/color-convert';
 
 /**
  * Color Mode picker — a weighted-k-means grid of the library's actual

--- a/src/features/scene-browser/components/scene-browser-panel.tsx
+++ b/src/features/scene-browser/components/scene-browser-panel.tsx
@@ -150,7 +150,7 @@ export function SceneBrowserPanel({ className }: SceneBrowserPanelProps) {
             />
           ) : (
             <Select value={scope ?? 'all'} onValueChange={handleScopeChange}>
-              <SelectTrigger className="h-8 w-36 text-[11px]">
+              <SelectTrigger className="h-6 w-36 text-[11px]">
                 <SelectValue placeholder="Scope" />
               </SelectTrigger>
               <SelectContent>
@@ -299,7 +299,7 @@ function CompactScopePicker({
         <button
           type="button"
           className={cn(
-            'relative flex h-8 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
+            'relative flex h-6 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
             scope
               ? 'border-primary/60 bg-primary/10 text-primary'
               : 'border-border bg-secondary text-muted-foreground hover:text-foreground',
@@ -354,7 +354,7 @@ function AnalyzeMenu({
           type="button"
           disabled={disabled || busy}
           className={cn(
-            'flex h-8 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
+            'flex h-6 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
             'border-border bg-secondary text-muted-foreground hover:text-foreground',
             (disabled || busy) && 'cursor-not-allowed opacity-60',
           )}

--- a/src/features/scene-browser/components/scene-palette-swatches.tsx
+++ b/src/features/scene-browser/components/scene-palette-swatches.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { cn } from '@/shared/ui/cn';
+import { labToRgb } from '../utils/color-convert';
 
 /**
  * Tiny row of color swatches showing the scene's dominant palette.
@@ -27,48 +28,6 @@ interface ScenePaletteSwatchesProps {
    * → setQuery). When omitted, swatches render non-interactively.
    */
   onSwatchClick?: (swatch: Swatch) => void;
-}
-
-export function labToRgb(l: number, a: number, b: number): [number, number, number] {
-  // Inverse of sRGB → Lab conversion: Lab → XYZ → linear sRGB → gamma.
-  const fy = (l + 16) / 116;
-  const fx = a / 500 + fy;
-  const fz = fy - b / 200;
-
-  const epsilon = 216 / 24389;
-  const kappa = 24389 / 27;
-
-  const xr = fx ** 3 > epsilon ? fx ** 3 : (116 * fx - 16) / kappa;
-  const yr = l > kappa * epsilon ? ((l + 16) / 116) ** 3 : l / kappa;
-  const zr = fz ** 3 > epsilon ? fz ** 3 : (116 * fz - 16) / kappa;
-
-  const refX = 0.95047;
-  const refZ = 1.08883;
-  const X = xr * refX;
-  const Y = yr * 1.0;
-  const Z = zr * refZ;
-
-  // XYZ → linear sRGB
-  let rLin =  3.2404542 * X + -1.5371385 * Y + -0.4985314 * Z;
-  let gLin = -0.9692660 * X +  1.8760108 * Y +  0.0415560 * Z;
-  let bLin =  0.0556434 * X + -0.2040259 * Y +  1.0572252 * Z;
-
-  const compand = (v: number): number => {
-    const clamped = Math.max(0, Math.min(1, v));
-    return clamped <= 0.0031308
-      ? 12.92 * clamped
-      : 1.055 * Math.pow(clamped, 1 / 2.4) - 0.055;
-  };
-
-  rLin = compand(rLin);
-  gLin = compand(gLin);
-  bLin = compand(bLin);
-
-  return [
-    Math.round(rLin * 255),
-    Math.round(gLin * 255),
-    Math.round(bLin * 255),
-  ];
 }
 
 function swatchColor(swatch: Swatch): string {

--- a/src/features/scene-browser/components/scene-search-input.tsx
+++ b/src/features/scene-browser/components/scene-search-input.tsx
@@ -33,7 +33,7 @@ export function SceneSearchModeButtons({ compact = false }: { compact?: boolean 
         type="button"
         onClick={() => setColorMode(!colorMode)}
         className={cn(
-          'flex h-8 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
+          'flex h-6 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
           colorMode
             ? 'border-primary/60 bg-primary/10 text-primary'
             : 'border-border bg-secondary text-muted-foreground hover:text-foreground',
@@ -51,7 +51,7 @@ export function SceneSearchModeButtons({ compact = false }: { compact?: boolean 
             <button
               type="button"
               className={cn(
-                'flex h-8 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
+                'flex h-6 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors',
                 semanticActive
                   ? 'border-primary/60 bg-primary/10 text-primary'
                   : 'border-border bg-secondary text-muted-foreground hover:text-foreground',

--- a/src/features/scene-browser/hooks/use-caption-thumbnail.ts
+++ b/src/features/scene-browser/hooks/use-caption-thumbnail.ts
@@ -12,6 +12,16 @@ import { requestLazyCaptionThumbnail } from '../utils/lazy-thumb';
  */
 const blobUrlCache = new Map<string, string>();
 const pendingLoads = new Map<string, Promise<string | null>>();
+// Monotonic version per relPath. Incremented on every invalidation so an
+// in-flight loadBlobUrl that started before an invalidate cannot repopulate
+// the cache with pre-invalidation bytes.
+const versionByKey = new Map<string, number>();
+
+function bumpVersion(key: string): number {
+  const next = (versionByKey.get(key) ?? 0) + 1;
+  versionByKey.set(key, next);
+  return next;
+}
 
 /**
  * Revoke and drop every blob URL tied to a media's caption thumbnails.
@@ -33,10 +43,14 @@ export function invalidateMediaCaptionThumbBlobs(
     if (key.startsWith(prefix) || explicitKeys.has(key)) {
       URL.revokeObjectURL(url);
       blobUrlCache.delete(key);
+      bumpVersion(key);
     }
   }
   for (const key of pendingLoads.keys()) {
-    if (key.startsWith(prefix) || explicitKeys.has(key)) pendingLoads.delete(key);
+    if (key.startsWith(prefix) || explicitKeys.has(key)) {
+      pendingLoads.delete(key);
+      bumpVersion(key);
+    }
   }
 }
 
@@ -46,10 +60,19 @@ async function loadBlobUrl(relPath: string): Promise<string | null> {
   const pending = pendingLoads.get(relPath);
   if (pending) return pending;
 
+  const startVersion = versionByKey.get(relPath) ?? 0;
   const promise = (async () => {
     const blob = await getCaptionThumbnailBlob(relPath);
     if (!blob) return null;
+    // Invalidation may have run while this read was in flight. In that case
+    // the freshly-loaded blob is stale; drop it instead of repopulating the
+    // cache with pre-invalidation bytes.
+    if ((versionByKey.get(relPath) ?? 0) !== startVersion) return null;
     const url = URL.createObjectURL(blob);
+    if ((versionByKey.get(relPath) ?? 0) !== startVersion) {
+      URL.revokeObjectURL(url);
+      return null;
+    }
     blobUrlCache.set(relPath, url);
     return url;
   })();

--- a/src/features/scene-browser/hooks/use-caption-thumbnail.ts
+++ b/src/features/scene-browser/hooks/use-caption-thumbnail.ts
@@ -14,21 +14,29 @@ const blobUrlCache = new Map<string, string>();
 const pendingLoads = new Map<string, Promise<string | null>>();
 
 /**
- * Revoke and drop every blob URL that lives under a media's
- * captions-thumbs directory. Callers should invoke this before a
- * re-analysis run so the next render loads the freshly-written JPEG
- * instead of the cached pre-overwrite blob.
+ * Revoke and drop every blob URL tied to a media's caption thumbnails.
+ * Callers should invoke this before a re-analysis run so the next render
+ * loads the freshly-written JPEG instead of the cached pre-overwrite blob.
+ *
+ * `thumbRelPaths` is needed for content-keyed thumbnails shared under
+ * `content/{hash}/ai/...`, which do not live under a media-specific prefix.
  */
-export function invalidateMediaCaptionThumbBlobs(mediaId: string): void {
+export function invalidateMediaCaptionThumbBlobs(
+  mediaId: string,
+  thumbRelPaths: readonly (string | undefined)[] = [],
+): void {
   const prefix = `media/${mediaId}/cache/ai/captions-thumbs/`;
+  const explicitKeys = new Set(
+    thumbRelPaths.filter((path): path is string => typeof path === 'string' && path.length > 0),
+  );
   for (const [key, url] of blobUrlCache) {
-    if (key.startsWith(prefix)) {
+    if (key.startsWith(prefix) || explicitKeys.has(key)) {
       URL.revokeObjectURL(url);
       blobUrlCache.delete(key);
     }
   }
   for (const key of pendingLoads.keys()) {
-    if (key.startsWith(prefix)) pendingLoads.delete(key);
+    if (key.startsWith(prefix) || explicitKeys.has(key)) pendingLoads.delete(key);
   }
 }
 

--- a/src/features/scene-browser/stores/scene-browser-store.ts
+++ b/src/features/scene-browser/stores/scene-browser-store.ts
@@ -74,7 +74,6 @@ const INITIAL_STATE: SceneBrowserState = {
 type SceneBrowserStoreApi = UseBoundStore<StoreApi<SceneBrowserState & SceneBrowserActions>>;
 
 declare global {
-  // eslint-disable-next-line no-var
   var __FREECUT_SCENE_BROWSER_STORE__: SceneBrowserStoreApi | undefined;
 }
 

--- a/src/features/scene-browser/utils/color-convert.ts
+++ b/src/features/scene-browser/utils/color-convert.ts
@@ -1,0 +1,44 @@
+/**
+ * Inverse of sRGB → Lab conversion: Lab → XYZ → linear sRGB → gamma.
+ * Used to render palette swatches back to their display colors.
+ */
+export function labToRgb(l: number, a: number, b: number): [number, number, number] {
+  const fy = (l + 16) / 116;
+  const fx = a / 500 + fy;
+  const fz = fy - b / 200;
+
+  const epsilon = 216 / 24389;
+  const kappa = 24389 / 27;
+
+  const xr = fx ** 3 > epsilon ? fx ** 3 : (116 * fx - 16) / kappa;
+  const yr = l > kappa * epsilon ? ((l + 16) / 116) ** 3 : l / kappa;
+  const zr = fz ** 3 > epsilon ? fz ** 3 : (116 * fz - 16) / kappa;
+
+  const refX = 0.95047;
+  const refZ = 1.08883;
+  const X = xr * refX;
+  const Y = yr * 1.0;
+  const Z = zr * refZ;
+
+  // XYZ → linear sRGB
+  let rLin =  3.2404542 * X + -1.5371385 * Y + -0.4985314 * Z;
+  let gLin = -0.9692660 * X +  1.8760108 * Y +  0.0415560 * Z;
+  let bLin =  0.0556434 * X + -0.2040259 * Y +  1.0572252 * Z;
+
+  const compand = (v: number): number => {
+    const clamped = Math.max(0, Math.min(1, v));
+    return clamped <= 0.0031308
+      ? 12.92 * clamped
+      : 1.055 * Math.pow(clamped, 1 / 2.4) - 0.055;
+  };
+
+  rLin = compand(rLin);
+  gLin = compand(gLin);
+  bLin = compand(bLin);
+
+  return [
+    Math.round(rLin * 255),
+    Math.round(gLin * 255),
+    Math.round(bLin * 255),
+  ];
+}

--- a/src/features/scene-browser/utils/embeddings-cache.ts
+++ b/src/features/scene-browser/utils/embeddings-cache.ts
@@ -59,6 +59,17 @@ function sceneId(mediaId: string, captionIndex: number): string {
   return `${mediaId}:${captionIndex}`;
 }
 
+async function getCaptionStorageOptions(
+  mediaId: string,
+  fallbackContentHash?: string,
+): Promise<{ contentHash?: string; sampleIntervalSec?: number }> {
+  const meta = await getCaptionsEmbeddingsMeta(mediaId).catch(() => null);
+  return {
+    contentHash: meta?.contentHash ?? fallbackContentHash,
+    sampleIntervalSec: meta?.sampleIntervalSec,
+  };
+}
+
 function populateFromInMemory(media: MediaMetadata): boolean {
   const captions = media.aiCaptions;
   if (!captions || captions.length === 0) return false;
@@ -89,7 +100,9 @@ async function hydrateFromDisk(mediaId: string, expectedCount: number): Promise<
   // When the envelope was persisted via the shared content-addressable cache,
   // the packed bins live under `content/{hash}/ai/` rather than per-media;
   // pass the hash so the reader looks up the right file.
-  const opts = meta.contentHash ? { contentHash: meta.contentHash } : undefined;
+  const opts = meta.contentHash
+    ? { contentHash: meta.contentHash, sampleIntervalSec: meta.sampleIntervalSec }
+    : undefined;
 
   let textOk = false;
   if (meta.embeddingModel === EMBEDDING_MODEL_ID && meta.embeddingDim === EMBEDDING_MODEL_DIM) {
@@ -203,9 +216,8 @@ export function indexMediaCaptions(mediaId: string): Promise<void> {
       throw new Error(`Embedding returned ${vectors.length} vectors for ${texts.length} captions`);
     }
 
-    await saveCaptionEmbeddings(mediaId, vectors, EMBEDDING_MODEL_DIM, {
-      contentHash: media.contentHash,
-    });
+    const storageOptions = await getCaptionStorageOptions(mediaId, media.contentHash);
+    await saveCaptionEmbeddings(mediaId, vectors, EMBEDDING_MODEL_DIM, storageOptions);
     // Persist the model metadata on captions.json so future sessions know
     // the bin matches. We rewrite the full captions payload — cheap, since
     // retroactive indexing is an explicit user action, not a hot path.
@@ -220,7 +232,8 @@ export function indexMediaCaptions(mediaId: string): Promise<void> {
     await mediaLibraryService.updateMediaCaptions(mediaId, capturedCaptions, {
       embeddingModel: EMBEDDING_MODEL_ID,
       embeddingDim: EMBEDDING_MODEL_DIM,
-      contentHash: media.contentHash,
+      contentHash: storageOptions.contentHash,
+      sampleIntervalSec: storageOptions.sampleIntervalSec,
     });
     useMediaLibraryStore.getState().updateMediaCaptions(mediaId, capturedCaptions);
 
@@ -276,9 +289,8 @@ export function indexMediaImageCaptions(mediaId: string): Promise<void> {
       throw new Error(`CLIP returned ${vectors.length} vectors for ${blobs.length} thumbnails`);
     }
 
-    await saveCaptionImageEmbeddings(mediaId, vectors, CLIP_EMBEDDING_DIM, {
-      contentHash: media.contentHash,
-    });
+    const storageOptions = await getCaptionStorageOptions(mediaId, media.contentHash);
+    await saveCaptionImageEmbeddings(mediaId, vectors, CLIP_EMBEDDING_DIM, storageOptions);
 
     // Patch captions.json with the image-model metadata. Fetch the latest
     // captions from the store so we preserve concurrent edits (rare, but
@@ -290,7 +302,8 @@ export function indexMediaImageCaptions(mediaId: string): Promise<void> {
         embeddingDim: EMBEDDING_MODEL_DIM,
         imageEmbeddingModel: CLIP_MODEL_ID,
         imageEmbeddingDim: CLIP_EMBEDDING_DIM,
-        contentHash: latest.contentHash,
+        contentHash: storageOptions.contentHash ?? latest.contentHash,
+        sampleIntervalSec: storageOptions.sampleIntervalSec,
       });
     }
 

--- a/src/features/scene-browser/utils/embeddings-cache.ts
+++ b/src/features/scene-browser/utils/embeddings-cache.ts
@@ -86,9 +86,14 @@ async function hydrateFromDisk(mediaId: string, expectedCount: number): Promise<
   const meta = await getCaptionsEmbeddingsMeta(mediaId);
   if (!meta) return { text: false, image: false };
 
+  // When the envelope was persisted via the shared content-addressable cache,
+  // the packed bins live under `content/{hash}/ai/` rather than per-media;
+  // pass the hash so the reader looks up the right file.
+  const opts = meta.contentHash ? { contentHash: meta.contentHash } : undefined;
+
   let textOk = false;
   if (meta.embeddingModel === EMBEDDING_MODEL_ID && meta.embeddingDim === EMBEDDING_MODEL_DIM) {
-    const vectors = await getCaptionEmbeddings(mediaId, meta.embeddingDim, expectedCount);
+    const vectors = await getCaptionEmbeddings(mediaId, meta.embeddingDim, expectedCount, opts);
     if (vectors) {
       vectors.forEach((vector, i) => embeddings.set(sceneId(mediaId, i), vector));
       textOk = true;
@@ -100,7 +105,7 @@ async function hydrateFromDisk(mediaId: string, expectedCount: number): Promise<
     meta.imageEmbeddingModel === CLIP_MODEL_ID
     && meta.imageEmbeddingDim === CLIP_EMBEDDING_DIM
   ) {
-    const vectors = await getCaptionImageEmbeddings(mediaId, meta.imageEmbeddingDim, expectedCount);
+    const vectors = await getCaptionImageEmbeddings(mediaId, meta.imageEmbeddingDim, expectedCount, opts);
     if (vectors) {
       vectors.forEach((vector, i) => imageEmbeddings.set(sceneId(mediaId, i), vector));
       imageOk = true;
@@ -198,7 +203,9 @@ export function indexMediaCaptions(mediaId: string): Promise<void> {
       throw new Error(`Embedding returned ${vectors.length} vectors for ${texts.length} captions`);
     }
 
-    await saveCaptionEmbeddings(mediaId, vectors, EMBEDDING_MODEL_DIM);
+    await saveCaptionEmbeddings(mediaId, vectors, EMBEDDING_MODEL_DIM, {
+      contentHash: media.contentHash,
+    });
     // Persist the model metadata on captions.json so future sessions know
     // the bin matches. We rewrite the full captions payload — cheap, since
     // retroactive indexing is an explicit user action, not a hot path.
@@ -213,6 +220,7 @@ export function indexMediaCaptions(mediaId: string): Promise<void> {
     await mediaLibraryService.updateMediaCaptions(mediaId, capturedCaptions, {
       embeddingModel: EMBEDDING_MODEL_ID,
       embeddingDim: EMBEDDING_MODEL_DIM,
+      contentHash: media.contentHash,
     });
     useMediaLibraryStore.getState().updateMediaCaptions(mediaId, capturedCaptions);
 
@@ -268,7 +276,9 @@ export function indexMediaImageCaptions(mediaId: string): Promise<void> {
       throw new Error(`CLIP returned ${vectors.length} vectors for ${blobs.length} thumbnails`);
     }
 
-    await saveCaptionImageEmbeddings(mediaId, vectors, CLIP_EMBEDDING_DIM);
+    await saveCaptionImageEmbeddings(mediaId, vectors, CLIP_EMBEDDING_DIM, {
+      contentHash: media.contentHash,
+    });
 
     // Patch captions.json with the image-model metadata. Fetch the latest
     // captions from the store so we preserve concurrent edits (rare, but
@@ -280,6 +290,7 @@ export function indexMediaImageCaptions(mediaId: string): Promise<void> {
         embeddingDim: EMBEDDING_MODEL_DIM,
         imageEmbeddingModel: CLIP_MODEL_ID,
         imageEmbeddingDim: CLIP_EMBEDDING_DIM,
+        contentHash: latest.contentHash,
       });
     }
 

--- a/src/features/scene-browser/utils/invalidate.ts
+++ b/src/features/scene-browser/utils/invalidate.ts
@@ -13,9 +13,13 @@
 import { invalidateMediaCaptionThumbBlobs } from '../hooks/use-caption-thumbnail';
 import { invalidateEmbeddingsCache } from './embeddings-cache';
 import { invalidateLazyThumbCache } from './lazy-thumb';
+import { useMediaLibraryStore } from '../deps/media-library';
 
 export function invalidateMediaCaptionThumbnails(mediaId: string): void {
-  invalidateMediaCaptionThumbBlobs(mediaId);
+  const thumbRelPaths = useMediaLibraryStore.getState().mediaById[mediaId]?.aiCaptions?.map(
+    (caption) => caption.thumbRelPath,
+  ) ?? [];
+  invalidateMediaCaptionThumbBlobs(mediaId, thumbRelPaths);
   invalidateLazyThumbCache(mediaId);
   // Semantic embeddings are tied 1:1 to caption indexes — a re-analyze
   // throws away the old caption array and generates a fresh one, so the

--- a/src/features/scene-browser/utils/lazy-thumb.ts
+++ b/src/features/scene-browser/utils/lazy-thumb.ts
@@ -210,7 +210,8 @@ async function generateOne(request: PendingRequest): Promise<string | null> {
     if (useMediaLibraryStore.getState().taggingMediaIds.has(mediaId)) {
       return null;
     }
-    const relPath = await saveCaptionThumbnail(mediaId, captionIndex, jpeg);
+    const contentHash = useMediaLibraryStore.getState().mediaById[mediaId]?.contentHash;
+    const relPath = await saveCaptionThumbnail(mediaId, captionIndex, jpeg, { contentHash });
     patchStoreThumbPath(mediaId, captionIndex, relPath);
     return relPath;
   } catch (error) {
@@ -260,7 +261,8 @@ export function requestLazyCaptionThumbnail(
   if (pending) return pending;
 
   const promise = (async () => {
-    const existing = await probeCaptionThumbnail(mediaId, captionIndex);
+    const contentHash = useMediaLibraryStore.getState().mediaById[mediaId]?.contentHash;
+    const existing = await probeCaptionThumbnail(mediaId, captionIndex, { contentHash });
     if (existing) {
       patchStoreThumbPath(mediaId, captionIndex, existing);
       resultCache.set(key, existing);

--- a/src/features/scene-browser/utils/lazy-thumb.ts
+++ b/src/features/scene-browser/utils/lazy-thumb.ts
@@ -13,7 +13,11 @@
 
 import { createLogger } from '@/shared/logging/logger';
 import { mediaLibraryService, useMediaLibraryStore, type MediaMetadata } from '../deps/media-library';
-import { probeCaptionThumbnail, saveCaptionThumbnail } from '../deps/storage';
+import {
+  getCaptionsEmbeddingsMeta,
+  probeCaptionThumbnail,
+  saveCaptionThumbnail,
+} from '../deps/storage';
 
 const log = createLogger('SceneBrowser:LazyThumb');
 
@@ -159,6 +163,17 @@ function patchStoreThumbPath(mediaId: string, captionIndex: number, relPath: str
   schedulePersist(mediaId);
 }
 
+async function getCaptionStorageOptions(
+  mediaId: string,
+): Promise<{ contentHash?: string; sampleIntervalSec?: number }> {
+  const media = useMediaLibraryStore.getState().mediaById[mediaId];
+  const meta = await getCaptionsEmbeddingsMeta(mediaId).catch(() => null);
+  return {
+    contentHash: meta?.contentHash ?? media?.contentHash,
+    sampleIntervalSec: meta?.sampleIntervalSec,
+  };
+}
+
 async function generateOne(request: PendingRequest): Promise<string | null> {
   const { mediaId, captionIndex, timeSec } = request;
   const state = useMediaLibraryStore.getState();
@@ -210,8 +225,8 @@ async function generateOne(request: PendingRequest): Promise<string | null> {
     if (useMediaLibraryStore.getState().taggingMediaIds.has(mediaId)) {
       return null;
     }
-    const contentHash = useMediaLibraryStore.getState().mediaById[mediaId]?.contentHash;
-    const relPath = await saveCaptionThumbnail(mediaId, captionIndex, jpeg, { contentHash });
+    const cacheOptions = await getCaptionStorageOptions(mediaId);
+    const relPath = await saveCaptionThumbnail(mediaId, captionIndex, jpeg, cacheOptions);
     patchStoreThumbPath(mediaId, captionIndex, relPath);
     return relPath;
   } catch (error) {
@@ -261,8 +276,8 @@ export function requestLazyCaptionThumbnail(
   if (pending) return pending;
 
   const promise = (async () => {
-    const contentHash = useMediaLibraryStore.getState().mediaById[mediaId]?.contentHash;
-    const existing = await probeCaptionThumbnail(mediaId, captionIndex, { contentHash });
+    const cacheOptions = await getCaptionStorageOptions(mediaId);
+    const existing = await probeCaptionThumbnail(mediaId, captionIndex, cacheOptions);
     if (existing) {
       patchStoreThumbPath(mediaId, captionIndex, existing);
       resultCache.set(key, existing);

--- a/src/features/timeline/components/clip-waveform/adaptive-render-version.ts
+++ b/src/features/timeline/components/clip-waveform/adaptive-render-version.ts
@@ -11,6 +11,9 @@ interface WaveformActiveTileCountOptions {
 interface AdaptiveWaveformRenderVersionOptions {
   baseVersion: string;
   pixelsPerSecond: number;
+  /** Total canvas render width in px. Included in the throttled zoom signal so
+   *  trim-extend (which grows width without changing pps) also triggers redraws. */
+  renderWidth: number;
   activeTileCount: number;
   phaseKey?: string;
 }
@@ -75,12 +78,13 @@ export function getWaveformZoomCommitPhaseMs(activeTileCount: number, phaseKey?:
 export function useAdaptiveWaveformRenderVersion({
   baseVersion,
   pixelsPerSecond,
+  renderWidth,
   activeTileCount,
   phaseKey,
 }: AdaptiveWaveformRenderVersionOptions): string {
   const zoomVersion = useMemo(
-    () => `e${Math.round(Math.max(1, pixelsPerSecond) * 1000)}`,
-    [pixelsPerSecond],
+    () => `e${Math.round(Math.max(1, pixelsPerSecond) * 1000)}:w${Math.round(renderWidth)}`,
+    [pixelsPerSecond, renderWidth],
   );
   const redrawIntervalMs = useMemo(
     () => getWaveformZoomRedrawIntervalMs(activeTileCount),

--- a/src/features/timeline/components/clip-waveform/compound-clip-waveform.tsx
+++ b/src/features/timeline/components/clip-waveform/compound-clip-waveform.tsx
@@ -301,6 +301,7 @@ export const CompoundClipWaveform = memo(function CompoundClipWaveform({
   const renderVersion = useAdaptiveWaveformRenderVersion({
     baseVersion: `${peaks?.length ?? 0}:${height}:${waveformsByMediaId.size}`,
     pixelsPerSecond,
+    renderWidth: renderClipWidth,
     activeTileCount,
     phaseKey: mediaIdsKey,
   });

--- a/src/features/timeline/components/clip-waveform/index.tsx
+++ b/src/features/timeline/components/clip-waveform/index.tsx
@@ -319,6 +319,7 @@ export const ClipWaveform = memo(function ClipWaveform({
   const renderVersion = useAdaptiveWaveformRenderVersion({
     baseVersion: `${loadedSamples}:${height}`,
     pixelsPerSecond,
+    renderWidth: renderClipWidth,
     activeTileCount,
     phaseKey: mediaId,
   });

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -23,17 +23,19 @@ vi.mock('../hooks/use-timeline-zoom', () => ({
   }),
 }));
 
-vi.mock('@/hooks/use-marquee-selection', () => ({
-  useMarqueeSelection: () => ({
-    marqueeState: {
-      active: false,
-      startX: 0,
-      startY: 0,
-      currentX: 0,
-      currentY: 0,
-    },
-  }),
-}));
+vi.mock('@/hooks/use-marquee-selection', () => {
+  const INACTIVE = { active: false, startX: 0, startY: 0, currentX: 0, currentY: 0 };
+  return {
+    useMarqueeSelection: () => ({
+      isActive: false,
+      marquee: {
+        subscribe: () => () => {},
+        getSnapshot: () => INACTIVE,
+      },
+      selectedIds: [],
+    }),
+  };
+});
 
 vi.mock('../hooks/use-waveform-prefetch', () => ({
   useWaveformPrefetch: () => {},

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -27,6 +27,7 @@ import {
   ZOOM_MIN_VELOCITY,
   TIMELINE_RULER_HEIGHT,
   TRACK_SECTION_DIVIDER_HEIGHT,
+  computeWheelZoomStep,
 } from '../constants';
 
 // Components
@@ -1561,23 +1562,7 @@ export const TimelineContent = memo(function TimelineContent({
         const rect = container.getBoundingClientRect();
         zoomCursorXRef.current = event.clientX - rect.left;
 
-        const currentZoom = zoomLevelRef.current;
-        // Use logarithmic zoom (multiplicative) for uniform perceptual speed
-        // This matches the slider's logarithmic behavior
-        const ZOOM_FACTOR = 1.15; // ~15% perceptual change per tick
-        const MIN_ZOOM = 0.01; // 1%
-        const MAX_ZOOM = 2; // 200%
-
-        let newZoom: number;
-        if (event.deltaY > 0) {
-          // Scroll down = zoom out (divide by factor)
-          newZoom = Math.max(MIN_ZOOM, currentZoom / ZOOM_FACTOR);
-        } else {
-          // Scroll up = zoom in (multiply by factor)
-          newZoom = Math.min(MAX_ZOOM, currentZoom * ZOOM_FACTOR);
-        }
-
-        applyZoomWithCursorAnchor(newZoom);
+        applyZoomWithCursorAnchor(computeWheelZoomStep(zoomLevelRef.current, event.deltaY));
         return;
       }
 

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -432,7 +432,7 @@ const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
     [containerRef, itemIds]
   );
 
-  const { marqueeState } = useMarqueeSelection({
+  const { marquee, isActive } = useMarqueeSelection({
     containerRef: containerRef as React.RefObject<HTMLElement>,
     items: marqueeItems,
     onSelectionChange,
@@ -444,10 +444,10 @@ const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
   });
 
   useEffect(() => {
-    onMarqueeActiveChange(marqueeState.active);
-  }, [marqueeState.active, onMarqueeActiveChange]);
+    onMarqueeActiveChange(isActive);
+  }, [isActive, onMarqueeActiveChange]);
 
-  return <MarqueeOverlay marqueeState={marqueeState} />;
+  return <MarqueeOverlay marquee={marquee} />;
 });
 
 interface TimelineTrackSectionsSurfaceProps {

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -12,13 +12,104 @@ import { useItemsStore } from '../../stores/items-store';
 import { useClipVisibility } from '../../hooks/use-clip-visibility';
 import { useZoomStore } from '../../stores/zoom-store';
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/app/editor-layout';
-import { summarizeCompositionClipContent } from '../../utils/composition-clip-summary';
+import {
+  getCompositionVisualSegments,
+  summarizeCompositionClipContent,
+  type CompositionVisualSegment,
+} from '../../utils/composition-clip-summary';
 import { hasLinkedAudioCompanion } from '@/shared/utils/linked-media';
 import { formatSignedFrameDelta } from '@/shared/utils/time-utils';
 import { isGifUrl, isWebpUrl } from '@/shared/utils/media-utils';
 
 const EMPTY_COMPOSITION_LOOKUP: Record<string, never> = {};
 const FILMSTRIP_MIN_WIDTH_PX = 5;
+
+interface CompositionFilmstripSegmentProps {
+  segment: CompositionVisualSegment;
+  wrapperDurationFrames: number;
+  wrapperClipWidthPx: number;
+  wrapperRenderWidthPx: number;
+  wrapperVisibleStartRatio: number;
+  wrapperVisibleEndRatio: number;
+  wrapperIsVisible: boolean;
+  fps: number;
+  pixelsPerSecond: number;
+  preferImmediateRendering: boolean;
+}
+
+function CompositionFilmstripSegment({
+  segment,
+  wrapperDurationFrames,
+  wrapperClipWidthPx,
+  wrapperRenderWidthPx,
+  wrapperVisibleStartRatio,
+  wrapperVisibleEndRatio,
+  wrapperIsVisible,
+  fps,
+  pixelsPerSecond,
+  preferImmediateRendering,
+}: CompositionFilmstripSegmentProps) {
+  const mediaId = segment.mediaId;
+  const mediaFps = useMediaLibraryStore(
+    useCallback((s) => s.mediaById[mediaId]?.fps || segment.sourceFps, [mediaId, segment.sourceFps]),
+  );
+  const mediaDuration = useMediaLibraryStore(
+    useCallback((s) => s.mediaById[mediaId]?.duration || 0, [mediaId]),
+  );
+
+  const wrapperSpan = Math.max(1, wrapperDurationFrames);
+  const widthFraction = Math.min(1, segment.durationInFrames / wrapperSpan);
+  const leftFraction = Math.max(0, segment.from / wrapperSpan);
+  const segmentClipWidth = Math.max(0, widthFraction * wrapperClipWidthPx);
+  const segmentRenderWidth = Math.max(0, widthFraction * wrapperRenderWidthPx);
+
+  const sourceDurationSeconds = mediaDuration > 0
+    ? mediaDuration
+    : segment.sourceDurationFrames / Math.max(1, mediaFps);
+  const sourceStartSeconds = mediaDuration > 0 && segment.sourceDurationFrames > 0
+    ? (segment.sourceStart / segment.sourceDurationFrames) * mediaDuration
+    : segment.sourceStart / Math.max(1, mediaFps);
+
+  const segmentEndFraction = leftFraction + widthFraction;
+  const overlapStart = Math.max(wrapperVisibleStartRatio, leftFraction);
+  const overlapEnd = Math.min(wrapperVisibleEndRatio, segmentEndFraction);
+  const hasOverlap = overlapEnd > overlapStart && widthFraction > 0;
+  const segmentVisibleStartRatio = hasOverlap
+    ? Math.max(0, Math.min(1, (overlapStart - leftFraction) / widthFraction))
+    : 0;
+  const segmentVisibleEndRatio = hasOverlap
+    ? Math.max(0, Math.min(1, (overlapEnd - leftFraction) / widthFraction))
+    : 0;
+  const segmentIsVisible = wrapperIsVisible && hasOverlap;
+
+  if (segmentClipWidth < FILMSTRIP_MIN_WIDTH_PX) return null;
+
+  return (
+    <div
+      className="absolute inset-y-0 overflow-hidden"
+      style={{
+        left: `${leftFraction * 100}%`,
+        width: `${widthFraction * 100}%`,
+      }}
+    >
+      <ClipFilmstrip
+        mediaId={mediaId}
+        clipWidth={segmentClipWidth}
+        renderWidth={segmentRenderWidth}
+        sourceStart={sourceStartSeconds}
+        sourceDuration={sourceDurationSeconds}
+        trimStart={0}
+        speed={segment.speed}
+        fps={fps}
+        isVisible={segmentIsVisible}
+        visibleStartRatio={segmentVisibleStartRatio}
+        visibleEndRatio={segmentVisibleEndRatio}
+        pixelsPerSecond={pixelsPerSecond}
+        preferImmediateRendering={preferImmediateRendering}
+      />
+    </div>
+  );
+}
 
 /**
  * Small render buffer: filmstrip/waveform are rendered slightly wider than the
@@ -110,8 +201,15 @@ export const ClipContent = memo(function ClipContent({
       compositionById,
       });
   }, [composition, compositionById]);
-  const compositionVisualSource = compositionSummary.visualSource;
-  const compositionVisualMediaId = compositionVisualSource?.mediaId ?? null;
+  const compositionVisualMediaId = compositionSummary.visualSource?.mediaId ?? null;
+  const visualSegments = useMemo<CompositionVisualSegment[]>(() => {
+    if (item.type !== 'composition' || !composition) return [];
+    return getCompositionVisualSegments({
+      wrapper: item,
+      parentFps: fps,
+      compositionById,
+    });
+  }, [item, fps, composition, compositionById]);
   const showCompositionWaveform = showWaveforms && compositionSummary.hasOwnedAudio && !hasCompositionAudioCompanion;
   const linkedSyncOffsetLabel = linkedSyncOffsetFrames === null
     ? null
@@ -189,25 +287,6 @@ export const ClipContent = memo(function ClipContent({
 
   const trimStart = (item.trimStart ?? 0) / fps;
   const speed = item.speed ?? 1;
-  const compositionVisualSourceFps = useMediaLibraryStore(
-    useCallback((s) => {
-      if (!compositionVisualMediaId) return fps;
-      return s.mediaById[compositionVisualMediaId]?.fps || fps;
-    }, [compositionVisualMediaId, fps])
-  );
-  const compositionVisualMediaDuration = useMediaLibraryStore(
-    useCallback((s) => {
-      if (!compositionVisualMediaId) return 0;
-      return s.mediaById[compositionVisualMediaId]?.duration || 0;
-    }, [compositionVisualMediaId])
-  );
-  const compositionVisualSourceDuration = compositionVisualMediaDuration > 0
-    ? compositionVisualMediaDuration
-    : ((compositionVisualSource?.sourceDuration ?? compositionSourceDurationFrames) / compositionVisualSourceFps);
-  const compositionVisualSourceStart = compositionVisualMediaDuration > 0
-    ? ((compositionVisualSource?.sourceStart ?? compositionSourceStartFrames) / Math.max(1, compositionVisualSource?.sourceDuration ?? compositionSourceDurationFrames)) * compositionVisualMediaDuration
-    : ((compositionVisualSource?.sourceStart ?? compositionSourceStartFrames) / compositionVisualSourceFps);
-  const compositionVisualSpeed = compositionVisualSource?.speed ?? 1;
   const compoundClipTimelineFps = composition?.fps ?? fps;
   const compoundClipSourceDuration = compositionSourceDurationFrames / compoundClipTimelineFps;
   const compoundClipSourceStart = compositionSourceStartFrames / compoundClipTimelineFps;
@@ -351,33 +430,31 @@ export const ClipContent = memo(function ClipContent({
     );
   }
 
-  // Composition item - filmstrip from topmost video in sub-comp, or label fallback
+  // Composition item - multi-segment filmstrip from visible sub-comp videos, or label fallback
   if (item.type === 'composition') {
-    if (compositionVisualMediaId) {
+    if (visualSegments.length > 0) {
       return (
         <div className="absolute inset-0 flex flex-col">
           {renderCompoundClipLabel(item.label || 'Compound Clip')}
           {showVisualContent && (
             <>
-              {/* Row 2: Filmstrip - flex-1 */}
+              {/* Row 2: Filmstrip stack - flex-1 */}
               <div className="relative overflow-hidden flex-1 min-h-0">
-                {showFilmstrips && (
-                  <ClipFilmstrip
-                    mediaId={compositionVisualMediaId}
-                    clipWidth={clipWidth}
-                    renderWidth={renderWidth}
-                    sourceStart={compositionVisualSourceStart}
-                    sourceDuration={compositionVisualSourceDuration}
-                    trimStart={0}
-                    speed={compositionVisualSpeed}
+                {showFilmstrips && visualSegments.map((segment) => (
+                  <CompositionFilmstripSegment
+                    key={segment.itemId}
+                    segment={segment}
+                    wrapperDurationFrames={item.durationInFrames}
+                    wrapperClipWidthPx={clipWidth}
+                    wrapperRenderWidthPx={renderWidth}
+                    wrapperVisibleStartRatio={clipVisibility.visibleStartRatio}
+                    wrapperVisibleEndRatio={clipVisibility.visibleEndRatio}
+                    wrapperIsVisible={clipVisibility.isVisible}
                     fps={fps}
-                    isVisible={clipVisibility.isVisible}
-                    visibleStartRatio={clipVisibility.visibleStartRatio}
-                    visibleEndRatio={clipVisibility.visibleEndRatio}
                     pixelsPerSecond={pixelsPerSecond}
                     preferImmediateRendering={preferImmediateRendering}
                   />
-                )}
+                ))}
               </div>
               {/* Row 3: Waveform */}
               {showCompositionWaveform && composition && (

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -170,7 +170,7 @@ export const ClipContent = memo(function ClipContent({
   const compositionSourceDurationFrames = Math.max(
     1,
     item.type === 'composition' || isCompositionAudioWrapper
-      ? (item.sourceDuration ?? composition?.durationInFrames ?? item.durationInFrames)
+      ? (composition?.durationInFrames ?? item.sourceDuration ?? item.durationInFrames)
       : sourceDurationFrames
   );
   const compositionSourceStartFrames = Math.max(

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -729,6 +729,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
   const contentPreviewItem = useMemo<TimelineItemType>(() => {
     let nextItem = previewBaseItem;
     let previewStartTrimDelta = 0;
+    let previewEndTrimDelta = 0;
     let previewDurationDelta = 0;
 
     // Active local trim (normal / rolling / ripple on trimmed item).
@@ -737,6 +738,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
         previewStartTrimDelta += trimDelta;
         previewDurationDelta += -trimDelta;
       } else {
+        previewEndTrimDelta += trimDelta;
         previewDurationDelta += trimDelta;
       }
     }
@@ -749,6 +751,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
         previewDurationDelta += -rollingEditDelta;
       } else if (rollingEditHandle === 'start') {
         // Neighbor end handle equivalent.
+        previewEndTrimDelta += rollingEditDelta;
         previewDurationDelta += rollingEditDelta;
       }
     }
@@ -759,6 +762,7 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
         previewStartTrimDelta += slideNeighborDelta;
         previewDurationDelta += -slideNeighborDelta;
       } else {
+        previewEndTrimDelta += slideNeighborDelta;
         previewDurationDelta += slideNeighborDelta;
       }
     }
@@ -813,6 +817,24 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
       nextItem = {
         ...nextItem,
         durationInFrames: Math.max(1, nextItem.durationInFrames + previewDurationDelta),
+      };
+    }
+
+    // Composition wrappers clip their inner segments by sourceEnd, so live
+    // end-trim needs sourceEnd bumped alongside durationInFrames — otherwise
+    // the filmstrip stops at the stale committed value while the clip grows.
+    const isCompositionWrapper = nextItem.type === 'composition'
+      || (nextItem.type === 'audio' && !!nextItem.compositionId);
+    if (isCompositionWrapper && previewEndTrimDelta !== 0 && nextItem.sourceEnd !== undefined) {
+      const endSourceFramesDelta = timelineToSourceFrames(
+        previewEndTrimDelta,
+        nextItem.speed ?? 1,
+        fps,
+        effectiveSourceFps,
+      );
+      nextItem = {
+        ...nextItem,
+        sourceEnd: Math.max((nextItem.sourceStart ?? 0) + 1, nextItem.sourceEnd + endSourceFramesDelta),
       };
     }
 

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -799,8 +799,16 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
       };
     }
 
+    // Composition wrappers clip their inner segments by sourceEnd/sourceStart,
+    // so treat them like video/audio for source-frame trims.
+    const isCompositionWrapper = nextItem.type === 'composition'
+      || (nextItem.type === 'audio' && !!nextItem.compositionId);
+
     // Start-trim equivalents shift sourceStart in source-frame units.
-    if ((previewBaseItem.type === 'video' || previewBaseItem.type === 'audio') && previewStartTrimDelta !== 0) {
+    const supportsStartTrimSourceShift = previewBaseItem.type === 'video'
+      || previewBaseItem.type === 'audio'
+      || isCompositionWrapper;
+    if (supportsStartTrimSourceShift && previewStartTrimDelta !== 0) {
       const sourceFramesDelta = timelineToSourceFrames(
         previewStartTrimDelta,
         nextItem.speed ?? 1,
@@ -823,8 +831,6 @@ export const TimelineItem = memo(function TimelineItem({ item, timelineDuration 
     // Composition wrappers clip their inner segments by sourceEnd, so live
     // end-trim needs sourceEnd bumped alongside durationInFrames — otherwise
     // the filmstrip stops at the stale committed value while the clip grows.
-    const isCompositionWrapper = nextItem.type === 'composition'
-      || (nextItem.type === 'audio' && !!nextItem.compositionId);
     if (isCompositionWrapper && previewEndTrimDelta !== 0 && nextItem.sourceEnd !== undefined) {
       const endSourceFramesDelta = timelineToSourceFrames(
         previewEndTrimDelta,

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -287,6 +287,12 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
     visibleTracks,
   ]);
 
+  const handleTimelineAreaMouseDown = useCallback((event: React.MouseEvent) => {
+    if (event.button !== 1) return;
+    if (!hasTrackSections) return;
+    handleSectionDividerMouseDown(event);
+  }, [handleSectionDividerMouseDown, hasTrackSections]);
+
   // Set first track as active on mount
   // Use primitive dependencies to avoid re-running on unrelated track changes
   const tracksLength = tracks.length;
@@ -746,7 +752,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
         <CompositionBreadcrumbs />
 
       {/* Timeline Content */}
-      <div className="flex-1 flex overflow-hidden min-h-0">
+      <div className="flex-1 flex overflow-hidden min-h-0" onMouseDown={handleTimelineAreaMouseDown}>
         {/* Track Headers Sidebar */}
         <div
           className="border-r border-border panel-bg flex-shrink-0 flex flex-col overflow-x-hidden"

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -290,6 +290,11 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
   const handleTimelineAreaMouseDown = useCallback((event: React.MouseEvent) => {
     if (event.button !== 1) return;
     if (!hasTrackSections) return;
+    // Only start a section-divider drag when the middle-click actually lands
+    // on the divider itself — otherwise middle-clicks on clips / gizmos /
+    // buttons inside the timeline row would hijack into an unwanted drag.
+    if (!(event.target instanceof Element)) return;
+    if (!event.target.closest('[data-track-section-divider]')) return;
     handleSectionDividerMouseDown(event);
   }, [handleSectionDividerMouseDown, hasTrackSections]);
 

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -27,6 +27,8 @@ import { EDITOR_LAYOUT_CSS_VALUES, getEditorLayout } from '@/app/editor-layout';
 import { useTrackHeightResize } from '../hooks/use-track-height-resize';
 import { resizeTracksOfKindByDelta } from '../utils/track-resize';
 import { useTimelineSettingsStore } from '../stores/timeline-settings-store';
+import { useZoomStore } from '../stores/zoom-store';
+import { computeWheelZoomStep } from '../constants';
 import {
   clampSectionDividerPosition,
   getTrackSectionLayout,
@@ -187,33 +189,60 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
     return () => observer.disconnect();
   }, []);
 
-  // Alt+scroll in track headers = resize track heights (mirrors timeline-content behavior)
+  // Wheel handling in track headers:
+  //   Alt+scroll  = resize track heights in the hovered zone
+  //   Shift+scroll = vertical scroll of the hovered zone
+  //   Ctrl/Cmd+scroll = zoom timeline in/out
+  const zoomHandlersRef = useRef(zoomHandlers);
+  useEffect(() => {
+    zoomHandlersRef.current = zoomHandlers;
+  }, [zoomHandlers]);
   useEffect(() => {
     const el = trackHeadersViewportRef.current;
     if (!el) return;
 
     const handler = (event: WheelEvent) => {
-      if (!event.altKey) return;
-      event.preventDefault();
+      if (event.ctrlKey || event.metaKey) {
+        event.preventDefault();
+        const z = zoomHandlersRef.current;
+        if (!z) return;
+        z.handleZoomChange(computeWheelZoomStep(useZoomStore.getState().level, event.deltaY));
+        return;
+      }
 
       const sectionEl = (event.target instanceof Element)
         ? event.target.closest('[data-track-section-scroll]') as HTMLElement | null
         : null;
       const zone = sectionEl?.dataset.trackSectionScroll as 'video' | 'audio' | undefined;
-      if (!zone) return;
 
-      const delta = event.deltaY > 0 ? -4 : 4;
-      const currentTracks = useItemsStore.getState().tracks;
-      const nextTracks = resizeTracksOfKindByDelta(currentTracks, zone, delta);
-      if (nextTracks !== currentTracks) {
-        useItemsStore.getState().setTracks(nextTracks);
-        useTimelineSettingsStore.getState().markDirty();
+      if (event.altKey) {
+        event.preventDefault();
+        if (!zone) return;
+        const delta = event.deltaY > 0 ? -4 : 4;
+        const currentTracks = useItemsStore.getState().tracks;
+        const nextTracks = resizeTracksOfKindByDelta(currentTracks, zone, delta);
+        if (nextTracks !== currentTracks) {
+          useItemsStore.getState().setTracks(nextTracks);
+          useTimelineSettingsStore.getState().markDirty();
+        }
+        return;
+      }
+
+      if (event.shiftKey) {
+        event.preventDefault();
+        const contentScroll = hasTrackSections
+          ? zone === 'audio'
+            ? audioTrackContentScrollRef.current
+            : videoTrackContentScrollRef.current
+          : allTrackContentScrollRef.current;
+        if (!contentScroll) return;
+        contentScroll.scrollTop += event.deltaY || event.deltaX;
       }
     };
 
     el.addEventListener('wheel', handler, { passive: false });
     return () => el.removeEventListener('wheel', handler);
-  }, []);
+  }, [hasTrackSections]);
 
   const handleSectionDividerMouseDown = useCallback((event: React.MouseEvent) => {
     if (!hasTrackSections) return;

--- a/src/features/timeline/components/track-row-frame.tsx
+++ b/src/features/timeline/components/track-row-frame.tsx
@@ -79,6 +79,7 @@ export function TrackSectionDivider({ className, onMouseDown }: TrackSectionDivi
       {onMouseDown && (
         <button
           type="button"
+          data-track-section-divider="true"
           className="absolute inset-0 z-40 cursor-row-resize bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
           aria-label="Resize video and audio track sections"
           onMouseDown={onMouseDown}

--- a/src/features/timeline/constants.ts
+++ b/src/features/timeline/constants.ts
@@ -73,6 +73,15 @@ export const ZOOM_MIN_VELOCITY = 0.001;
 export const ZOOM_MIN = MIN_ZOOM_LEVEL;
 export const ZOOM_MAX = MAX_ZOOM_LEVEL;
 
+// Wheel zoom step — multiplicative for uniform perceptual speed, matches slider's log scale
+export const WHEEL_ZOOM_FACTOR = 1.15;
+
+export function computeWheelZoomStep(currentZoom: number, deltaY: number): number {
+  return deltaY > 0
+    ? Math.max(ZOOM_MIN, currentZoom / WHEEL_ZOOM_FACTOR)
+    : Math.min(ZOOM_MAX, currentZoom * WHEEL_ZOOM_FACTOR);
+}
+
 // Temporary gate: keep slip/slide implementation in code, but hide the UI and
 // disable their keyboard shortcuts until the tools are ready to expose again.
 export const SLIP_SLIDE_TOOLS_ENABLED = false;

--- a/src/features/timeline/constants.ts
+++ b/src/features/timeline/constants.ts
@@ -77,9 +77,10 @@ export const ZOOM_MAX = MAX_ZOOM_LEVEL;
 export const WHEEL_ZOOM_FACTOR = 1.15;
 
 export function computeWheelZoomStep(currentZoom: number, deltaY: number): number {
-  return deltaY > 0
-    ? Math.max(ZOOM_MIN, currentZoom / WHEEL_ZOOM_FACTOR)
-    : Math.min(ZOOM_MAX, currentZoom * WHEEL_ZOOM_FACTOR);
+  if (deltaY > 0) return Math.max(ZOOM_MIN, currentZoom / WHEEL_ZOOM_FACTOR);
+  if (deltaY < 0) return Math.min(ZOOM_MAX, currentZoom * WHEEL_ZOOM_FACTOR);
+  // Pure horizontal wheel events — leave zoom unchanged.
+  return currentZoom;
 }
 
 // Temporary gate: keep slip/slide implementation in code, but hide the UI and

--- a/src/features/timeline/contracts/preview.ts
+++ b/src/features/timeline/contracts/preview.ts
@@ -31,6 +31,12 @@ export { createClassicTrack } from '../utils/classic-tracks';
 export {
   useCompositionsStore,
 } from '../stores/compositions-store';
+export type {
+  SubComposition,
+} from '../stores/compositions-store';
+export {
+  useCompositionNavigationStore,
+} from '../stores/composition-navigation-store';
 export {
   buildSubCompositionInput,
   collectSubCompositionMediaIds,

--- a/src/features/timeline/hooks/use-track-drag.ts
+++ b/src/features/timeline/hooks/use-track-drag.ts
@@ -102,6 +102,7 @@ export function useTrackDrag(track: TimelineTrack): UseTrackDragReturn {
    */
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
       const target = e.target;
       if (
         target instanceof Element &&

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -1,8 +1,9 @@
 /**
  * Filmstrip Storage
  *
- * Filmstrip frames are now persisted in the selected workspace folder:
- *   filmstrips/{mediaId}/
+ * Filmstrip frames are persisted in the workspace under the owning media
+ * cache directory:
+ *   media/{mediaId}/cache/filmstrip/
  *     meta.json - { width, height, isComplete, frameCount }
  *     0.jpg, 1.jpg, 2.jpg, ... (legacy caches may still use .webp)
  *
@@ -22,9 +23,9 @@ import {
 } from '@/infrastructure/storage/workspace-fs/fs-primitives';
 import { requireWorkspaceRoot } from '@/infrastructure/storage/workspace-fs/root';
 import {
-  filmstripFileFramePath,
+  filmstripDir,
+  filmstripFramePath,
   filmstripMetaPath,
-  WORKSPACE_FILMSTRIPS_DIR,
 } from '@/infrastructure/storage/workspace-fs/paths';
 
 const logger = createLogger('FilmstripStorage');
@@ -227,7 +228,7 @@ class FilmstripStorage {
         if (file.size <= 0) continue;
         await writeBlob(
           requireWorkspaceRoot(),
-          filmstripFileFramePath(mediaId, parsed.index, parsed.ext),
+          filmstripFramePath(mediaId, parsed.index, parsed.ext),
           file,
         );
       }
@@ -250,7 +251,7 @@ class FilmstripStorage {
   async saveFrameBlob(mediaId: string, index: number, blob: Blob): Promise<void> {
     await writeBlob(
       requireWorkspaceRoot(),
-      filmstripFileFramePath(mediaId, index, PRIMARY_FRAME_EXT),
+      filmstripFramePath(mediaId, index, PRIMARY_FRAME_EXT),
       blob,
     );
   }
@@ -260,7 +261,7 @@ class FilmstripStorage {
       const metadata = await this.ensureWorkspaceFilmstrip(mediaId);
       if (!metadata) return null;
 
-      const entries = await listDirectory(requireWorkspaceRoot(), [WORKSPACE_FILMSTRIPS_DIR, mediaId]);
+      const entries = await listDirectory(requireWorkspaceRoot(), filmstripDir(mediaId));
       const frameFilesByIndex = new Map<number, { blob: Blob; ext: string }>();
 
       for (const entry of entries) {
@@ -270,7 +271,7 @@ class FilmstripStorage {
 
         const blob = await readBlob(
           requireWorkspaceRoot(),
-          filmstripFileFramePath(mediaId, parsed.index, parsed.ext),
+          filmstripFramePath(mediaId, parsed.index, parsed.ext),
         );
         if (!blob || blob.size <= 0) continue;
 
@@ -323,7 +324,7 @@ class FilmstripStorage {
     const metadata = await this.ensureWorkspaceFilmstrip(mediaId);
     if (!metadata) return [];
 
-    const entries = await listDirectory(requireWorkspaceRoot(), [WORKSPACE_FILMSTRIPS_DIR, mediaId]);
+    const entries = await listDirectory(requireWorkspaceRoot(), filmstripDir(mediaId));
     const indices = new Set<number>();
 
     for (const entry of entries) {
@@ -337,7 +338,7 @@ class FilmstripStorage {
       if (!parsed) continue;
       const blob = await readBlob(
         requireWorkspaceRoot(),
-        filmstripFileFramePath(mediaId, parsed.index, parsed.ext),
+        filmstripFramePath(mediaId, parsed.index, parsed.ext),
       );
       if (blob && blob.size > 0) {
         indices.add(index);
@@ -353,12 +354,12 @@ class FilmstripStorage {
 
     let blob = await readBlob(
       requireWorkspaceRoot(),
-      filmstripFileFramePath(mediaId, index, PRIMARY_FRAME_EXT),
+      filmstripFramePath(mediaId, index, PRIMARY_FRAME_EXT),
     );
     if (!blob || blob.size === 0) {
       blob = await readBlob(
         requireWorkspaceRoot(),
-        filmstripFileFramePath(mediaId, index, LEGACY_FRAME_EXT),
+        filmstripFramePath(mediaId, index, LEGACY_FRAME_EXT),
       );
     }
     if (!blob || blob.size === 0) return null;
@@ -407,7 +408,7 @@ class FilmstripStorage {
 
   async delete(mediaId: string): Promise<void> {
     this.revokeUrls(mediaId);
-    await removeEntry(requireWorkspaceRoot(), [WORKSPACE_FILMSTRIPS_DIR, mediaId], {
+    await removeEntry(requireWorkspaceRoot(), filmstripDir(mediaId), {
       recursive: true,
     });
     await this.deleteLegacyFilmstrip(mediaId);
@@ -429,17 +430,21 @@ class FilmstripStorage {
       this.revokeUrls(mediaId);
     }
 
-    await removeEntry(requireWorkspaceRoot(), [WORKSPACE_FILMSTRIPS_DIR], {
-      recursive: true,
-    }).catch(() => undefined);
-    await this.clearLegacyFilmstrips();
-  }
+    // In v2, filmstrips live per-media under `media/<id>/cache/filmstrip/`.
+    // Enumerate media dirs and prune each one's filmstrip subtree.
+    try {
+      const mediaEntries = await listDirectory(requireWorkspaceRoot(), ['media']);
+      for (const entry of mediaEntries) {
+        if (entry.kind !== 'directory') continue;
+        await removeEntry(requireWorkspaceRoot(), filmstripDir(entry.name), {
+          recursive: true,
+        }).catch(() => undefined);
+      }
+    } catch {
+      // media dir may not exist yet — nothing to clear
+    }
 
-  async list(): Promise<string[]> {
-    const entries = await listDirectory(requireWorkspaceRoot(), [WORKSPACE_FILMSTRIPS_DIR]);
-    return entries
-      .filter((entry) => entry.kind === 'directory')
-      .map((entry) => entry.name);
+    await this.clearLegacyFilmstrips();
   }
 }
 

--- a/src/features/timeline/services/waveform-opfs-storage.ts
+++ b/src/features/timeline/services/waveform-opfs-storage.ts
@@ -691,14 +691,18 @@ class WaveformOPFSStorage {
 
       for (const name of entries) {
         await dir.removeEntry(name);
+        // Remove the corresponding workspace mirror so a later hydrate can't
+        // silently restore a waveform we just cleared.
+        if (name.endsWith('.bin')) {
+          const mediaId = name.slice(0, -'.bin'.length);
+          await removeWorkspaceCacheEntry(waveformMultiResPath(mediaId));
+        }
       }
 
       logger.debug(`Cleared ${entries.length} waveforms from OPFS`);
     } catch (error) {
       logger.error('Failed to clear waveforms:', error);
     }
-    // Workspace waveforms live per-media under `media/<id>/cache/waveform/`
-    // and are cleaned up with the enclosing media entry — no top-level sweep.
   }
 }
 

--- a/src/features/timeline/services/waveform-opfs-storage.ts
+++ b/src/features/timeline/services/waveform-opfs-storage.ts
@@ -35,8 +35,7 @@ import {
   removeWorkspaceCacheEntry,
 } from '@/infrastructure/storage/workspace-fs/cache-mirror';
 import {
-  waveformBinaryPath,
-  WORKSPACE_WAVEFORM_BIN_DIR,
+  waveformMultiResPath,
 } from '@/infrastructure/storage/workspace-fs/paths';
 
 const logger = createLogger('WaveformOPFS');
@@ -371,7 +370,7 @@ class WaveformOPFSStorage {
 
       // Mirror the binary to the workspace folder so other origins can reuse
       // the multi-resolution waveform without regenerating. Fire-and-forget.
-      void mirrorBytesToWorkspace(waveformBinaryPath(mediaId), buffer);
+      void mirrorBytesToWorkspace(waveformMultiResPath(mediaId), buffer);
 
       logger.debug(
         `Saved waveform ${mediaId}: ${levelCount} levels, ${(totalSize / 1024).toFixed(1)}KB`
@@ -402,7 +401,7 @@ class WaveformOPFSStorage {
    */
   private async hydrateFromWorkspace(mediaId: string): Promise<boolean> {
     try {
-      const blob = await readWorkspaceBlob(waveformBinaryPath(mediaId));
+      const blob = await readWorkspaceBlob(waveformMultiResPath(mediaId));
       if (!blob || blob.size === 0) return false;
 
       const bytes = await blob.arrayBuffer();
@@ -629,7 +628,7 @@ class WaveformOPFSStorage {
     } catch {
       // File may not exist, ignore
     }
-    void removeWorkspaceCacheEntry(waveformBinaryPath(mediaId));
+    void removeWorkspaceCacheEntry(waveformMultiResPath(mediaId));
   }
 
   /**
@@ -698,7 +697,8 @@ class WaveformOPFSStorage {
     } catch (error) {
       logger.error('Failed to clear waveforms:', error);
     }
-    void removeWorkspaceCacheEntry([WORKSPACE_WAVEFORM_BIN_DIR], { recursive: true });
+    // Workspace waveforms live per-media under `media/<id>/cache/waveform/`
+    // and are cleaned up with the enclosing media entry — no top-level sweep.
   }
 }
 

--- a/src/features/timeline/stores/actions/composition-actions.test.ts
+++ b/src/features/timeline/stores/actions/composition-actions.test.ts
@@ -293,6 +293,47 @@ describe('composition-actions split wrappers', () => {
     expect(useItemsStore.getState().items.some((item) => item.type === 'video' && item.id !== 'comp-a-second')).toBe(true);
   });
 
+  it('creates compound clip track with video kind when selection is a single mask shape', () => {
+    useItemsStore.getState().setTracks([
+      makeTrack({ id: 'track-v1', name: 'V1', kind: 'video', order: 0 }),
+    ]);
+    useItemsStore.getState().setItems([
+      {
+        id: 'shape-mask-1',
+        type: 'shape',
+        trackId: 'track-v1',
+        from: 0,
+        durationInFrames: 60,
+        shapeType: 'rect',
+        fillColor: '#ffffff',
+        isMask: true,
+      },
+    ]);
+    useSelectionStore.getState().selectItems(['shape-mask-1']);
+
+    const created = createPreComp('Compound Mask');
+    expect(created).toMatchObject({ type: 'composition', trackId: 'track-v1' });
+
+    const subComp = useCompositionsStore.getState().compositions[0];
+    expect(subComp).toBeDefined();
+    expect(subComp!.tracks).toHaveLength(1);
+    const subTrack = subComp!.tracks[0]!;
+    expect(subTrack.kind).toBe('video');
+    expect(subComp!.items).toHaveLength(1);
+    const subItem = subComp!.items[0]!;
+    expect(subItem.trackId).toBe(subTrack.id);
+    expect(subItem.type).toBe('shape');
+
+    useCompositionNavigationStore.getState().enterComposition(subComp!.id, 'Compound Mask');
+    const loadedTracks = useItemsStore.getState().tracks;
+    expect(loadedTracks).toHaveLength(1);
+    expect(loadedTracks[0]!.kind).toBe('video');
+    expect(loadedTracks[0]!.id).toBe(subTrack.id);
+    const loadedItems = useItemsStore.getState().items;
+    expect(loadedItems).toHaveLength(1);
+    expect(loadedItems[0]!.trackId).toBe(subTrack.id);
+  });
+
   it('creates nested compound clips while editing inside another compound clip', () => {
     useItemsStore.getState().setTracks([]);
     useItemsStore.getState().setItems([]);

--- a/src/features/timeline/stores/actions/composition-actions.test.ts
+++ b/src/features/timeline/stores/actions/composition-actions.test.ts
@@ -323,6 +323,7 @@ describe('composition-actions split wrappers', () => {
     const subItem = subComp!.items[0]!;
     expect(subItem.trackId).toBe(subTrack.id);
     expect(subItem.type).toBe('shape');
+    expect(subItem.type === 'shape' && subItem.isMask).toBe(true);
 
     useCompositionNavigationStore.getState().enterComposition(subComp!.id, 'Compound Mask');
     const loadedTracks = useItemsStore.getState().tracks;
@@ -332,6 +333,8 @@ describe('composition-actions split wrappers', () => {
     const loadedItems = useItemsStore.getState().items;
     expect(loadedItems).toHaveLength(1);
     expect(loadedItems[0]!.trackId).toBe(subTrack.id);
+    const loadedItem = loadedItems[0]!;
+    expect(loadedItem.type === 'shape' && loadedItem.isMask).toBe(true);
   });
 
   it('creates nested compound clips while editing inside another compound clip', () => {

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -25,7 +25,7 @@ import { useTimelineSettingsStore } from './timeline-settings-store';
 import { useTimelineCommandStore } from './timeline-command-store';
 import { useCompositionsStore } from './compositions-store';
 import { useCompositionNavigationStore } from './composition-navigation-store';
-import { getProject, updateProject, saveThumbnail } from '@/infrastructure/storage';
+import { getProject, updateProject, saveProjectThumbnail } from '@/infrastructure/storage';
 import {
   renderSingleFrame,
   convertTimelineToComposition,
@@ -770,14 +770,7 @@ export async function saveTimeline(projectId: string): Promise<void> {
 
         // Save thumbnail to workspace storage
         thumbnailId = `project:${projectId}:cover`;
-        await saveThumbnail({
-          id: thumbnailId,
-          mediaId: projectId,
-          blob: thumbnailBlob,
-          timestamp: Date.now(),
-          width: thumbWidth,
-          height: thumbHeight,
-        });
+        await saveProjectThumbnail(projectId, thumbnailBlob);
       } catch (thumbError) {
         // Thumbnail generation failure shouldn't block save
         event.set('thumbnailError', thumbError instanceof Error ? thumbError.message : String(thumbError));

--- a/src/features/timeline/utils/composition-clip-summary.test.ts
+++ b/src/features/timeline/utils/composition-clip-summary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AudioItem, CompositionItem, TimelineTrack, VideoItem } from '@/types/timeline';
 import {
   getCompositionOwnedAudioSources,
+  getCompositionVisualSegments,
   summarizeCompositionClipContent,
 } from './composition-clip-summary';
 
@@ -200,5 +201,273 @@ describe('composition-clip-summary', () => {
       sourceFps: 30,
       speed: 1,
     });
+  });
+
+  it('returns ordered visual segments for a compound clip spanning two sub-comp videos', () => {
+    const compositionById = {
+      'child-comp': {
+        id: 'child-comp',
+        name: 'Child',
+        items: [
+          makeVideoItem({
+            id: 'child-video-a',
+            trackId: 'child-track-v1',
+            from: 0,
+            durationInFrames: 60,
+            mediaId: 'media-a',
+            sourceStart: 0,
+            sourceEnd: 60,
+            sourceDuration: 600,
+            sourceFps: 30,
+          }),
+          makeVideoItem({
+            id: 'child-video-b',
+            trackId: 'child-track-v1',
+            from: 60,
+            durationInFrames: 60,
+            mediaId: 'media-b',
+            sourceStart: 0,
+            sourceEnd: 60,
+            sourceDuration: 600,
+            sourceFps: 30,
+          }),
+        ],
+        tracks: [makeTrack({ id: 'child-track-v1', name: 'V1', order: 0, kind: 'video' })],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 120,
+      },
+    };
+
+    const wrapper = makeCompositionItem({
+      id: 'parent-wrapper',
+      trackId: 'track-v1',
+      compositionId: 'child-comp',
+      from: 0,
+      durationInFrames: 120,
+      sourceStart: 0,
+      sourceEnd: 120,
+      sourceDuration: 120,
+      sourceFps: 30,
+      speed: 1,
+    });
+
+    const segments = getCompositionVisualSegments({
+      wrapper,
+      parentFps: 30,
+      compositionById,
+    });
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      itemId: 'child-video-a',
+      mediaId: 'media-a',
+      from: 0,
+      durationInFrames: 60,
+    });
+    expect(segments[1]).toMatchObject({
+      itemId: 'child-video-b',
+      mediaId: 'media-b',
+      from: 60,
+      durationInFrames: 60,
+    });
+  });
+
+  it('sorts segments so topmost tracks render last (painted on top)', () => {
+    const compositionById = {
+      'child-comp': {
+        id: 'child-comp',
+        name: 'Child',
+        items: [
+          makeVideoItem({
+            id: 'bottom-video',
+            trackId: 'child-track-v2',
+            from: 0,
+            durationInFrames: 60,
+            mediaId: 'media-bottom',
+          }),
+          makeVideoItem({
+            id: 'top-video',
+            trackId: 'child-track-v1',
+            from: 0,
+            durationInFrames: 60,
+            mediaId: 'media-top',
+          }),
+        ],
+        tracks: [
+          makeTrack({ id: 'child-track-v1', name: 'V1', order: 0, kind: 'video' }),
+          makeTrack({ id: 'child-track-v2', name: 'V2', order: 1, kind: 'video' }),
+        ],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 60,
+      },
+    };
+
+    const wrapper = makeCompositionItem({
+      compositionId: 'child-comp',
+      durationInFrames: 60,
+      sourceEnd: 60,
+      sourceDuration: 60,
+    });
+
+    const segments = getCompositionVisualSegments({
+      wrapper,
+      parentFps: 30,
+      compositionById,
+    });
+
+    expect(segments.map((s) => s.itemId)).toEqual(['bottom-video', 'top-video']);
+  });
+
+  it('recurses into a nested composition to surface its inner video segments', () => {
+    const compositionById = {
+      'inner-comp': {
+        id: 'inner-comp',
+        name: 'Inner',
+        items: [
+          makeVideoItem({
+            id: 'inner-video',
+            trackId: 'inner-track-v1',
+            from: 0,
+            durationInFrames: 60,
+            mediaId: 'inner-media',
+            sourceStart: 0,
+            sourceEnd: 60,
+            sourceDuration: 600,
+            sourceFps: 30,
+          }),
+        ],
+        tracks: [makeTrack({ id: 'inner-track-v1', name: 'V1', order: 0, kind: 'video' })],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 60,
+      },
+      'outer-comp': {
+        id: 'outer-comp',
+        name: 'Outer',
+        items: [
+          makeCompositionItem({
+            id: 'nested-wrapper',
+            trackId: 'outer-track-v1',
+            compositionId: 'inner-comp',
+            from: 0,
+            durationInFrames: 60,
+            sourceStart: 0,
+            sourceEnd: 60,
+            sourceDuration: 60,
+            sourceFps: 30,
+          }),
+          makeVideoItem({
+            id: 'outer-video',
+            trackId: 'outer-track-v1',
+            from: 60,
+            durationInFrames: 60,
+            mediaId: 'outer-media',
+            sourceStart: 0,
+            sourceEnd: 60,
+            sourceDuration: 600,
+            sourceFps: 30,
+          }),
+        ],
+        tracks: [makeTrack({ id: 'outer-track-v1', name: 'V1', order: 0, kind: 'video' })],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 120,
+      },
+    };
+
+    const wrapper = makeCompositionItem({
+      id: 'parent-wrapper',
+      compositionId: 'outer-comp',
+      durationInFrames: 120,
+      sourceStart: 0,
+      sourceEnd: 120,
+      sourceDuration: 120,
+      sourceFps: 30,
+    });
+
+    const segments = getCompositionVisualSegments({
+      wrapper,
+      parentFps: 30,
+      compositionById,
+    });
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      itemId: 'inner-video',
+      mediaId: 'inner-media',
+      from: 0,
+      durationInFrames: 60,
+    });
+    expect(segments[1]).toMatchObject({
+      itemId: 'outer-video',
+      mediaId: 'outer-media',
+      from: 60,
+      durationInFrames: 60,
+    });
+  });
+
+  it('guards against cyclic composition references', () => {
+    const compositionById = {
+      'self-ref': {
+        id: 'self-ref',
+        name: 'Self',
+        items: [
+          makeCompositionItem({
+            id: 'self-wrapper',
+            trackId: 'self-track',
+            compositionId: 'self-ref',
+            from: 0,
+            durationInFrames: 30,
+            sourceEnd: 30,
+            sourceDuration: 30,
+          }),
+        ],
+        tracks: [makeTrack({ id: 'self-track', name: 'V1', order: 0, kind: 'video' })],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 30,
+      },
+    };
+
+    const wrapper = makeCompositionItem({
+      compositionId: 'self-ref',
+      durationInFrames: 30,
+      sourceEnd: 30,
+      sourceDuration: 30,
+    });
+
+    const segments = getCompositionVisualSegments({
+      wrapper,
+      parentFps: 30,
+      compositionById,
+    });
+
+    expect(segments).toEqual([]);
+  });
+
+  it('returns empty segments when wrapper is not a composition', () => {
+    const segments = getCompositionVisualSegments({
+      wrapper: makeVideoItem(),
+      parentFps: 30,
+      compositionById: {},
+    });
+    expect(segments).toEqual([]);
   });
 });

--- a/src/features/timeline/utils/composition-clip-summary.ts
+++ b/src/features/timeline/utils/composition-clip-summary.ts
@@ -22,6 +22,30 @@ export interface CompositionVisualSource {
   speed: number;
 }
 
+/**
+ * A single visual clip from the sub-composition, mapped into the parent
+ * wrapper's local timeline. Multiple segments can cover a compound clip
+ * when the sub-comp contains several video clips. Segments on lower tracks
+ * (smaller `trackOrder`) render on top.
+ */
+export interface CompositionVisualSegment {
+  itemId: string;
+  mediaId: string;
+  /** Source-media start frame (native source fps) */
+  sourceStart: number;
+  /** Source-media total duration in native source frames (for the media file, not the sub-clip) */
+  sourceDurationFrames: number;
+  sourceFps: number;
+  /** Effective speed = nested item speed × wrapper speed */
+  speed: number;
+  /** Wrapper-local start frame in parent timeline fps */
+  from: number;
+  /** Wrapper-local duration in parent timeline frames */
+  durationInFrames: number;
+  /** Track order from the sub-comp (smaller = visually higher) */
+  trackOrder: number;
+}
+
 export interface CompositionClipSummary {
   visualMediaId: string | null;
   audioMediaId: string | null;
@@ -324,6 +348,104 @@ export function getCompositionOwnedAudioSources(params: {
 
     return [];
   });
+}
+
+/**
+ * Return ordered visual segments for a compound clip wrapper.
+ * Each segment represents one video clip from the sub-comp that covers part
+ * of the wrapper's displayed window. Nested composition items are recursed
+ * into so arbitrarily deep compounds contribute their own video segments.
+ * Segments are sorted with bottom tracks first so the DOM render order puts
+ * top tracks on top.
+ */
+export function getCompositionVisualSegments(params: {
+  wrapper: TimelineItem;
+  parentFps: number;
+  compositionById?: CompositionLookup;
+  mediaFpsById?: Record<string, number | undefined>;
+  mediaDurationFramesById?: Record<string, number | undefined>;
+  activeCompositionPath?: ReadonlySet<string>;
+}): CompositionVisualSegment[] {
+  const {
+    wrapper,
+    parentFps,
+    compositionById,
+    mediaFpsById,
+    mediaDurationFramesById,
+    activeCompositionPath = new Set<string>(),
+  } = params;
+  if (!compositionById) return [];
+  if (wrapper.type !== 'composition' || !wrapper.compositionId) return [];
+  if (activeCompositionPath.has(wrapper.compositionId)) return [];
+
+  const subComp = compositionById[wrapper.compositionId];
+  if (!subComp) return [];
+
+  const visibleTrackIds = getVisibleTrackIds(subComp.tracks);
+  const trackOrderMap = new Map(subComp.tracks.map((track) => [track.id, track.order ?? 0]));
+  const nextPath = new Set(activeCompositionPath);
+  nextPath.add(wrapper.compositionId);
+
+  const segments: CompositionVisualSegment[] = [];
+  for (const subItem of subComp.items) {
+    if (!visibleTrackIds.has(subItem.trackId)) continue;
+    if (subItem.type !== 'video' && subItem.type !== 'composition') continue;
+
+    const mapped = mapNestedItemToWrapperWindow({
+      subItem,
+      wrapper: wrapper as Extract<TimelineItem, { compositionId?: string }>,
+      parentFps,
+      subCompFps: subComp.fps,
+    });
+    if (!mapped) continue;
+
+    const trackOrder = trackOrderMap.get(subItem.trackId) ?? 0;
+
+    if (mapped.type === 'video' && mapped.mediaId) {
+      const sourceFps = mapped.sourceFps ?? mediaFpsById?.[mapped.mediaId] ?? parentFps;
+      const sourceDurationFrames = mediaDurationFramesById?.[mapped.mediaId]
+        ?? mapped.sourceDuration
+        ?? mapped.durationInFrames;
+
+      segments.push({
+        itemId: subItem.id,
+        mediaId: mapped.mediaId,
+        sourceStart: mapped.sourceStart ?? 0,
+        sourceDurationFrames,
+        sourceFps,
+        speed: mapped.speed ?? 1,
+        from: mapped.from,
+        durationInFrames: mapped.durationInFrames,
+        trackOrder,
+      });
+      continue;
+    }
+
+    if (mapped.type === 'composition' && mapped.compositionId) {
+      const nestedSegments = getCompositionVisualSegments({
+        wrapper: mapped,
+        parentFps,
+        compositionById,
+        mediaFpsById,
+        mediaDurationFramesById,
+        activeCompositionPath: nextPath,
+      });
+      for (const nested of nestedSegments) {
+        segments.push({
+          ...nested,
+          from: mapped.from + nested.from,
+          // Collapse nested ordering onto the outer item's track so DOM
+          // layering respects the sub-comp's track stack, not the grandchild's.
+          trackOrder,
+        });
+      }
+    }
+  }
+
+  // Higher trackOrder = visually lower. Render those first so lower-order
+  // (topmost) segments paint on top via DOM order.
+  segments.sort((a, b) => b.trackOrder - a.trackOrder);
+  return segments;
 }
 
 export function summarizeCompositionClipContent(params: {

--- a/src/features/timeline/utils/composition-clip-summary.ts
+++ b/src/features/timeline/utils/composition-clip-summary.ts
@@ -403,9 +403,11 @@ export function getCompositionVisualSegments(params: {
 
     if (mapped.type === 'video' && mapped.mediaId) {
       const sourceFps = mapped.sourceFps ?? mediaFpsById?.[mapped.mediaId] ?? parentFps;
+      // `durationInFrames` is in project FPS; convert to source-native frames
+      // when falling back so `sourceDurationFrames` is always consistent.
       const sourceDurationFrames = mediaDurationFramesById?.[mapped.mediaId]
         ?? mapped.sourceDuration
-        ?? mapped.durationInFrames;
+        ?? Math.round(mapped.durationInFrames * (sourceFps / parentFps));
 
       segments.push({
         itemId: subItem.id,

--- a/src/features/timeline/utils/track-resize.ts
+++ b/src/features/timeline/utils/track-resize.ts
@@ -135,7 +135,7 @@ function getSectionDividerBounds(
   if (!hasTrackSections) {
     return {
       hasTrackSections,
-      availablePaneHeight: 0,
+      availablePaneHeight: Math.max(0, viewportHeight),
       minimumSectionDividerPosition: 0,
       maximumSectionDividerPosition: 0,
     };

--- a/src/features/timeline/utils/trim-utils.test.ts
+++ b/src/features/timeline/utils/trim-utils.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { clampToAdjacentItems } from './trim-utils';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { clampToAdjacentItems, clampTrimAmount, calculateTrimSourceUpdate } from './trim-utils';
+import { useCompositionsStore } from '../stores/compositions-store';
 import type { TimelineItem } from '@/types/timeline';
 
 function makeItem(overrides: Partial<TimelineItem> & { id: string; trackId: string; from: number; durationInFrames: number }): TimelineItem {
@@ -96,6 +97,116 @@ describe('clampToAdjacentItems', () => {
       const otherTrack = makeItem({ id: 'b', trackId: 'track-2', from: 50, durationInFrames: 100 });
       const result = clampToAdjacentItems(item, 'start', -80, [item, otherTrack]);
       expect(result).toBe(-80);
+    });
+  });
+
+  describe('clampTrimAmount for composition items', () => {
+    beforeEach(() => {
+      useCompositionsStore.setState({
+        compositions: [],
+        compositionById: {},
+        mediaDependencyIds: [],
+        mediaDependencyVersion: 0,
+      });
+    });
+
+    it('uses live sub-comp duration instead of stale cached sourceDuration when extending', () => {
+      useCompositionsStore.getState().addComposition({
+        id: 'sub-1',
+        name: 'Sub',
+        items: [],
+        tracks: [],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 10800,
+      });
+
+      const wrapper = {
+        type: 'composition',
+        id: 'wrap-1',
+        trackId,
+        compositionId: 'sub-1',
+        from: 0,
+        durationInFrames: 3902,
+        sourceStart: 0,
+        sourceEnd: 3902,
+        sourceDuration: 3902,
+        sourceFps: 30,
+        speed: 1,
+      } as unknown as TimelineItem;
+
+      const result = clampTrimAmount(wrapper, 'end', 3000, 30);
+      expect(result.clampedAmount).toBe(3000);
+      expect(result.maxExtend).toBe(10800 - 3902);
+    });
+
+    it('uses live sub-comp duration for composition audio wrapper (type=audio with compositionId)', () => {
+      useCompositionsStore.getState().addComposition({
+        id: 'sub-audio',
+        name: 'Sub',
+        items: [],
+        tracks: [],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 10800,
+      });
+
+      const audioWrapper = {
+        type: 'audio',
+        id: 'wrap-audio',
+        trackId,
+        compositionId: 'sub-audio',
+        linkedGroupId: 'lg-1',
+        from: 0,
+        durationInFrames: 3902,
+        sourceStart: 0,
+        sourceEnd: 3902,
+        sourceDuration: 3902,
+        sourceFps: 30,
+        speed: 1,
+      } as unknown as TimelineItem;
+
+      const result = clampTrimAmount(audioWrapper, 'end', 3000, 30);
+      expect(result.clampedAmount).toBe(3000);
+      expect(result.maxExtend).toBe(10800 - 3902);
+    });
+
+    it('calculateTrimSourceUpdate respects live sub-comp duration when clamping sourceEnd', () => {
+      useCompositionsStore.getState().addComposition({
+        id: 'sub-2',
+        name: 'Sub',
+        items: [],
+        tracks: [],
+        transitions: [],
+        keyframes: [],
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 10800,
+      });
+
+      const wrapper = {
+        type: 'composition',
+        id: 'wrap-2',
+        trackId,
+        compositionId: 'sub-2',
+        from: 0,
+        durationInFrames: 3902,
+        sourceStart: 0,
+        sourceEnd: 3902,
+        sourceDuration: 3902,
+        sourceFps: 30,
+        speed: 1,
+      } as unknown as TimelineItem;
+
+      const update = calculateTrimSourceUpdate(wrapper, 'end', 3000, 6902, 30);
+      expect(update?.sourceEnd).toBe(6902);
     });
   });
 

--- a/src/features/timeline/utils/trim-utils.ts
+++ b/src/features/timeline/utils/trim-utils.ts
@@ -7,12 +7,31 @@ import {
   timelineToSourceFrames,
 } from './source-calculations';
 import { useCompositionsStore } from '../stores/compositions-store';
+import { isCompositionAudioItem } from '@/shared/utils/linked-media';
 
 export type TrimHandle = 'start' | 'end';
 
 interface TrimClampResult {
   clampedAmount: number;
   maxExtend: number | null;
+}
+
+/**
+ * For composition wrappers, the cached sourceDuration can grow stale when
+ * inner edits extend the sub-comp. Read the live sub-comp duration instead
+ * so the wrapper can be ripple/slide resized to match.
+ */
+function getEffectiveSourceDuration(item: TimelineItem): number | undefined {
+  const compositionId = item.type === 'composition'
+    ? item.compositionId
+    : isCompositionAudioItem(item)
+      ? item.compositionId
+      : null;
+  if (compositionId) {
+    const subComp = useCompositionsStore.getState().getComposition(compositionId);
+    if (subComp) return subComp.durationInFrames;
+  }
+  return getSourceProperties(item).sourceDuration;
 }
 
 /**
@@ -42,7 +61,8 @@ export function clampTrimAmount(
   let maxExtend: number | null = null;
 
   if (isMediaItem(item)) {
-    const { sourceStart, sourceDuration, sourceFps, speed } = getSourceProperties(item);
+    const { sourceStart, sourceFps, speed } = getSourceProperties(item);
+    const sourceDuration = getEffectiveSourceDuration(item);
     const effectiveSourceFps = sourceFps ?? timelineFps;
 
     if (handle === 'start') {
@@ -63,24 +83,6 @@ export function clampTrimAmount(
 
         if (item.durationInFrames + trimAmount > maxDuration) {
           clampedAmount = maxDuration - item.durationInFrames;
-        }
-      }
-    }
-  } else if (item.type === 'composition') {
-    const subComp = useCompositionsStore.getState().getComposition(item.compositionId);
-    if (subComp) {
-      const maxDuration = subComp.durationInFrames;
-      if (handle === 'end') {
-        // End handle: positive trimAmount = extending right
-        if (item.durationInFrames + trimAmount > maxDuration) {
-          clampedAmount = maxDuration - item.durationInFrames;
-          maxExtend = maxDuration - item.durationInFrames;
-        }
-      } else {
-        // Start handle: negative trimAmount = extending left
-        if (trimAmount < 0 && item.durationInFrames - trimAmount > maxDuration) {
-          clampedAmount = -(maxDuration - item.durationInFrames);
-          maxExtend = maxDuration - item.durationInFrames;
         }
       }
     }
@@ -193,7 +195,8 @@ export function calculateTrimSourceUpdate(
 ): TrimSourceUpdate | null {
   if (!isMediaItem(item)) return null;
 
-  const { sourceStart, sourceDuration, sourceFps, speed } = getSourceProperties(item);
+  const { sourceStart, sourceFps, speed } = getSourceProperties(item);
+  const sourceDuration = getEffectiveSourceDuration(item);
   const effectiveSourceFps = sourceFps ?? timelineFps;
 
   if (handle === 'start') {

--- a/src/hooks/use-marquee-selection.ts
+++ b/src/hooks/use-marquee-selection.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useEffectEvent } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, useEffectEvent } from 'react';
 
 /**
  * Marquee selection state
@@ -34,6 +34,16 @@ export interface MarqueeItem {
 interface ResolvedMarqueeItem {
   id: string;
   rect: Rect | null;
+}
+
+/**
+ * Subscription-based marquee controller. The snapshot updates on every RAF
+ * tick during a drag without causing the hook's consumer to re-render —
+ * only the overlay component (via `useSyncExternalStore`) re-renders.
+ */
+export interface MarqueeController {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => MarqueeState;
 }
 
 /**
@@ -124,26 +134,24 @@ function areStringListsEqual(previous: readonly string[], next: readonly string[
   return true;
 }
 
+const INACTIVE_SNAPSHOT: MarqueeState = Object.freeze({
+  active: false,
+  startX: 0,
+  startY: 0,
+  currentX: 0,
+  currentY: 0,
+});
+
 /**
  * Reusable marquee selection hook
  *
  * Provides mouse-based marquee (drag rectangle) selection for any grid/canvas of items.
  * Can be used for media library, timeline clips, preview gizmos, etc.
  *
- * @example
- * ```tsx
- * const { marqueeState, selectedIds } = useMarqueeSelection({
- *   containerRef,
- *   items: mediaItems.map(item => ({
- *     id: item.id,
- *     getBoundingRect: () => {
- *       const el = document.getElementById(item.id);
- *       return el?.getBoundingClientRect() || defaultRect;
- *     }
- *   })),
- *   onSelectionChange: (ids) => updateSelection(ids)
- * });
- * ```
+ * The rect state is exposed via an external-store subscription (`marquee.subscribe`
+ * / `marquee.getSnapshot`) rather than React state, so only `<MarqueeOverlay />`
+ * re-renders on each pointer move — the rest of the consuming tree stays quiet.
+ * Use `isActive` for effects that only need to fire on drag start/end.
  */
 // Global flag to track when marquee selection just finished
 // Used to prevent background click handlers from clearing selection
@@ -171,14 +179,30 @@ export function useMarqueeSelection({
   // Use refs for high-frequency updates during drag to avoid React re-renders
   const marqueeRef = useRef({ startX: 0, startY: 0, currentX: 0, currentY: 0 });
 
-  // React state for rendering - only updates on RAF (batched) or active state changes
-  const [marqueeState, setMarqueeState] = useState<MarqueeState>({
-    active: false,
-    startX: 0,
-    startY: 0,
-    currentX: 0,
-    currentY: 0,
-  });
+  // Subscription-based snapshot: updates on every RAF tick without forcing a
+  // re-render in the hook's consumer. Only the overlay subscribes.
+  const snapshotRef = useRef<MarqueeState>(INACTIVE_SNAPSHOT);
+  const listenersRef = useRef<Set<() => void>>(new Set());
+
+  const subscribe = useCallback((listener: () => void) => {
+    const listeners = listenersRef.current;
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => snapshotRef.current, []);
+
+  const publishSnapshot = useCallback((next: MarqueeState) => {
+    snapshotRef.current = next;
+    listenersRef.current.forEach((listener) => listener());
+  }, []);
+
+  // `isActive` is React state — flips only at drag start/end, so effects that
+  // gate on active state (e.g. disabling panel shortcuts) re-run only twice
+  // per drag instead of 60+ times.
+  const [isActive, setIsActive] = useState(false);
 
   const isDraggingRef = useRef(false);
   const hasMovedRef = useRef(false);
@@ -401,8 +425,9 @@ export function useMarqueeSelection({
       if (deltaX > threshold || deltaY > threshold) {
         hasMovedRef.current = true;
         captureResolvedItems();
-        // Activate marquee (triggers one re-render)
-        setMarqueeState({
+        // Flip isActive — one re-render, not one per frame.
+        setIsActive(true);
+        publishSnapshot({
           active: true,
           startX: m.startX,
           startY: m.startY,
@@ -424,12 +449,14 @@ export function useMarqueeSelection({
         rafIdRef.current = null;
         const m = marqueeRef.current;
 
-        // Update React state for rendering
-        setMarqueeState((prev) => ({
-          ...prev,
+        // Publish via subscription — only the overlay re-renders.
+        publishSnapshot({
+          active: true,
+          startX: m.startX,
+          startY: m.startY,
           currentX: m.currentX,
           currentY: m.currentY,
-        }));
+        });
 
         // Update selection
         updateSelectionFromRefs();
@@ -457,13 +484,8 @@ export function useMarqueeSelection({
     marqueeRef.current = { startX: 0, startY: 0, currentX: 0, currentY: 0 };
     resolvedItemsRef.current = null;
 
-    setMarqueeState({
-      active: false,
-      startX: 0,
-      startY: 0,
-      currentX: 0,
-      currentY: 0,
-    });
+    setIsActive(false);
+    publishSnapshot(INACTIVE_SNAPSHOT);
 
     // Only prevent background click if an actual marquee drag happened
     if (wasActualDrag) {
@@ -523,8 +545,11 @@ export function useMarqueeSelection({
     };
   }, []);
 
+  const marquee = useMemo<MarqueeController>(() => ({ subscribe, getSnapshot }), [subscribe, getSnapshot]);
+
   return {
-    marqueeState,
+    isActive,
+    marquee,
     selectedIds: prevSelectedIdsRef.current,
   };
 }

--- a/src/infrastructure/storage/index.ts
+++ b/src/infrastructure/storage/index.ts
@@ -33,6 +33,9 @@ export {
   getThumbnail,
   getThumbnailByMediaId,
   deleteThumbnailsByMediaId,
+  saveProjectThumbnail,
+  loadProjectThumbnail,
+  deleteProjectThumbnail,
 } from '@/infrastructure/storage/workspace-fs/thumbnails';
 
 // Content-addressable blob references

--- a/src/infrastructure/storage/index.ts
+++ b/src/infrastructure/storage/index.ts
@@ -92,8 +92,11 @@ export {
 // AI captions (vision-language-model frame descriptions)
 export {
   getCaptions,
+  getCaptionsByContentHash,
   saveCaptions,
+  adoptCaptionsFromCache,
   deleteCaptions,
+  deleteSharedCaptionsIfUnreferenced,
   saveCaptionThumbnail,
   getCaptionThumbnailBlob,
   probeCaptionThumbnail,

--- a/src/infrastructure/storage/workspace-fs/README.template.md
+++ b/src/infrastructure/storage/workspace-fs/README.template.md
@@ -25,18 +25,19 @@ normal tools. AI coding agents can read them directly without a browser.
 |       |-- source.link.json   <- OR a link descriptor to an external file
 |       |-- thumbnail.jpg
 |       `-- cache/
-|           |-- waveform/      <- audio peaks (binned binary)
+|           |-- filmstrip/     <- timeline frame thumbnails (0.jpg, 1.jpg, ...)
+|           |-- waveform/      <- audio peaks (binned binary + multi-res.bin)
 |           |-- gif-frames/    <- pre-extracted GIF frames
-|           |-- decoded-audio/ <- preview audio for non-browser codecs
-|           `-- transcript.json
-|-- filmstrips/
-|   `-- <mediaId>/             <- timeline thumbnail cache
-|       |-- meta.json
-|       `-- 0.jpg, 1.jpg, ...
+|           |-- decoded-audio/ <- chunked PCM for preview playback
+|           |-- preview-audio.wav  <- conformed WAV for non-browser codecs
+|           `-- ai/            <- transcripts, captions, scene cuts, ...
 `-- content/
-    `-- <hash>/
-        |-- refs.json          <- reference count
-        `-- data.<ext>         <- deduped blob
+    |-- <hash[0:2]>/<hash>/    <- content-addressable source dedup (reserved)
+    |   |-- refs.json
+    |   `-- data.<ext>
+    `-- proxies/<proxyKey>/    <- shared proxies (keyed by content fingerprint)
+        |-- proxy.mp4
+        `-- meta.json
 ```
 
 ## Safe to edit?

--- a/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
@@ -13,8 +13,17 @@
 
 import { createLogger } from '@/shared/logging/logger';
 
-import { readJson, removeEntry, writeJsonAtomic } from './fs-primitives';
-import { contentAiDir, contentAiRefsPath } from './paths';
+import { listDirectory, readJson, removeEntry, writeJsonAtomic } from './fs-primitives';
+import {
+  contentAiDir,
+  contentAiRefsPath,
+  contentCaptionCacheDir,
+  contentCaptionEmbeddingsPath,
+  contentCaptionImageEmbeddingsPath,
+  contentCaptionThumbsDir,
+  contentCaptionsJsonPath,
+  contentCaptionCacheVariantKey,
+} from './paths';
 import { requireWorkspaceRoot } from './root';
 import { withKeyLock } from './with-key-lock';
 
@@ -29,14 +38,18 @@ interface AiContentRefs {
   updatedAt: number;
 }
 
-function lockKey(hash: string): string {
-  return `ai-content-refs:${hash}`;
+function lockKey(hash: string, sampleIntervalSec?: number): string {
+  const variantKey = contentCaptionCacheVariantKey(sampleIntervalSec) ?? 'legacy';
+  return `ai-content-refs:${hash}:${variantKey}`;
 }
 
-export async function getAiContentRefs(hash: string): Promise<AiContentRefs | null> {
+export async function getAiContentRefs(
+  hash: string,
+  sampleIntervalSec?: number,
+): Promise<AiContentRefs | null> {
   const root = requireWorkspaceRoot();
   try {
-    return await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+    return await readJson<AiContentRefs>(root, contentAiRefsPath(hash, sampleIntervalSec));
   } catch (error) {
     logger.warn(`getAiContentRefs(${hash}) failed`, error);
     return null;
@@ -48,11 +61,15 @@ export async function getAiContentRefs(hash: string): Promise<AiContentRefs | nu
  * doesn't exist. Returns the post-add reference count. Idempotent — calling
  * twice with the same mediaId is a no-op.
  */
-export async function addAiContentRef(hash: string, mediaId: string): Promise<number> {
+export async function addAiContentRef(
+  hash: string,
+  mediaId: string,
+  sampleIntervalSec?: number,
+): Promise<number> {
   const root = requireWorkspaceRoot();
   try {
-    return await withKeyLock(lockKey(hash), async () => {
-      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+    return await withKeyLock(lockKey(hash, sampleIntervalSec), async () => {
+      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash, sampleIntervalSec));
       const now = Date.now();
       const set = new Set(existing?.mediaIds ?? []);
       set.add(mediaId);
@@ -62,7 +79,7 @@ export async function addAiContentRef(hash: string, mediaId: string): Promise<nu
         createdAt: existing?.createdAt ?? now,
         updatedAt: now,
       };
-      await writeJsonAtomic(root, contentAiRefsPath(hash), updated);
+      await writeJsonAtomic(root, contentAiRefsPath(hash, sampleIntervalSec), updated);
       return updated.mediaIds.length;
     });
   } catch (error) {
@@ -76,11 +93,15 @@ export async function addAiContentRef(hash: string, mediaId: string): Promise<nu
  * Idempotent — removing a mediaId that isn't in the set is a no-op that
  * returns the unchanged count. Missing refs file also returns 0.
  */
-export async function removeAiContentRef(hash: string, mediaId: string): Promise<number> {
+export async function removeAiContentRef(
+  hash: string,
+  mediaId: string,
+  sampleIntervalSec?: number,
+): Promise<number> {
   const root = requireWorkspaceRoot();
   try {
-    return await withKeyLock(lockKey(hash), async () => {
-      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+    return await withKeyLock(lockKey(hash, sampleIntervalSec), async () => {
+      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash, sampleIntervalSec));
       if (!existing) return 0;
       const remaining = existing.mediaIds.filter((id) => id !== mediaId);
       if (remaining.length === existing.mediaIds.length) {
@@ -91,7 +112,7 @@ export async function removeAiContentRef(hash: string, mediaId: string): Promise
         mediaIds: remaining,
         updatedAt: Date.now(),
       };
-      await writeJsonAtomic(root, contentAiRefsPath(hash), updated);
+      await writeJsonAtomic(root, contentAiRefsPath(hash, sampleIntervalSec), updated);
       return remaining.length;
     });
   } catch (error) {
@@ -105,11 +126,33 @@ export async function removeAiContentRef(hash: string, mediaId: string): Promise
  * this only after {@link removeAiContentRef} returns 0 — this is the GC step
  * for the shared cache.
  */
-export async function deleteAiContent(hash: string): Promise<void> {
+export async function deleteAiContent(
+  hash: string,
+  sampleIntervalSec?: number,
+): Promise<void> {
   const root = requireWorkspaceRoot();
   try {
-    await withKeyLock(lockKey(hash), async () => {
-      await removeEntry(root, contentAiDir(hash), { recursive: true });
+    await withKeyLock(lockKey(hash, sampleIntervalSec), async () => {
+      if (contentCaptionCacheVariantKey(sampleIntervalSec)) {
+        await removeEntry(root, contentCaptionCacheDir(hash, sampleIntervalSec), { recursive: true });
+        return;
+      }
+
+      const legacyEntries = [
+        contentCaptionsJsonPath(hash),
+        contentCaptionEmbeddingsPath(hash),
+        contentCaptionImageEmbeddingsPath(hash),
+        contentCaptionThumbsDir(hash),
+        contentAiRefsPath(hash),
+      ];
+      for (const segments of legacyEntries) {
+        await removeEntry(root, segments, { recursive: true }).catch(() => undefined);
+      }
+
+      const aiEntries = await listDirectory(root, contentAiDir(hash)).catch(() => []);
+      if (aiEntries.length === 0) {
+        await removeEntry(root, contentAiDir(hash), { recursive: true }).catch(() => undefined);
+      }
     });
   } catch (error) {
     logger.warn(`deleteAiContent(${hash}) failed`, error);

--- a/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
@@ -1,0 +1,117 @@
+/**
+ * Reference tracking for AI outputs stored in the content-addressable tree.
+ *
+ * Parallel to `content.ts` (which tracks source-blob refs) — this one tracks
+ * which `mediaId`s reference the shared AI cache at `content/{shard}/{hash}/ai/`.
+ * Separate lifecycle so a media item with `handle` storage (no source blob in
+ * the content tree) still benefits from caption dedup.
+ *
+ * The refs file is a `Set<mediaId>` serialized as a sorted array. Adding /
+ * removing is idempotent. When the set empties, the caller is responsible
+ * for tearing down the `ai/` subtree (see `captions.ts:deleteCaptionsCache`).
+ */
+
+import { createLogger } from '@/shared/logging/logger';
+
+import { readJson, removeEntry, writeJsonAtomic } from './fs-primitives';
+import { contentAiDir, contentAiRefsPath } from './paths';
+import { requireWorkspaceRoot } from './root';
+import { withKeyLock } from './with-key-lock';
+
+const logger = createLogger('WorkspaceFS:AiContentRefs');
+
+interface AiContentRefs {
+  /** Schema version for this refs file. Bump when the shape changes. */
+  schemaVersion: 1;
+  /** Sorted list of mediaIds that reference the cached AI outputs. */
+  mediaIds: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+function lockKey(hash: string): string {
+  return `ai-content-refs:${hash}`;
+}
+
+export async function getAiContentRefs(hash: string): Promise<AiContentRefs | null> {
+  const root = requireWorkspaceRoot();
+  try {
+    return await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+  } catch (error) {
+    logger.warn(`getAiContentRefs(${hash}) failed`, error);
+    return null;
+  }
+}
+
+/**
+ * Add `mediaId` to the reference set for `hash`, creating the file when it
+ * doesn't exist. Returns the post-add reference count. Idempotent — calling
+ * twice with the same mediaId is a no-op.
+ */
+export async function addAiContentRef(hash: string, mediaId: string): Promise<number> {
+  const root = requireWorkspaceRoot();
+  try {
+    return await withKeyLock(lockKey(hash), async () => {
+      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+      const now = Date.now();
+      const set = new Set(existing?.mediaIds ?? []);
+      set.add(mediaId);
+      const updated: AiContentRefs = {
+        schemaVersion: 1,
+        mediaIds: [...set].sort(),
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      };
+      await writeJsonAtomic(root, contentAiRefsPath(hash), updated);
+      return updated.mediaIds.length;
+    });
+  } catch (error) {
+    logger.error(`addAiContentRef(${hash}, ${mediaId}) failed`, error);
+    throw error;
+  }
+}
+
+/**
+ * Drop `mediaId` from the reference set. Returns the post-remove count.
+ * Idempotent — removing a mediaId that isn't in the set is a no-op that
+ * returns the unchanged count. Missing refs file also returns 0.
+ */
+export async function removeAiContentRef(hash: string, mediaId: string): Promise<number> {
+  const root = requireWorkspaceRoot();
+  try {
+    return await withKeyLock(lockKey(hash), async () => {
+      const existing = await readJson<AiContentRefs>(root, contentAiRefsPath(hash));
+      if (!existing) return 0;
+      const remaining = existing.mediaIds.filter((id) => id !== mediaId);
+      if (remaining.length === existing.mediaIds.length) {
+        return remaining.length;
+      }
+      const updated: AiContentRefs = {
+        ...existing,
+        mediaIds: remaining,
+        updatedAt: Date.now(),
+      };
+      await writeJsonAtomic(root, contentAiRefsPath(hash), updated);
+      return remaining.length;
+    });
+  } catch (error) {
+    logger.error(`removeAiContentRef(${hash}, ${mediaId}) failed`, error);
+    throw error;
+  }
+}
+
+/**
+ * Remove the `content/{shard}/{hash}/ai/` subtree. Caller is expected to do
+ * this only after {@link removeAiContentRef} returns 0 — this is the GC step
+ * for the shared cache.
+ */
+export async function deleteAiContent(hash: string): Promise<void> {
+  const root = requireWorkspaceRoot();
+  try {
+    await withKeyLock(lockKey(hash), async () => {
+      await removeEntry(root, contentAiDir(hash), { recursive: true });
+    });
+  } catch (error) {
+    logger.warn(`deleteAiContent(${hash}) failed`, error);
+  }
+}

--- a/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-content-refs.ts
@@ -133,8 +133,21 @@ export async function deleteAiContent(
   const root = requireWorkspaceRoot();
   try {
     await withKeyLock(lockKey(hash, sampleIntervalSec), async () => {
+      // Re-check for refs inside the lock. A concurrent `addAiContentRef` that
+      // landed between the caller's ref-removal and our lock acquisition would
+      // otherwise be orphaned by the deletion below.
+      const currentRefs = await readJson<AiContentRefs>(root, contentAiRefsPath(hash, sampleIntervalSec));
+      if (currentRefs && currentRefs.mediaIds.length > 0) {
+        return;
+      }
+
       if (contentCaptionCacheVariantKey(sampleIntervalSec)) {
         await removeEntry(root, contentCaptionCacheDir(hash, sampleIntervalSec), { recursive: true });
+        // Sweep the parent ai/ dir if this was the last variant.
+        const remaining = await listDirectory(root, contentAiDir(hash)).catch(() => []);
+        if (remaining.length === 0) {
+          await removeEntry(root, contentAiDir(hash), { recursive: true }).catch(() => undefined);
+        }
         return;
       }
 

--- a/src/infrastructure/storage/workspace-fs/ai-outputs/index.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-outputs/index.ts
@@ -14,8 +14,11 @@ export {
 } from './types';
 export {
   readAiOutput,
+  readAiOutputAt,
   writeAiOutput,
+  writeAiOutputAt,
   deleteAiOutput,
+  deleteAiOutputAt,
   listAiOutputs,
   getMediaIdsWithAiOutput,
 } from './io';

--- a/src/infrastructure/storage/workspace-fs/ai-outputs/io.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-outputs/io.ts
@@ -29,13 +29,26 @@ export async function readAiOutput<K extends AiOutputKind>(
   mediaId: string,
   kind: K,
 ): Promise<AiOutput<K> | undefined> {
+  return readAiOutputAt(aiOutputPath(mediaId, kind), kind, `readAiOutput(${mediaId}, ${kind})`);
+}
+
+/**
+ * Read an AI output envelope from an arbitrary workspace path. Used by the
+ * content-keyed caption cache where the envelope lives under
+ * `content/{shard}/{hash}/ai/` rather than `media/{id}/cache/ai/`.
+ */
+export async function readAiOutputAt<K extends AiOutputKind>(
+  segments: string[],
+  kind: K,
+  context = `readAiOutputAt(${segments.join('/')}, ${kind})`,
+): Promise<AiOutput<K> | undefined> {
   const root = requireWorkspaceRoot();
   try {
-    const result = await readJson<AiOutput<K>>(root, aiOutputPath(mediaId, kind));
+    const result = await readJson<AiOutput<K>>(root, segments);
     return result ?? undefined;
   } catch (error) {
-    logger.error(`readAiOutput(${mediaId}, ${kind}) failed`, error);
-    throw new Error(`Failed to load AI output ${kind} for ${mediaId}`);
+    logger.error(`${context} failed`, error);
+    throw new Error(`Failed to load AI output ${kind}`);
   }
 }
 
@@ -55,9 +68,21 @@ interface WriteInput<K extends AiOutputKind> {
 export async function writeAiOutput<K extends AiOutputKind>(
   input: WriteInput<K>,
 ): Promise<AiOutput<K>> {
+  return writeAiOutputAt(aiOutputPath(input.mediaId, input.kind), input);
+}
+
+/**
+ * Same as {@link writeAiOutput} but at an explicit path. The envelope still
+ * records `mediaId` from the input for provenance — for the content-keyed
+ * cache, this is the mediaId of the run that populated the cache first.
+ */
+export async function writeAiOutputAt<K extends AiOutputKind>(
+  segments: string[],
+  input: WriteInput<K>,
+): Promise<AiOutput<K>> {
   const root = requireWorkspaceRoot();
   const now = Date.now();
-  const existing = await readJson<AiOutput<K>>(root, aiOutputPath(input.mediaId, input.kind));
+  const existing = await readJson<AiOutput<K>>(root, segments);
 
   const envelope: AiOutput<K> = {
     schemaVersion: AI_OUTPUT_SCHEMA_VERSION,
@@ -72,11 +97,11 @@ export async function writeAiOutput<K extends AiOutputKind>(
   };
 
   try {
-    await writeJsonAtomic(root, aiOutputPath(input.mediaId, input.kind), envelope);
+    await writeJsonAtomic(root, segments, envelope);
     return envelope;
   } catch (error) {
-    logger.error(`writeAiOutput(${input.mediaId}, ${input.kind}) failed`, error);
-    throw new Error(`Failed to save AI output ${input.kind} for ${input.mediaId}`);
+    logger.error(`writeAiOutputAt(${segments.join('/')}, ${input.kind}) failed`, error);
+    throw new Error(`Failed to save AI output ${input.kind}`);
   }
 }
 
@@ -84,12 +109,19 @@ export async function deleteAiOutput(
   mediaId: string,
   kind: AiOutputKind,
 ): Promise<void> {
+  return deleteAiOutputAt(aiOutputPath(mediaId, kind), `deleteAiOutput(${mediaId}, ${kind})`);
+}
+
+export async function deleteAiOutputAt(
+  segments: string[],
+  context = `deleteAiOutputAt(${segments.join('/')})`,
+): Promise<void> {
   const root = requireWorkspaceRoot();
   try {
-    await removeEntry(root, aiOutputPath(mediaId, kind));
+    await removeEntry(root, segments);
   } catch (error) {
-    logger.error(`deleteAiOutput(${mediaId}, ${kind}) failed`, error);
-    throw new Error(`Failed to delete AI output ${kind} for ${mediaId}`);
+    logger.error(`${context} failed`, error);
+    throw new Error(`Failed to delete AI output`);
   }
 }
 

--- a/src/infrastructure/storage/workspace-fs/ai-outputs/types.ts
+++ b/src/infrastructure/storage/workspace-fs/ai-outputs/types.ts
@@ -81,6 +81,14 @@ export type CaptionsPayload = {
   imageEmbeddingModel?: string;
   /** Dimension of each image embedding vector, e.g. 512 for CLIP base. */
   imageEmbeddingDim?: number;
+  /**
+   * SHA-256 of the source media bytes. When present, this envelope was
+   * saved via the shared content-addressable cache — embedding bins and
+   * caption thumbnails live under `content/{shard}/{hash}/ai/` and are
+   * shared across every mediaId that resolves to the same hash. Per-caption
+   * `thumbRelPath` values point into the content tree in this mode.
+   */
+  contentHash?: string;
   captions: MediaCaption[];
 };
 

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -113,13 +113,47 @@ async function stripProxyKeyPrefixes(
         continue;
       }
 
+      // Read every file up front. Aborting on the first unreadable file
+      // avoids a destructive half-move: we only delete oldDir once every
+      // expected file has been successfully copied to newDir.
       const files = await listDirectory(root, oldDir);
+      const filePayloads: Array<{ name: string; blob: Blob }> = [];
+      let allReadable = true;
       for (const file of files) {
         if (file.kind !== 'file') continue;
-        const blob = await readBlob(root, [...oldDir, file.name]);
-        if (!blob) continue;
-        await writeBlob(root, [...newDir, file.name], blob);
+        const blob = await readBlob(root, [...oldDir, file.name]).catch(() => null);
+        if (!blob) {
+          allReadable = false;
+          break;
+        }
+        filePayloads.push({ name: file.name, blob });
       }
+      if (!allReadable) {
+        logger.warn(`stripProxyKeyPrefixes: aborting ${oldName} — unreadable file, leaving source intact`);
+        continue;
+      }
+
+      let allWritten = true;
+      const written: string[] = [];
+      for (const payload of filePayloads) {
+        try {
+          await writeBlob(root, [...newDir, payload.name], payload.blob);
+          written.push(payload.name);
+        } catch (error) {
+          logger.warn(`stripProxyKeyPrefixes: write failed for ${oldName}/${payload.name}`, error);
+          allWritten = false;
+          break;
+        }
+      }
+      if (!allWritten) {
+        // Roll back partial writes so we leave the new location empty and the
+        // old directory untouched for a retry on next bootstrap.
+        for (const name of written) {
+          await removeEntry(root, [...newDir, name], { recursive: false }).catch(() => undefined);
+        }
+        continue;
+      }
+
       await removeEntry(root, oldDir, { recursive: true });
       renamed++;
     } catch (error) {

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -11,8 +11,10 @@ import {
   PROJECTS_DIR,
   README_FILENAME,
   WORKSPACE_SCHEMA_VERSION,
+  proxiesRoot,
 } from './paths';
-import { exists, writeBlob, writeJsonAtomic } from './fs-primitives';
+import { exists, listDirectory, readBlob, removeEntry, writeBlob, writeJsonAtomic } from './fs-primitives';
+import { migrateWorkspaceV2 } from './migrate-workspace-v2';
 import readmeTemplate from './README.template.md?raw';
 
 const logger = createLogger('WorkspaceBootstrap');
@@ -79,6 +81,54 @@ async function sweepStrandedTmpFiles(
   return removed;
 }
 
+const PROXY_KEY_TAG_PATTERN = /^[hof]-/;
+
+/**
+ * Rename any `content/proxies/{h|o|f}-*` folders to their un-tagged form.
+ * Safe to call every bootstrap: returns 0 when nothing matches.
+ *
+ * Moves via copy-then-delete because FileSystemDirectoryHandle doesn't yet
+ * expose a cross-browser rename. If both old and new names exist (e.g. a
+ * partial prior run), the new name wins and the prefixed one is removed.
+ */
+async function stripProxyKeyPrefixes(
+  root: FileSystemDirectoryHandle,
+): Promise<number> {
+  const entries = await listDirectory(root, proxiesRoot());
+  let renamed = 0;
+  for (const entry of entries) {
+    if (entry.kind !== 'directory') continue;
+    if (!PROXY_KEY_TAG_PATTERN.test(entry.name)) continue;
+
+    const oldName = entry.name;
+    const newName = oldName.slice(2);
+    const oldDir = [...proxiesRoot(), oldName];
+    const newDir = [...proxiesRoot(), newName];
+
+    try {
+      if (await exists(root, newDir)) {
+        // New name already present — drop the prefixed copy and move on.
+        await removeEntry(root, oldDir, { recursive: true });
+        renamed++;
+        continue;
+      }
+
+      const files = await listDirectory(root, oldDir);
+      for (const file of files) {
+        if (file.kind !== 'file') continue;
+        const blob = await readBlob(root, [...oldDir, file.name]);
+        if (!blob) continue;
+        await writeBlob(root, [...newDir, file.name], blob);
+      }
+      await removeEntry(root, oldDir, { recursive: true });
+      renamed++;
+    } catch (error) {
+      logger.warn(`stripProxyKeyPrefixes: failed to rename ${oldName}`, error);
+    }
+  }
+  return renamed;
+}
+
 export async function bootstrapWorkspace(
   root: FileSystemDirectoryHandle,
 ): Promise<void> {
@@ -103,6 +153,42 @@ export async function bootstrapWorkspace(
     } catch (error) {
       logger.warn('Failed to write workspace marker', error);
     }
+  } else {
+    // Marker present — may need migration. Must run before any other
+    // workspace read path in consumer code that would otherwise fail on
+    // the old layout.
+    try {
+      const report = await migrateWorkspaceV2(root);
+      if (report.ran) {
+        logger.info('Workspace migration finished', {
+          from: report.fromVersion,
+          to: report.toVersion,
+          filmstrips: report.filmstripMediaMoved,
+          waveforms: report.waveformBinMoved,
+          previewAudio: report.previewAudioMoved,
+          proxies: report.proxiesMoved,
+          thumbnailMetaRemoved: report.thumbnailMetaRemoved,
+          projectThumbnailsFixed: report.projectThumbnailsFixed,
+          errors: report.errors.length,
+          durationMs: Math.round(report.durationMs),
+        });
+      }
+    } catch (error) {
+      logger.warn('Workspace migration failed', error);
+    }
+  }
+
+  // One-off cleanup: proxy folders historically carried an `h-`/`o-`/`f-`
+  // source-type tag. The tag carries no information the format's shape
+  // doesn't already convey, so we strip it in place. Idempotent — runs
+  // every bootstrap but is O(0) once no prefixed names remain.
+  try {
+    const renamed = await stripProxyKeyPrefixes(root);
+    if (renamed > 0) {
+      logger.info(`Stripped source-type prefix from ${renamed} proxy folder(s)`);
+    }
+  } catch (error) {
+    logger.warn('stripProxyKeyPrefixes failed', error);
   }
 
   // Clean up any `.tmp` files stranded by a prior crash.

--- a/src/infrastructure/storage/workspace-fs/captions.test.ts
+++ b/src/infrastructure/storage/workspace-fs/captions.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/logging/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    event: vi.fn(),
+    startEvent: () => ({ set: vi.fn(), merge: vi.fn(), success: vi.fn(), failure: vi.fn() }),
+    child: vi.fn(),
+    setLevel: vi.fn(),
+  }),
+  createOperationId: () => 'op-test',
+}));
+
+import {
+  adoptCaptionsFromCache,
+  deleteCaptions,
+  getCaptionEmbeddings,
+  getCaptionsByContentHash,
+  getCaptionsEmbeddingsMeta,
+  saveCaptionEmbeddings,
+  saveCaptions,
+} from './captions';
+import { contentCaptionThumbRelPath } from './paths';
+import { setWorkspaceRoot } from './root';
+import { asHandle, createRoot } from './__tests__/in-memory-handle';
+import { __resetKeyLocksForTesting } from './with-key-lock';
+
+beforeEach(() => {
+  setWorkspaceRoot(null);
+  __resetKeyLocksForTesting();
+});
+
+afterEach(() => {
+  setWorkspaceRoot(null);
+  __resetKeyLocksForTesting();
+});
+
+describe('workspace-fs captions', () => {
+  it('stores shared caption assets in separate cache variants per sample interval', async () => {
+    setWorkspaceRoot(asHandle(createRoot()));
+    const hash = 'a'.repeat(64);
+
+    await saveCaptions({
+      mediaId: 'm1',
+      captions: [{ timeSec: 0, text: 'three-second' }],
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      sampleIntervalSec: 3,
+      contentHash: hash,
+    });
+    await saveCaptionEmbeddings('m1', [Float32Array.from([1, 2])], 2, {
+      contentHash: hash,
+      sampleIntervalSec: 3,
+    });
+    const shortThumb = contentCaptionThumbRelPath(hash, 0, 3);
+
+    await saveCaptions({
+      mediaId: 'm2',
+      captions: [{ timeSec: 0, text: 'ten-second' }],
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      sampleIntervalSec: 10,
+      contentHash: hash,
+    });
+    await saveCaptionEmbeddings('m2', [Float32Array.from([3, 4])], 2, {
+      contentHash: hash,
+      sampleIntervalSec: 10,
+    });
+    const longThumb = contentCaptionThumbRelPath(hash, 0, 10);
+
+    const shortCache = await getCaptionsByContentHash(hash, 3);
+    const longCache = await getCaptionsByContentHash(hash, 10);
+    const shortVectors = await getCaptionEmbeddings('m1', 2, 1, {
+      contentHash: hash,
+      sampleIntervalSec: 3,
+    });
+    const longVectors = await getCaptionEmbeddings('m2', 2, 1, {
+      contentHash: hash,
+      sampleIntervalSec: 10,
+    });
+
+    expect(shortCache?.data.captions[0]?.text).toBe('three-second');
+    expect(longCache?.data.captions[0]?.text).toBe('ten-second');
+    expect(shortThumb).toContain('/si-300/');
+    expect(longThumb).toContain('/si-1000/');
+    expect(shortThumb).not.toBe(longThumb);
+    expect(Array.from(shortVectors?.[0] ?? [])).toEqual([1, 2]);
+    expect(Array.from(longVectors?.[0] ?? [])).toEqual([3, 4]);
+  });
+
+  it('keeps other interval variants alive when deleting one shared caption cache entry', async () => {
+    setWorkspaceRoot(asHandle(createRoot()));
+    const hash = 'b'.repeat(64);
+
+    await saveCaptions({
+      mediaId: 'm1',
+      captions: [{ timeSec: 0, text: 'three-second' }],
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      sampleIntervalSec: 3,
+      contentHash: hash,
+    });
+    await saveCaptions({
+      mediaId: 'm2',
+      captions: [{ timeSec: 0, text: 'ten-second' }],
+      service: 'lfm-captioning',
+      model: 'lfm-2.5-vl',
+      sampleIntervalSec: 10,
+      contentHash: hash,
+    });
+
+    const adopted = await adoptCaptionsFromCache('m3', hash, 3);
+    expect(adopted?.data.captions[0]?.text).toBe('three-second');
+    expect((await getCaptionsEmbeddingsMeta('m3'))?.sampleIntervalSec).toBe(3);
+
+    await deleteCaptions('m1');
+
+    expect(await getCaptionsByContentHash(hash, 3)).toBeDefined();
+    expect(await getCaptionsByContentHash(hash, 10)).toBeDefined();
+
+    await deleteCaptions('m3');
+
+    expect(await getCaptionsByContentHash(hash, 3)).toBeUndefined();
+    expect(await getCaptionsByContentHash(hash, 10)).toBeDefined();
+  });
+});

--- a/src/infrastructure/storage/workspace-fs/captions.ts
+++ b/src/infrastructure/storage/workspace-fs/captions.ts
@@ -123,9 +123,20 @@ async function resolveSharedCaptionCache(
 
   const legacyEnvelope = await readAiOutputAt(contentCaptionsJsonPath(hash), 'captions');
   if (!legacyEnvelope) return undefined;
+  const legacyInterval = resolveSampleIntervalSec(legacyEnvelope.data, legacyEnvelope.params);
+  // When a specific interval was requested, a legacy envelope is only
+  // acceptable if its resolved interval matches — otherwise callers would
+  // silently reuse captions generated at a different density.
+  if (
+    sampleIntervalSec !== undefined
+    && legacyInterval !== undefined
+    && Math.abs(legacyInterval - sampleIntervalSec) >= 0.01
+  ) {
+    return undefined;
+  }
   return {
     envelope: legacyEnvelope,
-    sampleIntervalSec: resolveSampleIntervalSec(legacyEnvelope.data, legacyEnvelope.params),
+    sampleIntervalSec: legacyInterval,
   };
 }
 
@@ -169,6 +180,22 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
     captions: input.captions,
   };
 
+  // Read any prior per-media envelope *before* overwriting — when the same
+  // media is re-analyzed with different source bytes, we need to release the
+  // old shared-cache ref so it doesn't leak a stale entry.
+  let priorContentHash: string | undefined;
+  let priorSampleIntervalSec: number | undefined;
+  if (input.contentHash) {
+    try {
+      const prior = await readAiOutput(input.mediaId, 'captions');
+      priorContentHash = prior?.data.contentHash;
+      priorSampleIntervalSec = resolveSampleIntervalSec(prior?.data, prior?.params);
+    } catch {
+      priorContentHash = undefined;
+      priorSampleIntervalSec = undefined;
+    }
+  }
+
   try {
     const written = await writeAiOutput({
       mediaId: input.mediaId,
@@ -180,8 +207,10 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
     });
 
     if (input.contentHash) {
+      const mirrorPath = contentCaptionsJsonPath(input.contentHash, input.sampleIntervalSec);
+      let mirrorWritten = false;
       try {
-        await writeAiOutputAt(contentCaptionsJsonPath(input.contentHash, input.sampleIntervalSec), {
+        await writeAiOutputAt(mirrorPath, {
           mediaId: input.mediaId,
           kind: 'captions',
           service: input.service,
@@ -189,11 +218,43 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
           params: input.sampleIntervalSec !== undefined ? { sampleIntervalSec: input.sampleIntervalSec } : {},
           data,
         });
+        mirrorWritten = true;
         await addAiContentRef(input.contentHash, input.mediaId, input.sampleIntervalSec);
+        // Release the prior ref once the new ref has landed. Same hash/interval
+        // is idempotent so we skip; only call for genuine changes. Failures are
+        // logged, not rethrown — the new ref is already in place.
+        if (
+          priorContentHash
+          && (priorContentHash !== input.contentHash
+            || priorSampleIntervalSec !== input.sampleIntervalSec)
+        ) {
+          try {
+            await deleteSharedCaptionsIfUnreferenced(
+              priorContentHash,
+              input.mediaId,
+              priorSampleIntervalSec,
+            );
+          } catch (error) {
+            logger.warn(
+              `saveCaptions: failed to release prior ref ${priorContentHash} for ${input.mediaId}`,
+              error,
+            );
+          }
+        }
       } catch (error) {
         // Per-media envelope is already the authoritative record; log and move
-        // on so caption save doesn't fail the whole analyze pipeline.
+        // on so caption save doesn't fail the whole analyze pipeline. If the
+        // mirror was written but ref registration failed, roll back the mirror
+        // so it doesn't orphan — GC only runs when a ref is removed.
         logger.warn(`saveCaptions: content-cache mirror failed for ${input.contentHash}`, error);
+        if (mirrorWritten) {
+          await deleteAiOutputAt(mirrorPath).catch((rollbackError) => {
+            logger.warn(
+              `saveCaptions: failed to roll back orphaned mirror at ${input.contentHash}`,
+              rollbackError,
+            );
+          });
+        }
       }
     }
 
@@ -568,6 +629,15 @@ export async function adoptCaptionsFromCache(
   if (!resolved) return undefined;
   const { envelope, sampleIntervalSec: resolvedInterval } = resolved;
 
+  const adoptedEnvelope: AiOutput<'captions'> = {
+    ...envelope,
+    data: {
+      ...envelope.data,
+      contentHash: hash,
+      sampleIntervalSec: resolvedInterval ?? envelope.data.sampleIntervalSec,
+    },
+  };
+
   try {
     await writeAiOutputAt(aiOutputPath(mediaId, 'captions'), {
       mediaId,
@@ -575,14 +645,10 @@ export async function adoptCaptionsFromCache(
       service: envelope.service,
       model: envelope.model,
       params: envelope.params,
-      data: {
-        ...envelope.data,
-        contentHash: hash,
-        sampleIntervalSec: resolvedInterval ?? envelope.data.sampleIntervalSec,
-      },
+      data: adoptedEnvelope.data,
     });
     await addAiContentRef(hash, mediaId, resolvedInterval);
-    return envelope;
+    return adoptedEnvelope;
   } catch (error) {
     logger.warn(`adoptCaptionsFromCache(${mediaId}, ${hash}) failed`, error);
     // On failure the mediaId has no local envelope — caller should fall

--- a/src/infrastructure/storage/workspace-fs/captions.ts
+++ b/src/infrastructure/storage/workspace-fs/captions.ts
@@ -1,22 +1,55 @@
 /**
- * Per-media AI captions (vision-language-model frame descriptions).
+ * Per-media AI captions (vision-language-model frame descriptions), with a
+ * content-addressable cache so multiple mediaIds resolving to the same source
+ * bytes share caption generation cost.
  *
- * Stored at `media/{mediaId}/cache/ai/captions.json` as an {@link AiOutput}
- * envelope. A denormalized copy lives on `MediaMetadata.aiCaptions` as a
- * read-path convenience for UI consumers — writers must keep them in sync.
+ * Two-location layout:
+ *  - Per-media envelope lives at `media/{mediaId}/cache/ai/captions.json`
+ *    and mirrors `MediaMetadata.aiCaptions`. It records whether the
+ *    companion heavy assets (embeddings bins, thumbnail JPEGs) live under
+ *    the per-media cache dir or the shared content tree.
+ *  - When the source's SHA-256 is known at save time, embedding bins and
+ *    caption thumbnails are written once to `content/{shard}/{hash}/ai/`.
+ *    The envelope carries `contentHash` so readers route their bin/thumb
+ *    lookups there. The ai-refs file (`content/{shard}/{hash}/ai/refs.json`)
+ *    tracks which mediaIds share the cache so the directory can be GC'd
+ *    when the last reference goes away.
+ *
+ * Callers that only know a mediaId still work — lookup helpers consult the
+ * envelope to decide whether heavy assets live per-media or shared. Callers
+ * that want dedup at save time pass `contentHash` in the options.
  */
 
 import type { MediaCaption } from '@/infrastructure/analysis';
 import { createLogger } from '@/shared/logging/logger';
 
-import { readAiOutput, writeAiOutput, deleteAiOutput } from './ai-outputs';
+import {
+  addAiContentRef,
+  deleteAiContent,
+  removeAiContentRef,
+} from './ai-content-refs';
+import {
+  readAiOutput,
+  readAiOutputAt,
+  writeAiOutput,
+  writeAiOutputAt,
+  deleteAiOutput,
+  deleteAiOutputAt,
+  type AiOutput,
+} from './ai-outputs';
 import { readArrayBuffer, readBlob, removeEntry, writeBlob } from './fs-primitives';
 import {
+  aiOutputPath,
   captionEmbeddingsPath,
   captionImageEmbeddingsPath,
   captionThumbPath,
   captionThumbRelPath,
   captionThumbsDir,
+  contentCaptionEmbeddingsPath,
+  contentCaptionImageEmbeddingsPath,
+  contentCaptionThumbPath,
+  contentCaptionThumbRelPath,
+  contentCaptionsJsonPath,
 } from './paths';
 import { requireWorkspaceRoot } from './root';
 
@@ -39,6 +72,22 @@ interface SaveCaptionsInput {
   imageEmbeddingModel?: string;
   /** Dimension of each image embedding vector. */
   imageEmbeddingDim?: number;
+  /**
+   * SHA-256 of the source media bytes. When provided, the envelope and heavy
+   * assets are mirrored into the shared content cache and this mediaId is
+   * registered as a ref-holder.
+   */
+  contentHash?: string;
+}
+
+/** Options common to most read/write helpers. */
+interface ContentKeyedOptions {
+  /**
+   * SHA-256 of the source bytes. When present, the helper targets the shared
+   * content-addressable location; when absent, falls back to the per-media
+   * location for backwards compatibility with pre-cache saves.
+   */
+  contentHash?: string;
 }
 
 export async function getCaptions(
@@ -53,7 +102,33 @@ export async function getCaptions(
   }
 }
 
+/**
+ * Look up the shared-cache captions envelope by content hash. Used at the
+ * start of analysis so the expensive captioner can be skipped when another
+ * media item has already produced captions for the same source bytes.
+ */
+export async function getCaptionsByContentHash(
+  hash: string,
+): Promise<AiOutput<'captions'> | undefined> {
+  try {
+    return await readAiOutputAt(contentCaptionsJsonPath(hash), 'captions');
+  } catch (error) {
+    logger.warn(`getCaptionsByContentHash(${hash}) failed`, error);
+    return undefined;
+  }
+}
+
 export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCaption[]> {
+  const data = {
+    sampleIntervalSec: input.sampleIntervalSec,
+    embeddingModel: input.embeddingModel,
+    embeddingDim: input.embeddingDim,
+    imageEmbeddingModel: input.imageEmbeddingModel,
+    imageEmbeddingDim: input.imageEmbeddingDim,
+    contentHash: input.contentHash,
+    captions: input.captions,
+  };
+
   try {
     const written = await writeAiOutput({
       mediaId: input.mediaId,
@@ -61,15 +136,27 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
       service: input.service,
       model: input.model,
       params: input.sampleIntervalSec !== undefined ? { sampleIntervalSec: input.sampleIntervalSec } : {},
-      data: {
-        sampleIntervalSec: input.sampleIntervalSec,
-        embeddingModel: input.embeddingModel,
-        embeddingDim: input.embeddingDim,
-        imageEmbeddingModel: input.imageEmbeddingModel,
-        imageEmbeddingDim: input.imageEmbeddingDim,
-        captions: input.captions,
-      },
+      data,
     });
+
+    if (input.contentHash) {
+      try {
+        await writeAiOutputAt(contentCaptionsJsonPath(input.contentHash), {
+          mediaId: input.mediaId,
+          kind: 'captions',
+          service: input.service,
+          model: input.model,
+          params: input.sampleIntervalSec !== undefined ? { sampleIntervalSec: input.sampleIntervalSec } : {},
+          data,
+        });
+        await addAiContentRef(input.contentHash, input.mediaId);
+      } catch (error) {
+        // Per-media envelope is already the authoritative record; log and move
+        // on so caption save doesn't fail the whole analyze pipeline.
+        logger.warn(`saveCaptions: content-cache mirror failed for ${input.contentHash}`, error);
+      }
+    }
+
     return written.data.captions;
   } catch (error) {
     logger.error(`saveCaptions(${input.mediaId}) failed`, error);
@@ -89,6 +176,7 @@ export async function getCaptionsEmbeddingsMeta(
   embeddingDim?: number;
   imageEmbeddingModel?: string;
   imageEmbeddingDim?: number;
+  contentHash?: string;
 } | null> {
   const envelope = await readAiOutput(mediaId, 'captions');
   if (!envelope) return null;
@@ -97,6 +185,7 @@ export async function getCaptionsEmbeddingsMeta(
     embeddingDim: envelope.data.embeddingDim,
     imageEmbeddingModel: envelope.data.imageEmbeddingModel,
     imageEmbeddingDim: envelope.data.imageEmbeddingDim,
+    contentHash: envelope.data.contentHash,
   };
 }
 
@@ -105,12 +194,15 @@ export async function getCaptionsEmbeddingsMeta(
  * `captionCount * embeddingDim` floats, stored in caption index order.
  * The companion `captions.json` records {@link embeddingModel} and
  * {@link embeddingDim} so a later read can detect model-drift before
- * trusting the payload.
+ * trusting the payload. Writes to the shared content cache when
+ * {@link ContentKeyedOptions.contentHash} is provided, otherwise to the
+ * per-media cache dir.
  */
 export async function saveCaptionEmbeddings(
   mediaId: string,
   vectors: Float32Array[],
   embeddingDim: number,
+  opts: ContentKeyedOptions = {},
 ): Promise<void> {
   if (vectors.length === 0) return;
   const root = requireWorkspaceRoot();
@@ -123,8 +215,11 @@ export async function saveCaptionEmbeddings(
     }
     packed.set(vector, index * embeddingDim);
   });
+  const target = opts.contentHash
+    ? contentCaptionEmbeddingsPath(opts.contentHash)
+    : captionEmbeddingsPath(mediaId);
   try {
-    await writeBlob(root, captionEmbeddingsPath(mediaId), packed.buffer);
+    await writeBlob(root, target, packed.buffer);
   } catch (error) {
     logger.error(`saveCaptionEmbeddings(${mediaId}) failed`, error);
     throw new Error(`Failed to save caption embeddings: ${mediaId}`);
@@ -135,17 +230,22 @@ export async function saveCaptionEmbeddings(
  * Load caption embeddings back into an array of `Float32Array`s. Returns
  * `null` when no `.bin` exists (pre-feature captions) or when the saved
  * vector count doesn't match `expectedCount` (captions changed under our
- * feet and the bin is stale).
+ * feet and the bin is stale). Reads from the shared content cache when
+ * {@link ContentKeyedOptions.contentHash} is provided, otherwise per-media.
  */
 export async function getCaptionEmbeddings(
   mediaId: string,
   embeddingDim: number,
   expectedCount: number,
+  opts: ContentKeyedOptions = {},
 ): Promise<Float32Array[] | null> {
   if (expectedCount === 0) return [];
   const root = requireWorkspaceRoot();
+  const target = opts.contentHash
+    ? contentCaptionEmbeddingsPath(opts.contentHash)
+    : captionEmbeddingsPath(mediaId);
   try {
-    const buffer = await readArrayBuffer(root, captionEmbeddingsPath(mediaId));
+    const buffer = await readArrayBuffer(root, target);
     if (!buffer) return null;
     const expectedFloats = expectedCount * embeddingDim;
     const got = buffer.byteLength / Float32Array.BYTES_PER_ELEMENT;
@@ -167,8 +267,12 @@ export async function getCaptionEmbeddings(
   }
 }
 
-export async function deleteCaptionEmbeddings(mediaId: string): Promise<void> {
+export async function deleteCaptionEmbeddings(
+  mediaId: string,
+  opts: ContentKeyedOptions = {},
+): Promise<void> {
   const root = requireWorkspaceRoot();
+  // Always clear the per-media location — safe no-op when file is absent.
   try {
     await removeEntry(root, captionEmbeddingsPath(mediaId));
   } catch (error) {
@@ -179,6 +283,9 @@ export async function deleteCaptionEmbeddings(mediaId: string): Promise<void> {
   } catch (error) {
     logger.warn(`deleteCaptionImageEmbeddings(${mediaId}) failed`, error);
   }
+  // Shared content-tree bins are GC'd by deleteSharedCaptionsIfUnreferenced
+  // when the last ref goes away; individual deletes don't touch them.
+  void opts.contentHash;
 }
 
 /**
@@ -191,6 +298,7 @@ export async function saveCaptionImageEmbeddings(
   mediaId: string,
   vectors: Float32Array[],
   embeddingDim: number,
+  opts: ContentKeyedOptions = {},
 ): Promise<void> {
   if (vectors.length === 0) return;
   const root = requireWorkspaceRoot();
@@ -203,8 +311,11 @@ export async function saveCaptionImageEmbeddings(
     }
     packed.set(vector, index * embeddingDim);
   });
+  const target = opts.contentHash
+    ? contentCaptionImageEmbeddingsPath(opts.contentHash)
+    : captionImageEmbeddingsPath(mediaId);
   try {
-    await writeBlob(root, captionImageEmbeddingsPath(mediaId), packed.buffer);
+    await writeBlob(root, target, packed.buffer);
   } catch (error) {
     logger.error(`saveCaptionImageEmbeddings(${mediaId}) failed`, error);
     throw new Error(`Failed to save caption image embeddings: ${mediaId}`);
@@ -215,11 +326,15 @@ export async function getCaptionImageEmbeddings(
   mediaId: string,
   embeddingDim: number,
   expectedCount: number,
+  opts: ContentKeyedOptions = {},
 ): Promise<Float32Array[] | null> {
   if (expectedCount === 0) return [];
   const root = requireWorkspaceRoot();
+  const target = opts.contentHash
+    ? contentCaptionImageEmbeddingsPath(opts.contentHash)
+    : captionImageEmbeddingsPath(mediaId);
   try {
-    const buffer = await readArrayBuffer(root, captionImageEmbeddingsPath(mediaId));
+    const buffer = await readArrayBuffer(root, target);
     if (!buffer) return null;
     const expectedFloats = expectedCount * embeddingDim;
     const got = buffer.byteLength / Float32Array.BYTES_PER_ELEMENT;
@@ -241,31 +356,29 @@ export async function getCaptionImageEmbeddings(
   }
 }
 
-export async function deleteCaptions(mediaId: string): Promise<void> {
-  try {
-    await deleteAiOutput(mediaId, 'captions');
-    await deleteCaptionThumbnails(mediaId);
-    await deleteCaptionEmbeddings(mediaId);
-  } catch (error) {
-    logger.error(`deleteCaptions(${mediaId}) failed`, error);
-    throw new Error(`Failed to delete captions: ${mediaId}`);
-  }
-}
-
 /**
  * Persist a single caption thumbnail JPEG. Returns the workspace-relative
  * path to stash on the corresponding `MediaCaption.thumbRelPath` so the
- * Scene Browser can load the blob back on demand.
+ * Scene Browser can load the blob back on demand. Writes to the shared
+ * content tree when {@link ContentKeyedOptions.contentHash} is provided
+ * so duplicate imports of the same source share a single thumbnail set.
  */
 export async function saveCaptionThumbnail(
   mediaId: string,
   index: number,
   blob: Blob,
+  opts: ContentKeyedOptions = {},
 ): Promise<string> {
   const root = requireWorkspaceRoot();
+  const segments = opts.contentHash
+    ? contentCaptionThumbPath(opts.contentHash, index)
+    : captionThumbPath(mediaId, index);
+  const relPath = opts.contentHash
+    ? contentCaptionThumbRelPath(opts.contentHash, index)
+    : captionThumbRelPath(mediaId, index);
   try {
-    await writeBlob(root, captionThumbPath(mediaId, index), blob);
-    return captionThumbRelPath(mediaId, index);
+    await writeBlob(root, segments, blob);
+    return relPath;
   } catch (error) {
     logger.error(`saveCaptionThumbnail(${mediaId}, ${index}) failed`, error);
     throw new Error(`Failed to save caption thumbnail: ${mediaId}#${index}`);
@@ -275,7 +388,8 @@ export async function saveCaptionThumbnail(
 /**
  * Load a previously-saved caption thumbnail by its workspace-relative path.
  * Returns `null` when the file is missing (captions from before the feature
- * landed, or the directory was pruned).
+ * landed, or the directory was pruned). Works for both per-media and
+ * content-tree paths since the relPath encodes the full location.
  */
 export async function getCaptionThumbnailBlob(
   relPath: string,
@@ -296,20 +410,26 @@ export async function getCaptionThumbnailBlob(
  * pair. Returns the workspace-relative path when the file exists so the
  * caller can reuse it without regenerating — useful for captions whose
  * `thumbRelPath` pointer was dropped across a reload but whose JPEG is
- * still on disk.
+ * still on disk. When `contentHash` is provided the content-tree location
+ * is probed first.
  */
 export async function probeCaptionThumbnail(
   mediaId: string,
   captionIndex: number,
+  opts: ContentKeyedOptions = {},
 ): Promise<string | null> {
-  const relPath = captionThumbRelPath(mediaId, captionIndex);
-  const blob = await getCaptionThumbnailBlob(relPath);
-  return blob ? relPath : null;
+  if (opts.contentHash) {
+    const shared = contentCaptionThumbRelPath(opts.contentHash, captionIndex);
+    if (await getCaptionThumbnailBlob(shared)) return shared;
+  }
+  const local = captionThumbRelPath(mediaId, captionIndex);
+  return (await getCaptionThumbnailBlob(local)) ? local : null;
 }
 
 /**
- * Remove the `captions-thumbs` directory for a media item. No-op when the
- * directory is absent; never throws — thumbnail cleanup is opportunistic.
+ * Remove the per-media `captions-thumbs` directory. Shared thumbnails in the
+ * content tree are untouched — they're GC'd via
+ * {@link deleteSharedCaptionsIfUnreferenced} when the last media ref drops.
  */
 export async function deleteCaptionThumbnails(mediaId: string): Promise<void> {
   const root = requireWorkspaceRoot();
@@ -317,5 +437,96 @@ export async function deleteCaptionThumbnails(mediaId: string): Promise<void> {
     await removeEntry(root, captionThumbsDir(mediaId), { recursive: true });
   } catch (error) {
     logger.warn(`deleteCaptionThumbnails(${mediaId}) failed`, error);
+  }
+}
+
+/**
+ * Decrement the shared content cache for `hash` on behalf of `mediaId`. If
+ * no mediaIds remain, tears down the entire `content/{shard}/{hash}/ai/`
+ * subtree — captions envelope, bins, and thumbnails in one sweep. Safe to
+ * call when the hash has no shared cache (returns early).
+ */
+export async function deleteSharedCaptionsIfUnreferenced(
+  hash: string,
+  mediaId: string,
+): Promise<void> {
+  try {
+    const remaining = await removeAiContentRef(hash, mediaId);
+    if (remaining === 0) {
+      // deleteAiContent is a warn-and-continue no-op when the dir is absent.
+      await deleteAiContent(hash);
+    }
+  } catch (error) {
+    logger.warn(`deleteSharedCaptionsIfUnreferenced(${hash}, ${mediaId}) failed`, error);
+  }
+}
+
+export async function deleteCaptions(mediaId: string): Promise<void> {
+  // Read the envelope first so we know whether a shared cache ref needs to
+  // be released. Missing envelope means there's nothing to deref.
+  let contentHash: string | undefined;
+  try {
+    const envelope = await readAiOutput(mediaId, 'captions');
+    contentHash = envelope?.data.contentHash;
+  } catch {
+    contentHash = undefined;
+  }
+
+  try {
+    await deleteAiOutput(mediaId, 'captions');
+    await deleteCaptionThumbnails(mediaId);
+    await deleteCaptionEmbeddings(mediaId);
+  } catch (error) {
+    logger.error(`deleteCaptions(${mediaId}) failed`, error);
+    throw new Error(`Failed to delete captions: ${mediaId}`);
+  }
+
+  if (contentHash) {
+    await deleteSharedCaptionsIfUnreferenced(contentHash, mediaId);
+  }
+}
+
+/**
+ * Populate a media item's per-media caption state from the shared content
+ * cache. Writes `media/{mediaId}/cache/ai/captions.json` from the shared
+ * envelope (so subsequent reads are cheap local reads) and registers this
+ * media as a ref-holder. Heavy assets (bins, thumbnails) are not copied —
+ * they stay shared in the content tree and are resolved by readers that
+ * carry `contentHash` through.
+ *
+ * Returns the persisted captions on success, or `undefined` when the cache
+ * miss (so the caller falls through to full analysis).
+ */
+export async function adoptCaptionsFromCache(
+  mediaId: string,
+  hash: string,
+): Promise<AiOutput<'captions'> | undefined> {
+  const envelope = await getCaptionsByContentHash(hash);
+  if (!envelope) return undefined;
+
+  try {
+    await writeAiOutputAt(aiOutputPath(mediaId, 'captions'), {
+      mediaId,
+      kind: 'captions',
+      service: envelope.service,
+      model: envelope.model,
+      params: envelope.params,
+      data: { ...envelope.data, contentHash: hash },
+    });
+    await addAiContentRef(hash, mediaId);
+    return envelope;
+  } catch (error) {
+    logger.warn(`adoptCaptionsFromCache(${mediaId}, ${hash}) failed`, error);
+    // On failure the mediaId has no local envelope — caller should fall
+    // through to regenerating captions rather than trusting a partial state.
+    try {
+      await deleteAiOutputAt(
+        aiOutputPath(mediaId, 'captions'),
+        `adoptCaptionsFromCache: rollback ${mediaId}`,
+      );
+    } catch {
+      // ignore rollback failure; worst case is a stale envelope on disk
+    }
+    return undefined;
   }
 }

--- a/src/infrastructure/storage/workspace-fs/captions.ts
+++ b/src/infrastructure/storage/workspace-fs/captions.ts
@@ -88,6 +88,45 @@ interface ContentKeyedOptions {
    * location for backwards compatibility with pre-cache saves.
    */
   contentHash?: string;
+  /**
+   * Caption sampling interval that produced this cache entry. Shared caption
+   * assets are versioned by this value so different analysis cadences do not
+   * overwrite one another.
+   */
+  sampleIntervalSec?: number;
+}
+
+interface ResolvedSharedCaptionCache {
+  envelope: AiOutput<'captions'>;
+  sampleIntervalSec?: number;
+}
+
+function resolveSampleIntervalSec(
+  input: { sampleIntervalSec?: number } | undefined,
+  fallback: Record<string, unknown> | undefined,
+): number | undefined {
+  if (input?.sampleIntervalSec !== undefined) return input.sampleIntervalSec;
+  const fromParams = fallback?.sampleIntervalSec;
+  return typeof fromParams === 'number' ? fromParams : undefined;
+}
+
+async function resolveSharedCaptionCache(
+  hash: string,
+  sampleIntervalSec?: number,
+): Promise<ResolvedSharedCaptionCache | undefined> {
+  const variantEnvelope = sampleIntervalSec === undefined
+    ? undefined
+    : await readAiOutputAt(contentCaptionsJsonPath(hash, sampleIntervalSec), 'captions');
+  if (variantEnvelope) {
+    return { envelope: variantEnvelope, sampleIntervalSec };
+  }
+
+  const legacyEnvelope = await readAiOutputAt(contentCaptionsJsonPath(hash), 'captions');
+  if (!legacyEnvelope) return undefined;
+  return {
+    envelope: legacyEnvelope,
+    sampleIntervalSec: resolveSampleIntervalSec(legacyEnvelope.data, legacyEnvelope.params),
+  };
 }
 
 export async function getCaptions(
@@ -109,9 +148,10 @@ export async function getCaptions(
  */
 export async function getCaptionsByContentHash(
   hash: string,
+  sampleIntervalSec?: number,
 ): Promise<AiOutput<'captions'> | undefined> {
   try {
-    return await readAiOutputAt(contentCaptionsJsonPath(hash), 'captions');
+    return (await resolveSharedCaptionCache(hash, sampleIntervalSec))?.envelope;
   } catch (error) {
     logger.warn(`getCaptionsByContentHash(${hash}) failed`, error);
     return undefined;
@@ -141,7 +181,7 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
 
     if (input.contentHash) {
       try {
-        await writeAiOutputAt(contentCaptionsJsonPath(input.contentHash), {
+        await writeAiOutputAt(contentCaptionsJsonPath(input.contentHash, input.sampleIntervalSec), {
           mediaId: input.mediaId,
           kind: 'captions',
           service: input.service,
@@ -149,7 +189,7 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
           params: input.sampleIntervalSec !== undefined ? { sampleIntervalSec: input.sampleIntervalSec } : {},
           data,
         });
-        await addAiContentRef(input.contentHash, input.mediaId);
+        await addAiContentRef(input.contentHash, input.mediaId, input.sampleIntervalSec);
       } catch (error) {
         // Per-media envelope is already the authoritative record; log and move
         // on so caption save doesn't fail the whole analyze pipeline.
@@ -172,6 +212,7 @@ export async function saveCaptions(input: SaveCaptionsInput): Promise<MediaCapti
 export async function getCaptionsEmbeddingsMeta(
   mediaId: string,
 ): Promise<{
+  sampleIntervalSec?: number;
   embeddingModel?: string;
   embeddingDim?: number;
   imageEmbeddingModel?: string;
@@ -181,6 +222,7 @@ export async function getCaptionsEmbeddingsMeta(
   const envelope = await readAiOutput(mediaId, 'captions');
   if (!envelope) return null;
   return {
+    sampleIntervalSec: resolveSampleIntervalSec(envelope.data, envelope.params),
     embeddingModel: envelope.data.embeddingModel,
     embeddingDim: envelope.data.embeddingDim,
     imageEmbeddingModel: envelope.data.imageEmbeddingModel,
@@ -216,7 +258,7 @@ export async function saveCaptionEmbeddings(
     packed.set(vector, index * embeddingDim);
   });
   const target = opts.contentHash
-    ? contentCaptionEmbeddingsPath(opts.contentHash)
+    ? contentCaptionEmbeddingsPath(opts.contentHash, opts.sampleIntervalSec)
     : captionEmbeddingsPath(mediaId);
   try {
     await writeBlob(root, target, packed.buffer);
@@ -241,11 +283,17 @@ export async function getCaptionEmbeddings(
 ): Promise<Float32Array[] | null> {
   if (expectedCount === 0) return [];
   const root = requireWorkspaceRoot();
-  const target = opts.contentHash
-    ? contentCaptionEmbeddingsPath(opts.contentHash)
-    : captionEmbeddingsPath(mediaId);
+  const sharedTarget = opts.contentHash
+    ? contentCaptionEmbeddingsPath(opts.contentHash, opts.sampleIntervalSec)
+    : null;
   try {
-    const buffer = await readArrayBuffer(root, target);
+    let buffer = sharedTarget ? await readArrayBuffer(root, sharedTarget) : null;
+    if (!buffer && sharedTarget && opts.sampleIntervalSec !== undefined) {
+      buffer = await readArrayBuffer(root, contentCaptionEmbeddingsPath(opts.contentHash!));
+    }
+    if (!buffer) {
+      buffer = await readArrayBuffer(root, captionEmbeddingsPath(mediaId));
+    }
     if (!buffer) return null;
     const expectedFloats = expectedCount * embeddingDim;
     const got = buffer.byteLength / Float32Array.BYTES_PER_ELEMENT;
@@ -312,7 +360,7 @@ export async function saveCaptionImageEmbeddings(
     packed.set(vector, index * embeddingDim);
   });
   const target = opts.contentHash
-    ? contentCaptionImageEmbeddingsPath(opts.contentHash)
+    ? contentCaptionImageEmbeddingsPath(opts.contentHash, opts.sampleIntervalSec)
     : captionImageEmbeddingsPath(mediaId);
   try {
     await writeBlob(root, target, packed.buffer);
@@ -330,11 +378,17 @@ export async function getCaptionImageEmbeddings(
 ): Promise<Float32Array[] | null> {
   if (expectedCount === 0) return [];
   const root = requireWorkspaceRoot();
-  const target = opts.contentHash
-    ? contentCaptionImageEmbeddingsPath(opts.contentHash)
-    : captionImageEmbeddingsPath(mediaId);
+  const sharedTarget = opts.contentHash
+    ? contentCaptionImageEmbeddingsPath(opts.contentHash, opts.sampleIntervalSec)
+    : null;
   try {
-    const buffer = await readArrayBuffer(root, target);
+    let buffer = sharedTarget ? await readArrayBuffer(root, sharedTarget) : null;
+    if (!buffer && sharedTarget && opts.sampleIntervalSec !== undefined) {
+      buffer = await readArrayBuffer(root, contentCaptionImageEmbeddingsPath(opts.contentHash!));
+    }
+    if (!buffer) {
+      buffer = await readArrayBuffer(root, captionImageEmbeddingsPath(mediaId));
+    }
     if (!buffer) return null;
     const expectedFloats = expectedCount * embeddingDim;
     const got = buffer.byteLength / Float32Array.BYTES_PER_ELEMENT;
@@ -371,10 +425,10 @@ export async function saveCaptionThumbnail(
 ): Promise<string> {
   const root = requireWorkspaceRoot();
   const segments = opts.contentHash
-    ? contentCaptionThumbPath(opts.contentHash, index)
+    ? contentCaptionThumbPath(opts.contentHash, index, opts.sampleIntervalSec)
     : captionThumbPath(mediaId, index);
   const relPath = opts.contentHash
-    ? contentCaptionThumbRelPath(opts.contentHash, index)
+    ? contentCaptionThumbRelPath(opts.contentHash, index, opts.sampleIntervalSec)
     : captionThumbRelPath(mediaId, index);
   try {
     await writeBlob(root, segments, blob);
@@ -419,8 +473,12 @@ export async function probeCaptionThumbnail(
   opts: ContentKeyedOptions = {},
 ): Promise<string | null> {
   if (opts.contentHash) {
-    const shared = contentCaptionThumbRelPath(opts.contentHash, captionIndex);
+    const shared = contentCaptionThumbRelPath(opts.contentHash, captionIndex, opts.sampleIntervalSec);
     if (await getCaptionThumbnailBlob(shared)) return shared;
+    if (opts.sampleIntervalSec !== undefined) {
+      const legacyShared = contentCaptionThumbRelPath(opts.contentHash, captionIndex);
+      if (await getCaptionThumbnailBlob(legacyShared)) return legacyShared;
+    }
   }
   const local = captionThumbRelPath(mediaId, captionIndex);
   return (await getCaptionThumbnailBlob(local)) ? local : null;
@@ -449,12 +507,13 @@ export async function deleteCaptionThumbnails(mediaId: string): Promise<void> {
 export async function deleteSharedCaptionsIfUnreferenced(
   hash: string,
   mediaId: string,
+  sampleIntervalSec?: number,
 ): Promise<void> {
   try {
-    const remaining = await removeAiContentRef(hash, mediaId);
+    const remaining = await removeAiContentRef(hash, mediaId, sampleIntervalSec);
     if (remaining === 0) {
       // deleteAiContent is a warn-and-continue no-op when the dir is absent.
-      await deleteAiContent(hash);
+      await deleteAiContent(hash, sampleIntervalSec);
     }
   } catch (error) {
     logger.warn(`deleteSharedCaptionsIfUnreferenced(${hash}, ${mediaId}) failed`, error);
@@ -465,11 +524,14 @@ export async function deleteCaptions(mediaId: string): Promise<void> {
   // Read the envelope first so we know whether a shared cache ref needs to
   // be released. Missing envelope means there's nothing to deref.
   let contentHash: string | undefined;
+  let sampleIntervalSec: number | undefined;
   try {
     const envelope = await readAiOutput(mediaId, 'captions');
     contentHash = envelope?.data.contentHash;
+    sampleIntervalSec = resolveSampleIntervalSec(envelope?.data, envelope?.params);
   } catch {
     contentHash = undefined;
+    sampleIntervalSec = undefined;
   }
 
   try {
@@ -482,7 +544,7 @@ export async function deleteCaptions(mediaId: string): Promise<void> {
   }
 
   if (contentHash) {
-    await deleteSharedCaptionsIfUnreferenced(contentHash, mediaId);
+    await deleteSharedCaptionsIfUnreferenced(contentHash, mediaId, sampleIntervalSec);
   }
 }
 
@@ -500,9 +562,11 @@ export async function deleteCaptions(mediaId: string): Promise<void> {
 export async function adoptCaptionsFromCache(
   mediaId: string,
   hash: string,
+  sampleIntervalSec?: number,
 ): Promise<AiOutput<'captions'> | undefined> {
-  const envelope = await getCaptionsByContentHash(hash);
-  if (!envelope) return undefined;
+  const resolved = await resolveSharedCaptionCache(hash, sampleIntervalSec);
+  if (!resolved) return undefined;
+  const { envelope, sampleIntervalSec: resolvedInterval } = resolved;
 
   try {
     await writeAiOutputAt(aiOutputPath(mediaId, 'captions'), {
@@ -511,9 +575,13 @@ export async function adoptCaptionsFromCache(
       service: envelope.service,
       model: envelope.model,
       params: envelope.params,
-      data: { ...envelope.data, contentHash: hash },
+      data: {
+        ...envelope.data,
+        contentHash: hash,
+        sampleIntervalSec: resolvedInterval ?? envelope.data.sampleIntervalSec,
+      },
     });
-    await addAiContentRef(hash, mediaId);
+    await addAiContentRef(hash, mediaId, resolvedInterval);
     return envelope;
   } catch (error) {
     logger.warn(`adoptCaptionsFromCache(${mediaId}, ${hash}) failed`, error);

--- a/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.test.ts
+++ b/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/logging/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    event: vi.fn(),
+    startEvent: () => ({ set: vi.fn(), merge: vi.fn(), success: vi.fn(), failure: vi.fn() }),
+    child: vi.fn(),
+    setLevel: vi.fn(),
+  }),
+  createOperationId: () => 'op-test',
+}));
+
+import { MemDir } from './__tests__/in-memory-handle';
+import { setWorkspaceRoot } from './root';
+import { __resetKeyLocksForTesting } from './with-key-lock';
+import { migrateWorkspaceV2 } from './migrate-workspace-v2';
+import { MARKER_FILENAME, WORKSPACE_SCHEMA_VERSION } from './paths';
+
+const asHandle = (m: MemDir) => m as unknown as FileSystemDirectoryHandle;
+
+async function createDir(root: MemDir, path: string[]): Promise<MemDir> {
+  let dir = root;
+  for (const p of path) {
+    dir = await dir.getDirectoryHandle(p, { create: true });
+  }
+  return dir;
+}
+
+async function writeFile(root: MemDir, path: string[], body: string): Promise<void> {
+  const dir = await createDir(root, path.slice(0, -1));
+  const fh = await dir.getFileHandle(path[path.length - 1]!, { create: true });
+  const w = await fh.createWritable();
+  await w.write(body);
+  await w.close();
+}
+
+async function readFileText(root: MemDir, path: string[]): Promise<string | null> {
+  let dir = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    try {
+      dir = await dir.getDirectoryHandle(path[i]!);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const fh = await dir.getFileHandle(path[path.length - 1]!);
+    return (await fh.getFile()).text();
+  } catch {
+    return null;
+  }
+}
+
+async function exists(root: MemDir, path: string[]): Promise<boolean> {
+  let dir = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    try {
+      dir = await dir.getDirectoryHandle(path[i]!);
+    } catch {
+      return false;
+    }
+  }
+  try {
+    await dir.getFileHandle(path[path.length - 1]!);
+    return true;
+  } catch {
+    /* not a file */
+  }
+  try {
+    await dir.getDirectoryHandle(path[path.length - 1]!);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeMarkerV1(root: MemDir): Promise<void> {
+  await writeFile(root, [MARKER_FILENAME], JSON.stringify({
+    schemaVersion: '1.0',
+    createdAt: 1700000000000,
+  }));
+}
+
+beforeEach(() => {
+  setWorkspaceRoot(null);
+  __resetKeyLocksForTesting();
+});
+
+afterEach(() => {
+  setWorkspaceRoot(null);
+  __resetKeyLocksForTesting();
+});
+
+describe('migrateWorkspaceV2', () => {
+  it('no-ops on a fresh workspace with no marker', async () => {
+    const root = new MemDir('ws');
+    const report = await migrateWorkspaceV2(asHandle(root));
+    expect(report.ran).toBe(false);
+    expect(report.fromVersion).toBeNull();
+  });
+
+  it('no-ops when marker already at current version', async () => {
+    const root = new MemDir('ws');
+    await writeFile(root, [MARKER_FILENAME], JSON.stringify({
+      schemaVersion: WORKSPACE_SCHEMA_VERSION,
+      createdAt: 1,
+    }));
+    const report = await migrateWorkspaceV2(asHandle(root));
+    expect(report.ran).toBe(false);
+    expect(report.fromVersion).toBe(WORKSPACE_SCHEMA_VERSION);
+  });
+
+  it('moves filmstrips into media/<id>/cache/filmstrip/', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['filmstrips', 'm1', '0.jpg'], 'jpeg-0');
+    await writeFile(root, ['filmstrips', 'm1', '1.jpg'], 'jpeg-1');
+    await writeFile(root, ['filmstrips', 'm1', 'meta.json'], '{"v":1}');
+    await writeFile(root, ['filmstrips', 'm2', '0.jpg'], 'jpeg-m2');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.ran).toBe(true);
+    expect(report.filmstripMediaMoved).toBe(2);
+    expect(report.errors).toEqual([]);
+    expect(await readFileText(root, ['media', 'm1', 'cache', 'filmstrip', '0.jpg'])).toBe('jpeg-0');
+    expect(await readFileText(root, ['media', 'm1', 'cache', 'filmstrip', '1.jpg'])).toBe('jpeg-1');
+    expect(await readFileText(root, ['media', 'm1', 'cache', 'filmstrip', 'meta.json'])).toBe('{"v":1}');
+    expect(await readFileText(root, ['media', 'm2', 'cache', 'filmstrip', '0.jpg'])).toBe('jpeg-m2');
+    expect(await exists(root, ['filmstrips'])).toBe(false);
+  });
+
+  it('moves waveform-bin/<id>.bin into media/<id>/cache/waveform/multi-res.bin', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['waveform-bin', 'm1.bin'], 'bin-m1');
+    await writeFile(root, ['waveform-bin', 'm2.bin'], 'bin-m2');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.waveformBinMoved).toBe(2);
+    expect(await readFileText(root, ['media', 'm1', 'cache', 'waveform', 'multi-res.bin'])).toBe('bin-m1');
+    expect(await readFileText(root, ['media', 'm2', 'cache', 'waveform', 'multi-res.bin'])).toBe('bin-m2');
+    expect(await exists(root, ['waveform-bin'])).toBe(false);
+  });
+
+  it('moves sharded preview-audio/<hex>/<hex>/<id>.wav into media/<id>/cache/preview-audio.wav', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['preview-audio', 'ab', 'cd', 'mediaA.wav'], 'wav-A');
+    await writeFile(root, ['preview-audio', '12', '34', 'mediaB.wav'], 'wav-B');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.previewAudioMoved).toBe(2);
+    expect(await readFileText(root, ['media', 'mediaA', 'cache', 'preview-audio.wav'])).toBe('wav-A');
+    expect(await readFileText(root, ['media', 'mediaB', 'cache', 'preview-audio.wav'])).toBe('wav-B');
+    expect(await exists(root, ['preview-audio'])).toBe(false);
+  });
+
+  it('moves proxies/<key>/* into content/proxies/<key>/*', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['proxies', 'f-abc123-10485760-1700000000', 'proxy.mp4'], 'mp4-bytes');
+    await writeFile(root, ['proxies', 'f-abc123-10485760-1700000000', 'meta.json'], '{"w":640}');
+    await writeFile(root, ['proxies', 'h-deadbeef', 'proxy.mp4'], 'mp4-hash');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.proxiesMoved).toBe(2);
+    expect(await readFileText(root, ['content', 'proxies', 'f-abc123-10485760-1700000000', 'proxy.mp4'])).toBe('mp4-bytes');
+    expect(await readFileText(root, ['content', 'proxies', 'f-abc123-10485760-1700000000', 'meta.json'])).toBe('{"w":640}');
+    expect(await readFileText(root, ['content', 'proxies', 'h-deadbeef', 'proxy.mp4'])).toBe('mp4-hash');
+    expect(await exists(root, ['proxies'])).toBe(false);
+  });
+
+  it('deletes stray thumbnail.meta.json sidecars', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['media', 'm1', 'metadata.json'], '{}');
+    await writeFile(root, ['media', 'm1', 'thumbnail.jpg'], 'jpg');
+    await writeFile(root, ['media', 'm1', 'thumbnail.meta.json'], '{"id":"x"}');
+    await writeFile(root, ['media', 'm2', 'metadata.json'], '{}');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.thumbnailMetaRemoved).toBe(1);
+    expect(await exists(root, ['media', 'm1', 'thumbnail.meta.json'])).toBe(false);
+    expect(await exists(root, ['media', 'm1', 'thumbnail.jpg'])).toBe(true);
+  });
+
+  it('relocates stray media/<projectId>/thumbnail.jpg to projects/<id>/thumbnail.jpg', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    // A real project directory
+    await writeFile(root, ['projects', 'projX', 'project.json'], '{}');
+    // Contaminated "media" entry bearing the project cover
+    await writeFile(root, ['media', 'projX', 'thumbnail.jpg'], 'project-cover');
+
+    // Plus a real media entry to confirm the routine doesn't touch it
+    await writeFile(root, ['media', 'realMedia', 'metadata.json'], '{}');
+    await writeFile(root, ['media', 'realMedia', 'thumbnail.jpg'], 'media-cover');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.projectThumbnailsFixed).toBe(1);
+    expect(await readFileText(root, ['projects', 'projX', 'thumbnail.jpg'])).toBe('project-cover');
+    expect(await exists(root, ['media', 'projX'])).toBe(false);
+    // Real media untouched
+    expect(await readFileText(root, ['media', 'realMedia', 'thumbnail.jpg'])).toBe('media-cover');
+  });
+
+  it('leaves real media/<id>/ alone when the id collides with a project id but has metadata.json', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['projects', 'colliding', 'project.json'], '{}');
+    await writeFile(root, ['media', 'colliding', 'metadata.json'], '{}');
+    await writeFile(root, ['media', 'colliding', 'thumbnail.jpg'], 'real-media');
+
+    const report = await migrateWorkspaceV2(asHandle(root));
+
+    expect(report.projectThumbnailsFixed).toBe(0);
+    expect(await exists(root, ['media', 'colliding', 'metadata.json'])).toBe(true);
+    expect(await readFileText(root, ['media', 'colliding', 'thumbnail.jpg'])).toBe('real-media');
+  });
+
+  it('bumps the marker to v2 after a successful migration', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['waveform-bin', 'm1.bin'], 'bytes');
+
+    await migrateWorkspaceV2(asHandle(root));
+
+    const marker = JSON.parse((await readFileText(root, [MARKER_FILENAME]))!) as {
+      schemaVersion: string;
+      createdAt: number;
+    };
+    expect(marker.schemaVersion).toBe(WORKSPACE_SCHEMA_VERSION);
+    expect(marker.createdAt).toBe(1700000000000);
+  });
+
+  it('running twice is a no-op on the second call', async () => {
+    const root = new MemDir('ws');
+    await writeMarkerV1(root);
+    await writeFile(root, ['filmstrips', 'm1', '0.jpg'], 'f0');
+
+    const first = await migrateWorkspaceV2(asHandle(root));
+    const second = await migrateWorkspaceV2(asHandle(root));
+
+    expect(first.ran).toBe(true);
+    expect(second.ran).toBe(false);
+    expect(second.fromVersion).toBe(WORKSPACE_SCHEMA_VERSION);
+  });
+});

--- a/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
+++ b/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
@@ -1,0 +1,422 @@
+/**
+ * One-shot v1 → v2 workspace layout migrator.
+ *
+ * v1 (legacy): per-media caches scattered at the workspace root:
+ *   filmstrips/<mediaId>/*.jpg
+ *   waveform-bin/<mediaId>.bin
+ *   preview-audio/<hex>/<hex>/<mediaId>.wav
+ *   proxies/<proxyKey>/*
+ *   media/<id>/thumbnail.meta.json                 (sidecar, unused by reads)
+ *   media/<projectId>/thumbnail.jpg                (contamination — project cover)
+ *
+ * v2 (new): everything per-media lives under `media/<id>/cache/`, shared
+ *          proxies under `content/proxies/`, project thumbnails under
+ *          `projects/<id>/thumbnail.jpg`.
+ *
+ * Triggered from `bootstrapWorkspace` before any other workspace read. Reads
+ * the marker's `schemaVersion` and no-ops when it already says `"2.0"`.
+ *
+ * All moves use copy-then-delete (bytes read into memory, written to target,
+ * source removed) because `FileSystemDirectoryHandle.move()` across parent
+ * directories is not yet supported across the browsers we target. Individual
+ * media migrations are guarded by the per-key lock used elsewhere so a
+ * concurrent write in another tab can't race a half-complete migration.
+ */
+
+import { createLogger } from '@/shared/logging/logger';
+import {
+  MARKER_FILENAME,
+  MEDIA_DIR,
+  PROJECTS_DIR,
+  WORKSPACE_SCHEMA_VERSION,
+  filmstripDir,
+  mediaDir,
+  previewAudioPath,
+  projectThumbnailPath,
+  proxiesRoot,
+  waveformMultiResPath,
+} from './paths';
+import {
+  exists,
+  listDirectory,
+  readBlob,
+  readJson,
+  removeEntry,
+  writeBlob,
+  writeJsonAtomic,
+} from './fs-primitives';
+import { withKeyLock } from './with-key-lock';
+import type { WorkspaceMarker } from './bootstrap';
+
+const logger = createLogger('WorkspaceV2Migrator');
+
+const LEGACY_FILMSTRIPS_DIR = 'filmstrips';
+const LEGACY_WAVEFORM_BIN_DIR = 'waveform-bin';
+const LEGACY_PREVIEW_AUDIO_DIR = 'preview-audio';
+const LEGACY_PROXIES_DIR = 'proxies';
+const LEGACY_THUMBNAIL_META_FILENAME = 'thumbnail.meta.json';
+const LEGACY_MEDIA_THUMBNAIL_FILENAME = 'thumbnail.jpg';
+
+export interface MigrationReport {
+  ran: boolean;
+  fromVersion: string | null;
+  toVersion: string;
+  filmstripMediaMoved: number;
+  waveformBinMoved: number;
+  previewAudioMoved: number;
+  proxiesMoved: number;
+  thumbnailMetaRemoved: number;
+  projectThumbnailsFixed: number;
+  errors: string[];
+  durationMs: number;
+}
+
+/**
+ * Entry point. Safe to call on every bootstrap — returns early when the
+ * marker already claims v2 or is missing (fresh workspace will get a v2
+ * marker written by bootstrap).
+ */
+export async function migrateWorkspaceV2(
+  root: FileSystemDirectoryHandle,
+): Promise<MigrationReport> {
+  const start = performance.now();
+  const report: MigrationReport = {
+    ran: false,
+    fromVersion: null,
+    toVersion: WORKSPACE_SCHEMA_VERSION,
+    filmstripMediaMoved: 0,
+    waveformBinMoved: 0,
+    previewAudioMoved: 0,
+    proxiesMoved: 0,
+    thumbnailMetaRemoved: 0,
+    projectThumbnailsFixed: 0,
+    errors: [],
+    durationMs: 0,
+  };
+
+  const marker = await readJson<WorkspaceMarker>(root, [MARKER_FILENAME]);
+  if (!marker) {
+    // Fresh workspace — bootstrap will write a v2 marker.
+    report.durationMs = performance.now() - start;
+    return report;
+  }
+
+  report.fromVersion = marker.schemaVersion;
+  if (marker.schemaVersion === WORKSPACE_SCHEMA_VERSION) {
+    report.durationMs = performance.now() - start;
+    return report;
+  }
+
+  report.ran = true;
+  logger.info(`Migrating workspace ${marker.schemaVersion} → ${WORKSPACE_SCHEMA_VERSION}`);
+
+  const knownProjectIds = await collectProjectIds(root);
+
+  try {
+    report.filmstripMediaMoved = await migrateFilmstrips(root, report.errors);
+  } catch (error) {
+    report.errors.push(`filmstrips: ${describe(error)}`);
+  }
+  try {
+    report.waveformBinMoved = await migrateWaveformBins(root, report.errors);
+  } catch (error) {
+    report.errors.push(`waveform-bin: ${describe(error)}`);
+  }
+  try {
+    report.previewAudioMoved = await migratePreviewAudio(root, report.errors);
+  } catch (error) {
+    report.errors.push(`preview-audio: ${describe(error)}`);
+  }
+  try {
+    report.proxiesMoved = await migrateProxies(root, report.errors);
+  } catch (error) {
+    report.errors.push(`proxies: ${describe(error)}`);
+  }
+  try {
+    report.thumbnailMetaRemoved = await dropThumbnailMetaSidecars(root, report.errors);
+  } catch (error) {
+    report.errors.push(`thumbnail-meta: ${describe(error)}`);
+  }
+  try {
+    report.projectThumbnailsFixed = await fixProjectThumbnailContamination(
+      root,
+      knownProjectIds,
+      report.errors,
+    );
+  } catch (error) {
+    report.errors.push(`project-thumbnails: ${describe(error)}`);
+  }
+
+  if (report.errors.length === 0) {
+    const next: WorkspaceMarker = {
+      ...marker,
+      schemaVersion: WORKSPACE_SCHEMA_VERSION,
+    };
+    await writeJsonAtomic(root, [MARKER_FILENAME], next);
+    logger.info('Workspace migrated to v2', report);
+  } else {
+    logger.warn('Workspace migration completed with errors; marker left at v1 for retry', {
+      errorCount: report.errors.length,
+    });
+  }
+
+  report.durationMs = performance.now() - start;
+  return report;
+}
+
+async function collectProjectIds(root: FileSystemDirectoryHandle): Promise<Set<string>> {
+  const entries = await listDirectory(root, [PROJECTS_DIR]);
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (entry.kind === 'directory') ids.add(entry.name);
+  }
+  return ids;
+}
+
+/* ──────────────────────────── filmstrips ─────────────────────────────── */
+
+async function migrateFilmstrips(
+  root: FileSystemDirectoryHandle,
+  errors: string[],
+): Promise<number> {
+  const entries = await listDirectory(root, [LEGACY_FILMSTRIPS_DIR]);
+  let migrated = 0;
+  for (const entry of entries) {
+    if (entry.kind !== 'directory') continue;
+    const mediaId = entry.name;
+    try {
+      await withKeyLock(`migrate-v2:filmstrip:${mediaId}`, async () => {
+        const files = await listDirectory(root, [LEGACY_FILMSTRIPS_DIR, mediaId]);
+        for (const file of files) {
+          if (file.kind !== 'file') continue;
+          const blob = await readBlob(root, [LEGACY_FILMSTRIPS_DIR, mediaId, file.name]);
+          if (!blob) continue;
+          await writeBlob(root, [...filmstripDir(mediaId), file.name], blob);
+        }
+        await removeEntry(root, [LEGACY_FILMSTRIPS_DIR, mediaId], { recursive: true });
+      });
+      migrated++;
+    } catch (error) {
+      errors.push(`filmstrip ${mediaId}: ${describe(error)}`);
+    }
+  }
+  if (migrated > 0) {
+    await removeTopLevelDirIfEmpty(root, LEGACY_FILMSTRIPS_DIR);
+  }
+  return migrated;
+}
+
+/* ──────────────────────────── waveform-bin ───────────────────────────── */
+
+async function migrateWaveformBins(
+  root: FileSystemDirectoryHandle,
+  errors: string[],
+): Promise<number> {
+  const entries = await listDirectory(root, [LEGACY_WAVEFORM_BIN_DIR]);
+  let migrated = 0;
+  for (const entry of entries) {
+    if (entry.kind !== 'file' || !entry.name.endsWith('.bin')) continue;
+    const mediaId = entry.name.slice(0, -'.bin'.length);
+    try {
+      await withKeyLock(`migrate-v2:waveform-bin:${mediaId}`, async () => {
+        const blob = await readBlob(root, [LEGACY_WAVEFORM_BIN_DIR, entry.name]);
+        if (!blob) return;
+        await writeBlob(root, waveformMultiResPath(mediaId), blob);
+        await removeEntry(root, [LEGACY_WAVEFORM_BIN_DIR, entry.name]);
+      });
+      migrated++;
+    } catch (error) {
+      errors.push(`waveform-bin ${mediaId}: ${describe(error)}`);
+    }
+  }
+  if (migrated > 0) {
+    await removeTopLevelDirIfEmpty(root, LEGACY_WAVEFORM_BIN_DIR);
+  }
+  return migrated;
+}
+
+/* ──────────────────────────── preview-audio ──────────────────────────── */
+
+/**
+ * Legacy layout is two-level sharded: `preview-audio/<hex2>/<hex2>/<mediaId>.wav`.
+ * Walk the shards and pull every `.wav` up to `media/<id>/cache/preview-audio.wav`.
+ */
+async function migratePreviewAudio(
+  root: FileSystemDirectoryHandle,
+  errors: string[],
+): Promise<number> {
+  const shard1Entries = await listDirectory(root, [LEGACY_PREVIEW_AUDIO_DIR]);
+  let migrated = 0;
+  for (const shard1 of shard1Entries) {
+    if (shard1.kind !== 'directory') continue;
+    const shard2Entries = await listDirectory(root, [LEGACY_PREVIEW_AUDIO_DIR, shard1.name]);
+    for (const shard2 of shard2Entries) {
+      if (shard2.kind !== 'directory') continue;
+      const files = await listDirectory(root, [LEGACY_PREVIEW_AUDIO_DIR, shard1.name, shard2.name]);
+      for (const file of files) {
+        if (file.kind !== 'file' || !file.name.endsWith('.wav')) continue;
+        const mediaId = file.name.slice(0, -'.wav'.length);
+        try {
+          await withKeyLock(`migrate-v2:preview-audio:${mediaId}`, async () => {
+            const blob = await readBlob(root, [
+              LEGACY_PREVIEW_AUDIO_DIR,
+              shard1.name,
+              shard2.name,
+              file.name,
+            ]);
+            if (!blob) return;
+            await writeBlob(root, previewAudioPath(mediaId), blob);
+            await removeEntry(root, [
+              LEGACY_PREVIEW_AUDIO_DIR,
+              shard1.name,
+              shard2.name,
+              file.name,
+            ]);
+          });
+          migrated++;
+        } catch (error) {
+          errors.push(`preview-audio ${mediaId}: ${describe(error)}`);
+        }
+      }
+      await removeDirIfEmpty(root, [LEGACY_PREVIEW_AUDIO_DIR, shard1.name, shard2.name]);
+    }
+    await removeDirIfEmpty(root, [LEGACY_PREVIEW_AUDIO_DIR, shard1.name]);
+  }
+  if (migrated > 0) {
+    await removeTopLevelDirIfEmpty(root, LEGACY_PREVIEW_AUDIO_DIR);
+  }
+  return migrated;
+}
+
+/* ──────────────────────────── proxies ────────────────────────────────── */
+
+async function migrateProxies(
+  root: FileSystemDirectoryHandle,
+  errors: string[],
+): Promise<number> {
+  const entries = await listDirectory(root, [LEGACY_PROXIES_DIR]);
+  let migrated = 0;
+  for (const entry of entries) {
+    if (entry.kind !== 'directory') continue;
+    const proxyKey = entry.name;
+    try {
+      await withKeyLock(`migrate-v2:proxy:${proxyKey}`, async () => {
+        const files = await listDirectory(root, [LEGACY_PROXIES_DIR, proxyKey]);
+        for (const file of files) {
+          if (file.kind !== 'file') continue;
+          const blob = await readBlob(root, [LEGACY_PROXIES_DIR, proxyKey, file.name]);
+          if (!blob) continue;
+          await writeBlob(root, [...proxiesRoot(), proxyKey, file.name], blob);
+        }
+        await removeEntry(root, [LEGACY_PROXIES_DIR, proxyKey], { recursive: true });
+      });
+      migrated++;
+    } catch (error) {
+      errors.push(`proxy ${proxyKey}: ${describe(error)}`);
+    }
+  }
+  if (migrated > 0) {
+    await removeTopLevelDirIfEmpty(root, LEGACY_PROXIES_DIR);
+  }
+  return migrated;
+}
+
+/* ──────────────────────────── thumbnail.meta sidecars ────────────────── */
+
+async function dropThumbnailMetaSidecars(
+  root: FileSystemDirectoryHandle,
+  errors: string[],
+): Promise<number> {
+  const entries = await listDirectory(root, [MEDIA_DIR]);
+  let removed = 0;
+  for (const entry of entries) {
+    if (entry.kind !== 'directory') continue;
+    const mediaId = entry.name;
+    const sidecarPath = [...mediaDir(mediaId), LEGACY_THUMBNAIL_META_FILENAME];
+    try {
+      if (!(await exists(root, sidecarPath))) continue;
+      await removeEntry(root, sidecarPath);
+      removed++;
+    } catch (error) {
+      errors.push(`thumbnail.meta ${mediaId}: ${describe(error)}`);
+    }
+  }
+  return removed;
+}
+
+/* ──────────────────────────── project-thumbnail contamination ────────── */
+
+/**
+ * Move any `media/<projectId>/thumbnail.jpg` back to `projects/<id>/thumbnail.jpg`.
+ *
+ * Identified by folder-name collision with a known project id. The legacy
+ * contamination only ever wrote `thumbnail.jpg` (and the now-dropped
+ * `thumbnail.meta.json`) — the stray media dir has no `metadata.json`, which
+ * is what distinguishes it from a real media entry that happens to collide
+ * with a project id.
+ */
+async function fixProjectThumbnailContamination(
+  root: FileSystemDirectoryHandle,
+  knownProjectIds: Set<string>,
+  errors: string[],
+): Promise<number> {
+  const mediaEntries = await listDirectory(root, [MEDIA_DIR]);
+  let fixed = 0;
+  for (const entry of mediaEntries) {
+    if (entry.kind !== 'directory') continue;
+    if (!knownProjectIds.has(entry.name)) continue;
+
+    const id = entry.name;
+    try {
+      const contents = await listDirectory(root, mediaDir(id));
+      const hasMetadata = contents.some(
+        (e) => e.kind === 'file' && e.name === 'metadata.json',
+      );
+      if (hasMetadata) {
+        // Real media that happens to share an id with a project — leave it
+        // alone. Extremely unlikely but the ids are UUID-ish, not guaranteed
+        // disjoint across namespaces.
+        continue;
+      }
+
+      const thumbnailBlob = await readBlob(root, [...mediaDir(id), LEGACY_MEDIA_THUMBNAIL_FILENAME]);
+      if (thumbnailBlob) {
+        await writeBlob(root, projectThumbnailPath(id), thumbnailBlob);
+      }
+      await removeEntry(root, mediaDir(id), { recursive: true });
+      fixed++;
+    } catch (error) {
+      errors.push(`project-thumbnail ${id}: ${describe(error)}`);
+    }
+  }
+  return fixed;
+}
+
+/* ──────────────────────────── helpers ────────────────────────────────── */
+
+async function removeTopLevelDirIfEmpty(
+  root: FileSystemDirectoryHandle,
+  dir: string,
+): Promise<void> {
+  await removeDirIfEmpty(root, [dir]);
+}
+
+async function removeDirIfEmpty(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+): Promise<void> {
+  const entries = await listDirectory(root, segments);
+  if (entries.length > 0) return;
+  try {
+    await removeEntry(root, segments);
+  } catch (error) {
+    // Non-fatal: the dir may have been removed concurrently or was never
+    // created. Callers don't care either way.
+    logger.debug('removeDirIfEmpty skipped', { segments, error });
+  }
+}
+
+function describe(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
+++ b/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
@@ -380,8 +380,21 @@ async function fixProjectThumbnailContamination(
       }
 
       const thumbnailBlob = await readBlob(root, [...mediaDir(id), LEGACY_MEDIA_THUMBNAIL_FILENAME]);
-      if (thumbnailBlob) {
-        await writeBlob(root, projectThumbnailPath(id), thumbnailBlob);
+      if (!thumbnailBlob) {
+        // Nothing usable to recover; don't drop the directory because we
+        // can't confirm this is actually contaminated state.
+        continue;
+      }
+      await writeBlob(root, projectThumbnailPath(id), thumbnailBlob);
+
+      // Only delete the directory when its contents match the expected
+      // contamination shape (just the legacy thumbnail file). Anything else
+      // is unknown state we don't want to silently discard.
+      const unexpectedContents = contents.some(
+        (e) => !(e.kind === 'file' && e.name === LEGACY_MEDIA_THUMBNAIL_FILENAME),
+      );
+      if (unexpectedContents) {
+        continue;
       }
       await removeEntry(root, mediaDir(id), { recursive: true });
       fixed++;

--- a/src/infrastructure/storage/workspace-fs/orphan-sweep.test.ts
+++ b/src/infrastructure/storage/workspace-fs/orphan-sweep.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MemDir } from './__tests__/in-memory-handle';
 import { setWorkspaceRoot } from './root';
 import { sweepWorkspaceOrphans } from './orphan-sweep';
-import { writeBlob } from './fs-primitives';
 
 const asHandle = (m: MemDir) => m as unknown as FileSystemDirectoryHandle;
 
@@ -12,10 +11,6 @@ async function createDir(root: MemDir, path: string[]): Promise<MemDir> {
     dir = await dir.getDirectoryHandle(p, { create: true });
   }
   return dir;
-}
-
-async function createLiveMedia(root: MemDir, mediaId: string): Promise<void> {
-  await createDir(root, ['media', mediaId]);
 }
 
 beforeEach(() => setWorkspaceRoot(null));
@@ -32,95 +27,31 @@ describe('sweepWorkspaceOrphans', () => {
     expect(report.liveMediaCount).toBe(0);
   });
 
-  it('detects orphaned filmstrip directories', async () => {
+  it('counts live media entries', async () => {
     const root = new MemDir('ws');
     setWorkspaceRoot(asHandle(root));
-    await createLiveMedia(root, 'alive-1');
-    await createDir(root, ['filmstrips', 'alive-1']); // kept
-    await createDir(root, ['filmstrips', 'orphan-a']); // gone
-    await createDir(root, ['filmstrips', 'orphan-b']); // gone
-
-    const report = await sweepWorkspaceOrphans({ dryRun: true });
-
-    expect(report.filmstripOrphans.sort()).toEqual(['orphan-a', 'orphan-b']);
-    expect(report.totalRemoved).toBe(2);
-    // dryRun: nothing actually removed
-    const entries: string[] = [];
-    for await (const e of (await root.getDirectoryHandle('filmstrips')).values()) {
-      entries.push(e.name);
-    }
-    expect(entries.sort()).toEqual(['alive-1', 'orphan-a', 'orphan-b']);
-  });
-
-  it('removes orphaned filmstrip directories when not in dry-run', async () => {
-    const root = new MemDir('ws');
-    setWorkspaceRoot(asHandle(root));
-    await createLiveMedia(root, 'alive-1');
-    await createDir(root, ['filmstrips', 'alive-1']);
-    await createDir(root, ['filmstrips', 'orphan-a']);
-
-    await sweepWorkspaceOrphans();
-
-    const entries: string[] = [];
-    for await (const e of (await root.getDirectoryHandle('filmstrips')).values()) {
-      entries.push(e.name);
-    }
-    expect(entries).toEqual(['alive-1']);
-  });
-
-  it('detects orphaned waveform-bin files stripped of extension', async () => {
-    const root = new MemDir('ws');
-    setWorkspaceRoot(asHandle(root));
-    await createLiveMedia(root, 'alive-1');
-    await writeBlob(asHandle(root), ['waveform-bin', 'alive-1.bin'], new Uint8Array([1]));
-    await writeBlob(asHandle(root), ['waveform-bin', 'orphan-a.bin'], new Uint8Array([1]));
-    await writeBlob(asHandle(root), ['waveform-bin', 'orphan-b.bin'], new Uint8Array([1]));
+    await createDir(root, ['media', 'm1']);
+    await createDir(root, ['media', 'm2']);
 
     const report = await sweepWorkspaceOrphans();
 
-    expect(report.waveformBinOrphans.sort()).toEqual(['orphan-a.bin', 'orphan-b.bin']);
-    const entries: string[] = [];
-    for await (const e of (await root.getDirectoryHandle('waveform-bin')).values()) {
-      entries.push(e.name);
-    }
-    expect(entries).toEqual(['alive-1.bin']);
+    expect(report.liveMediaCount).toBe(2);
+    expect(report.totalRemoved).toBe(0);
   });
 
-  it('detects orphaned preview-audio directories', async () => {
+  it('does not remove per-media caches in v2 layout (structural guarantee)', async () => {
     const root = new MemDir('ws');
     setWorkspaceRoot(asHandle(root));
-    await createLiveMedia(root, 'alive-1');
-    await createDir(root, ['preview-audio', 'alive-1']);
-    await createDir(root, ['preview-audio', 'orphan-a']);
+    // In v2, filmstrip/waveform/preview-audio all live inside media/<id>/cache/,
+    // so they cannot outlive their parent media entry.
+    await createDir(root, ['media', 'alive', 'cache', 'filmstrip']);
 
-    const report = await sweepWorkspaceOrphans();
+    const report = await sweepWorkspaceOrphans({ dryRun: false });
 
-    expect(report.previewAudioOrphans).toEqual(['orphan-a']);
-  });
-
-  it('ignores entries with unrecognized shapes (e.g. stray .bin in filmstrips)', async () => {
-    const root = new MemDir('ws');
-    setWorkspaceRoot(asHandle(root));
-    // Filmstrips are expected to be directories per-media. A stray file is
-    // not treated as a mediaId, just skipped.
-    await writeBlob(asHandle(root), ['filmstrips', 'README.txt'], new Uint8Array([1]));
-
-    const report = await sweepWorkspaceOrphans();
-
-    expect(report.filmstripOrphans).toEqual([]);
-  });
-
-  it('reports totalRemoved across all three cache kinds', async () => {
-    const root = new MemDir('ws');
-    setWorkspaceRoot(asHandle(root));
-    await createLiveMedia(root, 'alive-1');
-    await createDir(root, ['filmstrips', 'orphan-a']);
-    await createDir(root, ['preview-audio', 'orphan-b']);
-    await writeBlob(asHandle(root), ['waveform-bin', 'orphan-c.bin'], new Uint8Array([1]));
-
-    const report = await sweepWorkspaceOrphans();
-
-    expect(report.totalRemoved).toBe(3);
-    expect(report.liveMediaCount).toBe(1);
+    expect(report.totalRemoved).toBe(0);
+    // Still there
+    const cache = await root.getDirectoryHandle('media');
+    const alive = await cache.getDirectoryHandle('alive');
+    await expect(alive.getDirectoryHandle('cache')).resolves.toBeTruthy();
   });
 });

--- a/src/infrastructure/storage/workspace-fs/orphan-sweep.ts
+++ b/src/infrastructure/storage/workspace-fs/orphan-sweep.ts
@@ -1,52 +1,36 @@
 /**
  * Workspace orphan sweeper.
  *
- * Scans the workspace-level mirror-cache directories (keyed by mediaId)
- * and removes entries whose mediaId is no longer present in `media/`.
+ * In v2 (see paths.ts schema notes), per-media caches (filmstrip, waveform,
+ * preview-audio, etc.) live *inside* `media/<id>/cache/`. Removing a media
+ * entry also removes its caches, so orphans are structurally impossible for
+ * those caches.
  *
- * Why: the media-library-service inline cleanup handles the happy path
- * ("delete the last project using this media → wipe its caches"), but
- * can leave orphans behind if:
- *   - an inline cleanup call threw partway through
- *   - a prior app version didn't clean these dirs on delete
- *   - the user wiped a media-library entry manually on disk
+ * This sweep still exists as a hook for future orphan classes — currently
+ * `content/proxies/<proxyKey>/` is content-fingerprint keyed and could
+ * accumulate orphans if proxy-service cleanup is skipped. That reverse
+ * mapping needs proxy-service cooperation and is tracked as follow-up.
  *
  * Usage:
  *   - Dev / debug: `window.__DEBUG__.cleanOrphans({ dryRun: true })`
  *     then `window.__DEBUG__.cleanOrphans()` to actually remove.
- *   - Later (UI): a "Clean up caches" button on the projects/settings
- *     screen can call `sweepWorkspaceOrphans()` and surface the report.
  *
  * Does NOT touch:
- *   - `projects/` — those are authoritative, not caches.
- *   - `.trash/` — trash has its own TTL sweep (see soft-delete).
- *   - `proxies/` — proxyKeys aren't mediaIds; reverse-mapping would need
- *     proxy-service cooperation. Tracked as follow-up.
- *   - `content/` — refcounted; stale content is handled by the refcount
- *     logic, and orphaned content blobs should be rare enough to GC
- *     separately.
+ *   - `projects/` — authoritative.
+ *   - `.trash/` — separate TTL sweep.
+ *   - `content/proxies/` — reverse-mapping TODO.
+ *   - `content/<hash[0:2]>/` — refcounted, handled by refcount logic.
  */
 
 import { createLogger } from '@/shared/logging/logger';
 import { requireWorkspaceRoot } from './root';
-import {
-  listDirectory,
-  removeEntry,
-} from './fs-primitives';
-import {
-  MEDIA_DIR,
-  WORKSPACE_FILMSTRIPS_DIR,
-  WORKSPACE_PREVIEW_AUDIO_DIR,
-  WORKSPACE_WAVEFORM_BIN_DIR,
-} from './paths';
+import { listDirectory } from './fs-primitives';
+import { MEDIA_DIR } from './paths';
 
 const logger = createLogger('WorkspaceFS:OrphanSweep');
 
 export interface OrphanSweepReport {
   liveMediaCount: number;
-  filmstripOrphans: string[];
-  previewAudioOrphans: string[];
-  waveformBinOrphans: string[];
   /** Total entries that were (or would be, in dry-run) removed. */
   totalRemoved: number;
   /** Dry-run = report only, do not touch disk. */
@@ -58,47 +42,11 @@ export interface OrphanSweepOptions {
   dryRun?: boolean;
 }
 
-async function getLiveMediaIds(
+async function countLiveMedia(
   root: FileSystemDirectoryHandle,
-): Promise<Set<string>> {
+): Promise<number> {
   const entries = await listDirectory(root, [MEDIA_DIR]);
-  return new Set(
-    entries.filter((e) => e.kind === 'directory').map((e) => e.name),
-  );
-}
-
-async function findOrphansIn(
-  root: FileSystemDirectoryHandle,
-  dir: string,
-  live: Set<string>,
-  /** Extract the mediaId from an entry name. For directories, the name
-   *  IS the mediaId. For files like `{mediaId}.bin`, strip the extension. */
-  extract: (name: string, kind: 'file' | 'directory') => string | null,
-): Promise<string[]> {
-  const entries = await listDirectory(root, [dir]);
-  const orphans: string[] = [];
-  for (const entry of entries) {
-    const mediaId = extract(entry.name, entry.kind);
-    if (!mediaId) continue;
-    if (!live.has(mediaId)) {
-      orphans.push(entry.name);
-    }
-  }
-  return orphans;
-}
-
-async function removeOrphansIn(
-  root: FileSystemDirectoryHandle,
-  dir: string,
-  orphanNames: string[],
-): Promise<void> {
-  for (const name of orphanNames) {
-    try {
-      await removeEntry(root, [dir, name], { recursive: true });
-    } catch (error) {
-      logger.warn(`Failed to remove orphan ${dir}/${name}`, error);
-    }
-  }
+  return entries.filter((e) => e.kind === 'directory').length;
 }
 
 export async function sweepWorkspaceOrphans(
@@ -108,56 +56,15 @@ export async function sweepWorkspaceOrphans(
   const started = Date.now();
   const root = requireWorkspaceRoot();
 
-  const live = await getLiveMediaIds(root);
-
-  const [filmstripOrphans, previewAudioOrphans, waveformBinOrphans] = await Promise.all([
-    // filmstrips/{mediaId}/
-    findOrphansIn(root, WORKSPACE_FILMSTRIPS_DIR, live, (name, kind) =>
-      kind === 'directory' ? name : null,
-    ),
-    // preview-audio/{mediaId}/
-    findOrphansIn(root, WORKSPACE_PREVIEW_AUDIO_DIR, live, (name, kind) =>
-      kind === 'directory' ? name : null,
-    ),
-    // waveform-bin/{mediaId}.bin
-    findOrphansIn(root, WORKSPACE_WAVEFORM_BIN_DIR, live, (name, kind) => {
-      if (kind !== 'file') return null;
-      return name.endsWith('.bin') ? name.slice(0, -'.bin'.length) : null;
-    }),
-  ]);
-
-  if (!dryRun) {
-    await Promise.all([
-      removeOrphansIn(root, WORKSPACE_FILMSTRIPS_DIR, filmstripOrphans),
-      removeOrphansIn(root, WORKSPACE_PREVIEW_AUDIO_DIR, previewAudioOrphans),
-      removeOrphansIn(root, WORKSPACE_WAVEFORM_BIN_DIR, waveformBinOrphans),
-    ]);
-  }
-
-  const totalRemoved =
-    filmstripOrphans.length +
-    previewAudioOrphans.length +
-    waveformBinOrphans.length;
+  const liveMediaCount = await countLiveMedia(root);
 
   const report: OrphanSweepReport = {
-    liveMediaCount: live.size,
-    filmstripOrphans,
-    previewAudioOrphans,
-    waveformBinOrphans,
-    totalRemoved,
+    liveMediaCount,
+    totalRemoved: 0,
     dryRun,
     durationMs: Date.now() - started,
   };
 
-  if (totalRemoved > 0) {
-    logger.info(
-      `${dryRun ? 'Would remove' : 'Removed'} ${totalRemoved} orphan cache entries` +
-        ` (${filmstripOrphans.length} filmstrip, ${previewAudioOrphans.length} preview-audio,` +
-        ` ${waveformBinOrphans.length} waveform-bin)`,
-    );
-  } else {
-    logger.info('No orphan cache entries found');
-  }
-
+  logger.info('Orphan sweep: v2 layout has no orphaned per-media caches');
   return report;
 }

--- a/src/infrastructure/storage/workspace-fs/paths.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.ts
@@ -319,6 +319,53 @@ export function captionThumbRelPath(mediaId: string, index: number): string {
   return captionThumbPath(mediaId, index).join('/');
 }
 
+/* ---------------- Content-keyed caption storage (shared cache) ---------------- */
+//
+// Captions are a pure function of source bytes, so when contentHash is known
+// the envelope, packed embedding bins, and per-scene thumbnail JPEGs live in
+// the content-addressable tree and are shared across every mediaId that
+// resolves to the same hash. Reference counts for this cache live in the
+// sibling `ai/refs.json` and are independent of the source-blob `refs.json`
+// — media items using `handle` storage dedup their captions even though their
+// source bytes never land in `content/{hash}/data.{ext}`.
+
+export function contentAiDir(hash: string): string[] {
+  return [...contentDir(hash), CACHE_AI_DIR];
+}
+
+export function contentAiRefsPath(hash: string): string[] {
+  return [...contentAiDir(hash), CONTENT_REFS_FILENAME];
+}
+
+export function contentCaptionsJsonPath(hash: string): string[] {
+  return [...contentAiDir(hash), 'captions.json'];
+}
+
+export function contentCaptionEmbeddingsPath(hash: string): string[] {
+  return [...contentAiDir(hash), 'captions-embeddings.bin'];
+}
+
+export function contentCaptionImageEmbeddingsPath(hash: string): string[] {
+  return [...contentAiDir(hash), 'captions-image-embeddings.bin'];
+}
+
+export function contentCaptionThumbsDir(hash: string): string[] {
+  return [...contentAiDir(hash), CACHE_CAPTION_THUMBS_DIR];
+}
+
+export function contentCaptionThumbPath(hash: string, index: number): string[] {
+  return [...contentCaptionThumbsDir(hash), `${index}.jpg`];
+}
+
+/**
+ * Workspace-root-relative path for a content-keyed caption thumbnail. Stored
+ * on `MediaCaption.thumbRelPath` when captions are shared — different mediaIds
+ * sharing a hash all resolve their thumbs through this path.
+ */
+export function contentCaptionThumbRelPath(hash: string, index: number): string {
+  return contentCaptionThumbPath(hash, index).join('/');
+}
+
 /**
  * Legacy path kept only for read-fallback. New writes go through
  * `aiOutputPath(mediaId, 'transcript')`.

--- a/src/infrastructure/storage/workspace-fs/paths.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.ts
@@ -321,40 +321,71 @@ export function captionThumbRelPath(mediaId: string, index: number): string {
 
 /* ---------------- Content-keyed caption storage (shared cache) ---------------- */
 //
-// Captions are a pure function of source bytes, so when contentHash is known
-// the envelope, packed embedding bins, and per-scene thumbnail JPEGs live in
-// the content-addressable tree and are shared across every mediaId that
-// resolves to the same hash. Reference counts for this cache live in the
-// sibling `ai/refs.json` and are independent of the source-blob `refs.json`
-// — media items using `handle` storage dedup their captions even though their
-// source bytes never land in `content/{hash}/data.{ext}`.
+// Captions are a pure function of source bytes plus the analysis parameters
+// that affect output cardinality (today: sampleIntervalSec). When contentHash
+// is known, the envelope, packed embedding bins, and per-scene thumbnail JPEGs
+// live in the content-addressable tree and are shared across every mediaId
+// that resolves to the same hash AND caption-cache variant. Reference counts
+// for this cache live in a sibling `refs.json` and are independent of the
+// source-blob `refs.json` — media items using `handle` storage dedup their
+// captions even though their source bytes never land in `content/{hash}/data.{ext}`.
 
 export function contentAiDir(hash: string): string[] {
   return [...contentDir(hash), CACHE_AI_DIR];
 }
 
-export function contentAiRefsPath(hash: string): string[] {
-  return [...contentAiDir(hash), CONTENT_REFS_FILENAME];
+/**
+ * Shared caption cache variant key. Rounded to centiseconds so values that
+ * differ only by tiny float noise still resolve to the same on-disk cache.
+ * Returns null for legacy/unversioned cache records.
+ */
+export function contentCaptionCacheVariantKey(sampleIntervalSec?: number): string | null {
+  if (
+    sampleIntervalSec === undefined
+    || !Number.isFinite(sampleIntervalSec)
+    || sampleIntervalSec <= 0
+  ) {
+    return null;
+  }
+  return `si-${Math.round(sampleIntervalSec * 100)}`;
 }
 
-export function contentCaptionsJsonPath(hash: string): string[] {
-  return [...contentAiDir(hash), 'captions.json'];
+/**
+ * Segments for the shared caption cache root. Legacy caches live directly
+ * under `content/{hash}/ai/`; interval-versioned caches live under
+ * `content/{hash}/ai/{variantKey}/`.
+ */
+export function contentCaptionCacheDir(hash: string, sampleIntervalSec?: number): string[] {
+  const variantKey = contentCaptionCacheVariantKey(sampleIntervalSec);
+  return variantKey ? [...contentAiDir(hash), variantKey] : contentAiDir(hash);
 }
 
-export function contentCaptionEmbeddingsPath(hash: string): string[] {
-  return [...contentAiDir(hash), 'captions-embeddings.bin'];
+export function contentAiRefsPath(hash: string, sampleIntervalSec?: number): string[] {
+  return [...contentCaptionCacheDir(hash, sampleIntervalSec), CONTENT_REFS_FILENAME];
 }
 
-export function contentCaptionImageEmbeddingsPath(hash: string): string[] {
-  return [...contentAiDir(hash), 'captions-image-embeddings.bin'];
+export function contentCaptionsJsonPath(hash: string, sampleIntervalSec?: number): string[] {
+  return [...contentCaptionCacheDir(hash, sampleIntervalSec), 'captions.json'];
 }
 
-export function contentCaptionThumbsDir(hash: string): string[] {
-  return [...contentAiDir(hash), CACHE_CAPTION_THUMBS_DIR];
+export function contentCaptionEmbeddingsPath(hash: string, sampleIntervalSec?: number): string[] {
+  return [...contentCaptionCacheDir(hash, sampleIntervalSec), 'captions-embeddings.bin'];
 }
 
-export function contentCaptionThumbPath(hash: string, index: number): string[] {
-  return [...contentCaptionThumbsDir(hash), `${index}.jpg`];
+export function contentCaptionImageEmbeddingsPath(hash: string, sampleIntervalSec?: number): string[] {
+  return [...contentCaptionCacheDir(hash, sampleIntervalSec), 'captions-image-embeddings.bin'];
+}
+
+export function contentCaptionThumbsDir(hash: string, sampleIntervalSec?: number): string[] {
+  return [...contentCaptionCacheDir(hash, sampleIntervalSec), CACHE_CAPTION_THUMBS_DIR];
+}
+
+export function contentCaptionThumbPath(
+  hash: string,
+  index: number,
+  sampleIntervalSec?: number,
+): string[] {
+  return [...contentCaptionThumbsDir(hash, sampleIntervalSec), `${index}.jpg`];
 }
 
 /**
@@ -362,8 +393,12 @@ export function contentCaptionThumbPath(hash: string, index: number): string[] {
  * on `MediaCaption.thumbRelPath` when captions are shared — different mediaIds
  * sharing a hash all resolve their thumbs through this path.
  */
-export function contentCaptionThumbRelPath(hash: string, index: number): string {
-  return contentCaptionThumbPath(hash, index).join('/');
+export function contentCaptionThumbRelPath(
+  hash: string,
+  index: number,
+  sampleIntervalSec?: number,
+): string {
+  return contentCaptionThumbPath(hash, index, sampleIntervalSec).join('/');
 }
 
 /**

--- a/src/infrastructure/storage/workspace-fs/paths.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.ts
@@ -16,31 +16,43 @@
  * ├── projects/
  * │   └── {id}/
  * │       ├── project.json
- * │       ├── thumbnail.jpg
+ * │       ├── thumbnail.jpg          # project cover
  * │       └── media-links.json
  * ├── media/
  * │   └── {id}/
  * │       ├── metadata.json
- * │       ├── source.{ext}  |  source.link.json
+ * │       ├── {sanitized-name}.{ext}  |  source.link.json
  * │       ├── thumbnail.jpg
  * │       └── cache/
- * │           ├── filmstrip/{meta.json,frame-N.jpg}
- * │           ├── waveform/{meta.json,bin-N.bin}
+ * │           ├── filmstrip/{meta.json,N.jpg}
+ * │           ├── waveform/{meta.json,bin-N.bin,multi-res.bin}
  * │           ├── gif-frames/{meta.json,frame-N.png}
  * │           ├── decoded-audio/{meta.json,left-N.bin,right-N.bin}
+ * │           ├── preview-audio.wav
  * │           └── ai/
  * │               ├── transcript.json
  * │               ├── captions.json
  * │               ├── scenes.json
  * │               └── {kind}.json          # new AI outputs go here, one file per kind
  * └── content/
- *     └── {hash[0:2]}/{hash}/
- *         ├── refs.json
- *         └── data.{ext}
+ *     ├── {hash[0:2]}/{hash}/            # content-addressable source dedup (reserved)
+ *     │   ├── refs.json
+ *     │   └── data.{ext}
+ *     └── proxies/{proxyKey}/            # shared proxies (keyed by content fingerprint)
+ *         ├── proxy.mp4
+ *         └── meta.json
  * ```
+ *
+ * Schema versions:
+ * - 1.0: filmstrips/waveform-bin/preview-audio/proxies lived at the workspace
+ *        root; project thumbnails were stored under media/<projectId>/.
+ *        `thumbnail.meta.json` sidecar next to every media thumbnail.
+ * - 2.0: per-media caches unified under `media/<id>/cache/`, proxies moved
+ *        to `content/proxies/`, project thumbnails fixed to `projects/<id>/`,
+ *        thumbnail.meta.json sidecar dropped.
  */
 
-export const WORKSPACE_SCHEMA_VERSION = '1.0';
+export const WORKSPACE_SCHEMA_VERSION = '2.0';
 
 export const README_FILENAME = 'README.md';
 export const MARKER_FILENAME = '.freecut-workspace.json';
@@ -72,9 +84,16 @@ export const MEDIA_SOURCE_LINK_FILENAME = 'source.link.json';
 export const MEDIA_CACHE_DIR = 'cache';
 
 export const CACHE_WAVEFORM_DIR = 'waveform';
+export const CACHE_FILMSTRIP_DIR = 'filmstrip';
 export const CACHE_GIF_FRAMES_DIR = 'gif-frames';
 export const CACHE_DECODED_AUDIO_DIR = 'decoded-audio';
 export const CACHE_AI_DIR = 'ai';
+/** Single file per media under cache/. Non-browser audio codecs are decoded
+ *  once to WAV and reused for preview playback. */
+export const CACHE_PREVIEW_AUDIO_FILENAME = 'preview-audio.wav';
+/** Single file per media under cache/waveform/. Header-indexed multi-res
+ *  binary format for timeline waveform rendering. */
+export const CACHE_WAVEFORM_MULTI_RES_FILENAME = 'multi-res.bin';
 /** Per-caption thumbnail JPEGs captured alongside LFM caption generation. */
 export const CACHE_CAPTION_THUMBS_DIR = 'captions-thumbs';
 /**
@@ -199,6 +218,34 @@ export function waveformBinPath(mediaId: string, binIndex: number): string[] {
   return [...waveformDir(mediaId), `bin-${binIndex}.bin`];
 }
 
+/** Segments for `media/{id}/cache/waveform/multi-res.bin` — the header-indexed
+ *  binary used by the timeline waveform renderer. Separate from the chunked
+ *  `bin-{N}.bin` format which is produced by the decoded-audio pipeline. */
+export function waveformMultiResPath(mediaId: string): string[] {
+  return [...waveformDir(mediaId), CACHE_WAVEFORM_MULTI_RES_FILENAME];
+}
+
+/** Segments for `media/{id}/cache/filmstrip/`. */
+export function filmstripDir(mediaId: string): string[] {
+  return [...mediaCacheDir(mediaId), CACHE_FILMSTRIP_DIR];
+}
+
+/** Segments for `media/{id}/cache/filmstrip/{N}.{ext}` — one frame per second. */
+export function filmstripFramePath(mediaId: string, frameIndex: number, ext: string): string[] {
+  return [...filmstripDir(mediaId), `${frameIndex}.${ext}`];
+}
+
+/** Segments for `media/{id}/cache/filmstrip/meta.json`. */
+export function filmstripMetaPath(mediaId: string): string[] {
+  return [...filmstripDir(mediaId), CACHE_META_FILENAME];
+}
+
+/** Segments for `media/{id}/cache/preview-audio.wav` — conformed preview
+ *  audio for non-browser-native codecs. One WAV per media. */
+export function previewAudioPath(mediaId: string): string[] {
+  return [...mediaCacheDir(mediaId), CACHE_PREVIEW_AUDIO_FILENAME];
+}
+
 export function gifFramesDir(mediaId: string): string[] {
   return [...mediaCacheDir(mediaId), CACHE_GIF_FRAMES_DIR];
 }
@@ -299,46 +346,28 @@ export function contentDataPath(hash: string, extension: string): string[] {
   return [...contentDir(hash), `data.${ext}`];
 }
 
-/* ---------------- Shared persisted caches ---------------- */
+/* ---------------- Content-deduped shared store ---------------- */
 //
-// These caches live outside the media metadata tree so other origins can reuse
-// them without regenerating. Some still hydrate from legacy OPFS on demand.
-// Filmstrips intentionally use top-level `filmstrips/{mediaId}/...`.
+// Proxies are shared across mediaIds that resolve to the same source (via
+// content hash or file fingerprint), so they live under `content/proxies/`
+// rather than `media/<id>/cache/` — different mediaIds can reuse the same
+// proxy file. The sibling `content/<hash[0:2]>/<hash>/` tree is reserved
+// for future source-blob dedup via `contentDir()` / `contentDataPath()`.
 
-export const WORKSPACE_PROXIES_DIR = 'proxies';
-export const WORKSPACE_FILMSTRIPS_DIR = 'filmstrips';
-export const WORKSPACE_PREVIEW_AUDIO_DIR = 'preview-audio';
-export const WORKSPACE_WAVEFORM_BIN_DIR = 'waveform-bin';
+export const CONTENT_PROXIES_DIR = 'proxies';
+
+export function proxiesRoot(): string[] {
+  return [CONTENT_DIR, CONTENT_PROXIES_DIR];
+}
 
 export function proxyFilePath(proxyKey: string): string[] {
-  return [WORKSPACE_PROXIES_DIR, proxyKey, 'proxy.mp4'];
+  return [...proxiesRoot(), proxyKey, 'proxy.mp4'];
 }
 
 export function proxyMetaPath(proxyKey: string): string[] {
-  return [WORKSPACE_PROXIES_DIR, proxyKey, 'meta.json'];
+  return [...proxiesRoot(), proxyKey, 'meta.json'];
 }
 
-export function filmstripFileFramePath(mediaId: string, frameIndex: number, ext: string): string[] {
-  return [WORKSPACE_FILMSTRIPS_DIR, mediaId, `${frameIndex}.${ext}`];
-}
-
-export function filmstripMetaPath(mediaId: string): string[] {
-  return [WORKSPACE_FILMSTRIPS_DIR, mediaId, 'meta.json'];
-}
-
-export function previewAudioPath(relativePath: string): string[] {
-  // Legacy metadata may already include the top-level 'preview-audio/' prefix.
-  // Normalize that away so workspace paths stay rooted at one shared folder.
-  const normalized = relativePath.replace(/^preview-audio\//, '');
-  return [WORKSPACE_PREVIEW_AUDIO_DIR, ...normalized.split('/').filter(Boolean)];
-}
-
-/**
- * Fast multi-resolution waveform binary. The timeline renderer still keeps an
- * OPFS-local copy for range reads, while the workspace mirror enables
- * cross-origin reuse. Different from
- * `waveformBinPath` above, which addresses bins inside the per-media cache.
- */
-export function waveformBinaryPath(mediaId: string): string[] {
-  return [WORKSPACE_WAVEFORM_BIN_DIR, `${mediaId}.bin`];
+export function proxyDir(proxyKey: string): string[] {
+  return [...proxiesRoot(), proxyKey];
 }

--- a/src/infrastructure/storage/workspace-fs/thumbnails.test.ts
+++ b/src/infrastructure/storage/workspace-fs/thumbnails.test.ts
@@ -41,25 +41,25 @@ afterEach(() => {
 });
 
 describe('workspace-fs thumbnails', () => {
-  it('saveThumbnail writes binary and meta sidecar', async () => {
+  it('saveThumbnail writes the jpeg blob to media/<id>/thumbnail.jpg', async () => {
     const root = createRoot();
     setWorkspaceRoot(asHandle(root));
     await saveThumbnail(makeThumbnail('m1'));
 
-    // binary exists (assert non-null; contents checked via retrieval below)
-    const text = await readFileText(root, 'media', 'm1', 'thumbnail.meta.json');
+    const text = await readFileText(root, 'media', 'm1', 'thumbnail.jpg');
     expect(text).not.toBeNull();
-    const meta = JSON.parse(text!);
-    expect(meta).toEqual({ id: 't-m1', mediaId: 'm1', timestamp: 0, width: 320, height: 180 });
+    // Sidecar was dropped in v2 — must not be written.
+    expect(await readFileText(root, 'media', 'm1', 'thumbnail.meta.json')).toBeNull();
   });
 
-  it('getThumbnailByMediaId returns saved thumbnail', async () => {
+  it('getThumbnailByMediaId returns saved thumbnail with id derived from mediaId', async () => {
     const root = createRoot();
     setWorkspaceRoot(asHandle(root));
     await saveThumbnail(makeThumbnail('m1'));
     const t = await getThumbnailByMediaId('m1');
     expect(t).toBeDefined();
-    expect(t!.id).toBe('t-m1');
+    // v2: id is derived from mediaId; the caller-supplied id is ignored.
+    expect(t!.id).toBe('m1');
     expect(t!.mediaId).toBe('m1');
   });
 
@@ -69,23 +69,22 @@ describe('workspace-fs thumbnails', () => {
     expect(await getThumbnailByMediaId('missing')).toBeUndefined();
   });
 
-  it('getThumbnail (by thumbnail id) scans media dirs', async () => {
+  it('getThumbnail(id) treats id as mediaId in v2', async () => {
     const root = createRoot();
     setWorkspaceRoot(asHandle(root));
-    await saveThumbnail(makeThumbnail('m1', 't-abc'));
-    await saveThumbnail(makeThumbnail('m2', 't-xyz'));
-    const t = await getThumbnail('t-xyz');
+    await saveThumbnail(makeThumbnail('m1'));
+    const t = await getThumbnail('m1');
     expect(t).toBeDefined();
-    expect(t!.mediaId).toBe('m2');
+    expect(t!.mediaId).toBe('m1');
   });
 
-  it('deleteThumbnailsByMediaId clears both sidecar and binary', async () => {
+  it('deleteThumbnailsByMediaId removes the jpeg', async () => {
     const root = createRoot();
     setWorkspaceRoot(asHandle(root));
     await saveThumbnail(makeThumbnail('m1'));
     await deleteThumbnailsByMediaId('m1');
     expect(await getThumbnailByMediaId('m1')).toBeUndefined();
-    expect(await readFileText(root, 'media', 'm1', 'thumbnail.meta.json')).toBeNull();
+    expect(await readFileText(root, 'media', 'm1', 'thumbnail.jpg')).toBeNull();
   });
 
   it('saveThumbnail overwrites prior thumbnail for the same media', async () => {
@@ -93,7 +92,9 @@ describe('workspace-fs thumbnails', () => {
     setWorkspaceRoot(asHandle(root));
     await saveThumbnail(makeThumbnail('m1', 'first'));
     await saveThumbnail(makeThumbnail('m1', 'second'));
+    // Structure-level check: only one thumbnail entry remains for this media.
     const t = await getThumbnailByMediaId('m1');
-    expect(t!.id).toBe('second');
+    expect(t).toBeDefined();
+    expect(t!.mediaId).toBe('m1');
   });
 });

--- a/src/infrastructure/storage/workspace-fs/thumbnails.ts
+++ b/src/infrastructure/storage/workspace-fs/thumbnails.ts
@@ -2,15 +2,20 @@
  * Media thumbnails backed by the workspace folder.
  *
  * One thumbnail per media, stored as:
- *   `media/{mediaId}/thumbnail.jpg`            (binary blob)
- *   `media/{mediaId}/thumbnail.meta.json`      (ThumbnailData minus blob)
+ *   `media/{mediaId}/thumbnail.jpg`
  *
  * The legacy IDB supported multiple thumbnails per media but in practice
  * getThumbnailByMediaId always returned the first — so we collapse to one
  * per media. If a caller saves a new thumbnail it overwrites the existing.
  *
- * `getThumbnail(id)` (lookup by thumbnail id, rarely used) scans media
- * dirs and matches on sidecar meta.
+ * v2 note: the `thumbnail.meta.json` sidecar was dropped. `ThumbnailData.id`
+ * is derived from `mediaId` on read; callers that want a change-marker
+ * (cache-busting) should keep tracking `media.thumbnailId` on the media
+ * metadata record rather than reading it from the blob.
+ *
+ * Project thumbnails live under `projects/{projectId}/thumbnail.jpg`
+ * (see `saveProjectThumbnail` / `loadProjectThumbnail`) — do not pass
+ * project ids into the media-scoped helpers below.
  */
 
 import type { ThumbnailData } from '@/types/storage';
@@ -18,36 +23,17 @@ import { createLogger } from '@/shared/logging/logger';
 
 import { requireWorkspaceRoot } from './root';
 import {
-  listDirectory,
   readBlob,
-  readJson,
   removeEntry,
   writeBlob,
-  writeJsonAtomic,
 } from './fs-primitives';
 import {
-  MEDIA_DIR,
-  mediaDir,
   mediaThumbnailPath,
+  projectThumbnailPath,
 } from './paths';
 import { blobToArrayBuffer } from './blob-utils';
 
 const logger = createLogger('WorkspaceFS:Thumbnails');
-
-const THUMBNAIL_META_FILENAME = 'thumbnail.meta.json';
-
-interface ThumbnailMeta {
-  id: string;
-  mediaId: string;
-  timestamp: number;
-  width: number;
-  height: number;
-}
-
-function thumbnailMetaPath(mediaId: string): string[] {
-  return [...mediaDir(mediaId), THUMBNAIL_META_FILENAME];
-}
-
 
 /* ────────────────────────────── Public API ───────────────────────────── */
 
@@ -56,37 +42,19 @@ export async function saveThumbnail(thumbnail: ThumbnailData): Promise<void> {
   try {
     const bytes = new Uint8Array(await blobToArrayBuffer(thumbnail.blob));
     await writeBlob(root, mediaThumbnailPath(thumbnail.mediaId), bytes);
-    const meta: ThumbnailMeta = {
-      id: thumbnail.id,
-      mediaId: thumbnail.mediaId,
-      timestamp: thumbnail.timestamp,
-      width: thumbnail.width,
-      height: thumbnail.height,
-    };
-    await writeJsonAtomic(root, thumbnailMetaPath(thumbnail.mediaId), meta);
   } catch (error) {
     logger.error('saveThumbnail failed', error);
     throw new Error('Failed to save thumbnail', { cause: error });
   }
 }
 
+/**
+ * Legacy lookup-by-thumbnail-id. In v2 the id is derived from mediaId, so
+ * `id` and `mediaId` are interchangeable — callers should migrate to
+ * `getThumbnailByMediaId`.
+ */
 export async function getThumbnail(id: string): Promise<ThumbnailData | undefined> {
-  const root = requireWorkspaceRoot();
-  try {
-    const dirs = await listDirectory(root, [MEDIA_DIR]);
-    for (const entry of dirs) {
-      if (entry.kind !== 'directory') continue;
-      const meta = await readJson<ThumbnailMeta>(root, thumbnailMetaPath(entry.name));
-      if (!meta || meta.id !== id) continue;
-      const blob = await readBlob(root, mediaThumbnailPath(meta.mediaId));
-      if (!blob) return undefined;
-      return { id: meta.id, mediaId: meta.mediaId, blob, timestamp: meta.timestamp, width: meta.width, height: meta.height };
-    }
-    return undefined;
-  } catch (error) {
-    logger.error(`getThumbnail(${id}) failed`, error);
-    throw new Error(`Failed to load thumbnail: ${id}`);
-  }
+  return getThumbnailByMediaId(id);
 }
 
 export async function getThumbnailByMediaId(
@@ -94,11 +62,16 @@ export async function getThumbnailByMediaId(
 ): Promise<ThumbnailData | undefined> {
   const root = requireWorkspaceRoot();
   try {
-    const meta = await readJson<ThumbnailMeta>(root, thumbnailMetaPath(mediaId));
-    if (!meta) return undefined;
     const blob = await readBlob(root, mediaThumbnailPath(mediaId));
     if (!blob) return undefined;
-    return { id: meta.id, mediaId: meta.mediaId, blob, timestamp: meta.timestamp, width: meta.width, height: meta.height };
+    return {
+      id: mediaId,
+      mediaId,
+      blob,
+      timestamp: 0,
+      width: 0,
+      height: 0,
+    };
   } catch (error) {
     logger.error(`getThumbnailByMediaId(${mediaId}) failed`, error);
     return undefined;
@@ -109,9 +82,44 @@ export async function deleteThumbnailsByMediaId(mediaId: string): Promise<void> 
   const root = requireWorkspaceRoot();
   try {
     await removeEntry(root, mediaThumbnailPath(mediaId));
-    await removeEntry(root, thumbnailMetaPath(mediaId));
   } catch (error) {
     logger.error(`deleteThumbnailsByMediaId(${mediaId}) failed`, error);
     throw new Error('Failed to delete thumbnails');
+  }
+}
+
+/* ─────────────────────────── Project thumbnails ───────────────────────── */
+
+export async function saveProjectThumbnail(
+  projectId: string,
+  blob: Blob,
+): Promise<void> {
+  const root = requireWorkspaceRoot();
+  try {
+    const bytes = new Uint8Array(await blobToArrayBuffer(blob));
+    await writeBlob(root, projectThumbnailPath(projectId), bytes);
+  } catch (error) {
+    logger.error(`saveProjectThumbnail(${projectId}) failed`, error);
+    throw new Error('Failed to save project thumbnail', { cause: error });
+  }
+}
+
+export async function loadProjectThumbnail(projectId: string): Promise<Blob | undefined> {
+  const root = requireWorkspaceRoot();
+  try {
+    const blob = await readBlob(root, projectThumbnailPath(projectId));
+    return blob ?? undefined;
+  } catch (error) {
+    logger.error(`loadProjectThumbnail(${projectId}) failed`, error);
+    return undefined;
+  }
+}
+
+export async function deleteProjectThumbnail(projectId: string): Promise<void> {
+  const root = requireWorkspaceRoot();
+  try {
+    await removeEntry(root, projectThumbnailPath(projectId));
+  } catch (error) {
+    logger.error(`deleteProjectThumbnail(${projectId}) failed`, error);
   }
 }

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -20,7 +20,7 @@ import {
 import { Progress } from '@/components/ui/progress';
 import { useProjectStore } from '@/features/projects/stores/project-store';
 import { useProjectActions } from '@/features/projects/hooks/use-project-actions';
-import { useProjectsLoading, useProjectsError } from '@/features/projects/hooks/use-project-selectors';
+import { useProjects, useProjectsLoading, useProjectsError } from '@/features/projects/hooks/use-project-selectors';
 import { cleanupBlobUrls } from '@/features/media-library/utils/media-resolver';
 import type { Project } from '@/types/project';
 import type { ProjectFormData } from '@/features/projects/utils/validation';
@@ -80,8 +80,13 @@ function ProjectsIndex() {
   };
 
   const isLoading = useProjectsLoading();
+  const projects = useProjects();
   const error = useProjectsError();
   const { loadProjects, updateProject } = useProjectActions();
+
+  // Only show the full-page spinner for the genuine initial load — mutations
+  // (delete/duplicate/update) should never blank the populated list.
+  const showInitialLoadingSpinner = isLoading && projects.length === 0;
 
   // Load projects on mount
   useEffect(() => {
@@ -309,7 +314,7 @@ function ProjectsIndex() {
         </div>
 
         {/* Loading state */}
-        {isLoading ? (
+        {showInitialLoadingSpinner ? (
           <div className="max-w-[1920px] mx-auto px-6 py-16 flex items-center justify-center">
             <div className="text-center">
               <div className="w-12 h-12 border-4 border-primary/20 border-t-primary rounded-full animate-spin mx-auto mb-4" />

--- a/src/routes/projects/new.tsx
+++ b/src/routes/projects/new.tsx
@@ -56,7 +56,7 @@ function NewProject() {
     <div className="min-h-screen bg-background">
       {/* Header */}
       <div className="panel-header border-b border-border">
-        <div className="max-w-[1920px] mx-auto px-6 py-5 flex items-center justify-between">
+        <div className="max-w-7xl mx-auto px-6 py-5 flex items-center justify-between">
           <Link to="/">
             <FreeCutLogo variant="full" size="md" className="hover:opacity-80 transition-opacity" />
           </Link>
@@ -80,7 +80,7 @@ function NewProject() {
       </div>
 
       {/* Content */}
-      <div className="max-w-[1920px] mx-auto">
+      <div className="max-w-7xl mx-auto px-6 py-8">
         <ProjectForm onSubmit={handleSubmit} isSubmitting={isSubmitting} hideHeader={true} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Workspace-fs v2 migration with per-media caches, content-addressed refs, and shared caption cache versioned by sample interval
- Preview/compound-clip fixes: nested effects refresh, frame cache invalidation on sub-comp edits, reliable repaint, GPU effects inside compound clips
- Media library UX: dedup imports/captions by content, scenes segmented control next to search, right-click context menu, header toolbar wrap fix
- Timeline: multi-segment filmstrip for compound clips, wheel zoom/scroll/resize in track headers, live sub-comp duration for trim/display
- Perf: marquee subscription-based controller, earlier preview re-render on priority media ready, eliminated Add Effect picker flash
- Projects: no spinner-blanking during mutations, width constraint on new project page

## Test plan
- [ ] Import media, confirm dedup by content hash
- [ ] Open existing workspace → v2 migration runs cleanly
- [ ] Nested compound clips render effects and update during playback
- [ ] Marquee selection on large timelines stays smooth
- [ ] Scenes toggle + search segmented control behaves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context menu with multi-selection actions in the Media Library.
  * Content-addressable caption cache for faster caption reuse.
  * Prewarming of effect previews to speed up GPU thumbnails.

* **Improvements**
  * Better nested-composition visual segments and GPU-effect detection.
  * More responsive waveform/redraw behavior tied to render width.
  * Project thumbnail loading/saving switched to project-scoped APIs.

* **Bug Fixes**
  * More reliable marquee selection overlay rendering and behavior.
  * Trim/preview logic corrected for composition wrappers.

* **Infrastructure**
  * Workspace filesystem migrated to v2 with reorganized per-media cache layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->