### PR TITLE
test: characterize StableVideoSequence comparator

### DIFF
--- a/src/features/composition-runtime/components/stable-video-sequence-comparator.ts
+++ b/src/features/composition-runtime/components/stable-video-sequence-comparator.ts
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react'
+import type { TimelineItem, VideoItem } from '@/types/timeline'
+import type { AudioEqSettings } from '@/types/audio'
+import type { ResolvedTransitionWindow } from '@/core/timeline/transitions/transition-planner'
+import {
+  appendResolvedAudioEqSources,
+  areAudioEqStagesEqual,
+  getAudioEqSettings,
+} from '@/shared/utils/audio-eq'
+import type { StableVideoGroup } from '../utils/video-scene'
+export type StableVideoSequenceComparatorItem = VideoItem & {
+  zIndex: number
+  muted: boolean
+  trackAudioEq?: AudioEqSettings
+  trackOrder: number
+  trackVisible: boolean
+  _sequenceFrameOffset?: number
+  _poolClipId?: string
+  _sharedTransitionSync?: boolean
+}
+
+/**
+ * Custom comparison for GroupRenderer to ensure re-render when item properties change.
+ * Default React.memo shallow comparison only checks reference equality, which may miss
+ * cases where group.items contains items with changed properties (like speed after rate stretch).
+ */
+export function areGroupPropsEqual(
+  prevProps: {
+    group: StableVideoGroup<StableVideoSequenceComparatorItem>
+    renderItem: (item: StableVideoSequenceComparatorItem) => ReactNode
+    transitionWindows?: ResolvedTransitionWindow<TimelineItem>[]
+  },
+  nextProps: {
+    group: StableVideoGroup<StableVideoSequenceComparatorItem>
+    renderItem: (item: StableVideoSequenceComparatorItem) => ReactNode
+    transitionWindows?: ResolvedTransitionWindow<TimelineItem>[]
+  },
+): boolean {
+  // Quick reference check first
+  if (
+    prevProps.group === nextProps.group &&
+    prevProps.renderItem === nextProps.renderItem &&
+    prevProps.transitionWindows === nextProps.transitionWindows
+  ) {
+    return true
+  }
+
+  // If renderItem changed, need to re-render
+  if (prevProps.renderItem !== nextProps.renderItem) {
+    return false
+  }
+
+  if (prevProps.transitionWindows !== nextProps.transitionWindows) {
+    return false
+  }
+
+  // Check if group structure changed
+  if (
+    prevProps.group.originKey !== nextProps.group.originKey ||
+    prevProps.group.minFrom !== nextProps.group.minFrom ||
+    prevProps.group.maxEnd !== nextProps.group.maxEnd ||
+    prevProps.group.items.length !== nextProps.group.items.length
+  ) {
+    return false
+  }
+
+  // Deep check: compare item properties that affect rendering
+  for (let i = 0; i < prevProps.group.items.length; i++) {
+    const prevItem = prevProps.group.items[i]!
+    const nextItem = nextProps.group.items[i]!
+    if (
+      prevItem.id !== nextItem.id ||
+      prevItem.speed !== nextItem.speed ||
+      prevItem.sourceStart !== nextItem.sourceStart ||
+      prevItem.sourceEnd !== nextItem.sourceEnd ||
+      prevItem.from !== nextItem.from ||
+      prevItem.durationInFrames !== nextItem.durationInFrames ||
+      prevItem.trackVisible !== nextItem.trackVisible ||
+      prevItem.muted !== nextItem.muted ||
+      (prevItem.crop?.left ?? 0) !== (nextItem.crop?.left ?? 0) ||
+      (prevItem.crop?.right ?? 0) !== (nextItem.crop?.right ?? 0) ||
+      (prevItem.crop?.top ?? 0) !== (nextItem.crop?.top ?? 0) ||
+      (prevItem.crop?.bottom ?? 0) !== (nextItem.crop?.bottom ?? 0) ||
+      (prevItem.crop?.softness ?? 0) !== (nextItem.crop?.softness ?? 0) ||
+      prevItem.cornerPin !== nextItem.cornerPin ||
+      prevItem.blendMode !== nextItem.blendMode ||
+      prevItem.src !== nextItem.src ||
+      prevItem.audioSrc !== nextItem.audioSrc ||
+      prevItem.reverseConformSrc !== nextItem.reverseConformSrc ||
+      prevItem.reverseConformPreviewSrc !== nextItem.reverseConformPreviewSrc ||
+      prevItem.reverseConformStatus !== nextItem.reverseConformStatus ||
+      (prevItem.audioPitchSemitones ?? 0) !== (nextItem.audioPitchSemitones ?? 0) ||
+      (prevItem.audioPitchCents ?? 0) !== (nextItem.audioPitchCents ?? 0) ||
+      !areAudioEqStagesEqual(
+        appendResolvedAudioEqSources(
+          undefined,
+          prevItem.trackAudioEq,
+          getAudioEqSettings(prevItem),
+        ),
+        appendResolvedAudioEqSources(
+          undefined,
+          nextItem.trackAudioEq,
+          getAudioEqSettings(nextItem),
+        ),
+      )
+    ) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/features/composition-runtime/components/stable-video-sequence.test.tsx
+++ b/src/features/composition-runtime/components/stable-video-sequence.test.tsx
@@ -32,6 +32,183 @@ vi.mock('./video-content', () => ({
 }))
 
 import { StableVideoSequence } from './stable-video-sequence'
+import type { StableVideoSequenceItem } from './stable-video-sequence'
+import { areGroupPropsEqual } from './stable-video-sequence-comparator'
+import type { StableVideoGroup } from '../utils/video-scene'
+
+const renderComparatorItem = (
+  overrides: Partial<StableVideoSequenceItem> = {},
+): StableVideoSequenceItem => ({
+  id: 'clip-1',
+  label: 'Clip 1',
+  mediaId: 'media-1',
+  originId: 'origin-1',
+  type: 'video',
+  trackId: 'track-1',
+  from: 10,
+  durationInFrames: 60,
+  sourceStart: 5,
+  sourceEnd: 65,
+  sourceDuration: 120,
+  sourceFps: 30,
+  src: 'blob:video',
+  audioSrc: 'blob:audio',
+  speed: 1,
+  zIndex: 1,
+  muted: false,
+  trackOrder: 0,
+  trackVisible: true,
+  ...overrides,
+})
+
+const renderComparatorGroup = (
+  item: StableVideoSequenceItem = renderComparatorItem(),
+  overrides: Partial<StableVideoGroup<StableVideoSequenceItem>> = {},
+): StableVideoGroup<StableVideoSequenceItem> => ({
+  originKey: 'media-1-origin-1-clip-1',
+  minFrom: 10,
+  maxEnd: 70,
+  items: [item],
+  ...overrides,
+})
+
+const comparatorProps = (
+  group: StableVideoGroup<StableVideoSequenceItem>,
+  renderItem = vi.fn(),
+) => ({
+  group,
+  renderItem,
+  transitionWindows: undefined,
+})
+
+describe('areGroupPropsEqual', () => {
+  it.each([
+    ['id', { id: 'clip-2' }],
+    ['speed', { speed: 1.25 }],
+    ['sourceStart', { sourceStart: 12 }],
+    ['sourceEnd', { sourceEnd: 72 }],
+    ['from', { from: 12 }],
+    ['durationInFrames', { durationInFrames: 72 }],
+    ['trackVisible', { trackVisible: false }],
+    ['muted', { muted: true }],
+    ['crop left', { crop: { left: 0.1 } }],
+    ['crop right', { crop: { right: 0.1 } }],
+    ['crop top', { crop: { top: 0.1 } }],
+    ['crop bottom', { crop: { bottom: 0.1 } }],
+    ['crop softness', { crop: { softness: 0.25 } }],
+    [
+      'cornerPin reference',
+      {
+        cornerPin: {
+          topLeft: [0, 0] as [number, number],
+          topRight: [1, 0] as [number, number],
+          bottomRight: [1, 1] as [number, number],
+          bottomLeft: [0, 1] as [number, number],
+        },
+      },
+    ],
+    ['blendMode', { blendMode: 'multiply' }],
+    ['src', { src: 'blob:video-2' }],
+    ['audioSrc', { audioSrc: 'blob:audio-2' }],
+    ['reverseConformSrc', { reverseConformSrc: 'blob:reverse' }],
+    ['reverseConformPreviewSrc', { reverseConformPreviewSrc: 'blob:reverse-preview' }],
+    ['reverseConformStatus', { reverseConformStatus: 'ready' as const }],
+    ['audioPitchSemitones', { audioPitchSemitones: 2 }],
+    ['audioPitchCents', { audioPitchCents: 25 }],
+    ['clip audio EQ', { audioEqEnabled: true, audioEqMidGainDb: 3 }],
+    ['track audio EQ', { trackAudioEq: { enabled: true, midGainDb: 4 } }],
+  ])('invalidates when the compared %s field changes', (_name, overrides) => {
+    const renderItem = vi.fn()
+    const prevProps = comparatorProps(renderComparatorGroup(), renderItem)
+    const nextProps = comparatorProps(
+      renderComparatorGroup(renderComparatorItem(overrides as Partial<StableVideoSequenceItem>)),
+      renderItem,
+    )
+
+    expect(areGroupPropsEqual(prevProps, nextProps)).toBe(false)
+  })
+
+  it.each([
+    ['same props references', comparatorProps(renderComparatorGroup())],
+    ['same render-signature values in new references', comparatorProps(renderComparatorGroup())],
+  ])('does not invalidate for %s', (_name, nextProps) => {
+    const renderItem = vi.fn()
+    const prevProps = comparatorProps(renderComparatorGroup(), renderItem)
+    const stableNextProps =
+      _name === 'same props references' ? prevProps : comparatorProps(nextProps.group, renderItem)
+
+    expect(areGroupPropsEqual(prevProps, stableNextProps)).toBe(true)
+  })
+
+  it.each([
+    ['renderItem callback', { renderItem: vi.fn() }],
+    ['transition windows reference', { transitionWindows: [] }],
+    ['originKey', { group: renderComparatorGroup(undefined, { originKey: 'other-origin' }) }],
+    ['minFrom', { group: renderComparatorGroup(undefined, { minFrom: 9 }) }],
+    ['maxEnd', { group: renderComparatorGroup(undefined, { maxEnd: 80 }) }],
+    [
+      'item count',
+      {
+        group: renderComparatorGroup(undefined, {
+          items: [renderComparatorItem(), renderComparatorItem({ id: 'clip-2', from: 70 })],
+        }),
+      },
+    ],
+  ])('invalidates when %s changes', (_name, override) => {
+    const renderItem = vi.fn()
+    const prevProps = comparatorProps(renderComparatorGroup(), renderItem)
+    const nextProps = {
+      ...prevProps,
+      ...override,
+    }
+
+    expect(areGroupPropsEqual(prevProps, nextProps)).toBe(false)
+  })
+
+  it.each([
+    ['currentFrame', { currentFrame: 24 }],
+    ['sequence frame offset', { _sequenceFrameOffset: 12 }],
+    ['pool clip id', { _poolClipId: 'pool-2' }],
+    ['transition sync marker', { _sharedTransitionSync: true }],
+  ])(
+    'characterizes %s as a frame-only/runtime-only field that does not invalidate',
+    (_name, overrides) => {
+      const renderItem = vi.fn()
+      const prevProps = comparatorProps(renderComparatorGroup(), renderItem)
+      const nextProps = comparatorProps(
+        renderComparatorGroup(renderComparatorItem(overrides as Partial<StableVideoSequenceItem>)),
+        renderItem,
+      )
+
+      expect(areGroupPropsEqual(prevProps, nextProps)).toBe(true)
+    },
+  )
+
+  it.each([
+    ['transform', { transform: { x: 10 } }],
+    ['opacity', { opacity: 0.5 }],
+    ['fit', { fit: 'cover' }],
+    ['volume', { volume: -6 }],
+    ['fadeIn', { fadeIn: 0.5 }],
+    [
+      'effects',
+      { effects: [{ id: 'effect-1', type: 'gpu-effect', effectId: 'gpu-blur', params: {} }] },
+    ],
+    ['sourceFps', { sourceFps: 24 }],
+    ['sourceDuration', { sourceDuration: 240 }],
+    ['isReversed', { isReversed: true }],
+    ['reverseConformPath', { reverseConformPath: '/cache/reverse.mp4' }],
+  ])('documents current comparator gap: %s does not invalidate yet', (_name, overrides) => {
+    const renderItem = vi.fn()
+    const prevProps = comparatorProps(renderComparatorGroup(), renderItem)
+    const nextProps = comparatorProps(
+      renderComparatorGroup(renderComparatorItem(overrides as Partial<StableVideoSequenceItem>)),
+      renderItem,
+    )
+
+    expect(areGroupPropsEqual(prevProps, nextProps)).toBe(true)
+  })
+})
 
 describe('StableVideoSequence', () => {
   beforeEach(() => {

--- a/src/features/composition-runtime/components/stable-video-sequence.tsx
+++ b/src/features/composition-runtime/components/stable-video-sequence.tsx
@@ -33,13 +33,10 @@ import { collectTransitionParticipantClipIds } from '../utils/transition-scene'
 import { buildTransitionShadowWarmupRequests } from '../utils/transition-shadow-warmup'
 import { createLogger } from '@/shared/logging/logger'
 import { useMediaLibraryStore } from '@/features/composition-runtime/deps/stores'
-import {
-  appendResolvedAudioEqSources,
-  areAudioEqStagesEqual,
-  getAudioEqSettings,
-} from '@/shared/utils/audio-eq'
+import { appendResolvedAudioEqSources, getAudioEqSettings } from '@/shared/utils/audio-eq'
 import { resolveReverseConformedVideoItem } from '@/shared/utils/reverse-conform-item'
 import { useNestedMediaResolutionMode } from '../contexts/nested-media-resolution-context'
+import { areGroupPropsEqual } from './stable-video-sequence-comparator'
 
 const warmupLog = createLogger('StableVideoWarmup')
 const SAME_ORIGIN_SHADOW_MOUNT_LOOKAHEAD_FRAMES = 8
@@ -78,98 +75,6 @@ interface StableVideoSequenceProps {
  * 2. Memoizes the RENDERED OUTPUT so renderItem isn't called every frame
  * This prevents re-renders of canvas-based effects like halftone on every frame.
  */
-/**
- * Custom comparison for GroupRenderer to ensure re-render when item properties change.
- * Default React.memo shallow comparison only checks reference equality, which may miss
- * cases where group.items contains items with changed properties (like speed after rate stretch).
- */
-function areGroupPropsEqual(
-  prevProps: {
-    group: StableVideoGroup<StableVideoSequenceItem>
-    renderItem: (item: StableVideoSequenceItem) => React.ReactNode
-    transitionWindows?: ResolvedTransitionWindow<TimelineItem>[]
-  },
-  nextProps: {
-    group: StableVideoGroup<StableVideoSequenceItem>
-    renderItem: (item: StableVideoSequenceItem) => React.ReactNode
-    transitionWindows?: ResolvedTransitionWindow<TimelineItem>[]
-  },
-): boolean {
-  // Quick reference check first
-  if (
-    prevProps.group === nextProps.group &&
-    prevProps.renderItem === nextProps.renderItem &&
-    prevProps.transitionWindows === nextProps.transitionWindows
-  ) {
-    return true
-  }
-
-  // If renderItem changed, need to re-render
-  if (prevProps.renderItem !== nextProps.renderItem) {
-    return false
-  }
-
-  if (prevProps.transitionWindows !== nextProps.transitionWindows) {
-    return false
-  }
-
-  // Check if group structure changed
-  if (
-    prevProps.group.originKey !== nextProps.group.originKey ||
-    prevProps.group.minFrom !== nextProps.group.minFrom ||
-    prevProps.group.maxEnd !== nextProps.group.maxEnd ||
-    prevProps.group.items.length !== nextProps.group.items.length
-  ) {
-    return false
-  }
-
-  // Deep check: compare item properties that affect rendering
-  for (let i = 0; i < prevProps.group.items.length; i++) {
-    const prevItem = prevProps.group.items[i]!
-    const nextItem = nextProps.group.items[i]!
-    if (
-      prevItem.id !== nextItem.id ||
-      prevItem.speed !== nextItem.speed ||
-      prevItem.sourceStart !== nextItem.sourceStart ||
-      prevItem.sourceEnd !== nextItem.sourceEnd ||
-      prevItem.from !== nextItem.from ||
-      prevItem.durationInFrames !== nextItem.durationInFrames ||
-      prevItem.trackVisible !== nextItem.trackVisible ||
-      prevItem.muted !== nextItem.muted ||
-      (prevItem.crop?.left ?? 0) !== (nextItem.crop?.left ?? 0) ||
-      (prevItem.crop?.right ?? 0) !== (nextItem.crop?.right ?? 0) ||
-      (prevItem.crop?.top ?? 0) !== (nextItem.crop?.top ?? 0) ||
-      (prevItem.crop?.bottom ?? 0) !== (nextItem.crop?.bottom ?? 0) ||
-      (prevItem.crop?.softness ?? 0) !== (nextItem.crop?.softness ?? 0) ||
-      prevItem.cornerPin !== nextItem.cornerPin ||
-      prevItem.blendMode !== nextItem.blendMode ||
-      prevItem.src !== nextItem.src ||
-      prevItem.audioSrc !== nextItem.audioSrc ||
-      prevItem.reverseConformSrc !== nextItem.reverseConformSrc ||
-      prevItem.reverseConformPreviewSrc !== nextItem.reverseConformPreviewSrc ||
-      prevItem.reverseConformStatus !== nextItem.reverseConformStatus ||
-      (prevItem.audioPitchSemitones ?? 0) !== (nextItem.audioPitchSemitones ?? 0) ||
-      (prevItem.audioPitchCents ?? 0) !== (nextItem.audioPitchCents ?? 0) ||
-      !areAudioEqStagesEqual(
-        appendResolvedAudioEqSources(
-          undefined,
-          prevItem.trackAudioEq,
-          getAudioEqSettings(prevItem),
-        ),
-        appendResolvedAudioEqSources(
-          undefined,
-          nextItem.trackAudioEq,
-          getAudioEqSettings(nextItem),
-        ),
-      )
-    ) {
-      return false
-    }
-  }
-
-  return true
-}
-
 const SHADOW_STYLE: React.CSSProperties = {
   position: 'absolute',
   top: 0,


### PR DESCRIPTION
## Summary
- Extracts the existing `StableVideoSequence` memo comparator into a testable helper without changing comparison logic.
- Adds characterization coverage for currently invalidating fields such as crop, cornerPin, blendMode, source paths, reverse conform state, timing/source trim fields, pitch, clip EQ, and track EQ.
- Pins current non-invalidating behavior for frame/runtime-only props and documents comparator gaps for later refactor work.

## Verification
- `npm run lint` — passed with 4 pre-existing warnings.
- `env -u NODE_ENV npm run test:run -- src/features/composition-runtime/components/stable-video-sequence.test.tsx` — passed, 49 tests.
- `npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports` — passed.
- `git diff --check` — passed.
- Push hook quality checks passed.

## Notes
Opened from the main/default Hermes profile because the Kanban worker profile lacked `gh` auth/token.

Kanban: `t_eb0f8584`
