### PR TITLE
Corner-pin text export, FPS estimation, legacy media reimport fixes

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -32,6 +32,22 @@ Two tiers:
 
 Separate packages (future CLI/API) get their own semver and their own changelog under their package directory. This file is for the web app only.
 
+## Preconditions (run before any mode)
+
+Two checks block all other work. Both must pass before drafting, appending, or rolling up.
+
+### 1. Current must not span past weeks
+
+`current` is the in-progress week — Mon–Sun, anchored to **this week's Monday**. If `current.date` falls in an earlier ISO week than today, you are rollup-overdue: the bullets in `current` belong to one or more closed weeks, not to the present.
+
+Compute this week's Monday from today (in repo-local time): `monday = today - ((today.getDay() + 6) % 7)`. If `current.date` is not in `[monday, monday+6]`, **stop and run rollup mode first**, even if the user asked for append. Do not append into a stale `current` — it merges this week's bullets with last week's and corrupts both.
+
+If `current` spans multiple closed weeks (the bullets were appended across several Mondays without rollup), do **partitioning rollup**: walk the git log per week and re-split the bullets into the correct `[YYYY.MM.DD]` releases, then start a fresh `current` for this week.
+
+### 2. CHANGELOG.md heading must match `current.date`
+
+The markdown header `## [Current] — week of YYYY-MM-DD` is a literal string and does not auto-derive from JSON. Any time you write `current` (append, rollup, partition), recompute the heading as `## [Current] — week of <Monday-of-current.date>` and update it. Never leave the heading frozen at an old Monday — that is the bug that caused the 2026-04-13→2026-05-02 drift.
+
 ## Modes
 
 The user invokes one of these explicitly. Default to asking which mode if unclear.
@@ -49,10 +65,16 @@ The user asks "draft changelog bullets for this week" or similar. Produce bullet
 
 After the user approves drafted bullets, write them into `current` in `changelog.json` and reflect in `CHANGELOG.md`.
 
+0. **Run preconditions first.** If `current.date` is older than this week's Monday → rollup before appending.
 1. Merge with existing `current.groups` — **dedupe by title**. If a new bullet refines or walks back something already there, edit the existing bullet rather than adding a duplicate.
 2. Update `current.date` to today.
-3. Update both `CHANGELOG.md` and `src/data/changelog.json`.
-4. Do not create tags. Do not update `package.json`.
+3. Update `CHANGELOG.md`:
+   - Bump `## [Current] — week of <date>` to `<this week's Monday>` if the heading is stale.
+   - Insert new bullets at the top of each group (Added / Fixed / Improved).
+4. Update `src/data/changelog.json` to mirror.
+5. Do not create tags. Do not update `package.json`.
+
+If `current` already has ~15+ bullets in any one group when you arrive, mention this to the user — it's a signal that a rollup is overdue, not a license to keep appending.
 
 `scripts/changelog-append.mjs` and `npm run changelog:append` exist as a convenience for scripted runs, but the manual path (skill curates, then writes) is preferred — it produces better user-facing copy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,36 +4,99 @@ All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the 
 
 <!-- Entries below are generated via the `changelog` skill. Newest first. -->
 
-## [Current] — week of 2026-04-13
+## [Current] — week of 2026-04-27
 
 ### Added
 - Motion, iris, shape, and DaVinci-style wipe transition packs
 - Lens warp zoom transition
 - Liquid distort transition
-- Transition placement controls with alignment-aware drops
 - Searchable transition preset picker
 - Tunable transition parameters in the properties panel
+- Transition placement controls with alignment-aware drops
 - Compound clips can now host transitions
-- Projects now live on disk in a workspace folder you choose
-- Multi-workspace support with waveform mirroring
-- Multi-select projects with marquee and bulk delete
-- Trash section with soft-delete, undo, and permanent delete
-- Legacy browser-storage migration progress banner
-- Per-clip pitch shift in semitones and cents
-- Compact DaVinci-style six-band clip EQ with floating panel
-- Mixer tuck handle to slide channel strips behind the bus
-- Separate project master bus from per-device monitor volume
+- Reset buttons on transition parameter sliders
+- Extract embedded subtitles from video files (works for MKVs over 2GB)
+- Subtitle segments on the timeline with live cue overlay during playback
+- Cue editor in the inspector with bold/italic/underline, positioning, and click-to-seek
+- Subtitle style presets, including a TikTok-style preset
+- Burn or embed subtitles in exports
+- Reverse playback for video, audio, and GPU effects
+- Reverse-aware exports preserve the reversed audio and video
+- Detect and remove silence across selected clips with preview overlay and ripple delete
 
 ### Fixed
 - Effect drag overlays no longer stick or hijack adjacent lanes
 - Transition preset selection syncs with the chosen direction
 - Removed the transition duration cap
-- Removed Kokoro voice quality options
-- Preview no longer fails when media blobs expire
+- Multi-channel audio downmixes to stereo with proper coefficients on export
+- Subtitle cues trim and split alongside their segment
+- Cue time inputs accept 4-digit seconds without truncating
+- Preview no longer drifts from stale player frames while paused
+- Paused scrub stays on the rendered path with sharp output
+
+### Improved
+- Subtitle cue editor stays responsive with hundreds of cues
+- Smoother playback start when entering a transition
+
+## [2026.04.20] — week of 2026-04-20 to 2026-04-26
+
+### Added
+- Stacked text spans for mixed-style titles
+- Text box backgrounds and scalable text presets
+- Richer text animation presets grouped by layout
+- Animated text previews in the runtime and editor
+- Promote span text controls and move preset selector to the inspector
+- Canvas snap system overhaul with visual guides
+- Video flip transforms (horizontal and vertical)
+- Transform anchors in preview and export
+- Anchor and flip controls keyframeable inside compound clips
+- Keyframeable color effect parameters
+- MOSS multilingual TTS in the browser
+- Replace Kitten TTS with Kokoro TTS
+- Collapsible AI panel sections
+- Import media from a direct URL
+- Dedup media imports and captions by content
+- Move scenes toggle next to search as a segmented control
+
+### Fixed
+- Animated crop renders correctly in exports
+- Curves effect now uses point-based S-curves
+- Compound clip hover preview renders through the canvas engine
+- Restore middle-click drag to resize the A/V divider from anywhere
+- Smooth live pitch preview on Semi Tones and Cents sliders
+- Pixel-snap audio volume line to avoid sub-pixel blur
+- Stop nested video black flashes from stale references
+- Project list no longer blanks with a spinner during edits
+- Add Effect picker no longer flashes on first open
+- Live-trim attached captions during regular trims
+- Batch playback speed undo as a single step
+
+## [2026.04.13] — week of 2026-04-13 to 2026-04-19
+
+### Added
+- Per-clip pitch shift in semitones and cents
+- Compact DaVinci-style six-band clip EQ with floating panels
+- Mixer tuck handle to slide channel strips behind the bus
+- Separate project master bus from per-device monitor volume
+- AI caption generation with timeline insertion
+- AI analysis indicators in the media library
+- Find scenes with a similar palette
+- Color mode with library palette grid
+- Scene browser hotkey
+- Projects now live on disk in a workspace folder you choose
+- Multi-workspace support with waveform mirroring
+- Multi-select projects with marquee, bulk delete, and double-click to open
+- Trash section with soft-delete, undo, and permanent delete
+- Legacy browser-storage migration progress banner
+- What's New dialog with weekly changelog viewer
+- Source monitor scrubbing matches timeline playback
+
+### Fixed
 - Disabled tracks remain editable and styled after reload
 - Pen mask tracks are now visible in classic timelines
-- Transitions stay aligned to source time across splits
 - Pen paths default to shapes with 5-second duration
+- Transitions stay aligned to source time across splits
+- Preview no longer fails when media blobs expire
 - UI accessibility, transition alpha, and viewport clamp fixes
 
 ### Improved

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freecut",
-  "version": "2026.04.06",
+  "version": "2026.04.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
   "current": {
     "version": "current",
-    "date": "2026-04-30",
+    "date": "2026-05-02",
     "groups": {
       "added": [
         {
@@ -14,97 +14,43 @@
           "title": "Liquid distort transition"
         },
         {
-          "title": "Transition placement controls with alignment-aware drops"
-        },
-        {
           "title": "Searchable transition preset picker"
         },
         {
           "title": "Tunable transition parameters in the properties panel"
         },
         {
+          "title": "Transition placement controls with alignment-aware drops"
+        },
+        {
           "title": "Compound clips can now host transitions"
         },
         {
-          "title": "Projects now live on disk in a workspace folder you choose"
+          "title": "Reset buttons on transition parameter sliders"
         },
         {
-          "title": "Multi-workspace support with waveform mirroring"
+          "title": "Extract embedded subtitles from video files (works for MKVs over 2GB)"
         },
         {
-          "title": "Multi-select projects with marquee and bulk delete"
+          "title": "Subtitle segments on the timeline with live cue overlay during playback"
         },
         {
-          "title": "Trash section with soft-delete, undo, and permanent delete"
+          "title": "Cue editor in the inspector with bold/italic/underline, positioning, and click-to-seek"
         },
         {
-          "title": "Legacy browser-storage migration progress banner"
+          "title": "Subtitle style presets, including a TikTok-style preset"
         },
         {
-          "title": "Per-clip pitch shift in semitones and cents"
+          "title": "Burn or embed subtitles in exports"
         },
         {
-          "title": "Compact DaVinci-style six-band clip EQ with floating panel"
+          "title": "Reverse playback for video, audio, and GPU effects"
         },
         {
-          "title": "Mixer tuck handle to slide channel strips behind the bus"
+          "title": "Reverse-aware exports preserve the reversed audio and video"
         },
         {
-          "title": "Separate project master bus from per-device monitor volume"
-        },
-        {
-          "title": "What's New dialog shows weekly changelog"
-        },
-        {
-          "title": "Overhaul canvas snap system"
-        },
-        {
-          "title": "Promote span text controls and move preset selector"
-        },
-        {
-          "title": "Add keyframeable color effect params"
-        },
-        {
-          "title": "Import media from a direct URL"
-        },
-        {
-          "title": "Move scenes toggle next to search as segmented control"
-        },
-        {
-          "title": "Dedup media imports and captions by content"
-        },
-        {
-          "title": "Multi-segment filmstrip for compound clips"
-        },
-        {
-          "title": "Replace card dropdown with right-click context menu"
-        },
-        {
-          "title": "Wheel zoom/scroll/resize in track headers"
-        },
-        {
-          "title": "Migrate to v2 layout with per-media caches"
-        },
-        {
-          "title": "Grid view, responsive header, analyze service"
-        },
-        {
-          "title": "Add color mode with library palette grid"
-        },
-        {
-          "title": "Find scenes with a similar palette"
-        },
-        {
-          "title": "Add AI analysis indicators and align proxy colors"
-        },
-        {
-          "title": "Add AI caption generation with timeline insertion"
-        },
-        {
-          "title": "Expand glyph atlas text rendering"
-        },
-        {
-          "title": "Enable GPU transition compositing"
+          "title": "Detect and remove silence across selected clips with preview overlay and ripple delete"
         }
       ],
       "fixed": [
@@ -118,212 +64,210 @@
           "title": "Removed the transition duration cap"
         },
         {
-          "title": "Removed Kokoro voice quality options"
+          "title": "Multi-channel audio downmixes to stereo with proper coefficients on export"
         },
         {
-          "title": "Preview no longer fails when media blobs expire"
+          "title": "Subtitle cues trim and split alongside their segment"
         },
         {
-          "title": "Disabled tracks remain editable and styled after reload"
+          "title": "Cue time inputs accept 4-digit seconds without truncating"
         },
         {
-          "title": "Pen mask tracks are now visible in classic timelines"
+          "title": "Preview no longer drifts from stale player frames while paused"
         },
         {
-          "title": "Transitions stay aligned to source time across splits"
-        },
-        {
-          "title": "Pen paths default to shapes with 5-second duration"
-        },
-        {
-          "title": "UI accessibility, transition alpha, and viewport clamp fixes"
-        },
-        {
-          "title": "Resolve develop type errors"
-        },
-        {
-          "title": "Respect visible params and safer effect mapping"
-        },
-        {
-          "title": "Allow animating non-color GPU effect params"
-        },
-        {
-          "title": "Route effects keyframe deps through adapters"
-        },
-        {
-          "title": "Remove unused crop helpers"
-        },
-        {
-          "title": "Smooth live pitch preview on Semi Tones / Cents sliders"
-        },
-        {
-          "title": "Pixel-snap audio volume line to avoid subpixel blur"
-        },
-        {
-          "title": "Render compound clip hover preview via canvas engine"
-        },
-        {
-          "title": "Scale compound clip hover preview to fit wrapper"
-        },
-        {
-          "title": "Stop nested video black flashes from stale sequenceFromRef"
-        },
-        {
-          "title": "Restore MMB drag to resize A/V divider from anywhere"
-        },
-        {
-          "title": "Version shared caption cache by sample interval"
-        },
-        {
-          "title": "Stop blanking project list with spinner during mutations"
-        },
-        {
-          "title": "Eliminate Add Effect picker flash on first open"
-        },
-        {
-          "title": "Constrain new project page width to 7xl"
-        },
-        {
-          "title": "Refresh nested compound clip effects during playback"
-        },
-        {
-          "title": "Route SubComposition type through deps adapter"
-        },
-        {
-          "title": "Use live sub-comp duration for compound clip trim and display"
-        },
-        {
-          "title": "Correct available pane height when no track sections"
-        },
-        {
-          "title": "Reliably repaint compound clips on sub-comp edits and nav"
-        },
-        {
-          "title": "Invalidate frame cache when sub-compositions change"
-        },
-        {
-          "title": "Apply gpu effects and adjustment layers inside compound clips"
-        },
-        {
-          "title": "Input handling edge cases"
-        },
-        {
-          "title": "Prevent header toolbar from wrapping on narrow widths"
-        },
-        {
-          "title": "Add grid-cols-1 to DialogContent"
-        },
-        {
-          "title": "Hydrate proxies from workspace on fresh origins"
-        },
-        {
-          "title": "Remove motion semantic search, tighten color queries"
-        },
-        {
-          "title": "Use palette-only ranking for color queries"
-        },
-        {
-          "title": "Route timeline transcribe dialog through media contract"
-        },
-        {
-          "title": "Move preview and filmstrip caches into workspace fs"
-        },
-        {
-          "title": "Queue and unify transcription progress flows"
-        },
-        {
-          "title": "Transcribe custom-decoded audio from conformed wav"
-        },
-        {
-          "title": "Anchor timeline slider zoom at the playhead"
-        },
-        {
-          "title": "Route analysis imports through infrastructure facade"
-        },
-        {
-          "title": "Route preview scrub throttle through contract"
-        },
-        {
-          "title": "Keep AI analysis off timeline caption tracks"
-        },
-        {
-          "title": "Lower skim overlay below popovers"
-        },
-        {
-          "title": "Unify ruler scrub handoff to avoid preview flashes"
-        },
-        {
-          "title": "Speed up media skimming and preserve program preview"
-        },
-        {
-          "title": "Sync preview timecode and playhead during scrubbing"
-        },
-        {
-          "title": "Prefer Player path for generated caption scrubs"
-        },
-        {
-          "title": "Harden text atlas, transition cache, and compositor buffer pool"
-        },
-        {
-          "title": "Update commit message generation"
-        },
-        {
-          "title": "Preserve mask coverage in GPU blend transitions"
-        },
-        {
-          "title": "Preserve GPU layer uniforms per pass"
-        },
-        {
-          "title": "Skip occluded sub-comp tracks in export rendering"
-        },
-        {
-          "title": "Handle commit message generation request"
-        },
-        {
-          "title": "Flatten curved GPU shape paths"
-        },
-        {
-          "title": "Generate single-line commit message"
-        },
-        {
-          "title": "Keep GPU shape effects on texture path"
-        },
-        {
-          "title": "Share transition participant rendering"
-        },
-        {
-          "title": "Route audio time stretch through infrastructure"
-        },
-        {
-          "title": "Keep generated reports parseable in checks"
-        },
-        {
-          "title": "Keep runtime hooks in sync with latest refs"
-        },
-        {
-          "title": "Tighten memo deps in preview and timeline hooks"
+          "title": "Paused scrub stays on the rendered path with sharp output"
         }
       ],
       "improved": [
         {
-          "title": "Compact clip shell for narrow clips with short-circuited fades"
+          "title": "Subtitle cue editor stays responsive with hundreds of cues"
         },
         {
-          "title": "Smoother filmstrip rendering when zooming the timeline"
-        },
-        {
-          "title": "Smaller 960×540 proxy resolution with worker-side loading"
-        },
-        {
-          "title": "Kick re-render as soon as priority media is ready"
-        },
-        {
-          "title": "Subscription-based controller isolates overlay re-renders"
+          "title": "Smoother playback start when entering a transition"
         }
       ]
     }
   },
   "releases": [
+    {
+      "version": "2026.04.20",
+      "date": "2026-04-20",
+      "groups": {
+        "added": [
+          {
+            "title": "Stacked text spans for mixed-style titles"
+          },
+          {
+            "title": "Text box backgrounds and scalable text presets"
+          },
+          {
+            "title": "Richer text animation presets grouped by layout"
+          },
+          {
+            "title": "Animated text previews in the runtime and editor"
+          },
+          {
+            "title": "Promote span text controls and move preset selector to the inspector"
+          },
+          {
+            "title": "Canvas snap system overhaul with visual guides"
+          },
+          {
+            "title": "Video flip transforms (horizontal and vertical)"
+          },
+          {
+            "title": "Transform anchors in preview and export"
+          },
+          {
+            "title": "Anchor and flip controls keyframeable inside compound clips"
+          },
+          {
+            "title": "Keyframeable color effect parameters"
+          },
+          {
+            "title": "MOSS multilingual TTS in the browser"
+          },
+          {
+            "title": "Replace Kitten TTS with Kokoro TTS"
+          },
+          {
+            "title": "Collapsible AI panel sections"
+          },
+          {
+            "title": "Import media from a direct URL"
+          },
+          {
+            "title": "Dedup media imports and captions by content"
+          },
+          {
+            "title": "Move scenes toggle next to search as a segmented control"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Animated crop renders correctly in exports"
+          },
+          {
+            "title": "Curves effect now uses point-based S-curves"
+          },
+          {
+            "title": "Compound clip hover preview renders through the canvas engine"
+          },
+          {
+            "title": "Restore middle-click drag to resize the A/V divider from anywhere"
+          },
+          {
+            "title": "Smooth live pitch preview on Semi Tones and Cents sliders"
+          },
+          {
+            "title": "Pixel-snap audio volume line to avoid sub-pixel blur"
+          },
+          {
+            "title": "Stop nested video black flashes from stale references"
+          },
+          {
+            "title": "Project list no longer blanks with a spinner during edits"
+          },
+          {
+            "title": "Add Effect picker no longer flashes on first open"
+          },
+          {
+            "title": "Live-trim attached captions during regular trims"
+          },
+          {
+            "title": "Batch playback speed undo as a single step"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2026.04.13",
+      "date": "2026-04-13",
+      "groups": {
+        "added": [
+          {
+            "title": "Per-clip pitch shift in semitones and cents"
+          },
+          {
+            "title": "Compact DaVinci-style six-band clip EQ with floating panels"
+          },
+          {
+            "title": "Mixer tuck handle to slide channel strips behind the bus"
+          },
+          {
+            "title": "Separate project master bus from per-device monitor volume"
+          },
+          {
+            "title": "AI caption generation with timeline insertion"
+          },
+          {
+            "title": "AI analysis indicators in the media library"
+          },
+          {
+            "title": "Find scenes with a similar palette"
+          },
+          {
+            "title": "Color mode with library palette grid"
+          },
+          {
+            "title": "Scene browser hotkey"
+          },
+          {
+            "title": "Projects now live on disk in a workspace folder you choose"
+          },
+          {
+            "title": "Multi-workspace support with waveform mirroring"
+          },
+          {
+            "title": "Multi-select projects with marquee, bulk delete, and double-click to open"
+          },
+          {
+            "title": "Trash section with soft-delete, undo, and permanent delete"
+          },
+          {
+            "title": "Legacy browser-storage migration progress banner"
+          },
+          {
+            "title": "What's New dialog with weekly changelog viewer"
+          },
+          {
+            "title": "Source monitor scrubbing matches timeline playback"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Disabled tracks remain editable and styled after reload"
+          },
+          {
+            "title": "Pen mask tracks are now visible in classic timelines"
+          },
+          {
+            "title": "Pen paths default to shapes with 5-second duration"
+          },
+          {
+            "title": "Transitions stay aligned to source time across splits"
+          },
+          {
+            "title": "Preview no longer fails when media blobs expire"
+          },
+          {
+            "title": "UI accessibility, transition alpha, and viewport clamp fixes"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Compact clip shell for narrow clips with short-circuited fades"
+          },
+          {
+            "title": "Smoother filmstrip rendering when zooming the timeline"
+          },
+          {
+            "title": "Smaller 960×540 proxy resolution with worker-side loading"
+          }
+        ]
+      }
+    },
     {
       "version": "2026.04.06",
       "date": "2026-04-06",

--- a/src/features/composition-runtime/utils/corner-pin.ts
+++ b/src/features/composition-runtime/utils/corner-pin.ts
@@ -311,7 +311,13 @@ export function drawCornerPinImage(
   dstY: number,
   pin: CornerPinOffsets,
   subdivisions: number = 16,
+  renderer: 'mesh' | 'projective' = 'mesh',
 ): void {
+  if (renderer === 'projective') {
+    drawCornerPinImageProjective(ctx, source, srcW, srcH, dstX, dstY, pin)
+    return
+  }
+
   const H = computeCornerPinHomography(srcW, srcH, pin)
 
   for (let row = 0; row < subdivisions; row++) {
@@ -362,4 +368,116 @@ export function drawCornerPinImage(
       )
     }
   }
+}
+
+function createWarpCanvas(
+  width: number,
+  height: number,
+): { canvas: OffscreenCanvas | HTMLCanvasElement; ctx: OffscreenCanvasRenderingContext2D } | null {
+  const w = Math.max(1, Math.ceil(width))
+  const h = Math.max(1, Math.ceil(height))
+
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(w, h)
+    const ctx = canvas.getContext('2d')
+    return ctx ? { canvas, ctx } : null
+  }
+
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = w
+  canvas.height = h
+  const ctx = canvas.getContext('2d')
+  return ctx ? { canvas, ctx: ctx as unknown as OffscreenCanvasRenderingContext2D } : null
+}
+
+function sampleBilinear(
+  sourceData: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number,
+): number[] {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.min(width - 1, x0 + 1)
+  const y1 = Math.min(Math.floor(sourceData.length / (width * 4)) - 1, y0 + 1)
+  const tx = x - x0
+  const ty = y - y0
+
+  const i00 = (y0 * width + x0) * 4
+  const i10 = (y0 * width + x1) * 4
+  const i01 = (y1 * width + x0) * 4
+  const i11 = (y1 * width + x1) * 4
+
+  const out = [0, 0, 0, 0]
+  for (let i = 0; i < 4; i++) {
+    const top = sourceData[i00 + i]! * (1 - tx) + sourceData[i10 + i]! * tx
+    const bottom = sourceData[i01 + i]! * (1 - tx) + sourceData[i11 + i]! * tx
+    out[i] = top * (1 - ty) + bottom * ty
+  }
+  return out
+}
+
+function drawCornerPinImageProjective(
+  ctx: OffscreenCanvasRenderingContext2D,
+  source: CanvasImageSource,
+  srcW: number,
+  srcH: number,
+  dstX: number,
+  dstY: number,
+  pin: CornerPinOffsets,
+): void {
+  const sourceCanvas = createWarpCanvas(srcW, srcH)
+  if (!sourceCanvas) return
+
+  sourceCanvas.ctx.clearRect(0, 0, srcW, srcH)
+  sourceCanvas.ctx.drawImage(source, 0, 0, srcW, srcH)
+
+  let sourceImage: ImageData
+  try {
+    sourceImage = sourceCanvas.ctx.getImageData(0, 0, srcW, srcH)
+  } catch {
+    return
+  }
+
+  const corners: [number, number][] = [
+    [dstX + pin.topLeft[0], dstY + pin.topLeft[1]],
+    [dstX + srcW + pin.topRight[0], dstY + pin.topRight[1]],
+    [dstX + srcW + pin.bottomRight[0], dstY + srcH + pin.bottomRight[1]],
+    [dstX + pin.bottomLeft[0], dstY + srcH + pin.bottomLeft[1]],
+  ]
+  const minX = Math.floor(Math.min(...corners.map(([x]) => x))) - 1
+  const minY = Math.floor(Math.min(...corners.map(([, y]) => y))) - 1
+  const maxX = Math.ceil(Math.max(...corners.map(([x]) => x))) + 1
+  const maxY = Math.ceil(Math.max(...corners.map(([, y]) => y))) + 1
+  const outW = Math.max(1, maxX - minX)
+  const outH = Math.max(1, maxY - minY)
+  const outputCanvas = createWarpCanvas(outW, outH)
+  if (!outputCanvas) return
+
+  const outputImage = outputCanvas.ctx.createImageData(outW, outH)
+  const inverse = invertCornerPinHomography(computeCornerPinHomography(srcW, srcH, pin))
+  if (!inverse) return
+
+  for (let y = 0; y < outH; y++) {
+    const dy = minY + y - dstY + 0.5
+    for (let x = 0; x < outW; x++) {
+      const dx = minX + x - dstX + 0.5
+      const [sx, sy] = projectPoint(inverse, dx, dy)
+      if (sx < 0 || sy < 0 || sx > srcW - 1 || sy > srcH - 1) continue
+
+      const sample = sampleBilinear(sourceImage.data, srcW, sx, sy)
+      const outOffset = (y * outW + x) * 4
+      outputImage.data[outOffset] = sample[0]!
+      outputImage.data[outOffset + 1] = sample[1]!
+      outputImage.data[outOffset + 2] = sample[2]!
+      outputImage.data[outOffset + 3] = sample[3]!
+    }
+  }
+
+  outputCanvas.ctx.putImageData(outputImage, 0, 0)
+  ctx.drawImage(outputCanvas.canvas, minX, minY)
 }

--- a/src/features/composition-runtime/utils/corner-pin.ts
+++ b/src/features/composition-runtime/utils/corner-pin.ts
@@ -412,13 +412,45 @@ function sampleBilinear(
   const i01 = (y1 * width + x0) * 4
   const i11 = (y1 * width + x1) * 4
 
-  const out = [0, 0, 0, 0]
-  for (let i = 0; i < 4; i++) {
-    const top = sourceData[i00 + i]! * (1 - tx) + sourceData[i10 + i]! * tx
-    const bottom = sourceData[i01 + i]! * (1 - tx) + sourceData[i11 + i]! * tx
-    out[i] = top * (1 - ty) + bottom * ty
+  // Premultiplied bilinear: interpolating straight RGBA across an alpha
+  // discontinuity bleeds opaque colors into transparent pixels (visible as
+  // dark halos on text/shape edges). Premultiply RGB by alpha first,
+  // interpolate, then unpremultiply.
+  const a00 = sourceData[i00 + 3]! / 255
+  const a10 = sourceData[i10 + 3]! / 255
+  const a01 = sourceData[i01 + 3]! / 255
+  const a11 = sourceData[i11 + 3]! / 255
+
+  const interp = (v00: number, v10: number, v01: number, v11: number): number => {
+    const top = v00 * (1 - tx) + v10 * tx
+    const bottom = v01 * (1 - tx) + v11 * tx
+    return top * (1 - ty) + bottom * ty
   }
-  return out
+
+  const r = interp(
+    sourceData[i00]! * a00,
+    sourceData[i10]! * a10,
+    sourceData[i01]! * a01,
+    sourceData[i11]! * a11,
+  )
+  const g = interp(
+    sourceData[i00 + 1]! * a00,
+    sourceData[i10 + 1]! * a10,
+    sourceData[i01 + 1]! * a01,
+    sourceData[i11 + 1]! * a11,
+  )
+  const b = interp(
+    sourceData[i00 + 2]! * a00,
+    sourceData[i10 + 2]! * a10,
+    sourceData[i01 + 2]! * a01,
+    sourceData[i11 + 2]! * a11,
+  )
+  const aOut = interp(a00, a10, a01, a11)
+
+  if (aOut <= 0) {
+    return [0, 0, 0, 0]
+  }
+  return [r / aOut, g / aOut, b / aOut, aOut * 255]
 }
 
 function drawCornerPinImageProjective(

--- a/src/features/export/utils/canvas-item-renderer.corner-pin.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.corner-pin.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import type { ShapeItem } from '@/types/timeline'
+import type { ShapeItem, TextItem } from '@/types/timeline'
 import type { ItemRenderContext, ItemTransform } from './canvas-item-renderer'
+import { TextMeasurementCache } from './canvas-pool'
 
 const mockFns = vi.hoisted(() => ({
   drawCornerPinImageMock: vi.fn(),
@@ -29,15 +30,35 @@ function createMockCtx(): OffscreenCanvasRenderingContext2D {
     restore: vi.fn(),
     drawImage: vi.fn(),
     beginPath: vi.fn(),
+    rect: vi.fn(),
     roundRect: vi.fn(),
     clip: vi.fn(),
     translate: vi.fn(),
     rotate: vi.fn(),
     scale: vi.fn(),
     fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
     clearRect: vi.fn(),
+    measureText: vi.fn((text: string) => ({
+      width: text.length * 10,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+    })),
     globalAlpha: 1,
     globalCompositeOperation: 'source-over',
+    font: '',
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    lineJoin: 'miter',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    shadowColor: 'transparent',
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
   } as unknown as OffscreenCanvasRenderingContext2D
 }
 
@@ -127,6 +148,71 @@ describe('canvas-item-renderer corner pin export path', () => {
 
     expect(mockFns.drawCornerPinImageMock).toHaveBeenCalledTimes(1)
     expect(mockFns.drawCornerPinImageMock.mock.calls[0]?.length).toBe(7)
+  })
+
+  it('uses projective corner pin rendering for text to avoid mesh wireframe seams', async () => {
+    const item: TextItem = {
+      id: 'text-1',
+      type: 'text',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Pinned title',
+      text: 'Headline',
+      color: '#ffffff',
+      fontSize: 72,
+      textAlign: 'center',
+      verticalAlign: 'middle',
+      cornerPin: {
+        topLeft: [0, 0],
+        topRight: [24, -12],
+        bottomRight: [10, 16],
+        bottomLeft: [-18, 8],
+      },
+      transform: {
+        x: 0,
+        y: 0,
+        width: 420,
+        height: 160,
+        rotation: 0,
+        opacity: 1,
+      },
+    }
+
+    const ctx = createMockCtx()
+    const rctx: ItemRenderContext = {
+      fps: 30,
+      canvasSettings: { width: 1280, height: 720, fps: 30 },
+      canvasPool: {} as ItemRenderContext['canvasPool'],
+      textMeasureCache: new TextMeasurementCache(),
+      renderMode: 'export',
+      videoExtractors: new Map(),
+      videoElements: new Map(),
+      useMediabunny: new Set(),
+      mediabunnyDisabledItems: new Set(),
+      mediabunnyFailureCountByItem: new Map(),
+      imageElements: new Map(),
+      gifFramesMap: new Map(),
+      keyframesMap: new Map(),
+      adjustmentLayers: [],
+      subCompRenderData: new Map(),
+    }
+    const transform: ItemTransform = {
+      x: 0,
+      y: 0,
+      width: 420,
+      height: 160,
+      anchorX: 210,
+      anchorY: 80,
+      rotation: 0,
+      opacity: 1,
+      cornerRadius: 0,
+    }
+
+    await renderItem(ctx, item, transform, 0, rctx)
+
+    expect(mockFns.drawCornerPinImageMock).toHaveBeenCalledTimes(1)
+    expect(mockFns.drawCornerPinImageMock.mock.calls[0]?.[8]).toBe('projective')
   })
 
   it('flattens faded corner pin output before applying opacity', async () => {

--- a/src/features/export/utils/canvas-item-renderer.ts
+++ b/src/features/export/utils/canvas-item-renderer.ts
@@ -606,6 +606,26 @@ async function renderItemWithCornerPin(
     )
   }
 
+  const cornerPinRenderer = item.type === 'text' ? 'projective' : 'mesh'
+  const drawPinnedImage = (targetCtx: OffscreenCanvasRenderingContext2D): void => {
+    const args = [
+      targetCtx,
+      pinCanvas,
+      pinSourceWidth,
+      pinSourceHeight,
+      left + cornerPinTargetRect.x,
+      top + cornerPinTargetRect.y,
+      resolvedCornerPin,
+    ] as const
+
+    if (cornerPinRenderer === 'projective') {
+      drawCornerPinImage(...args, undefined, cornerPinRenderer)
+      return
+    }
+
+    drawCornerPinImage(...args)
+  }
+
   ctx.save()
   if (needsFlattenedOpacity) {
     ctx.globalAlpha = transform.opacity
@@ -625,29 +645,13 @@ async function renderItemWithCornerPin(
           flatCanvas.height = rctx.canvasSettings.height
         }
         flatCtx.clearRect(0, 0, flatCanvas.width, flatCanvas.height)
-        drawCornerPinImage(
-          flatCtx,
-          pinCanvas,
-          pinSourceWidth,
-          pinSourceHeight,
-          left + cornerPinTargetRect.x,
-          top + cornerPinTargetRect.y,
-          resolvedCornerPin,
-        )
+        drawPinnedImage(flatCtx)
         ctx.drawImage(flatCanvas, 0, 0)
       } finally {
         rctx.canvasPool.release(flatCanvas)
       }
     } else {
-      drawCornerPinImage(
-        ctx,
-        pinCanvas,
-        pinSourceWidth,
-        pinSourceHeight,
-        left + cornerPinTargetRect.x,
-        top + cornerPinTargetRect.y,
-        resolvedCornerPin,
-      )
+      drawPinnedImage(ctx)
     }
   } finally {
     ctx.restore()

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -239,16 +239,22 @@ describe('MediaLibraryService', () => {
       )
     })
 
-    it('returns existing media with isDuplicate flag when file already in project', async () => {
+    it('refreshes legacy project duplicate source when file already in project', async () => {
       const existingMedia = makeMediaMetadata({
         id: 'existing-1',
         fileName: 'video.mp4',
         fileSize: 4,
       })
+      const refreshedMedia = {
+        ...existingMedia,
+        fileHandle: {} as FileSystemFileHandle,
+        fileLastModified: 1234,
+      }
       indexedDbMocks.getAllMedia.mockResolvedValue([])
       indexedDbMocks.getMediaForProject.mockResolvedValue([existingMedia])
+      indexedDbMocks.updateMedia.mockResolvedValue(refreshedMedia)
 
-      const mockFile = new File(['data'], 'video.mp4', { type: 'video/mp4' })
+      const mockFile = new File(['data'], 'video.mp4', { type: 'video/mp4', lastModified: 1234 })
       const mockHandle = {
         name: 'video.mp4',
         getFile: vi.fn().mockResolvedValue(mockFile),
@@ -258,6 +264,16 @@ describe('MediaLibraryService', () => {
 
       const result = await mediaLibraryService.importMediaWithHandle(mockHandle, 'project-1')
 
+      expect(indexedDbMocks.updateMedia).toHaveBeenCalledWith(
+        'existing-1',
+        expect.objectContaining({
+          storageType: 'handle',
+          fileHandle: mockHandle,
+          fileName: 'video.mp4',
+          fileSize: 4,
+          fileLastModified: 1234,
+        }),
+      )
       expect(result.isDuplicate).toBe(true)
       expect(result.id).toBe('existing-1')
       expect(indexedDbMocks.createMedia).not.toHaveBeenCalled()

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -676,7 +676,21 @@ class MediaLibraryService {
         (m.fileLastModified === null || m.fileLastModified === undefined),
     )
     if (existingMedia) {
-      return { ...existingMedia, isDuplicate: true }
+      const updates: Partial<MediaMetadata> = {
+        fileName: file.name,
+        fileSize: file.size,
+        fileLastModified: file.lastModified,
+        updatedAt: Date.now(),
+      }
+
+      if (existingMedia.storageType === 'handle' || !existingMedia.opfsPath) {
+        updates.storageType = 'handle'
+        updates.fileHandle = handle
+      }
+
+      const refreshedMedia = await updateMediaDB(existingMedia.id, updates)
+      mirrorSourceToWorkspaceInBackground(refreshedMedia.id, file, file.name)
+      return { ...refreshedMedia, isDuplicate: true }
     }
 
     // Stage 4: Process media in worker (metadata + thumbnail in one pass, off main thread)

--- a/src/features/media-library/workers/media-processor.worker.ts
+++ b/src/features/media-library/workers/media-processor.worker.ts
@@ -14,7 +14,9 @@ import { createLogger } from '@/shared/logging/logger'
 const logger = createLogger('MediaProcessorWorker')
 const KEYFRAME_EXTRACTION_TIMEOUT_MS = 8_000
 const KEYFRAME_EXTRACTION_MAX_PACKETS = 5_000
+const FPS_ESTIMATION_TIMEOUT_MS = 5_000
 const FPS_ESTIMATION_MAX_PACKETS = 180
+const FPS_ESTIMATION_HARD_PACKET_CAP = 2_000
 const THUMBNAIL_TIMEOUT_MS = 12_000
 
 // Type definitions for mediabunny module
@@ -232,20 +234,40 @@ async function estimateVideoFps(
     sink = new mb.EncodedPacketSink(videoTrack)
     const durations: number[] = []
     const timestamps: number[] = []
+    const startedAt = performance.now()
+    const iterator = sink
+      .packets(undefined, undefined, { metadataOnly: true })
+      [Symbol.asyncIterator]()
+    let processedPackets = 0
 
-    for await (const packet of sink.packets(undefined, undefined, { metadataOnly: true })) {
-      if (Number.isFinite(packet.duration) && packet.duration > 0) {
-        durations.push(packet.duration)
-      }
-      if (Number.isFinite(packet.timestamp)) {
-        timestamps.push(packet.timestamp)
-      }
-      packet.close?.()
+    while (true) {
+      const result = await withTimeout(iterator.next(), FPS_ESTIMATION_TIMEOUT_MS, 'FPS estimation')
+      if (result.done) break
+      const packet = result.value
+      processedPackets++
 
-      if (timestamps.length >= FPS_ESTIMATION_MAX_PACKETS) {
+      try {
+        if (Number.isFinite(packet.duration) && packet.duration > 0) {
+          durations.push(packet.duration)
+        }
+        if (Number.isFinite(packet.timestamp)) {
+          timestamps.push(packet.timestamp)
+        }
+      } finally {
+        packet.close?.()
+      }
+
+      if (timestamps.length >= FPS_ESTIMATION_MAX_PACKETS) break
+      if (processedPackets >= FPS_ESTIMATION_HARD_PACKET_CAP) {
+        logger.warn('FPS estimation reached hard packet cap; using partial sample')
+        break
+      }
+      if (performance.now() - startedAt > FPS_ESTIMATION_TIMEOUT_MS) {
+        logger.warn('FPS estimation reached time budget; using partial sample')
         break
       }
     }
+    await iterator.return?.()
 
     const medianDuration = median(durations)
     if (medianDuration && medianDuration > 0) {
@@ -363,10 +385,12 @@ async function extractVideoMetadata(file: File): Promise<VideoMetadata> {
     // Prefer per-packet durations over short prefix average rate. Matroska
     // DefaultDuration flows into packet.duration and is more stable for
     // fractional CFR sources such as 24000/1001.
-    const [fps, keyframeTimestamps] = await Promise.all([
-      estimateVideoFps(mb, videoTrack),
-      extractKeyframeTimestamps(mb, videoTrack),
-    ])
+    //
+    // Run sequentially: both helpers create an EncodedPacketSink on the same
+    // track, and concurrent iteration would share one packet-read cursor and
+    // interleave reads — yielding a wrong FPS or corrupted keyframe index.
+    const fps = await estimateVideoFps(mb, videoTrack)
+    const keyframeTimestamps = await extractKeyframeTimestamps(mb, videoTrack)
 
     const audioCodec = audioTrack?.codec
     const audioCodecSupported = isAudioCodecSupported(audioCodec)

--- a/src/features/media-library/workers/media-processor.worker.ts
+++ b/src/features/media-library/workers/media-processor.worker.ts
@@ -14,6 +14,7 @@ import { createLogger } from '@/shared/logging/logger'
 const logger = createLogger('MediaProcessorWorker')
 const KEYFRAME_EXTRACTION_TIMEOUT_MS = 8_000
 const KEYFRAME_EXTRACTION_MAX_PACKETS = 5_000
+const FPS_ESTIMATION_MAX_PACKETS = 180
 const THUMBNAIL_TIMEOUT_MS = 12_000
 
 // Type definitions for mediabunny module
@@ -69,7 +70,11 @@ interface MediabunnyEncodedPacketSink {
     packet: MediabunnyEncodedPacket,
     options?: MediabunnyPacketRetrievalOptions,
   ): Promise<MediabunnyEncodedPacket | null>
-  packets(startTimestamp?: number, endTimestamp?: number): AsyncIterable<MediabunnyEncodedPacket>
+  packets(
+    startTimestamp?: number,
+    endTimestamp?: number,
+    options?: MediabunnyPacketRetrievalOptions,
+  ): AsyncIterable<MediabunnyEncodedPacket>
   dispose?(): void
 }
 
@@ -180,6 +185,96 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
   })
 }
 
+function median(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null
+  }
+  const left = sorted[middle - 1]
+  const right = sorted[middle]
+  return left !== undefined && right !== undefined ? (left + right) / 2 : null
+}
+
+function snapCommonFrameRate(fps: number): number {
+  if (!Number.isFinite(fps) || fps <= 0) return 30
+
+  const commonRates = [
+    24000 / 1001,
+    24,
+    25,
+    30000 / 1001,
+    30,
+    48,
+    50,
+    60000 / 1001,
+    60,
+    120000 / 1001,
+    120,
+    240000 / 1001,
+    240,
+  ]
+
+  const closest = commonRates.reduce((best, candidate) =>
+    Math.abs(candidate - fps) < Math.abs(best - fps) ? candidate : best,
+  )
+  const tolerance = closest >= 100 ? 0.08 : closest >= 50 ? 0.04 : 0.02
+  return Math.abs(closest - fps) <= tolerance ? Number(closest.toPrecision(12)) : fps
+}
+
+async function estimateVideoFps(
+  mb: MediabunnyModule,
+  videoTrack: MediabunnyVideoTrack,
+): Promise<number> {
+  let sink: MediabunnyEncodedPacketSink | null = null
+  try {
+    sink = new mb.EncodedPacketSink(videoTrack)
+    const durations: number[] = []
+    const timestamps: number[] = []
+
+    for await (const packet of sink.packets(undefined, undefined, { metadataOnly: true })) {
+      if (Number.isFinite(packet.duration) && packet.duration > 0) {
+        durations.push(packet.duration)
+      }
+      if (Number.isFinite(packet.timestamp)) {
+        timestamps.push(packet.timestamp)
+      }
+      packet.close?.()
+
+      if (timestamps.length >= FPS_ESTIMATION_MAX_PACKETS) {
+        break
+      }
+    }
+
+    const medianDuration = median(durations)
+    if (medianDuration && medianDuration > 0) {
+      return snapCommonFrameRate(1 / medianDuration)
+    }
+
+    const deltas = timestamps
+      .slice(1)
+      .map((timestamp, index) => timestamp - timestamps[index]!)
+      .filter((delta) => Number.isFinite(delta) && delta > 0)
+    const medianDelta = median(deltas)
+    if (medianDelta && medianDelta > 0) {
+      return snapCommonFrameRate(1 / medianDelta)
+    }
+  } catch (error) {
+    logger.warn('Duration-based FPS estimation failed; falling back to packet stats:', error)
+  } finally {
+    sink?.dispose?.()
+  }
+
+  try {
+    const packetStats = await videoTrack.computePacketStats(FPS_ESTIMATION_MAX_PACKETS)
+    return snapCommonFrameRate(packetStats?.averagePacketRate || 30)
+  } catch (error) {
+    logger.warn('Packet-stat FPS estimation failed; using default FPS:', error)
+    return 30
+  }
+}
+
 /**
  * Extract keyframe timestamps using mediabunny's EncodedPacketSink.
  *
@@ -265,9 +360,11 @@ async function extractVideoMetadata(file: File): Promise<VideoMetadata> {
       throw new Error('No video track found in file')
     }
 
-    // Get FPS and keyframe index in parallel with packet stats
-    const [packetStats, keyframeTimestamps] = await Promise.all([
-      videoTrack.computePacketStats(50),
+    // Prefer per-packet durations over short prefix average rate. Matroska
+    // DefaultDuration flows into packet.duration and is more stable for
+    // fractional CFR sources such as 24000/1001.
+    const [fps, keyframeTimestamps] = await Promise.all([
+      estimateVideoFps(mb, videoTrack),
       extractKeyframeTimestamps(mb, videoTrack),
     ])
 
@@ -286,7 +383,7 @@ async function extractVideoMetadata(file: File): Promise<VideoMetadata> {
       duration: duration || 0,
       width: videoTrack.displayWidth || 1920,
       height: videoTrack.displayHeight || 1080,
-      fps: packetStats?.averagePacketRate || 30,
+      fps,
       codec: videoTrack.codec || 'unknown',
       bitrate: 0,
       audioCodec,

--- a/src/features/media-library/workers/media-processor.worker.ts
+++ b/src/features/media-library/workers/media-processor.worker.ts
@@ -9,7 +9,7 @@
  * This prevents UI blocking when importing media files.
  */
 
-import { createLogger } from '@/shared/logging/logger'
+import { createLogger, createOperationId } from '@/shared/logging/logger'
 
 const logger = createLogger('MediaProcessorWorker')
 const KEYFRAME_EXTRACTION_TIMEOUT_MS = 8_000
@@ -229,7 +229,19 @@ async function estimateVideoFps(
   mb: MediabunnyModule,
   videoTrack: MediabunnyVideoTrack,
 ): Promise<number> {
+  const opId = createOperationId()
+  const event = logger.startEvent('video.fpsEstimation', opId)
+  event.merge({
+    codec: videoTrack.codec,
+    width: videoTrack.displayWidth,
+    height: videoTrack.displayHeight,
+    maxPackets: FPS_ESTIMATION_MAX_PACKETS,
+    hardPacketCap: FPS_ESTIMATION_HARD_PACKET_CAP,
+    timeoutMs: FPS_ESTIMATION_TIMEOUT_MS,
+  })
+
   let sink: MediabunnyEncodedPacketSink | null = null
+  let durationSamplingError: unknown = null
   try {
     sink = new mb.EncodedPacketSink(videoTrack)
     const durations: number[] = []
@@ -239,6 +251,7 @@ async function estimateVideoFps(
       .packets(undefined, undefined, { metadataOnly: true })
       [Symbol.asyncIterator]()
     let processedPackets = 0
+    let exitReason: 'iterator-done' | 'sample-cap' | 'hard-cap' | 'time-budget' = 'iterator-done'
 
     while (true) {
       const result = await withTimeout(iterator.next(), FPS_ESTIMATION_TIMEOUT_MS, 'FPS estimation')
@@ -257,21 +270,34 @@ async function estimateVideoFps(
         packet.close?.()
       }
 
-      if (timestamps.length >= FPS_ESTIMATION_MAX_PACKETS) break
+      if (timestamps.length >= FPS_ESTIMATION_MAX_PACKETS) {
+        exitReason = 'sample-cap'
+        break
+      }
       if (processedPackets >= FPS_ESTIMATION_HARD_PACKET_CAP) {
-        logger.warn('FPS estimation reached hard packet cap; using partial sample')
+        exitReason = 'hard-cap'
         break
       }
       if (performance.now() - startedAt > FPS_ESTIMATION_TIMEOUT_MS) {
-        logger.warn('FPS estimation reached time budget; using partial sample')
+        exitReason = 'time-budget'
         break
       }
     }
     await iterator.return?.()
 
+    event.merge({
+      processedPackets,
+      durationSamples: durations.length,
+      timestampSamples: timestamps.length,
+      exitReason,
+      sampleDurationMs: Math.round(performance.now() - startedAt),
+    })
+
     const medianDuration = median(durations)
     if (medianDuration && medianDuration > 0) {
-      return snapCommonFrameRate(1 / medianDuration)
+      const fps = snapCommonFrameRate(1 / medianDuration)
+      event.success({ source: 'packet-duration', fps })
+      return fps
     }
 
     const deltas = timestamps
@@ -280,19 +306,32 @@ async function estimateVideoFps(
       .filter((delta) => Number.isFinite(delta) && delta > 0)
     const medianDelta = median(deltas)
     if (medianDelta && medianDelta > 0) {
-      return snapCommonFrameRate(1 / medianDelta)
+      const fps = snapCommonFrameRate(1 / medianDelta)
+      event.success({ source: 'timestamp-delta', fps })
+      return fps
     }
   } catch (error) {
-    logger.warn('Duration-based FPS estimation failed; falling back to packet stats:', error)
+    durationSamplingError = error
+    event.set('durationSamplingError', error instanceof Error ? error.message : String(error))
   } finally {
     sink?.dispose?.()
   }
 
   try {
     const packetStats = await videoTrack.computePacketStats(FPS_ESTIMATION_MAX_PACKETS)
-    return snapCommonFrameRate(packetStats?.averagePacketRate || 30)
+    const fps = snapCommonFrameRate(packetStats?.averagePacketRate || 30)
+    event.success({
+      source: 'packet-stats-fallback',
+      fps,
+      averagePacketRate: packetStats?.averagePacketRate ?? null,
+    })
+    return fps
   } catch (error) {
-    logger.warn('Packet-stat FPS estimation failed; using default FPS:', error)
+    event.failure(durationSamplingError ?? error, {
+      source: 'default-fallback',
+      fps: 30,
+      packetStatsError: error instanceof Error ? error.message : String(error),
+    })
     return 30
   }
 }


### PR DESCRIPTION
## Summary
- Use projective corner-pin renderer for text in export to avoid mesh wireframe seams
- Estimate FPS from packet durations when media metadata lacks it
- Refresh legacy media duplicates on reimport
- Changelog updates

## Test plan
- [ ] Export a project containing a text item with a corner-pin transform; verify no mesh seams
- [ ] Import media with missing FPS metadata; verify FPS is estimated correctly
- [ ] Reimport a previously imported legacy media file; verify duplicates are refreshed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced subtitle editor, searchable presets, embed/burn exports, silence detection, reverse playback, enhanced transition controls

* **Bug Fixes**
  * Audio downmix, cue trimming/time input, preview/pause/scrub consistency

* **Improved**
  * More accurate video FPS detection, more robust corner-pinned text rendering, refreshed media import/duplicate handling

* **Documentation**
  * Changelog updated with week-based preconditions and safer append behavior (warnings for large groups)

* **Chores**
  * Project version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->