### PR TITLE
chore: sync package-lock version to 2026.04.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freecut",
-  "version": "2026.04.06",
+  "version": "2026.04.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freecut",
-      "version": "2026.04.06",
+      "version": "2026.04.20",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@huggingface/transformers": "^4.0.1",


### PR DESCRIPTION
## Summary
- Syncs `package-lock.json` `version` field from `2026.04.06` to `2026.04.20` to match `package.json`.

## Test plan
- [x] `npm ci` succeeds
- [x] Pre-push checks pass