### PR TITLE
fix(preview): align player geometry without overscan

### DIFF
--- a/src/features/player/Player.test.ts
+++ b/src/features/player/Player.test.ts
@@ -2,14 +2,23 @@ import { describe, expect, it } from 'vite-plus/test'
 import { calculatePlayerContentLayout } from './player-layout'
 
 describe('calculatePlayerContentLayout', () => {
-  it('keeps fractional container dimensions instead of rounding through clientWidth', () => {
+  it('preserves uniform scale for fractional near-exact fits', () => {
     const layout = calculatePlayerContentLayout(986.65625, 555, 1920, 1080)
 
     expect(layout.width).toBeCloseTo(986.65625, 5)
-    expect(layout.height).toBeCloseTo(555, 5)
+    expect(layout.height).toBeCloseTo(554.99414, 5)
     expect(layout.scale).toBeCloseTo(0.51388346, 8)
-    expect(layout.scaleX).toBeCloseTo(0.51388346, 8)
-    expect(layout.scaleY).toBeCloseTo(0.51388889, 8)
+    expect(layout.scaleX).toBeCloseTo(layout.scale, 8)
+    expect(layout.scaleY).toBeCloseTo(layout.scale, 8)
+  })
+
+  it('preserves uniform scale for near-exact aspect-ratio fits instead of stretching one axis', () => {
+    const layout = calculatePlayerContentLayout(1281, 720, 1280, 720)
+
+    expect(layout.scaleX).toBe(layout.scale)
+    expect(layout.scaleY).toBe(layout.scale)
+    expect(layout.width).toBe(1280)
+    expect(layout.height).toBe(720)
   })
 
   it('keeps real letterboxing when the container is not a near-exact aspect fit', () => {

--- a/src/features/player/Player.tsx
+++ b/src/features/player/Player.tsx
@@ -63,11 +63,14 @@ interface PlayerProps {
   /** Custom styles */
   style?: React.CSSProperties
 
-  /** Width of the player */
+  /** Width of the rendered composition */
   width?: number
 
-  /** Height of the player */
+  /** Height of the rendered composition */
   height?: number
+
+  /** Explicit CSS layout rectangle to scale the composition into. */
+  layoutSize?: { width: number; height: number }
 
   /** Callback when playback ends */
   onEnded?: () => void
@@ -313,6 +316,7 @@ const PlayerInner = forwardRef<PlayerRef, PlayerProps>(
       style,
       width = 1280,
       height = 720,
+      layoutSize,
       onEnded,
       onFrameChange,
       onPlayStateChange,
@@ -339,8 +343,10 @@ const PlayerInner = forwardRef<PlayerRef, PlayerProps>(
       if (!container || !contentHost || !contentScale) return
 
       const containerRect = container.getBoundingClientRect()
-      const containerWidth = containerRect.width || container.clientWidth
-      const containerHeight = containerRect.height || container.clientHeight
+      const measuredWidth = containerRect.width || container.clientWidth
+      const measuredHeight = containerRect.height || container.clientHeight
+      const containerWidth = layoutSize?.width ?? measuredWidth
+      const containerHeight = layoutSize?.height ?? measuredHeight
       const layout = calculatePlayerContentLayout(containerWidth, containerHeight, width, height)
 
       contentHost.style.width = `${layout.width}px`
@@ -351,7 +357,7 @@ const PlayerInner = forwardRef<PlayerRef, PlayerProps>(
       contentScale.style.width = `${width}px`
       contentScale.style.height = `${height}px`
       contentScale.style.transform = `scale(${layout.scaleX}, ${layout.scaleY})`
-    }, [height, width])
+    }, [height, layoutSize?.height, layoutSize?.width, width])
 
     useEffect(() => {
       const container = containerRef.current

--- a/src/features/player/player-layout.ts
+++ b/src/features/player/player-layout.ts
@@ -11,24 +11,6 @@ export function calculatePlayerContentLayout(
   const width = sourceWidth * scale
   const height = sourceHeight * scale
 
-  const nearExactFit =
-    containerWidth > 0 &&
-    containerHeight > 0 &&
-    sourceWidth > 0 &&
-    sourceHeight > 0 &&
-    Math.abs(containerWidth - width) <= 1 &&
-    Math.abs(containerHeight - height) <= 1
-
-  if (nearExactFit) {
-    return {
-      scale,
-      scaleX: containerWidth / sourceWidth,
-      scaleY: containerHeight / sourceHeight,
-      width: containerWidth,
-      height: containerHeight,
-    }
-  }
-
   return {
     scale,
     scaleX: scale,

--- a/src/features/preview/components/preview-stage.test.tsx
+++ b/src/features/preview/components/preview-stage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { render, screen } from '@testing-library/react'
-import type { ReactNode, RefObject } from 'react'
+import type { CSSProperties, ReactNode, RefObject } from 'react'
 import type { CompositionInputProps } from '@/types/export'
 
 const playbackState = vi.hoisted(() => ({
@@ -17,7 +17,24 @@ vi.mock('@/shared/state/playback', () => {
 })
 
 vi.mock('@/features/preview/deps/player-core', () => ({
-  Player: ({ children }: { children: ReactNode }) => <div data-testid="player">{children}</div>,
+  Player: ({
+    children,
+    layoutSize,
+    style,
+  }: {
+    children: ReactNode
+    layoutSize?: { width: number; height: number }
+    style?: CSSProperties
+  }) => (
+    <div
+      data-testid="player"
+      data-layout-width={layoutSize?.width}
+      data-layout-height={layoutSize?.height}
+      style={style}
+    >
+      {children}
+    </div>
+  ),
 }))
 
 vi.mock('@/features/preview/deps/composition-runtime', () => ({
@@ -100,5 +117,43 @@ describe('PreviewStage', () => {
     )
 
     expect(screen.getByTestId('main-composition')).toHaveAttribute('data-use-proxy-media', 'true')
+  })
+
+  it('keeps render surfaces on one exact geometry and passes that geometry to Player layout', () => {
+    render(
+      <PreviewStage
+        backgroundRef={createRef<HTMLDivElement>()}
+        playerRef={createRef()}
+        scrubCanvasRef={createRef<HTMLCanvasElement>()}
+        gpuEffectsCanvasRef={createRef<HTMLCanvasElement>()}
+        needsOverflow={false}
+        playerSize={{ width: 1280, height: 720 }}
+        playerRenderSize={{ width: 1280, height: 720 }}
+        totalFrames={120}
+        fps={30}
+        isResolving={false}
+        isRenderedOverlayVisible={true}
+        inputProps={createInputProps()}
+        onBackgroundClick={() => {}}
+        onFrameChange={() => {}}
+        onPlayStateChange={() => {}}
+        setPlayerContainerRefCallback={() => {}}
+      />,
+    )
+
+    const player = screen.getByTestId('player')
+    const canvases = document.querySelectorAll('canvas')
+
+    expect(player).toHaveStyle({ width: '100%', height: '100%' })
+    expect(player).toHaveAttribute('data-layout-width', '1280')
+    expect(player).toHaveAttribute('data-layout-height', '720')
+    expect(player.style.marginLeft).toBe('')
+    expect(player.style.marginTop).toBe('')
+
+    canvases.forEach((canvas) => {
+      expect(canvas).toHaveStyle({ width: '100%', height: '100%' })
+      expect(canvas.style.left).toBe('')
+      expect(canvas.style.top).toBe('')
+    })
   })
 })

--- a/src/features/preview/components/preview-stage.tsx
+++ b/src/features/preview/components/preview-stage.tsx
@@ -16,8 +16,6 @@ import { EDITOR_LAYOUT_CSS_VALUES } from '@/app/editor-layout'
 import { FAST_SCRUB_RENDERER_ENABLED } from '../utils/preview-constants'
 import { getPreviewPixelSnapOffset, ZERO_PIXEL_SNAP_OFFSET } from '../utils/preview-pixel-snap'
 
-const PREVIEW_SURFACE_OVERSCAN_PX = 1
-
 interface PreviewStageProps {
   backgroundRef: RefObject<HTMLDivElement | null>
   playerRef: RefObject<PlayerRef | null>
@@ -172,11 +170,10 @@ export const PreviewStage = memo(function PreviewStage({
                 autoPlay={false}
                 loop={false}
                 controls={false}
+                layoutSize={playerSize}
                 style={{
-                  width: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                  height: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                  marginLeft: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
-                  marginTop: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
+                  width: '100%',
+                  height: '100%',
                 }}
                 onFrameChange={onFrameChange}
                 onPlayStateChange={onPlayStateChange}
@@ -189,10 +186,8 @@ export const PreviewStage = memo(function PreviewStage({
                   ref={scrubCanvasRef}
                   className="absolute inset-0 pointer-events-none"
                   style={{
-                    width: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                    height: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                    left: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
-                    top: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
+                    width: '100%',
+                    height: '100%',
                     zIndex: 4,
                     visibility: isRenderedOverlayVisible ? 'visible' : 'hidden',
                   }}
@@ -203,10 +198,8 @@ export const PreviewStage = memo(function PreviewStage({
                 ref={gpuEffectsCanvasRef}
                 className="absolute inset-0 pointer-events-none"
                 style={{
-                  width: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                  height: `calc(100% + ${PREVIEW_SURFACE_OVERSCAN_PX * 2}px)`,
-                  left: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
-                  top: `${-PREVIEW_SURFACE_OVERSCAN_PX}px`,
+                  width: '100%',
+                  height: '100%',
                   zIndex: 5,
                   visibility: 'hidden',
                 }}


### PR DESCRIPTION
## Summary
- Remove preview surface overscan/bleed and keep Player/canvas surfaces on exact geometry
- Add explicit Player layout size for preview so layout is not inferred from overpainted DOM size
- Preserve uniform player scaling by removing near-exact non-uniform stretch behavior
- Add regression coverage for exact preview surface geometry and uniform scale

## Test Plan
- NODE_ENV=test npm run test:run -- src/features/preview/components/preview-stage.test.tsx src/features/player/Player.test.ts
- NODE_ENV=test ./node_modules/.bin/vp check --no-fmt src/features/preview/components/preview-stage.tsx src/features/preview/components/preview-stage.test.tsx src/features/player/Player.tsx src/features/player/Player.test.ts src/features/player/player-layout.ts

## Notes
- Pre-push quality checks passed with 0 errors and existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Player component now supports optional layout size override for flexible dimension control.

* **Improvements**
  * Enhanced player scaling to maintain uniform scaling across all aspect ratio configurations.
  * Simplified preview stage rendering by removing overscan expansion for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->