### PR TITLE
refactor: consolidate low-risk FreeCut cleanup helpers

### DIFF
--- a/src/features/export/components/export-preview-player.tsx
+++ b/src/features/export/components/export-preview-player.tsx
@@ -2,6 +2,9 @@ import { useState, useRef, useEffect, useCallback, useSyncExternalStore } from '
 import { Button } from '@/components/ui/button'
 import { Slider } from '@/components/ui/slider'
 import { Play, Pause, Volume2, VolumeX, Maximize, Minimize } from 'lucide-react'
+import { createLogger } from '@/shared/logging/logger'
+
+const log = createLogger('ExportPreviewPlayer')
 
 interface ExportPreviewPlayerProps {
   src: string
@@ -85,11 +88,15 @@ export function ExportPreviewPlayer({ src, isVideo }: ExportPreviewPlayerProps) 
   const handleFullscreen = useCallback(() => {
     if (!isVideo) return
     if (document.fullscreenElement) {
-      document.exitFullscreen().catch(console.error)
+      document.exitFullscreen().catch((error: unknown) => {
+        log.warn('Failed to exit fullscreen', { error })
+      })
     } else {
       const el = containerRef.current
       if (el?.requestFullscreen) {
-        el.requestFullscreen().catch(console.error)
+        el.requestFullscreen().catch((error: unknown) => {
+          log.warn('Failed to enter fullscreen', { error })
+        })
       }
     }
   }, [isVideo])

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -126,6 +126,7 @@ import { useCompositionNavigationStore } from '../../stores/composition-navigati
 import { useTimelineItemOverlayStore } from '../../stores/timeline-item-overlay-store'
 import { useRollHoverStore } from '../../stores/roll-hover-store'
 import { useZoomStore } from '../../stores/zoom-store'
+import { frameToPixelsNow, pixelsToFrameNow } from '../../utils/zoom-conversions'
 import { timelineToSourceFrames } from '../../utils/source-calculations'
 import { computeSlideContinuitySourceDelta } from '../../utils/slide-utils'
 import { getTransitionBridgeBounds } from '../../utils/transition-preview-geometry'
@@ -176,21 +177,6 @@ const JOIN_INDICATOR_MIN_ZOOM_PPS = 30
 const SPEED_BADGE_EPSILON = 0.005
 const TRANSITION_DROP_HIT_MIN_WIDTH_PX = 72
 const TRANSITION_DROP_HIT_MAX_WIDTH_PX = 240
-
-function getPixelsPerSecondNow(): number {
-  return useZoomStore.getState().pixelsPerSecond
-}
-
-function frameToPixelsNow(frame: number): number {
-  const fps = useTimelineStore.getState().fps
-  return fps > 0 ? (frame / fps) * getPixelsPerSecondNow() : 0
-}
-
-function pixelsToFrameNow(pixels: number): number {
-  const fps = useTimelineStore.getState().fps
-  const pixelsPerSecond = getPixelsPerSecondNow()
-  return fps > 0 && pixelsPerSecond > 0 ? Math.round((pixels / pixelsPerSecond) * fps) : 0
-}
 
 function getFramePositionStyle(frame: number): string {
   return `calc(${frame} * var(--timeline-px-per-frame, 0px))`

--- a/src/features/timeline/stores/edit-preview-store-factory.ts
+++ b/src/features/timeline/stores/edit-preview-store-factory.ts
@@ -9,17 +9,33 @@ type EditPreviewStore<State, PreviewParams, ExtraActions> = State &
   EditPreviewActions<PreviewParams> &
   ExtraActions
 
-type EditPreviewStoreOptions<State, PreviewParams, ExtraActions> = {
+type NoExtraActions = Record<never, never>
+
+type EditPreviewExtraActionsFactory<State, PreviewParams, ExtraActions> = (
+  set: StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>['setState'],
+) => ExtraActions
+
+type EditPreviewStoreBaseOptions<State, PreviewParams> = {
   initialState: () => State
   normalizePreview?: (params: PreviewParams) => Partial<State>
-  createActions?: (
-    set: StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>['setState'],
-  ) => ExtraActions
 }
 
+type EditPreviewStoreOptions<State, PreviewParams, ExtraActions> = EditPreviewStoreBaseOptions<
+  State,
+  PreviewParams
+> &
+  ([keyof ExtraActions] extends [never]
+    ? { createActions?: never }
+    : { createActions: EditPreviewExtraActionsFactory<State, PreviewParams, ExtraActions> })
+
+type EditPreviewStoreImplementationOptions<State, PreviewParams, ExtraActions> =
+  EditPreviewStoreBaseOptions<State, PreviewParams> & {
+    createActions?: EditPreviewExtraActionsFactory<State, PreviewParams, ExtraActions>
+  }
+
 export function createEditPreviewStore<State extends object, PreviewParams extends object>(
-  options: EditPreviewStoreOptions<State, PreviewParams, Record<string, never>>,
-): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, Record<string, never>>>>
+  options: EditPreviewStoreOptions<State, PreviewParams, NoExtraActions>,
+): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, NoExtraActions>>>
 export function createEditPreviewStore<
   State extends object,
   PreviewParams extends object,
@@ -32,7 +48,7 @@ export function createEditPreviewStore<
   PreviewParams extends object,
   ExtraActions extends object,
 >(
-  options: EditPreviewStoreOptions<State, PreviewParams, ExtraActions>,
+  options: EditPreviewStoreImplementationOptions<State, PreviewParams, ExtraActions>,
 ): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>> {
   return create<EditPreviewStore<State, PreviewParams, ExtraActions>>()((set) => ({
     ...options.initialState(),

--- a/src/features/timeline/stores/edit-preview-store-factory.ts
+++ b/src/features/timeline/stores/edit-preview-store-factory.ts
@@ -1,0 +1,49 @@
+import { create, type StoreApi, type UseBoundStore } from 'zustand'
+
+type EditPreviewActions<PreviewParams> = {
+  setPreview: (params: PreviewParams) => void
+  clearPreview: () => void
+}
+
+type EditPreviewStore<State, PreviewParams, ExtraActions> = State &
+  EditPreviewActions<PreviewParams> &
+  ExtraActions
+
+type EditPreviewStoreOptions<State, PreviewParams, ExtraActions> = {
+  initialState: () => State
+  normalizePreview?: (params: PreviewParams) => Partial<State>
+  createActions?: (
+    set: StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>['setState'],
+  ) => ExtraActions
+}
+
+export function createEditPreviewStore<State extends object, PreviewParams extends object>(
+  options: EditPreviewStoreOptions<State, PreviewParams, Record<string, never>>,
+): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, Record<string, never>>>>
+export function createEditPreviewStore<
+  State extends object,
+  PreviewParams extends object,
+  ExtraActions extends object,
+>(
+  options: EditPreviewStoreOptions<State, PreviewParams, ExtraActions>,
+): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>>
+export function createEditPreviewStore<
+  State extends object,
+  PreviewParams extends object,
+  ExtraActions extends object,
+>(
+  options: EditPreviewStoreOptions<State, PreviewParams, ExtraActions>,
+): UseBoundStore<StoreApi<EditPreviewStore<State, PreviewParams, ExtraActions>>> {
+  return create<EditPreviewStore<State, PreviewParams, ExtraActions>>()((set) => ({
+    ...options.initialState(),
+    setPreview: (params) =>
+      set(
+        (options.normalizePreview?.(params) ?? params) as Partial<
+          EditPreviewStore<State, PreviewParams, ExtraActions>
+        >,
+      ),
+    clearPreview: () =>
+      set(options.initialState() as Partial<EditPreviewStore<State, PreviewParams, ExtraActions>>),
+    ...(options.createActions?.(set) ?? ({} as ExtraActions)),
+  }))
+}

--- a/src/features/timeline/stores/ripple-edit-preview-store.ts
+++ b/src/features/timeline/stores/ripple-edit-preview-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface RippleEditPreviewState {
   /** The item being trimmed */
@@ -28,24 +28,22 @@ interface RippleEditPreviewActions {
   clearPreview: () => void
 }
 
-export const useRippleEditPreviewStore = create<
-  RippleEditPreviewState & RippleEditPreviewActions
->()((set) => ({
+const createInitialState = (): RippleEditPreviewState => ({
   trimmedItemId: null,
   handle: null,
   trackId: null,
   downstreamItemIds: new Set<string>(),
   delta: 0,
   trimDelta: 0,
-  setPreview: (params) => set(params),
-  setDeltas: (delta, trimDelta) => set({ delta, trimDelta }),
-  clearPreview: () =>
-    set({
-      trimmedItemId: null,
-      handle: null,
-      trackId: null,
-      downstreamItemIds: new Set<string>(),
-      delta: 0,
-      trimDelta: 0,
-    }),
-}))
+})
+
+export const useRippleEditPreviewStore = createEditPreviewStore<
+  RippleEditPreviewState,
+  Parameters<RippleEditPreviewActions['setPreview']>[0],
+  Pick<RippleEditPreviewActions, 'setDeltas'>
+>({
+  initialState: createInitialState,
+  createActions: (set) => ({
+    setDeltas: (delta, trimDelta) => set({ delta, trimDelta }),
+  }),
+})

--- a/src/features/timeline/stores/rolling-edit-preview-store.ts
+++ b/src/features/timeline/stores/rolling-edit-preview-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface RollingEditPreviewState {
   /** The item being directly trimmed (the one the user grabbed) */
@@ -25,23 +25,23 @@ interface RollingEditPreviewActions {
   clearPreview: () => void
 }
 
-export const useRollingEditPreviewStore = create<
-  RollingEditPreviewState & RollingEditPreviewActions
->()((set) => ({
+const createInitialState = (): RollingEditPreviewState => ({
   trimmedItemId: null,
   neighborItemId: null,
   handle: null,
   neighborDelta: 0,
   constrained: false,
-  setPreview: (params) => set({ ...params, constrained: params.constrained ?? false }),
-  setNeighborDelta: (neighborDelta, constrained) =>
-    set({ neighborDelta, constrained: constrained ?? false }),
-  clearPreview: () =>
-    set({
-      trimmedItemId: null,
-      neighborItemId: null,
-      handle: null,
-      neighborDelta: 0,
-      constrained: false,
-    }),
-}))
+})
+
+export const useRollingEditPreviewStore = createEditPreviewStore<
+  RollingEditPreviewState,
+  Parameters<RollingEditPreviewActions['setPreview']>[0],
+  Pick<RollingEditPreviewActions, 'setNeighborDelta'>
+>({
+  initialState: createInitialState,
+  normalizePreview: (params) => ({ ...params, constrained: params.constrained ?? false }),
+  createActions: (set) => ({
+    setNeighborDelta: (neighborDelta, constrained) =>
+      set({ neighborDelta, constrained: constrained ?? false }),
+  }),
+})

--- a/src/features/timeline/stores/slide-edit-preview-store.ts
+++ b/src/features/timeline/stores/slide-edit-preview-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface SlideEditPreviewState {
   /** The item being slid */
@@ -32,32 +32,29 @@ interface SlideEditPreviewActions {
   clearPreview: () => void
 }
 
-export const useSlideEditPreviewStore = create<SlideEditPreviewState & SlideEditPreviewActions>()(
-  (set) => ({
-    itemId: null,
-    trackId: null,
-    leftNeighborId: null,
-    rightNeighborId: null,
-    slideDelta: 0,
-    minDelta: 0,
-    maxDelta: 0,
-    setPreview: (params) =>
-      set({
-        ...params,
-        minDelta: params.minDelta ?? 0,
-        maxDelta: params.maxDelta ?? 0,
-      }),
+const createInitialState = (): SlideEditPreviewState => ({
+  itemId: null,
+  trackId: null,
+  leftNeighborId: null,
+  rightNeighborId: null,
+  slideDelta: 0,
+  minDelta: 0,
+  maxDelta: 0,
+})
+
+export const useSlideEditPreviewStore = createEditPreviewStore<
+  SlideEditPreviewState,
+  Parameters<SlideEditPreviewActions['setPreview']>[0],
+  Pick<SlideEditPreviewActions, 'setSlideDelta' | 'setSlideRange'>
+>({
+  initialState: createInitialState,
+  normalizePreview: (params) => ({
+    ...params,
+    minDelta: params.minDelta ?? 0,
+    maxDelta: params.maxDelta ?? 0,
+  }),
+  createActions: (set) => ({
     setSlideDelta: (slideDelta) => set({ slideDelta }),
     setSlideRange: (minDelta, maxDelta) => set({ minDelta, maxDelta }),
-    clearPreview: () =>
-      set({
-        itemId: null,
-        trackId: null,
-        leftNeighborId: null,
-        rightNeighborId: null,
-        slideDelta: 0,
-        minDelta: 0,
-        maxDelta: 0,
-      }),
   }),
-)
+})

--- a/src/features/timeline/stores/slip-edit-preview-store.ts
+++ b/src/features/timeline/stores/slip-edit-preview-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface SlipEditPreviewState {
   /** The item being slipped */
@@ -15,18 +15,19 @@ interface SlipEditPreviewActions {
   clearPreview: () => void
 }
 
-export const useSlipEditPreviewStore = create<SlipEditPreviewState & SlipEditPreviewActions>()(
-  (set) => ({
-    itemId: null,
-    trackId: null,
-    slipDelta: 0,
-    setPreview: (params) => set(params),
+const createInitialState = (): SlipEditPreviewState => ({
+  itemId: null,
+  trackId: null,
+  slipDelta: 0,
+})
+
+export const useSlipEditPreviewStore = createEditPreviewStore<
+  SlipEditPreviewState,
+  Parameters<SlipEditPreviewActions['setPreview']>[0],
+  Pick<SlipEditPreviewActions, 'setSlipDelta'>
+>({
+  initialState: createInitialState,
+  createActions: (set) => ({
     setSlipDelta: (slipDelta) => set({ slipDelta }),
-    clearPreview: () =>
-      set({
-        itemId: null,
-        trackId: null,
-        slipDelta: 0,
-      }),
   }),
-)
+})

--- a/src/features/timeline/stores/track-push-preview-store.ts
+++ b/src/features/timeline/stores/track-push-preview-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface TrackPushPreviewState {
   /** The anchor item being pushed */
@@ -22,20 +22,20 @@ interface TrackPushPreviewActions {
   clearPreview: () => void
 }
 
-export const useTrackPushPreviewStore = create<TrackPushPreviewState & TrackPushPreviewActions>()(
-  (set) => ({
-    anchorItemId: null,
-    trackId: null,
-    shiftedItemIds: new Set<string>(),
-    delta: 0,
-    setPreview: (params) => set(params),
+const createInitialState = (): TrackPushPreviewState => ({
+  anchorItemId: null,
+  trackId: null,
+  shiftedItemIds: new Set<string>(),
+  delta: 0,
+})
+
+export const useTrackPushPreviewStore = createEditPreviewStore<
+  TrackPushPreviewState,
+  Parameters<TrackPushPreviewActions['setPreview']>[0],
+  Pick<TrackPushPreviewActions, 'setDelta'>
+>({
+  initialState: createInitialState,
+  createActions: (set) => ({
     setDelta: (delta) => set({ delta }),
-    clearPreview: () =>
-      set({
-        anchorItemId: null,
-        trackId: null,
-        shiftedItemIds: new Set<string>(),
-        delta: 0,
-      }),
   }),
-)
+})

--- a/src/features/timeline/utils/filler-word-removal-preview.ts
+++ b/src/features/timeline/utils/filler-word-removal-preview.ts
@@ -1,11 +1,12 @@
 import type { MediaTranscript, MediaTranscriptWord } from '@/types/storage'
-import type { TimelineItem } from '@/types/timeline'
 import { mediaTranscriptionService } from '@/features/timeline/deps/media-transcription-service'
 import { useItemsStore } from '@/features/timeline/stores/items-store'
-import { useTimelineItemOverlayStore } from '@/features/timeline/stores/timeline-item-overlay-store'
-import { useTimelineSettingsStore } from '@/features/timeline/stores/timeline-settings-store'
-import { sourceSecondsToTimelineFrame } from '@/features/timeline/utils/media-item-frames'
 import { createLogger } from '@/shared/logging/logger'
+import {
+  applyRemovalPreviewOverlays,
+  clearRemovalPreviewOverlays,
+  isAudioVideoItem,
+} from '@/features/timeline/utils/removal-preview-overlays'
 import type { AudioSilenceRange } from '@/shared/utils/audio-silence'
 
 const logger = createLogger('FillerWordRemovalPreview')
@@ -135,18 +136,6 @@ export interface FillerAudioConfidence {
 export interface FillerPreviewSummary {
   rangeCount: number
   totalSeconds: number
-}
-
-function isAudioVideoItem(item: TimelineItem | undefined): item is TimelineItem & {
-  type: 'video' | 'audio'
-  mediaId: string
-} {
-  return (
-    item !== undefined &&
-    (item.type === 'video' || item.type === 'audio') &&
-    typeof item.mediaId === 'string' &&
-    item.mediaId.length > 0
-  )
 }
 
 function normalizeWord(text: string): string {
@@ -357,70 +346,19 @@ export async function analyzeFillerWordsForItems(
   return rangesByMediaId
 }
 
-function getItemPreviewRanges(
-  item: TimelineItem,
-  ranges: readonly AudioSilenceRange[],
-  timelineFps: number,
-): Array<{ startRatio: number; endRatio: number; seconds: number }> {
-  return ranges.flatMap((range) => {
-    const startFrame = sourceSecondsToTimelineFrame(item, range.start, timelineFps)
-    const endFrame = sourceSecondsToTimelineFrame(item, range.end, timelineFps)
-    const startRatio = Math.max(0, Math.min(1, (startFrame - item.from) / item.durationInFrames))
-    const endRatio = Math.max(0, Math.min(1, (endFrame - item.from) / item.durationInFrames))
-    if (endRatio <= startRatio) return []
-    return [
-      {
-        startRatio,
-        endRatio,
-        seconds: ((endRatio - startRatio) * item.durationInFrames) / timelineFps,
-      },
-    ]
-  })
-}
-
 export function clearFillerPreviewOverlays(itemIds: readonly string[]): void {
-  const overlayStore = useTimelineItemOverlayStore.getState()
-  for (const itemId of itemIds) {
-    overlayStore.removeOverlay(itemId, FILLER_REMOVAL_PREVIEW_OVERLAY_ID)
-  }
+  clearRemovalPreviewOverlays(itemIds, FILLER_REMOVAL_PREVIEW_OVERLAY_ID)
 }
 
 export function applyFillerPreviewOverlays(
   itemIds: readonly string[],
   rangesByMediaId: FillerRangesByMediaId,
 ): FillerPreviewSummary {
-  const timelineFps = useTimelineSettingsStore.getState().fps
-  const itemsById = useItemsStore.getState().itemById
-  const overlayStore = useTimelineItemOverlayStore.getState()
-  let rangeCount = 0
-  let totalSeconds = 0
-
-  for (const itemId of itemIds) {
-    const item = itemsById[itemId]
-    if (!isAudioVideoItem(item)) {
-      overlayStore.removeOverlay(itemId, FILLER_REMOVAL_PREVIEW_OVERLAY_ID)
-      continue
-    }
-
-    const ranges = rangesByMediaId[item.mediaId] ?? []
-    const previewRanges = getItemPreviewRanges(item, ranges, timelineFps)
-    if (previewRanges.length === 0) {
-      overlayStore.removeOverlay(itemId, FILLER_REMOVAL_PREVIEW_OVERLAY_ID)
-      continue
-    }
-
-    rangeCount += previewRanges.length
-    totalSeconds += previewRanges.reduce((sum, range) => sum + range.seconds, 0)
-    overlayStore.upsertOverlay(itemId, {
-      id: FILLER_REMOVAL_PREVIEW_OVERLAY_ID,
-      label: `${previewRanges.length} filler range${previewRanges.length === 1 ? '' : 's'}`,
-      tone: 'warning',
-      ranges: previewRanges.map((range) => ({
-        startRatio: range.startRatio,
-        endRatio: range.endRatio,
-      })),
-    })
-  }
-
-  return { rangeCount, totalSeconds }
+  return applyRemovalPreviewOverlays({
+    itemIds,
+    rangesByMediaId,
+    overlayId: FILLER_REMOVAL_PREVIEW_OVERLAY_ID,
+    labelNoun: 'filler',
+    tone: 'warning',
+  })
 }

--- a/src/features/timeline/utils/removal-preview-overlays.test.ts
+++ b/src/features/timeline/utils/removal-preview-overlays.test.ts
@@ -1,0 +1,68 @@
+import type { TimelineItem } from '@/types/timeline'
+import { useItemsStore } from '@/features/timeline/stores/items-store'
+import { useTimelineSettingsStore } from '@/features/timeline/stores/timeline-settings-store'
+import { useTimelineItemOverlayStore } from '@/features/timeline/stores/timeline-item-overlay-store'
+import { applySilencePreviewOverlays } from './silence-removal-preview'
+import { applyFillerPreviewOverlays } from './filler-word-removal-preview'
+
+function audioItem(id: string, mediaId: string): TimelineItem {
+  return {
+    id,
+    type: 'audio',
+    name: id,
+    trackId: 'track-1',
+    from: 30,
+    durationInFrames: 90,
+    mediaId,
+    sourceStart: 0,
+    sourceDuration: 90,
+    sourceFps: 30,
+  } as unknown as TimelineItem
+}
+
+beforeEach(() => {
+  useTimelineSettingsStore.setState({ fps: 30 })
+  useItemsStore.getState().setItems([audioItem('item-1', 'media-1')])
+  useTimelineItemOverlayStore.setState({ overlaysByItemId: {} })
+})
+
+describe('removal preview overlays', () => {
+  it('preserves silence preview overlay labels, tone, ranges, and summary', () => {
+    const summary = applySilencePreviewOverlays(['item-1'], {
+      'media-1': [{ start: 1.5, end: 2.5 }],
+    })
+
+    expect(summary.rangeCount).toBe(1)
+    expect(summary.totalSeconds).toBeCloseTo(1)
+    expect(useTimelineItemOverlayStore.getState().overlaysByItemId['item-1']).toEqual([
+      {
+        id: 'silence-removal-preview',
+        label: '1 silent range',
+        tone: 'error',
+        ranges: [{ startRatio: 0.5, endRatio: 0.8333333333333334 }],
+      },
+    ])
+  })
+
+  it('preserves filler preview overlay labels, tone, ranges, and summary', () => {
+    const summary = applyFillerPreviewOverlays(['item-1'], {
+      'media-1': [
+        { start: 1.5, end: 2.0, text: 'um' },
+        { start: 2.2, end: 2.5, text: 'like' },
+      ],
+    })
+
+    expect(summary).toEqual({ rangeCount: 2, totalSeconds: 0.8 })
+    expect(useTimelineItemOverlayStore.getState().overlaysByItemId['item-1']).toEqual([
+      {
+        id: 'filler-word-removal-preview',
+        label: '2 filler ranges',
+        tone: 'warning',
+        ranges: [
+          { startRatio: 0.5, endRatio: 0.6666666666666666 },
+          { startRatio: 0.7333333333333333, endRatio: 0.8333333333333334 },
+        ],
+      },
+    ])
+  })
+})

--- a/src/features/timeline/utils/removal-preview-overlays.ts
+++ b/src/features/timeline/utils/removal-preview-overlays.ts
@@ -1,0 +1,99 @@
+import type { TimelineItem } from '@/types/timeline'
+import { useItemsStore } from '@/features/timeline/stores/items-store'
+import { useTimelineItemOverlayStore } from '@/features/timeline/stores/timeline-item-overlay-store'
+import { useTimelineSettingsStore } from '@/features/timeline/stores/timeline-settings-store'
+import { sourceSecondsToTimelineFrame } from '@/features/timeline/utils/media-item-frames'
+import type { AudioSilenceRange } from '@/shared/utils/audio-silence'
+
+export interface RemovalPreviewSummary {
+  rangeCount: number
+  totalSeconds: number
+}
+
+export function isAudioVideoItem(item: TimelineItem | undefined): item is TimelineItem & {
+  type: 'video' | 'audio'
+  mediaId: string
+} {
+  return (
+    item !== undefined &&
+    (item.type === 'video' || item.type === 'audio') &&
+    typeof item.mediaId === 'string' &&
+    item.mediaId.length > 0
+  )
+}
+
+function getItemPreviewRanges(
+  item: TimelineItem,
+  ranges: readonly AudioSilenceRange[],
+  timelineFps: number,
+): Array<{ startRatio: number; endRatio: number; seconds: number }> {
+  return ranges.flatMap((range) => {
+    const startFrame = sourceSecondsToTimelineFrame(item, range.start, timelineFps)
+    const endFrame = sourceSecondsToTimelineFrame(item, range.end, timelineFps)
+    const startRatio = Math.max(0, Math.min(1, (startFrame - item.from) / item.durationInFrames))
+    const endRatio = Math.max(0, Math.min(1, (endFrame - item.from) / item.durationInFrames))
+    if (endRatio <= startRatio) return []
+    return [
+      {
+        startRatio,
+        endRatio,
+        seconds: ((endRatio - startRatio) * item.durationInFrames) / timelineFps,
+      },
+    ]
+  })
+}
+
+export function clearRemovalPreviewOverlays(
+  itemIds: readonly string[],
+  overlayId: string,
+  overlayStore: ReturnType<
+    typeof useTimelineItemOverlayStore.getState
+  > = useTimelineItemOverlayStore.getState(),
+): void {
+  for (const itemId of itemIds) {
+    overlayStore.removeOverlay(itemId, overlayId)
+  }
+}
+
+export function applyRemovalPreviewOverlays(params: {
+  itemIds: readonly string[]
+  rangesByMediaId: Record<string, readonly AudioSilenceRange[]>
+  overlayId: string
+  labelNoun: string
+  tone: 'warning' | 'error'
+}): RemovalPreviewSummary {
+  const timelineFps = useTimelineSettingsStore.getState().fps
+  const itemsById = useItemsStore.getState().itemById
+  const overlayStore = useTimelineItemOverlayStore.getState()
+  let rangeCount = 0
+  let totalSeconds = 0
+
+  for (const itemId of params.itemIds) {
+    const item = itemsById[itemId]
+    if (!isAudioVideoItem(item)) {
+      overlayStore.removeOverlay(itemId, params.overlayId)
+      continue
+    }
+
+    const ranges = params.rangesByMediaId[item.mediaId] ?? []
+    const previewRanges = getItemPreviewRanges(item, ranges, timelineFps)
+    if (previewRanges.length === 0) {
+      overlayStore.removeOverlay(itemId, params.overlayId)
+      continue
+    }
+
+    rangeCount += previewRanges.length
+    totalSeconds += previewRanges.reduce((sum, range) => sum + range.seconds, 0)
+    overlayStore.upsertOverlay(itemId, {
+      id: params.overlayId,
+      label: `${previewRanges.length} ${params.labelNoun} range${previewRanges.length === 1 ? '' : 's'}`,
+      tone: params.tone,
+      ranges: previewRanges.map((range) => ({
+        startRatio: range.startRatio,
+        endRatio: range.endRatio,
+      })),
+    })
+  }
+
+  return { rangeCount, totalSeconds }
+}

--- a/src/features/timeline/utils/silence-removal-preview.ts
+++ b/src/features/timeline/utils/silence-removal-preview.ts
@@ -1,11 +1,12 @@
-import type { TimelineItem } from '@/types/timeline'
 import { getOrDecodeAudio } from '@/features/timeline/deps/composition-runtime'
 import { resolveMediaUrl } from '@/features/timeline/deps/media-library-resolver'
 import { useItemsStore } from '@/features/timeline/stores/items-store'
-import { useTimelineSettingsStore } from '@/features/timeline/stores/timeline-settings-store'
-import { useTimelineItemOverlayStore } from '@/features/timeline/stores/timeline-item-overlay-store'
-import { sourceSecondsToTimelineFrame } from '@/features/timeline/utils/media-item-frames'
 import { createLogger } from '@/shared/logging/logger'
+import {
+  applyRemovalPreviewOverlays,
+  clearRemovalPreviewOverlays,
+  isAudioVideoItem,
+} from '@/features/timeline/utils/removal-preview-overlays'
 import {
   detectSilentRanges,
   type AudioSilenceDetectionOptions,
@@ -35,39 +36,6 @@ export type SilenceRangesByMediaId = Record<string, AudioSilenceRange[]>
 export interface SilencePreviewSummary {
   rangeCount: number
   totalSeconds: number
-}
-
-function isAudioVideoItem(item: TimelineItem | undefined): item is TimelineItem & {
-  type: 'video' | 'audio'
-  mediaId: string
-} {
-  return (
-    item !== undefined &&
-    (item.type === 'video' || item.type === 'audio') &&
-    typeof item.mediaId === 'string' &&
-    item.mediaId.length > 0
-  )
-}
-
-function getItemPreviewRanges(
-  item: TimelineItem,
-  ranges: readonly AudioSilenceRange[],
-  timelineFps: number,
-): Array<{ startRatio: number; endRatio: number; seconds: number }> {
-  return ranges.flatMap((range) => {
-    const startFrame = sourceSecondsToTimelineFrame(item, range.start, timelineFps)
-    const endFrame = sourceSecondsToTimelineFrame(item, range.end, timelineFps)
-    const startRatio = Math.max(0, Math.min(1, (startFrame - item.from) / item.durationInFrames))
-    const endRatio = Math.max(0, Math.min(1, (endFrame - item.from) / item.durationInFrames))
-    if (endRatio <= startRatio) return []
-    return [
-      {
-        startRatio,
-        endRatio,
-        seconds: ((endRatio - startRatio) * item.durationInFrames) / timelineFps,
-      },
-    ]
-  })
 }
 
 export async function analyzeSilenceForItems(
@@ -121,48 +89,18 @@ export async function analyzeSilenceForItems(
 }
 
 export function clearSilencePreviewOverlays(itemIds: readonly string[]): void {
-  const overlayStore = useTimelineItemOverlayStore.getState()
-  for (const itemId of itemIds) {
-    overlayStore.removeOverlay(itemId, SILENCE_REMOVAL_PREVIEW_OVERLAY_ID)
-  }
+  clearRemovalPreviewOverlays(itemIds, SILENCE_REMOVAL_PREVIEW_OVERLAY_ID)
 }
 
 export function applySilencePreviewOverlays(
   itemIds: readonly string[],
   rangesByMediaId: SilenceRangesByMediaId,
 ): SilencePreviewSummary {
-  const timelineFps = useTimelineSettingsStore.getState().fps
-  const itemsById = useItemsStore.getState().itemById
-  const overlayStore = useTimelineItemOverlayStore.getState()
-  let rangeCount = 0
-  let totalSeconds = 0
-
-  for (const itemId of itemIds) {
-    const item = itemsById[itemId]
-    if (!isAudioVideoItem(item)) {
-      overlayStore.removeOverlay(itemId, SILENCE_REMOVAL_PREVIEW_OVERLAY_ID)
-      continue
-    }
-
-    const ranges = rangesByMediaId[item.mediaId] ?? []
-    const previewRanges = getItemPreviewRanges(item, ranges, timelineFps)
-    if (previewRanges.length === 0) {
-      overlayStore.removeOverlay(itemId, SILENCE_REMOVAL_PREVIEW_OVERLAY_ID)
-      continue
-    }
-
-    rangeCount += previewRanges.length
-    totalSeconds += previewRanges.reduce((sum, range) => sum + range.seconds, 0)
-    overlayStore.upsertOverlay(itemId, {
-      id: SILENCE_REMOVAL_PREVIEW_OVERLAY_ID,
-      label: `${previewRanges.length} silent range${previewRanges.length === 1 ? '' : 's'}`,
-      tone: 'error',
-      ranges: previewRanges.map((range) => ({
-        startRatio: range.startRatio,
-        endRatio: range.endRatio,
-      })),
-    })
-  }
-
-  return { rangeCount, totalSeconds }
+  return applyRemovalPreviewOverlays({
+    itemIds,
+    rangesByMediaId,
+    overlayId: SILENCE_REMOVAL_PREVIEW_OVERLAY_ID,
+    labelNoun: 'silent',
+    tone: 'error',
+  })
 }


### PR DESCRIPTION
## Summary
- Consolidates duplicated timeline edit-preview Zustand store boilerplate behind a shared factory while preserving exported store names/actions.
- Extracts shared filler/silence removal preview overlay mapping into a common utility with characterization coverage.
- Reuses existing timeline zoom conversion helpers in `TimelineItem`.
- Replaces export preview fullscreen `console.error` handlers with structured logger warnings.

## Verification
- `npm run lint` — passed; reported 4 pre-existing React hooks warnings in timeline drop components.
- `npm run test:run -- src/features/timeline/utils/removal-preview-overlays.test.ts src/features/timeline/utils/filler-word-removal-preview.test.ts src/features/timeline/stores/actions/item-actions.slip-slide.test.ts src/features/timeline/stores/actions/item-actions.track-push.test.ts src/features/timeline/components/timeline-item/tool-operation-overlay-utils.test.ts` — 31 tests passed.
- `npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports` — passed.
- `git diff --check` — passed.
- Independent staged-diff review passed.

## Notes
- Audio EQ static-config extraction intentionally skipped for a dedicated follow-up because it needs focused UI characterization.
- Proxy path centralization intentionally skipped for a dedicated follow-up because persisted path byte-for-byte compatibility needs focused storage tests.

Kanban: `t_7c2ca9fb`