### PR TITLE
refactor: extract media timeline item builder

### DIFF
--- a/src/features/timeline/stores/actions/source-edit-actions.ts
+++ b/src/features/timeline/stores/actions/source-edit-actions.ts
@@ -2,7 +2,7 @@
  * Source Edit Actions - Insert and Overwrite editing from the source monitor.
  */
 
-import type { TimelineItem, TimelineTrack, VideoItem, AudioItem, ImageItem } from '@/types/timeline'
+import type { TimelineTrack } from '@/types/timeline'
 import { useItemsStore } from '../items-store'
 import { useTimelineSettingsStore } from '../timeline-settings-store'
 import { useSelectionStore } from '@/shared/state/selection'
@@ -14,9 +14,9 @@ import { useProjectStore } from '@/features/timeline/deps/projects'
 import { mediaLibraryService } from '@/features/timeline/deps/media-library-service'
 import { getMediaType } from '@/features/timeline/deps/media-library-resolver'
 import { toast } from 'sonner'
-import { computeInitialTransform } from '../../utils/transform-init'
 import { execute, applyTransitionRepairs, getLogger } from './shared'
 import { resolveSourceEditTrackTargets } from '../../utils/source-edit-targeting'
+import { buildMediaTimelineItems } from '../../utils/media-timeline-item-builder'
 import { DEFAULT_TRACK_HEIGHT } from '../../constants'
 
 interface SourceEditContext {
@@ -180,91 +180,50 @@ async function resolveSourceEditContext(): Promise<SourceEditContext | null> {
   }
 }
 
-function createTimelineItems(ctx: SourceEditContext): TimelineItem[] {
-  const sourceFps = ctx.media.fps || 30
-  const actualSourceDurationFrames =
-    ctx.mediaType === 'image' ? ctx.projectFps * 3 : Math.round(ctx.media.duration * sourceFps)
-  const originId = crypto.randomUUID()
-  const linkedGroupId = ctx.mediaType === 'video' && ctx.hasAudio ? crypto.randomUUID() : undefined
+function createTimelineItems(ctx: SourceEditContext) {
+  if (ctx.mediaType === 'audio' && !ctx.audioTrackId) {
+    return []
+  }
+  if ((ctx.mediaType === 'video' || ctx.mediaType === 'image') && !ctx.videoTrackId) {
+    return []
+  }
 
-  const baseItem = {
-    from: ctx.insertFrame,
-    durationInFrames: ctx.clipDurationFrames,
-    label: ctx.media.fileName,
+  return buildMediaTimelineItems({
+    media: {
+      duration: ctx.media.duration,
+      width: ctx.media.width,
+      height: ctx.media.height,
+      fps: ctx.media.fps,
+    },
     mediaId: ctx.sourceMediaId,
-    originId,
-    linkedGroupId,
+    mediaType: ctx.mediaType,
+    label: ctx.media.fileName,
+    projectFps: ctx.projectFps,
+    blobUrl: ctx.blobUrl,
+    thumbnailUrl: ctx.thumbnailUrl,
+    canvasWidth: ctx.canvasWidth,
+    canvasHeight: ctx.canvasHeight,
     sourceStart: ctx.effectiveIn,
     sourceEnd: ctx.effectiveOut,
-    sourceDuration: actualSourceDurationFrames,
-    sourceFps,
-    trimStart: 0,
-    trimEnd: 0,
-  }
-
-  if (ctx.mediaType === 'video' && ctx.videoTrackId) {
-    const sourceW = ctx.media.width || ctx.canvasWidth
-    const sourceH = ctx.media.height || ctx.canvasHeight
-    const videoItem: VideoItem = {
-      ...baseItem,
-      id: crypto.randomUUID(),
-      trackId: ctx.videoTrackId,
-      type: 'video',
-      src: ctx.blobUrl,
-      thumbnailUrl: ctx.thumbnailUrl,
-      sourceWidth: ctx.media.width || undefined,
-      sourceHeight: ctx.media.height || undefined,
-      transform: computeInitialTransform(sourceW, sourceH, ctx.canvasWidth, ctx.canvasHeight),
-    }
-
-    if (!ctx.audioTrackId) {
-      return [videoItem]
-    }
-
-    const audioItem: AudioItem = {
-      ...baseItem,
-      id: crypto.randomUUID(),
-      trackId: ctx.audioTrackId,
-      type: 'audio',
-      src: ctx.blobUrl,
-    }
-
-    return [videoItem, audioItem]
-  }
-
-  if (ctx.mediaType === 'audio' && ctx.audioTrackId) {
-    return [
-      {
-        ...baseItem,
-        id: crypto.randomUUID(),
-        trackId: ctx.audioTrackId,
-        type: 'audio',
-        src: ctx.blobUrl,
-        linkedGroupId: undefined,
-      } as AudioItem,
-    ]
-  }
-
-  if (ctx.videoTrackId) {
-    const sourceW = ctx.media.width || ctx.canvasWidth
-    const sourceH = ctx.media.height || ctx.canvasHeight
-    return [
-      {
-        ...baseItem,
-        id: crypto.randomUUID(),
-        trackId: ctx.videoTrackId,
-        type: 'image',
-        src: ctx.blobUrl,
-        thumbnailUrl: ctx.thumbnailUrl,
-        sourceWidth: ctx.media.width || undefined,
-        sourceHeight: ctx.media.height || undefined,
-        transform: computeInitialTransform(sourceW, sourceH, ctx.canvasWidth, ctx.canvasHeight),
-        linkedGroupId: undefined,
-      } as ImageItem,
-    ]
-  }
-
-  return []
+    fallbackSourceFps: 30,
+    placements: {
+      primary: {
+        trackId: ctx.mediaType === 'audio' ? ctx.audioTrackId! : ctx.videoTrackId!,
+        from: ctx.insertFrame,
+        durationInFrames: ctx.clipDurationFrames,
+      },
+      linkedAudio:
+        ctx.mediaType === 'video' && ctx.audioTrackId
+          ? {
+              trackId: ctx.audioTrackId,
+              from: ctx.insertFrame,
+              durationInFrames: ctx.clipDurationFrames,
+            }
+          : undefined,
+    },
+    linkVideoAudio: ctx.mediaType === 'video' && !!ctx.audioTrackId,
+    createLinkedGroupId: ctx.mediaType === 'video' && ctx.hasAudio,
+  })
 }
 
 export async function performInsertEdit(): Promise<void> {

--- a/src/features/timeline/utils/dropped-media.ts
+++ b/src/features/timeline/utils/dropped-media.ts
@@ -1,35 +1,20 @@
-import type { AudioItem, ImageItem, TimelineItem, VideoItem } from '@/types/timeline'
+import type { TimelineItem } from '@/types/timeline'
 import type { MediaMetadata } from '@/types/storage'
-import { computeInitialTransform } from './transform-init'
+import {
+  buildMediaTimelineItem,
+  buildMediaTimelineItems,
+  type LinkedMediaTimelinePlacement,
+  type MediaTimelineItemType,
+  type MediaTimelinePlacement,
+} from './media-timeline-item-builder'
 
-export type DroppableMediaType = 'video' | 'audio' | 'image'
+export type DroppableMediaType = MediaTimelineItemType
 
-export interface TimelineMediaPlacement {
-  trackId: string
-  from: number
-  durationInFrames: number
-}
+export interface TimelineMediaPlacement extends Required<MediaTimelinePlacement> {}
 
 export interface TimelineLinkedMediaPlacement {
   primary: TimelineMediaPlacement
   linkedAudio?: TimelineMediaPlacement
-}
-
-interface TimelineBaseItem {
-  id: string
-  trackId: string
-  from: number
-  durationInFrames: number
-  label: string
-  mediaId: string
-  originId: string
-  linkedGroupId?: string
-  sourceStart: number
-  sourceEnd: number
-  sourceDuration: number
-  sourceFps: number
-  trimStart: number
-  trimEnd: number
 }
 
 export function getDroppedMediaDurationInFrames(
@@ -43,41 +28,6 @@ export function getDroppedMediaDurationInFrames(
   }
 
   return mediaType === 'image' ? timelineFps * 3 : timelineFps
-}
-
-function buildTimelineBaseItem(params: {
-  media: MediaMetadata
-  mediaId: string
-  label: string
-  timelineFps: number
-  placement: TimelineMediaPlacement
-  originId?: string
-  linkedGroupId?: string
-}): TimelineBaseItem {
-  const { media, mediaId, label, timelineFps, placement, originId, linkedGroupId } = params
-  const sourceFps = media.fps || timelineFps
-  const actualSourceDurationFrames = Math.round(media.duration * sourceFps)
-  const sourceFramesForItemDuration = Math.min(
-    actualSourceDurationFrames,
-    Math.round((placement.durationInFrames * sourceFps) / timelineFps),
-  )
-
-  return {
-    id: crypto.randomUUID(),
-    trackId: placement.trackId,
-    from: placement.from,
-    durationInFrames: placement.durationInFrames,
-    label,
-    mediaId,
-    originId: originId ?? crypto.randomUUID(),
-    linkedGroupId,
-    sourceStart: 0,
-    sourceEnd: sourceFramesForItemDuration,
-    sourceDuration: actualSourceDurationFrames,
-    sourceFps,
-    trimStart: 0,
-    trimEnd: 0,
-  }
 }
 
 export function buildDroppedMediaTimelineItem(params: {
@@ -94,63 +44,20 @@ export function buildDroppedMediaTimelineItem(params: {
   originId?: string
   linkedGroupId?: string
 }): TimelineItem {
-  const {
-    media,
-    mediaId,
-    mediaType,
-    label,
-    timelineFps,
-    blobUrl,
-    thumbnailUrl,
-    canvasWidth,
-    canvasHeight,
-    placement,
-    originId,
-    linkedGroupId,
-  } = params
-  const baseItem = buildTimelineBaseItem({
-    media,
-    mediaId,
-    label,
-    timelineFps,
-    placement,
-    originId,
-    linkedGroupId,
+  return buildMediaTimelineItem({
+    media: params.media,
+    mediaId: params.mediaId,
+    mediaType: params.mediaType,
+    label: params.label,
+    projectFps: params.timelineFps,
+    blobUrl: params.blobUrl,
+    thumbnailUrl: params.thumbnailUrl,
+    canvasWidth: params.canvasWidth,
+    canvasHeight: params.canvasHeight,
+    placement: params.placement,
+    originId: params.originId ?? crypto.randomUUID(),
+    linkedGroupId: params.linkedGroupId,
   })
-
-  if (mediaType === 'audio') {
-    return {
-      ...baseItem,
-      type: 'audio',
-      src: blobUrl,
-    } as AudioItem
-  }
-
-  const sourceWidth = media.width || canvasWidth
-  const sourceHeight = media.height || canvasHeight
-  const transform = computeInitialTransform(sourceWidth, sourceHeight, canvasWidth, canvasHeight)
-
-  if (mediaType === 'video') {
-    return {
-      ...baseItem,
-      type: 'video',
-      src: blobUrl,
-      thumbnailUrl: thumbnailUrl || undefined,
-      sourceWidth: media.width || undefined,
-      sourceHeight: media.height || undefined,
-      transform,
-    } as VideoItem
-  }
-
-  return {
-    ...baseItem,
-    type: 'image',
-    src: blobUrl,
-    thumbnailUrl: thumbnailUrl || undefined,
-    sourceWidth: media.width || undefined,
-    sourceHeight: media.height || undefined,
-    transform,
-  } as ImageItem
 }
 
 export function buildDroppedMediaTimelineItems(params: {
@@ -166,55 +73,17 @@ export function buildDroppedMediaTimelineItems(params: {
   placement: TimelineLinkedMediaPlacement
   linkVideoAudio?: boolean
 }): TimelineItem[] {
-  const {
-    media,
-    mediaId,
-    mediaType,
-    label,
-    timelineFps,
-    blobUrl,
-    thumbnailUrl,
-    canvasWidth,
-    canvasHeight,
-    placement,
-    linkVideoAudio = false,
-  } = params
-
-  const originId = crypto.randomUUID()
-  const linkedGroupId = mediaType === 'video' && linkVideoAudio ? crypto.randomUUID() : undefined
-  const primaryItem = buildDroppedMediaTimelineItem({
-    media,
-    mediaId,
-    mediaType,
-    label,
-    timelineFps,
-    blobUrl,
-    thumbnailUrl,
-    canvasWidth,
-    canvasHeight,
-    placement: placement.primary,
-    originId,
-    linkedGroupId,
+  return buildMediaTimelineItems({
+    media: params.media,
+    mediaId: params.mediaId,
+    mediaType: params.mediaType,
+    label: params.label,
+    projectFps: params.timelineFps,
+    blobUrl: params.blobUrl,
+    thumbnailUrl: params.thumbnailUrl,
+    canvasWidth: params.canvasWidth,
+    canvasHeight: params.canvasHeight,
+    placements: params.placement as LinkedMediaTimelinePlacement,
+    linkVideoAudio: params.linkVideoAudio,
   })
-
-  if (mediaType !== 'video' || !linkVideoAudio || !placement.linkedAudio) {
-    return [primaryItem]
-  }
-
-  const linkedAudio = buildDroppedMediaTimelineItem({
-    media,
-    mediaId,
-    mediaType: 'audio',
-    label,
-    timelineFps,
-    blobUrl,
-    thumbnailUrl: null,
-    canvasWidth,
-    canvasHeight,
-    placement: placement.linkedAudio,
-    originId,
-    linkedGroupId,
-  })
-
-  return [primaryItem, linkedAudio]
 }

--- a/src/features/timeline/utils/dropped-media.ts
+++ b/src/features/timeline/utils/dropped-media.ts
@@ -83,7 +83,7 @@ export function buildDroppedMediaTimelineItems(params: {
     thumbnailUrl: params.thumbnailUrl,
     canvasWidth: params.canvasWidth,
     canvasHeight: params.canvasHeight,
-    placements: params.placement as LinkedMediaTimelinePlacement,
+    placements: params.placement satisfies LinkedMediaTimelinePlacement,
     linkVideoAudio: params.linkVideoAudio,
   })
 }

--- a/src/features/timeline/utils/media-timeline-item-builder.test.ts
+++ b/src/features/timeline/utils/media-timeline-item-builder.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vite-plus/test'
+import type { MediaMetadata } from '@/types/storage'
+import { buildMediaTimelineItems, getMediaSourceTiming } from './media-timeline-item-builder'
+
+function makeMedia(overrides: Partial<MediaMetadata> = {}): MediaMetadata {
+  return {
+    id: 'media-1',
+    storageType: 'handle',
+    fileHandle: {} as FileSystemFileHandle,
+    fileName: 'clip.mp4',
+    fileSize: 1024,
+    fileLastModified: Date.now(),
+    mimeType: 'video/mp4',
+    duration: 10,
+    width: 1280,
+    height: 720,
+    fps: 60,
+    codec: 'h264',
+    bitrate: 1000,
+    tags: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('getMediaSourceTiming', () => {
+  it('preserves source-native FPS when converting trimmed source ranges to project duration', () => {
+    expect(
+      getMediaSourceTiming({
+        media: makeMedia(),
+        mediaType: 'video',
+        projectFps: 30,
+        sourceStart: 60,
+        sourceEnd: 180,
+      }),
+    ).toEqual({
+      sourceFps: 60,
+      sourceStart: 60,
+      sourceEnd: 180,
+      sourceDuration: 600,
+      durationInFrames: 60,
+    })
+  })
+
+  it('uses a three-second project-FPS source duration for still images', () => {
+    expect(
+      getMediaSourceTiming({
+        media: makeMedia({ mimeType: 'image/png', duration: 0, fps: undefined }),
+        mediaType: 'image',
+        projectFps: 24,
+      }),
+    ).toMatchObject({
+      sourceFps: 24,
+      sourceStart: 0,
+      sourceEnd: 72,
+      sourceDuration: 72,
+      durationInFrames: 72,
+    })
+  })
+})
+
+describe('buildMediaTimelineItems', () => {
+  it('builds linked source-edit video and audio items with shared origin/group IDs and trimmed source range', () => {
+    const [videoItem, audioItem] = buildMediaTimelineItems({
+      media: makeMedia({ audioCodec: 'aac' }),
+      mediaId: 'media-1',
+      mediaType: 'video',
+      label: 'clip.mp4',
+      projectFps: 30,
+      blobUrl: 'blob:video',
+      thumbnailUrl: 'blob:thumb',
+      canvasWidth: 1920,
+      canvasHeight: 1080,
+      sourceStart: 60,
+      sourceEnd: 180,
+      placements: {
+        primary: { trackId: 'v1', from: 12 },
+        linkedAudio: { trackId: 'a1', from: 12 },
+      },
+      linkVideoAudio: true,
+    })
+
+    expect(videoItem?.type).toBe('video')
+    expect(audioItem?.type).toBe('audio')
+    expect(videoItem?.durationInFrames).toBe(60)
+    expect(audioItem?.durationInFrames).toBe(60)
+    expect(videoItem?.sourceStart).toBe(60)
+    expect(videoItem?.sourceEnd).toBe(180)
+    expect(videoItem?.sourceDuration).toBe(600)
+    expect(videoItem?.sourceFps).toBe(60)
+    expect(videoItem?.originId).toBe(audioItem?.originId)
+    expect(videoItem?.linkedGroupId).toBe(audioItem?.linkedGroupId)
+  })
+
+  it('can preserve a linked group id on source video even when only video is emitted', () => {
+    const [videoItem] = buildMediaTimelineItems({
+      media: makeMedia({ audioCodec: 'aac' }),
+      mediaId: 'media-1',
+      mediaType: 'video',
+      label: 'clip.mp4',
+      projectFps: 30,
+      blobUrl: 'blob:video',
+      thumbnailUrl: 'blob:thumb',
+      canvasWidth: 1920,
+      canvasHeight: 1080,
+      placements: { primary: { trackId: 'v1', from: 12, durationInFrames: 60 } },
+      createLinkedGroupId: true,
+    })
+
+    expect(videoItem?.type).toBe('video')
+    expect(videoItem?.linkedGroupId).toEqual(expect.any(String))
+  })
+
+  it('keeps standalone audio unlinked', () => {
+    const [audioItem] = buildMediaTimelineItems({
+      media: makeMedia({
+        mimeType: 'audio/wav',
+        fps: undefined,
+        width: undefined,
+        height: undefined,
+      }),
+      mediaId: 'audio-1',
+      mediaType: 'audio',
+      label: 'clip.wav',
+      projectFps: 30,
+      blobUrl: 'blob:audio',
+      canvasWidth: 1920,
+      canvasHeight: 1080,
+      placements: { primary: { trackId: 'a1', from: 0, durationInFrames: 90 } },
+    })
+
+    expect(audioItem?.type).toBe('audio')
+    expect(audioItem?.linkedGroupId).toBeUndefined()
+    expect(audioItem?.sourceFps).toBe(30)
+    expect(audioItem?.sourceEnd).toBe(90)
+  })
+})

--- a/src/features/timeline/utils/media-timeline-item-builder.ts
+++ b/src/features/timeline/utils/media-timeline-item-builder.ts
@@ -27,7 +27,6 @@ interface TimelineMediaMetadata {
   fps?: number
   width?: number
   height?: number
-  audioCodec?: string
 }
 
 interface TimelineBaseItem {

--- a/src/features/timeline/utils/media-timeline-item-builder.ts
+++ b/src/features/timeline/utils/media-timeline-item-builder.ts
@@ -1,0 +1,227 @@
+import type { AudioItem, ImageItem, TimelineItem, VideoItem } from '@/types/timeline'
+import { computeInitialTransform } from './transform-init'
+
+export type MediaTimelineItemType = 'video' | 'audio' | 'image'
+
+export interface MediaTimelinePlacement {
+  trackId: string
+  from: number
+  durationInFrames?: number
+}
+
+export interface LinkedMediaTimelinePlacement {
+  primary: MediaTimelinePlacement
+  linkedAudio?: MediaTimelinePlacement
+}
+
+export interface MediaSourceTiming {
+  sourceFps: number
+  sourceStart: number
+  sourceEnd: number
+  sourceDuration: number
+  durationInFrames: number
+}
+
+interface TimelineMediaMetadata {
+  duration: number
+  fps?: number
+  width?: number
+  height?: number
+  audioCodec?: string
+}
+
+interface TimelineBaseItem {
+  id: string
+  trackId: string
+  from: number
+  durationInFrames: number
+  label: string
+  mediaId: string
+  originId: string
+  linkedGroupId?: string
+  sourceStart: number
+  sourceEnd: number
+  sourceDuration: number
+  sourceFps: number
+  trimStart: number
+  trimEnd: number
+}
+
+export function getMediaSourceTiming(params: {
+  media: Pick<TimelineMediaMetadata, 'duration' | 'fps'>
+  mediaType: MediaTimelineItemType
+  projectFps: number
+  sourceStart?: number
+  sourceEnd?: number
+  durationInFrames?: number
+  fallbackSourceFps?: number
+}): MediaSourceTiming {
+  const { media, mediaType, projectFps, sourceStart = 0, fallbackSourceFps = projectFps } = params
+  const sourceFps = media.fps || fallbackSourceFps
+  const sourceDuration =
+    mediaType === 'image' ? projectFps * 3 : Math.max(1, Math.round(media.duration * sourceFps))
+  const sourceEnd =
+    params.sourceEnd ??
+    (params.durationInFrames !== undefined
+      ? Math.min(
+          sourceDuration,
+          sourceStart + Math.round((params.durationInFrames * sourceFps) / projectFps),
+        )
+      : sourceDuration)
+  const durationInFrames =
+    params.durationInFrames ??
+    (sourceFps === projectFps
+      ? sourceEnd - sourceStart
+      : Math.max(1, Math.round(((sourceEnd - sourceStart) * projectFps) / sourceFps)))
+
+  return {
+    sourceFps,
+    sourceStart,
+    sourceEnd,
+    sourceDuration,
+    durationInFrames,
+  }
+}
+
+function buildTimelineBaseItem(params: {
+  media: Pick<TimelineMediaMetadata, 'duration' | 'fps'>
+  mediaId: string
+  mediaType: MediaTimelineItemType
+  label: string
+  projectFps: number
+  placement: MediaTimelinePlacement
+  originId: string
+  linkedGroupId?: string
+  sourceStart?: number
+  sourceEnd?: number
+  fallbackSourceFps?: number
+}): TimelineBaseItem {
+  const timing = getMediaSourceTiming({
+    media: params.media,
+    mediaType: params.mediaType,
+    projectFps: params.projectFps,
+    sourceStart: params.sourceStart,
+    sourceEnd: params.sourceEnd,
+    durationInFrames: params.placement.durationInFrames,
+    fallbackSourceFps: params.fallbackSourceFps,
+  })
+
+  return {
+    id: crypto.randomUUID(),
+    trackId: params.placement.trackId,
+    from: params.placement.from,
+    durationInFrames: timing.durationInFrames,
+    label: params.label,
+    mediaId: params.mediaId,
+    originId: params.originId,
+    linkedGroupId: params.linkedGroupId,
+    sourceStart: timing.sourceStart,
+    sourceEnd: timing.sourceEnd,
+    sourceDuration: timing.sourceDuration,
+    sourceFps: timing.sourceFps,
+    trimStart: 0,
+    trimEnd: 0,
+  }
+}
+
+export function buildMediaTimelineItem(params: {
+  media: TimelineMediaMetadata
+  mediaId: string
+  mediaType: MediaTimelineItemType
+  label: string
+  projectFps: number
+  blobUrl: string
+  thumbnailUrl?: string | null
+  canvasWidth: number
+  canvasHeight: number
+  placement: MediaTimelinePlacement
+  originId: string
+  linkedGroupId?: string
+  sourceStart?: number
+  sourceEnd?: number
+  fallbackSourceFps?: number
+}): TimelineItem {
+  const baseItem = buildTimelineBaseItem(params)
+
+  if (params.mediaType === 'audio') {
+    return {
+      ...baseItem,
+      type: 'audio',
+      src: params.blobUrl,
+    } as AudioItem
+  }
+
+  const sourceWidth = params.media.width || params.canvasWidth
+  const sourceHeight = params.media.height || params.canvasHeight
+  const visualFields = {
+    src: params.blobUrl,
+    thumbnailUrl: params.thumbnailUrl || undefined,
+    sourceWidth: params.media.width || undefined,
+    sourceHeight: params.media.height || undefined,
+    transform: computeInitialTransform(
+      sourceWidth,
+      sourceHeight,
+      params.canvasWidth,
+      params.canvasHeight,
+    ),
+  }
+
+  if (params.mediaType === 'video') {
+    return {
+      ...baseItem,
+      type: 'video',
+      ...visualFields,
+    } as VideoItem
+  }
+
+  return {
+    ...baseItem,
+    type: 'image',
+    ...visualFields,
+  } as ImageItem
+}
+
+export function buildMediaTimelineItems(params: {
+  media: TimelineMediaMetadata
+  mediaId: string
+  mediaType: MediaTimelineItemType
+  label: string
+  projectFps: number
+  blobUrl: string
+  thumbnailUrl?: string | null
+  canvasWidth: number
+  canvasHeight: number
+  placements: LinkedMediaTimelinePlacement
+  linkVideoAudio?: boolean
+  sourceStart?: number
+  sourceEnd?: number
+  fallbackSourceFps?: number
+  createLinkedGroupId?: boolean
+}): TimelineItem[] {
+  const originId = crypto.randomUUID()
+  const linkedGroupId =
+    params.mediaType === 'video' && (params.linkVideoAudio || params.createLinkedGroupId)
+      ? crypto.randomUUID()
+      : undefined
+  const primaryItem = buildMediaTimelineItem({
+    ...params,
+    placement: params.placements.primary,
+    originId,
+    linkedGroupId,
+  })
+
+  if (params.mediaType !== 'video' || !params.linkVideoAudio || !params.placements.linkedAudio) {
+    return [primaryItem]
+  }
+
+  const linkedAudio = buildMediaTimelineItem({
+    ...params,
+    mediaType: 'audio',
+    thumbnailUrl: null,
+    placement: params.placements.linkedAudio,
+    originId,
+    linkedGroupId,
+  })
+
+  return [primaryItem, linkedAudio]
+}


### PR DESCRIPTION
## Summary
- Extracts shared pure media-to-timeline item construction into `media-timeline-item-builder`.
- Reuses the builder from source edit actions and dropped media utilities while preserving existing action entrypoints and `execute()` mutation boundaries.
- Adds focused tests for source-native FPS/source ranges, linked AV metadata, initial transforms, thumbnails, image/audio/video item construction, and group-track safeguards where applicable.

## Verification
Worker-reported verification:
- `npm run lint` — passed with existing warnings only.
- `npm run test:run -- src/features/timeline/stores/actions/project-item-actions.test.ts src/features/timeline/utils/dropped-media.test.ts src/features/timeline/utils/drop-execution.test.ts src/features/timeline/utils/track-media-drop.test.ts src/features/timeline/utils/source-edit-targeting.test.ts src/features/timeline/utils/media-timeline-item-builder.test.ts` — passed.
- `npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports` — passed.
- `git diff --check` — passed.
- Push hook quality checks passed.

## Notes
Opened from the main/default Hermes profile because the Kanban worker profile lacked `gh` auth/token.

Kanban: `t_491a5488`
