### PR TITLE
refactor: centralize media proxy path builders

### DIFF
--- a/src/features/media-library/proxy-constants.ts
+++ b/src/features/media-library/proxy-constants.ts
@@ -3,7 +3,7 @@ export const PROXY_FILE_NAME = 'proxy.mp4'
 export const PROXY_META_FILE_NAME = 'meta.json'
 export const PROXY_SCHEMA_VERSION = 4
 
-export function proxyOpfsDir(proxyKey: string): string {
+function proxyOpfsDir(proxyKey: string): string {
   return `${PROXY_DIR}/${proxyKey}`
 }
 

--- a/src/features/media-library/proxy-constants.ts
+++ b/src/features/media-library/proxy-constants.ts
@@ -1,2 +1,16 @@
 export const PROXY_DIR = 'proxies'
+export const PROXY_FILE_NAME = 'proxy.mp4'
+export const PROXY_META_FILE_NAME = 'meta.json'
 export const PROXY_SCHEMA_VERSION = 4
+
+export function proxyOpfsDir(proxyKey: string): string {
+  return `${PROXY_DIR}/${proxyKey}`
+}
+
+export function proxyOpfsFilePath(proxyKey: string): string {
+  return `${proxyOpfsDir(proxyKey)}/${PROXY_FILE_NAME}`
+}
+
+export function proxyOpfsMetaPath(proxyKey: string): string {
+  return `${proxyOpfsDir(proxyKey)}/${PROXY_META_FILE_NAME}`
+}

--- a/src/features/media-library/services/proxy-service.test.ts
+++ b/src/features/media-library/services/proxy-service.test.ts
@@ -335,6 +335,62 @@ describe('proxyService.loadExistingProxies', () => {
     expect(removeEntry).toHaveBeenCalledWith('proxy-video-3', { recursive: true })
   })
 
+  it('registers loaded OPFS proxy object URLs with byte-for-byte persisted metadata paths', async () => {
+    const proxyDirectory = createDirectoryHandle({
+      files: {
+        'meta.json': createJsonFile({
+          version: 4,
+          width: 960,
+          height: 540,
+          sourceWidth: 3840,
+          sourceHeight: 2160,
+          status: 'ready',
+          createdAt: 1,
+        }),
+        'proxy.mp4': createBinaryFile(2048),
+      },
+    })
+    const proxyRoot = createDirectoryHandle({
+      directories: {
+        'f-abc123-10485760-1700000000': proxyDirectory,
+      },
+    })
+    const root = createDirectoryHandle({
+      directories: {
+        proxies: proxyRoot,
+      },
+    })
+
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: {
+        getDirectory: vi.fn().mockResolvedValue(root),
+      },
+    })
+
+    const { proxyService } = await import('./proxy-service')
+    proxyService.setProxyKey('video-golden', 'f-abc123-10485760-1700000000')
+
+    await expect(proxyService.loadExistingProxies(['video-golden'])).resolves.toEqual([])
+
+    expect(objectUrlRegistryMocks.registerObjectUrl).toHaveBeenCalledWith(
+      'blob:proxy',
+      expect.objectContaining({ size: 2048 }),
+      {
+        storageType: 'opfs',
+        opfsPath: 'proxies/f-abc123-10485760-1700000000/proxy.mp4',
+        fileSize: 2048,
+      },
+    )
+  })
+
+  it('exposes centralized OPFS proxy path strings byte-for-byte', async () => {
+    const { proxyOpfsFilePath, proxyOpfsMetaPath } = await import('../proxy-constants')
+
+    expect(proxyOpfsFilePath('h-deadbeef')).toBe('proxies/h-deadbeef/proxy.mp4')
+    expect(proxyOpfsMetaPath('h-deadbeef')).toBe('proxies/h-deadbeef/meta.json')
+  })
+
   it('prewarms the first filmstrip window when a proxy finishes loading', async () => {
     const proxyDirectory = createDirectoryHandle({
       files: {

--- a/src/features/media-library/services/proxy-service.ts
+++ b/src/features/media-library/services/proxy-service.ts
@@ -29,7 +29,13 @@ import {
   removeWorkspaceCacheEntry,
 } from '@/infrastructure/storage/workspace-fs/cache-mirror'
 import { proxyDir, proxyFilePath, proxyMetaPath } from '@/infrastructure/storage/workspace-fs/paths'
-import { PROXY_DIR, PROXY_SCHEMA_VERSION } from '../proxy-constants'
+import {
+  PROXY_DIR,
+  PROXY_FILE_NAME,
+  PROXY_META_FILE_NAME,
+  PROXY_SCHEMA_VERSION,
+  proxyOpfsFilePath,
+} from '../proxy-constants'
 import type { ProxyWorkerRequest, ProxyWorkerResponse } from '../workers/proxy-generation-worker'
 import { useMediaLibraryStore } from '../stores/media-library-store'
 import { enqueueBackgroundMediaWork } from './background-media-work'
@@ -39,10 +45,6 @@ const logger = createLogger('ProxyService')
 function revokeRegisteredObjectUrl(url: string): void {
   unregisterObjectUrl(url)
   URL.revokeObjectURL(url)
-}
-
-function getProxyOpfsPath(proxyKey: string): string {
-  return `${PROXY_DIR}/${proxyKey}/proxy.mp4`
 }
 
 function isBestEffortProxyCleanupError(error: unknown): boolean {
@@ -414,7 +416,7 @@ class ProxyService {
           const mediaDir = await proxyRoot.getDirectoryHandle(proxyKey)
 
           // Check metadata
-          const metaHandle = await mediaDir.getFileHandle('meta.json')
+          const metaHandle = await mediaDir.getFileHandle(PROXY_META_FILE_NAME)
           const metaFile = await metaHandle.getFile()
           const metadata: ProxyMetadata = JSON.parse(await metaFile.text())
 
@@ -455,7 +457,7 @@ class ProxyService {
           }
 
           // Load proxy file and create blob URL
-          const proxyHandle = await mediaDir.getFileHandle('proxy.mp4')
+          const proxyHandle = await mediaDir.getFileHandle(PROXY_FILE_NAME)
           const proxyFile = await proxyHandle.getFile()
 
           if (proxyFile.size === 0) {
@@ -467,7 +469,7 @@ class ProxyService {
           const blobUrl = URL.createObjectURL(proxyFile)
           registerObjectUrl(blobUrl, proxyFile, {
             storageType: 'opfs',
-            opfsPath: getProxyOpfsPath(proxyKey),
+            opfsPath: proxyOpfsFilePath(proxyKey),
             fileSize: proxyFile.size,
           })
           this.proxyBlobUrlByKey.set(proxyKey, blobUrl)
@@ -526,21 +528,21 @@ class ProxyService {
       const mediaDir = await opfsProxyRoot.getDirectoryHandle(proxyKey, {
         create: true,
       })
-      const proxyHandle = await mediaDir.getFileHandle('proxy.mp4', { create: true })
+      const proxyHandle = await mediaDir.getFileHandle(PROXY_FILE_NAME, { create: true })
       const proxyWritable = await proxyHandle.createWritable()
       await proxyWritable.write(proxyBlob)
       await proxyWritable.close()
 
-      const metaHandle = await mediaDir.getFileHandle('meta.json', { create: true })
+      const metaHandle = await mediaDir.getFileHandle(PROXY_META_FILE_NAME, { create: true })
       const metaWritable = await metaHandle.createWritable()
       await metaWritable.write(JSON.stringify(metadata))
       await metaWritable.close()
 
-      const opfsProxyFile = await (await mediaDir.getFileHandle('proxy.mp4')).getFile()
+      const opfsProxyFile = await (await mediaDir.getFileHandle(PROXY_FILE_NAME)).getFile()
       const blobUrl = URL.createObjectURL(opfsProxyFile)
       registerObjectUrl(blobUrl, opfsProxyFile, {
         storageType: 'opfs',
-        opfsPath: getProxyOpfsPath(proxyKey),
+        opfsPath: proxyOpfsFilePath(proxyKey),
         fileSize: opfsProxyFile.size,
       })
       this.proxyBlobUrlByKey.set(proxyKey, blobUrl)
@@ -626,7 +628,7 @@ class ProxyService {
       const root = await navigator.storage.getDirectory()
       const proxyRoot = await root.getDirectoryHandle(PROXY_DIR)
       const mediaDir = await proxyRoot.getDirectoryHandle(proxyKey)
-      const proxyHandle = await mediaDir.getFileHandle('proxy.mp4')
+      const proxyHandle = await mediaDir.getFileHandle(PROXY_FILE_NAME)
       const proxyFile = await proxyHandle.getFile()
 
       if (proxyFile.size === 0) {
@@ -642,7 +644,7 @@ class ProxyService {
       const blobUrl = URL.createObjectURL(proxyFile)
       registerObjectUrl(blobUrl, proxyFile, {
         storageType: 'opfs',
-        opfsPath: getProxyOpfsPath(proxyKey),
+        opfsPath: proxyOpfsFilePath(proxyKey),
         fileSize: proxyFile.size,
       })
       this.proxyBlobUrlByKey.set(proxyKey, blobUrl)
@@ -654,7 +656,7 @@ class ProxyService {
       void mirrorBlobToWorkspace(proxyFilePath(proxyKey), proxyFile)
       void (async () => {
         try {
-          const metaHandle = await mediaDir.getFileHandle('meta.json')
+          const metaHandle = await mediaDir.getFileHandle(PROXY_META_FILE_NAME)
           const metaFile = await metaHandle.getFile()
           const metadata = JSON.parse(await metaFile.text()) as ProxyMetadata
           await mirrorJsonToWorkspace(proxyMetaPath(proxyKey), metadata)
@@ -739,7 +741,7 @@ class ProxyService {
       for (const proxyKey of proxyKeys) {
         try {
           const mediaDir = await proxyRoot.getDirectoryHandle(proxyKey)
-          const proxyHandle = await mediaDir.getFileHandle('proxy.mp4')
+          const proxyHandle = await mediaDir.getFileHandle(PROXY_FILE_NAME)
           const proxyFile = await proxyHandle.getFile()
 
           if (proxyFile.size === 0) {
@@ -762,7 +764,7 @@ class ProxyService {
           const freshUrl = URL.createObjectURL(proxyFile)
           registerObjectUrl(freshUrl, proxyFile, {
             storageType: 'opfs',
-            opfsPath: getProxyOpfsPath(proxyKey),
+            opfsPath: proxyOpfsFilePath(proxyKey),
             fileSize: proxyFile.size,
           })
           this.proxyBlobUrlByKey.set(proxyKey, freshUrl)

--- a/src/infrastructure/storage/workspace-fs/paths.test.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { proxiesRoot, proxyDir, proxyFilePath, proxyMetaPath } from './paths'
+
+describe('workspace proxy path builders', () => {
+  it('preserves content-rooted proxy path segments byte-for-byte', () => {
+    const proxyKey = 'f-abc123-10485760-1700000000'
+
+    expect(proxiesRoot()).toEqual(['content', 'proxies'])
+    expect(proxyDir(proxyKey)).toEqual(['content', 'proxies', proxyKey])
+    expect(proxyFilePath(proxyKey)).toEqual(['content', 'proxies', proxyKey, 'proxy.mp4'])
+    expect(proxyMetaPath(proxyKey)).toEqual(['content', 'proxies', proxyKey, 'meta.json'])
+  })
+
+  it('preserves persisted workspace proxy path strings byte-for-byte', () => {
+    const proxyKey = 'h-deadbeef'
+
+    expect(proxyFilePath(proxyKey).join('/')).toBe('content/proxies/h-deadbeef/proxy.mp4')
+    expect(proxyMetaPath(proxyKey).join('/')).toBe('content/proxies/h-deadbeef/meta.json')
+  })
+})


### PR DESCRIPTION
## Summary
- Centralizes media proxy path construction behind shared proxy path helpers/constants.
- Preserves persisted proxy path strings byte-for-byte for workspace/object URL metadata compatibility.
- Adds golden tests for proxy path outputs and proxy-service persisted metadata path usage.

## Verification
- Worker committed and pushed branch `refactor/centralize-media-proxy-paths`.
- Commit: `4a03050d refactor(media): centralize proxy path builders`.
- Changed files:
  - `src/features/media-library/proxy-constants.ts`
  - `src/features/media-library/services/proxy-service.ts`
  - `src/features/media-library/services/proxy-service.test.ts`
  - `src/infrastructure/storage/workspace-fs/paths.test.ts`

## Notes
This PR was opened from the main Hermes profile because the Kanban worker profile lacked `gh` authentication/token despite successfully pushing the branch.

Kanban: `t_e9a0b751`
