### PR TITLE
develop -> staging: debug panel, reverse conform, vercel build fixes

### DIFF
--- a/src/features/editor/components/project-debug-panel.tsx
+++ b/src/features/editor/components/project-debug-panel.tsx
@@ -68,6 +68,8 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
   // Debug overlay toggle
   const showVideoDebugOverlay = useDebugStore((s) => s.showVideoDebugOverlay)
   const toggleVideoDebugOverlay = useDebugStore((s) => s.toggleVideoDebugOverlay)
+  const showPreviewPerfPanel = useDebugStore((s) => s.showPreviewPerfPanel)
+  const togglePreviewPerfPanel = useDebugStore((s) => s.togglePreviewPerfPanel)
 
   // Load available fixtures on mount
   useEffect(() => {
@@ -303,6 +305,24 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
                   <Eye className="h-3.5 w-3.5" />
                   Video Debug Overlay
                   {showVideoDebugOverlay && (
+                    <span className="ml-auto text-[10px] bg-amber-500/30 px-1.5 py-0.5 rounded">
+                      ON
+                    </span>
+                  )}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'w-full justify-start gap-2 h-8 text-xs',
+                    showPreviewPerfPanel && 'bg-amber-500/20 text-amber-300',
+                  )}
+                  onClick={togglePreviewPerfPanel}
+                  title="Show preview performance diagnostics"
+                >
+                  <Eye className="h-3.5 w-3.5" />
+                  Preview Perf Panel
+                  {showPreviewPerfPanel && (
                     <span className="ml-auto text-[10px] bg-amber-500/30 px-1.5 py-0.5 rounded">
                       ON
                     </span>

--- a/src/features/editor/components/project-debug-panel.tsx
+++ b/src/features/editor/components/project-debug-panel.tsx
@@ -31,6 +31,9 @@ import {
   FlaskConical,
   Play,
   Eye,
+  Activity,
+  Film,
+  Layers,
 } from 'lucide-react'
 import { useDebugStore } from '@/features/editor/stores/debug-store'
 import {
@@ -52,6 +55,15 @@ interface DebugAction {
 
 interface ProjectDebugPanelProps {
   projectId: string
+}
+
+type DebugApi = NonNullable<Window['__DEBUG__']>
+
+function getDebugApi(): DebugApi {
+  if (!window.__DEBUG__) {
+    throw new Error('Debug API is not initialized')
+  }
+  return window.__DEBUG__
 }
 
 export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
@@ -122,15 +134,28 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
   }, [])
 
   const handleLogSnapshot = useCallback(async () => {
+    const api = getDebugApi()
     const { exportProjectJson, getSnapshotStats } = await importJsonExportService()
     const snapshot = await exportProjectJson(projectId)
     const stats = getSnapshotStats(snapshot)
-    logger.debug('Project snapshot stats:', stats)
+    const mediaIds = await api.getProjectMedia(projectId)
+    logger.debug('Project snapshot summary:', {
+      project: {
+        id: snapshot.project.id,
+        name: snapshot.project.name,
+        duration: snapshot.project.duration,
+        metadata: snapshot.project.metadata,
+        schemaVersion: snapshot.project.schemaVersion,
+      },
+      stats,
+      mediaReferenceCount: snapshot.mediaReferences.length,
+      associatedMediaCount: mediaIds.length,
+    })
   }, [projectId])
 
-  const handleLogDBStats = useCallback(async () => {
+  const handleLogStorageStats = useCallback(async () => {
     const stats = await getDBStats()
-    logger.debug('IndexedDB stats:', stats)
+    logger.debug('Workspace storage stats:', stats)
   }, [])
 
   const handleValidateProject = useCallback(async () => {
@@ -138,13 +163,60 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
     const { validateSnapshotData } = await importJsonImportService()
     const snapshot = await exportProjectJson(projectId)
     const result = await validateSnapshotData(snapshot)
+    logger.debug('Project snapshot validation:', {
+      valid: result.valid,
+      errorCount: result.errors.length,
+      warningCount: result.warnings.length,
+      errors: result.errors,
+      warnings: result.warnings,
+    })
     if (!result.valid) {
-      logger.debug('Project validation errors:', result.errors)
-    }
-    if (result.warnings.length > 0) {
-      logger.debug('Project validation warnings:', result.warnings)
+      throw new Error(`${result.errors.length} validation error(s)`)
     }
   }, [projectId])
+
+  const handleLogTimelineState = useCallback(async () => {
+    const api = getDebugApi()
+    const [tracks, transitions, overlaps] = await Promise.all([
+      api.getTracks(),
+      api.getTransitions(),
+      api.overlaps(),
+    ])
+    logger.debug('Live timeline state:', { tracks, transitions, overlaps })
+  }, [])
+
+  const handleLogPlaybackState = useCallback(async () => {
+    const api = getDebugApi()
+    logger.debug('Playback and preview state:', {
+      playback: await api.getPlaybackState(),
+      previewPerf: api.previewPerf(),
+      jitter: api.jitter(),
+    })
+  }, [])
+
+  const handleLogMediaLibrary = useCallback(async () => {
+    const api = getDebugApi()
+    logger.debug('Media library summary:', await api.getMediaLibrary())
+  }, [])
+
+  const handleLogTransitionWindows = useCallback(async () => {
+    const api = getDebugApi()
+    logger.debug('Transition windows:', await api.getTransitionWindows())
+  }, [])
+
+  const handleCheckOverlaps = useCallback(async () => {
+    const api = getDebugApi()
+    const overlaps = await api.overlaps()
+    logger.debug('Timeline overlap check:', overlaps)
+    if (!overlaps.clean) {
+      throw new Error(`${overlaps.count} non-transition overlap(s)`)
+    }
+  }, [])
+
+  const handleDryRunOrphanSweep = useCallback(async () => {
+    const api = getDebugApi()
+    logger.debug('Workspace orphan sweep dry run:', await api.cleanOrphans({ dryRun: true }))
+  }, [])
 
   const handleGenerateFixture = useCallback(async () => {
     const { generateFixture } = await importTestFixtures()
@@ -213,22 +285,61 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
 
   const inspectActions: DebugAction[] = [
     {
-      label: 'Log Snapshot',
+      label: 'Project Summary',
       icon: <FileJson className="h-3.5 w-3.5" />,
       action: () => runAction(handleLogSnapshot, 'Logged to console'),
-      description: 'Log project snapshot to console',
+      description: 'Log project metadata, snapshot stats, and media counts',
     },
     {
-      label: 'Log DB Stats',
-      icon: <Database className="h-3.5 w-3.5" />,
-      action: () => runAction(handleLogDBStats, 'Logged to console'),
-      description: 'Log IndexedDB statistics',
+      label: 'Live Timeline',
+      icon: <Layers className="h-3.5 w-3.5" />,
+      action: () => runAction(handleLogTimelineState, 'Logged to console'),
+      description: 'Log current tracks, transitions, and overlap state',
+    },
+    {
+      label: 'Playback State',
+      icon: <Activity className="h-3.5 w-3.5" />,
+      action: () => runAction(handleLogPlaybackState, 'Logged to console'),
+      description: 'Log current playback, preview performance, and jitter state',
+    },
+    {
+      label: 'Media Library',
+      icon: <Film className="h-3.5 w-3.5" />,
+      action: () => runAction(handleLogMediaLibrary, 'Logged to console'),
+      description: 'Log current media library entries used by the editor',
+    },
+    {
+      label: 'Transitions',
+      icon: <Layers className="h-3.5 w-3.5" />,
+      action: () => runAction(handleLogTransitionWindows, 'Logged to console'),
+      description: 'Log resolved transition windows',
     },
     {
       label: 'Validate Schema',
       icon: <CheckCircle className="h-3.5 w-3.5" />,
-      action: () => runAction(handleValidateProject, 'Validation complete'),
-      description: 'Validate project against schema',
+      action: () => runAction(handleValidateProject, 'Snapshot schema valid'),
+      description: 'Validate exported project snapshot against the current schema',
+    },
+    {
+      label: 'Check Overlaps',
+      icon: <CheckCircle className="h-3.5 w-3.5" />,
+      action: () => runAction(handleCheckOverlaps, 'No overlaps found'),
+      description: 'Detect non-transition timeline overlaps',
+    },
+  ]
+
+  const storageActions: DebugAction[] = [
+    {
+      label: 'Storage Stats',
+      icon: <Database className="h-3.5 w-3.5" />,
+      action: () => runAction(handleLogStorageStats, 'Logged to console'),
+      description: 'Log workspace project count and browser storage estimate',
+    },
+    {
+      label: 'Dry Run Orphans',
+      icon: <Database className="h-3.5 w-3.5" />,
+      action: () => runAction(handleDryRunOrphanSweep, 'Logged to console'),
+      description: 'Scan workspace mirror caches for orphaned media entries without deleting',
     },
   ]
 
@@ -358,10 +469,22 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
             {/* Inspect Section */}
             <div>
               <div className="px-1 py-1 text-[10px] uppercase tracking-wider text-zinc-500 font-medium">
-                Inspect
+                Inspect Live State
               </div>
               <div className="space-y-0.5">
                 {inspectActions.map((action) => (
+                  <ActionButton key={action.label} action={action} />
+                ))}
+              </div>
+            </div>
+
+            {/* Storage Section */}
+            <div>
+              <div className="px-1 py-1 text-[10px] uppercase tracking-wider text-zinc-500 font-medium">
+                Storage
+              </div>
+              <div className="space-y-0.5">
+                {storageActions.map((action) => (
                   <ActionButton key={action.label} action={action} />
                 ))}
               </div>
@@ -371,7 +494,7 @@ export function ProjectDebugPanel({ projectId }: ProjectDebugPanelProps) {
             <div>
               <div className="px-1 py-1 text-[10px] uppercase tracking-wider text-zinc-500 font-medium flex items-center gap-1">
                 <FlaskConical className="h-3 w-3" />
-                Test Fixtures
+                Synthetic Fixtures
               </div>
               <div className="space-y-2 px-1">
                 <Select

--- a/src/features/editor/stores/debug-store.ts
+++ b/src/features/editor/stores/debug-store.ts
@@ -5,6 +5,10 @@ interface DebugState {
   showVideoDebugOverlay: boolean
   setShowVideoDebugOverlay: (show: boolean) => void
   toggleVideoDebugOverlay: () => void
+  /** Show preview performance diagnostics panel */
+  showPreviewPerfPanel: boolean
+  setShowPreviewPerfPanel: (show: boolean) => void
+  togglePreviewPerfPanel: () => void
   /** Debug panel open state */
   debugPanelOpen: boolean
   setDebugPanelOpen: (open: boolean) => void
@@ -29,6 +33,9 @@ export const useDebugStore = isDev
       setShowVideoDebugOverlay: (show) => set({ showVideoDebugOverlay: show }),
       toggleVideoDebugOverlay: () =>
         set((s) => ({ showVideoDebugOverlay: !s.showVideoDebugOverlay })),
+      showPreviewPerfPanel: false,
+      setShowPreviewPerfPanel: (show) => set({ showPreviewPerfPanel: show }),
+      togglePreviewPerfPanel: () => set((s) => ({ showPreviewPerfPanel: !s.showPreviewPerfPanel })),
       debugPanelOpen: false,
       setDebugPanelOpen: (open) => set({ debugPanelOpen: open }),
       toggleDebugPanel: () => set((s) => ({ debugPanelOpen: !s.debugPanelOpen })),
@@ -37,6 +44,9 @@ export const useDebugStore = isDev
       showVideoDebugOverlay: false,
       setShowVideoDebugOverlay: () => {},
       toggleVideoDebugOverlay: () => {},
+      showPreviewPerfPanel: false,
+      setShowPreviewPerfPanel: () => {},
+      togglePreviewPerfPanel: () => {},
       debugPanelOpen: false,
       setDebugPanelOpen: () => {},
       toggleDebugPanel: () => {},

--- a/src/features/preview/deps/README.md
+++ b/src/features/preview/deps/README.md
@@ -28,3 +28,6 @@ Preview-local adapters for external feature dependencies.
   keyframe animation hooks or auto-keyframing utilities.
 - `composition-runtime.ts`: the only allowed entry point for preview modules
   that need composition runtime components or transform/time utilities.
+- `editor-debug.ts`: the only allowed entry point for preview modules that
+  need editor-owned debug controls.
+- `editor-debug-contract.ts`: internal preview->editor debug binding.

--- a/src/features/preview/deps/editor-debug-contract.ts
+++ b/src/features/preview/deps/editor-debug-contract.ts
@@ -1,0 +1,5 @@
+/**
+ * Contract binding for editor-owned debug controls used by preview diagnostics.
+ */
+
+export { useDebugStore } from '@/features/editor/stores/debug-store'

--- a/src/features/preview/deps/editor-debug.ts
+++ b/src/features/preview/deps/editor-debug.ts
@@ -1,0 +1,5 @@
+/**
+ * Compatibility adapter that re-exports through editor-debug-contract.
+ */
+
+export * from './editor-debug-contract'

--- a/src/features/preview/hooks/use-preview-perf-panel.ts
+++ b/src/features/preview/hooks/use-preview-perf-panel.ts
@@ -14,6 +14,7 @@ export function usePreviewPerfPanel() {
   const setShowPerfPanel = useDebugStore((s) => s.setShowPreviewPerfPanel)
   const [perfPanelSnapshot, setPerfPanelSnapshot] = useState<PreviewPerfSnapshot | null>(null)
   const initializedRef = useRef(false)
+  const hasSyncedRef = useRef(false)
 
   useEffect(() => {
     if (!import.meta.env.DEV) return
@@ -66,6 +67,10 @@ export function usePreviewPerfPanel() {
 
   useEffect(() => {
     if (!import.meta.env.DEV || !initializedRef.current) return
+    if (!hasSyncedRef.current) {
+      hasSyncedRef.current = true
+      return
+    }
 
     window.__PREVIEW_PERF_PANEL__ = showPerfPanel
     try {

--- a/src/features/preview/hooks/use-preview-perf-panel.ts
+++ b/src/features/preview/hooks/use-preview-perf-panel.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useDebugStore } from '@/features/editor/stores/debug-store'
+import { useDebugStore } from '../deps/editor-debug'
 import {
   PREVIEW_PERF_PANEL_QUERY_KEY,
   PREVIEW_PERF_PANEL_STORAGE_KEY,

--- a/src/features/preview/hooks/use-preview-perf-panel.ts
+++ b/src/features/preview/hooks/use-preview-perf-panel.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useDebugStore } from '@/features/editor/stores/debug-store'
 import {
   PREVIEW_PERF_PANEL_QUERY_KEY,
   PREVIEW_PERF_PANEL_STORAGE_KEY,
@@ -9,8 +10,10 @@ import {
 const POLL_INTERVAL_MS = 250
 
 export function usePreviewPerfPanel() {
-  const [showPerfPanel, setShowPerfPanel] = useState(false)
+  const showPerfPanel = useDebugStore((s) => s.showPreviewPerfPanel)
+  const setShowPerfPanel = useDebugStore((s) => s.setShowPreviewPerfPanel)
   const [perfPanelSnapshot, setPerfPanelSnapshot] = useState<PreviewPerfSnapshot | null>(null)
+  const initializedRef = useRef(false)
 
   useEffect(() => {
     if (!import.meta.env.DEV) return
@@ -38,6 +41,7 @@ export function usePreviewPerfPanel() {
     }
 
     window.__PREVIEW_PERF_PANEL__ = panelEnabled
+    initializedRef.current = true
     setShowPerfPanel(panelEnabled)
     setPerfPanelSnapshot(panelEnabled ? (window.__PREVIEW_PERF__ ?? null) : null)
 
@@ -45,16 +49,7 @@ export function usePreviewPerfPanel() {
       if (!(event.altKey && event.shiftKey && event.key.toLowerCase() === 'p')) return
       event.preventDefault()
       const nextEnabled = !(window.__PREVIEW_PERF_PANEL__ === true)
-      window.__PREVIEW_PERF_PANEL__ = nextEnabled
-      try {
-        window.localStorage.setItem(PREVIEW_PERF_PANEL_STORAGE_KEY, nextEnabled ? '1' : '0')
-      } catch {
-        // Ignore storage failures (private mode / quota / disabled storage).
-      }
       setShowPerfPanel(nextEnabled)
-      if (!nextEnabled) {
-        setPerfPanelSnapshot(null)
-      }
     }
 
     const intervalId = setInterval(() => {
@@ -67,7 +62,20 @@ export function usePreviewPerfPanel() {
       window.removeEventListener('keydown', handleKeyDown)
       clearInterval(intervalId)
     }
-  }, [])
+  }, [setShowPerfPanel])
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || !initializedRef.current) return
+
+    window.__PREVIEW_PERF_PANEL__ = showPerfPanel
+    try {
+      window.localStorage.setItem(PREVIEW_PERF_PANEL_STORAGE_KEY, showPerfPanel ? '1' : '0')
+    } catch {
+      // Ignore storage failures (private mode / quota / disabled storage).
+    }
+
+    setPerfPanelSnapshot(showPerfPanel ? (window.__PREVIEW_PERF__ ?? null) : null)
+  }, [showPerfPanel])
 
   const latestRenderSourceSwitch = useMemo(
     () =>

--- a/src/features/project-bundle/services/test-fixtures.test.ts
+++ b/src/features/project-bundle/services/test-fixtures.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { getAvailableFixtures, generateFixture } from './test-fixtures'
+import { validateSnapshotData } from './json-import-service'
+
+describe('test fixtures', () => {
+  it('generates snapshots accepted by the current import validator', async () => {
+    for (const fixture of getAvailableFixtures()) {
+      const { snapshot } = generateFixture(fixture.type)
+      const result = await validateSnapshotData(snapshot)
+
+      expect(result.errors, fixture.type).toEqual([])
+      expect(result.valid, fixture.type).toBe(true)
+    }
+  })
+})

--- a/src/features/timeline/services/reverse-conform-service.test.ts
+++ b/src/features/timeline/services/reverse-conform-service.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import type { TimelineTrack, VideoItem } from '@/types/timeline'
+
+const renderCompositionMock = vi.fn()
+const readWorkspaceBlobMock = vi.fn()
+const mirrorBlobToWorkspaceMock = vi.fn()
+const getFileBlobMock = vi.fn()
+const saveFileMock = vi.fn()
+const resolveMediaUrlsMock = vi.fn()
+let mediaByIdMock: Record<string, { duration: number; fps: number }> = {}
+
+vi.mock('../deps/export-contract', () => ({
+  renderComposition: renderCompositionMock,
+}))
+
+vi.mock('@/infrastructure/storage/workspace-fs/cache-mirror', () => ({
+  mirrorBlobToWorkspace: mirrorBlobToWorkspaceMock,
+  readWorkspaceBlob: readWorkspaceBlobMock,
+}))
+
+vi.mock('../deps/media-library-service', () => ({
+  opfsService: {
+    getFileBlob: getFileBlobMock,
+    saveFile: saveFileMock,
+  },
+}))
+
+vi.mock('../deps/media-library-resolver', () => ({
+  resolveMediaUrls: resolveMediaUrlsMock,
+}))
+
+vi.mock('../deps/media-library-store', () => ({
+  useMediaLibraryStore: {
+    getState: () => ({ mediaById: mediaByIdMock }),
+  },
+}))
+
+function makeVideoItem(overrides: Partial<VideoItem> = {}): VideoItem {
+  return {
+    id: 'video-1',
+    type: 'video',
+    trackId: 'track-1',
+    from: 0,
+    durationInFrames: 60,
+    label: 'clip.mp4',
+    src: 'blob:video',
+    mediaId: 'media-1',
+    sourceStart: 0,
+    sourceEnd: 60,
+    sourceFps: 30,
+    ...overrides,
+  }
+}
+
+describe('reverseConformService', () => {
+  beforeEach(() => {
+    renderCompositionMock.mockReset()
+    readWorkspaceBlobMock.mockReset()
+    mirrorBlobToWorkspaceMock.mockReset()
+    getFileBlobMock.mockReset()
+    saveFileMock.mockReset()
+    resolveMediaUrlsMock.mockReset()
+    mediaByIdMock = {}
+
+    readWorkspaceBlobMock.mockResolvedValue(null)
+    getFileBlobMock.mockRejectedValue(new Error('cache miss'))
+    saveFileMock.mockResolvedValue(undefined)
+    mirrorBlobToWorkspaceMock.mockResolvedValue(undefined)
+    resolveMediaUrlsMock.mockImplementation(async (tracks) => tracks)
+    renderCompositionMock.mockResolvedValue({
+      blob: {
+        arrayBuffer: async () => new ArrayBuffer(0),
+        type: 'video/mp4',
+      },
+    })
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:reverse')
+  })
+
+  it('derives conform duration from explicit source bounds when the clip duration is zero', async () => {
+    const { reverseConformService } = await import('./reverse-conform-service')
+
+    await reverseConformService.prepareVideo(
+      makeVideoItem({
+        durationInFrames: 0,
+        sourceStart: 30,
+        sourceEnd: 90,
+      }),
+      30,
+    )
+
+    const renderRequest = renderCompositionMock.mock.calls[0]?.[0]
+    expect(renderRequest.composition.durationInFrames).toBe(60)
+    expect(renderRequest.composition.tracks[0].items[0]).toMatchObject({
+      durationInFrames: 60,
+      sourceStart: 30,
+      sourceEnd: 90,
+    })
+  })
+
+  it('falls back to media library duration when optimistic source bounds are zero', async () => {
+    mediaByIdMock = {
+      'media-1': {
+        duration: 2,
+        fps: 30,
+      },
+    }
+    const { reverseConformService } = await import('./reverse-conform-service')
+
+    await reverseConformService.prepareVideo(
+      makeVideoItem({
+        durationInFrames: 0,
+        sourceStart: 0,
+        sourceEnd: 0,
+        sourceDuration: 0,
+      }),
+      30,
+    )
+
+    const renderRequest = renderCompositionMock.mock.calls[0]?.[0]
+    expect(renderRequest.composition.durationInFrames).toBe(60)
+    expect(renderRequest.composition.tracks[0].items[0]).toMatchObject({
+      durationInFrames: 60,
+      sourceStart: 0,
+      sourceEnd: 60,
+      sourceDuration: 0,
+    })
+  })
+
+  it('allows mediaId-only clips to resolve their source during reverse preparation', async () => {
+    mediaByIdMock = {
+      'media-1': {
+        duration: 2,
+        fps: 30,
+      },
+    }
+    const { reverseConformService } = await import('./reverse-conform-service')
+    resolveMediaUrlsMock.mockImplementationOnce(async (tracks: TimelineTrack[]) =>
+      tracks.map((track) => ({
+        ...track,
+        items: track.items.map((item) =>
+          item.type === 'video' ? { ...item, src: 'blob:resolved-video' } : item,
+        ),
+      })),
+    )
+
+    await reverseConformService.prepareVideo(
+      makeVideoItem({
+        src: '',
+        durationInFrames: 0,
+        sourceStart: 0,
+        sourceEnd: 0,
+        sourceDuration: 0,
+      }),
+      30,
+    )
+
+    expect(resolveMediaUrlsMock).toHaveBeenCalled()
+    expect(renderCompositionMock).toHaveBeenCalled()
+  })
+})

--- a/src/features/timeline/services/reverse-conform-service.ts
+++ b/src/features/timeline/services/reverse-conform-service.ts
@@ -55,6 +55,13 @@ function getSourceStart(item: VideoItem): number {
   return item.sourceStart ?? item.trimStart ?? item.offset ?? 0
 }
 
+function resolveSourceFps(item: VideoItem, timelineFps: number): number {
+  if (item.sourceFps !== undefined && item.sourceFps > 0) return item.sourceFps
+  const media = item.mediaId ? useMediaLibraryStore.getState().mediaById[item.mediaId] : undefined
+  if (media?.fps && media.fps > 0) return media.fps
+  return timelineFps
+}
+
 function getSourceDuration(item: VideoItem, timelineFps: number): number | undefined {
   if (item.sourceDuration !== undefined && item.sourceDuration > 0) {
     return item.sourceDuration
@@ -72,10 +79,11 @@ function getConformDurationInFrames(item: VideoItem, timelineFps: number): numbe
     return Math.round(item.durationInFrames)
   }
 
+  const sourceFps = resolveSourceFps(item, timelineFps)
+  const speed = item.speed ?? 1
   const sourceStart = getSourceStart(item)
+
   if (item.sourceEnd !== undefined && item.sourceEnd > sourceStart) {
-    const sourceFps = item.sourceFps ?? timelineFps
-    const speed = item.speed ?? 1
     if (sourceFps > 0 && speed > 0) {
       return Math.max(
         1,
@@ -86,8 +94,6 @@ function getConformDurationInFrames(item: VideoItem, timelineFps: number): numbe
 
   const sourceDuration = getSourceDuration(item, timelineFps)
   if (sourceDuration !== undefined && sourceDuration > sourceStart) {
-    const sourceFps = item.sourceFps ?? timelineFps
-    const speed = item.speed ?? 1
     if (sourceFps > 0 && speed > 0) {
       return Math.max(
         1,
@@ -100,7 +106,7 @@ function getConformDurationInFrames(item: VideoItem, timelineFps: number): numbe
 }
 
 function getSourceEnd(item: VideoItem, timelineFps: number, durationInFrames: number): number {
-  const sourceFps = item.sourceFps ?? timelineFps
+  const sourceFps = resolveSourceFps(item, timelineFps)
   const speed = item.speed ?? 1
   const sourceFramesNeeded = (durationInFrames * speed * sourceFps) / timelineFps
   const sourceStart = getSourceStart(item)

--- a/src/features/timeline/services/reverse-conform-service.ts
+++ b/src/features/timeline/services/reverse-conform-service.ts
@@ -12,6 +12,7 @@ import {
 import { reverseConformFilePath } from '@/infrastructure/storage/workspace-fs/paths'
 import { opfsService } from '../deps/media-library-service'
 import { resolveMediaUrls } from '../deps/media-library-resolver'
+import { useMediaLibraryStore } from '../deps/media-library-store'
 
 export interface ReverseConformResult {
   itemId: string
@@ -54,11 +55,63 @@ function getSourceStart(item: VideoItem): number {
   return item.sourceStart ?? item.trimStart ?? item.offset ?? 0
 }
 
-function getSourceEnd(item: VideoItem, timelineFps: number): number {
+function getSourceDuration(item: VideoItem, timelineFps: number): number | undefined {
+  if (item.sourceDuration !== undefined && item.sourceDuration > 0) {
+    return item.sourceDuration
+  }
+
+  const media = item.mediaId ? useMediaLibraryStore.getState().mediaById[item.mediaId] : undefined
+  if (!media || media.duration <= 0) return undefined
+
+  const sourceFps = item.sourceFps ?? (media.fps || timelineFps)
+  return Math.round(media.duration * sourceFps)
+}
+
+function getConformDurationInFrames(item: VideoItem, timelineFps: number): number {
+  if (Number.isFinite(item.durationInFrames) && item.durationInFrames > 0) {
+    return Math.round(item.durationInFrames)
+  }
+
+  const sourceStart = getSourceStart(item)
+  if (item.sourceEnd !== undefined && item.sourceEnd > sourceStart) {
+    const sourceFps = item.sourceFps ?? timelineFps
+    const speed = item.speed ?? 1
+    if (sourceFps > 0 && speed > 0) {
+      return Math.max(
+        1,
+        Math.round(((item.sourceEnd - sourceStart) * timelineFps) / (speed * sourceFps)),
+      )
+    }
+  }
+
+  const sourceDuration = getSourceDuration(item, timelineFps)
+  if (sourceDuration !== undefined && sourceDuration > sourceStart) {
+    const sourceFps = item.sourceFps ?? timelineFps
+    const speed = item.speed ?? 1
+    if (sourceFps > 0 && speed > 0) {
+      return Math.max(
+        1,
+        Math.round(((sourceDuration - sourceStart) * timelineFps) / (speed * sourceFps)),
+      )
+    }
+  }
+
+  return 0
+}
+
+function getSourceEnd(item: VideoItem, timelineFps: number, durationInFrames: number): number {
   const sourceFps = item.sourceFps ?? timelineFps
   const speed = item.speed ?? 1
-  const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / timelineFps
-  return item.sourceEnd ?? getSourceStart(item) + sourceFramesNeeded
+  const sourceFramesNeeded = (durationInFrames * speed * sourceFps) / timelineFps
+  const sourceStart = getSourceStart(item)
+  const derivedSourceEnd = sourceStart + sourceFramesNeeded
+  const sourceDuration = getSourceDuration(item, timelineFps)
+  if (item.sourceEnd !== undefined && item.sourceEnd > sourceStart) {
+    return item.sourceEnd
+  }
+  return sourceDuration !== undefined
+    ? Math.min(sourceDuration, derivedSourceEnd)
+    : derivedSourceEnd
 }
 
 function getReverseConformKey(
@@ -67,6 +120,7 @@ function getReverseConformKey(
   quality: ReverseConformQuality,
   useProxy: boolean,
 ): string {
+  const durationInFrames = getConformDurationInFrames(item, timelineFps)
   return toSafeKey(
     [
       'v2',
@@ -75,8 +129,8 @@ function getReverseConformKey(
       item.mediaId ?? 'legacy',
       item.mediaId ? `media:${item.mediaId}` : item.src,
       getSourceStart(item),
-      getSourceEnd(item, timelineFps),
-      item.durationInFrames,
+      getSourceEnd(item, timelineFps, durationInFrames),
+      durationInFrames,
       item.sourceFps ?? timelineFps,
       timelineFps,
       item.speed ?? 1,
@@ -128,6 +182,7 @@ function buildConformComposition(
   quality: ReverseConformQuality,
 ): CompositionInputProps {
   const { width, height } = getConformDimensions(item, quality)
+  const durationInFrames = getConformDurationInFrames(item, timelineFps)
   const track: TimelineTrack = {
     id: 'reverse-conform-track',
     name: 'Reverse conform',
@@ -144,7 +199,7 @@ function buildConformComposition(
     id: `${item.id}:reverse-conform`,
     trackId: track.id,
     from: 0,
-    durationInFrames: item.durationInFrames,
+    durationInFrames,
     isReversed: true,
     reverseConformSrc: undefined,
     reverseConformPath: undefined,
@@ -152,7 +207,7 @@ function buildConformComposition(
     reverseConformPreviewPath: undefined,
     reverseConformStatus: undefined,
     sourceStart: getSourceStart(item),
-    sourceEnd: getSourceEnd(item, timelineFps),
+    sourceEnd: getSourceEnd(item, timelineFps, durationInFrames),
     sourceFps: item.sourceFps ?? timelineFps,
     transform: {
       x: 0,
@@ -173,7 +228,7 @@ function buildConformComposition(
     fps: timelineFps,
     width,
     height,
-    durationInFrames: item.durationInFrames,
+    durationInFrames,
     tracks: [track],
     transitions: [],
     backgroundColor: '#000000',
@@ -271,7 +326,7 @@ export const reverseConformService = {
     const quality = options.quality ?? 'preview'
     const useProxy = quality === 'preview' && options.useProxy !== false
     throwIfAborted(options.signal)
-    if (!item.src || item.durationInFrames <= 0) {
+    if ((!item.src && !item.mediaId) || getConformDurationInFrames(item, timelineFps) <= 0) {
       throw new Error('Cannot reverse an empty video clip')
     }
     const key = getReverseConformKey(item, timelineFps, quality, useProxy)

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm ci",
+  "installCommand": "ONNXRUNTIME_NODE_INSTALL=skip npm ci",
   "rewrites": [
     {
       "source": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "npm ci",
+  "installCommand": "ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm ci",
   "rewrites": [
     {
       "source": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "ONNXRUNTIME_NODE_INSTALL=skip npm ci",
+  "installCommand": "ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm ci",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Refresh debug panel diagnostics and refine its controls; route the preview's debug dependency through the deps adapter (preserves feature boundary)
- Allow reverse conform on `mediaId` clips and add coverage in `reverse-conform-service.test.ts`
- Skip onnxruntime CUDA install on Vercel to fix builds

## Test plan
- [ ] CI green on Vercel preview build (onnxruntime CUDA skipped)
- [ ] Debug panel renders and toggles work in dev
- [ ] Reverse conform works on clips referenced by `mediaId`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable Preview Performance Panel overlay in debug controls.
  * Expanded debug UI: "Inspect Live State" with richer runtime logs and a new "Storage" section for orphan dry‑runs.
  * Renamed "Test Fixtures" to "Synthetic Fixtures".
  * Alt+Shift+P toggles the Preview Perf Panel via the debug store; persistence and syncing are handled separately.

* **Bug Fixes**
  * Improved validation and error reporting for snapshot/overlap checks; stricter detection of problematic overlaps.

* **Tests**
  * Added fixture generation/validation tests.
  * Added reverse-conform duration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->