### PR TITLE
refactor(project-bundle): extract pure storage utilities

### DIFF
--- a/src/features/project-bundle/services/bundle-export-service.ts
+++ b/src/features/project-bundle/services/bundle-export-service.ts
@@ -22,6 +22,11 @@ import {
 
 import { createLogger } from '@/shared/logging/logger'
 import { convertTimelineForBundle } from './bundle-timeline'
+import {
+  computeBundleManifestChecksum,
+  getUniqueBundleFileName,
+  sanitizeDownloadFilename,
+} from './pure-utils'
 
 const logger = createLogger('BundleExportService')
 
@@ -113,17 +118,7 @@ export async function exportProjectBundle(
     const hash = media.contentHash || (await computeContentHashFromBuffer(buffer))
 
     // Ensure unique filename within bundle
-    let bundleFileName = media.fileName
-    let counter = 1
-    while (usedFilenames.has(`${hash}/${bundleFileName}`)) {
-      const ext = media.fileName.lastIndexOf('.')
-      if (ext > 0) {
-        bundleFileName = `${media.fileName.substring(0, ext)}_${counter}${media.fileName.substring(ext)}`
-      } else {
-        bundleFileName = `${media.fileName}_${counter}`
-      }
-      counter++
-    }
+    const bundleFileName = getUniqueBundleFileName(usedFilenames, hash, media.fileName)
     usedFilenames.add(`${hash}/${bundleFileName}`)
 
     const relativePath = `media/${hash}/${bundleFileName}`
@@ -183,14 +178,7 @@ export async function exportProjectBundle(
   }
 
   // Step 8: Compute manifest checksum and add manifest.json
-  const manifestForHash = { ...manifest, checksum: '' }
-  const manifestHashBuffer = await crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(JSON.stringify(manifestForHash)),
-  )
-  manifest.checksum = Array.from(new Uint8Array(manifestHashBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
+  manifest.checksum = await computeBundleManifestChecksum(manifest)
 
   const manifestFile = new ZipDeflate('manifest.json')
   zip.add(manifestFile)
@@ -213,7 +201,8 @@ export async function exportProjectBundle(
   }
 
   const blob = new Blob([result], { type: 'application/zip' })
-  const filename = sanitizeFilename(project.name) + BUNDLE_EXTENSION
+  const filename =
+    sanitizeDownloadFilename(project.name, { fallback: 'untitled' }) + BUNDLE_EXTENSION
 
   return {
     blob,
@@ -311,17 +300,7 @@ export async function exportProjectBundleStreaming(
       const buffer = await blob.arrayBuffer()
       const hash = media.contentHash || (await computeContentHashFromBuffer(buffer))
 
-      let bundleFileName = media.fileName
-      let counter = 1
-      while (usedFilenames.has(`${hash}/${bundleFileName}`)) {
-        const ext = media.fileName.lastIndexOf('.')
-        if (ext > 0) {
-          bundleFileName = `${media.fileName.substring(0, ext)}_${counter}${media.fileName.substring(ext)}`
-        } else {
-          bundleFileName = `${media.fileName}_${counter}`
-        }
-        counter++
-      }
+      const bundleFileName = getUniqueBundleFileName(usedFilenames, hash, media.fileName)
       usedFilenames.add(`${hash}/${bundleFileName}`)
 
       const relativePath = `media/${hash}/${bundleFileName}`
@@ -381,14 +360,7 @@ export async function exportProjectBundleStreaming(
     }
 
     // Step 8: Compute manifest checksum and add manifest.json
-    const manifestForHash = { ...manifest, checksum: '' }
-    const manifestHashBuffer = await crypto.subtle.digest(
-      'SHA-256',
-      new TextEncoder().encode(JSON.stringify(manifestForHash)),
-    )
-    manifest.checksum = Array.from(new Uint8Array(manifestHashBuffer))
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
+    manifest.checksum = await computeBundleManifestChecksum(manifest)
 
     const manifestFile = new ZipDeflate('manifest.json')
     zip.add(manifestFile)
@@ -405,7 +377,8 @@ export async function exportProjectBundleStreaming(
 
     onProgress?.({ percent: 100, stage: 'complete' })
 
-    const filename = sanitizeFilename(project.name) + BUNDLE_EXTENSION
+    const filename =
+      sanitizeDownloadFilename(project.name, { fallback: 'untitled' }) + BUNDLE_EXTENSION
 
     return {
       filename,
@@ -441,15 +414,4 @@ export function downloadBundle(result: ExportResult): void {
   a.click()
   document.body.removeChild(a)
   URL.revokeObjectURL(url)
-}
-
-/**
- * Sanitize filename for safe download
- */
-function sanitizeFilename(name: string): string {
-  const sanitized = name
-    .replace(/[<>:"/\\|?*]/g, '_')
-    .replace(/\s+/g, '_')
-    .substring(0, 100)
-  return sanitized || 'untitled'
 }

--- a/src/features/project-bundle/services/file-system-service.ts
+++ b/src/features/project-bundle/services/file-system-service.ts
@@ -5,6 +5,8 @@
  * and file writing during bundle import.
  */
 
+import { sanitizeBundleDirectoryName, sanitizeBundleFileName } from './pure-utils'
+
 interface FileSystemServiceError {
   type: 'permission_denied' | 'user_cancelled' | 'write_failed' | 'unknown'
   message: string
@@ -42,7 +44,7 @@ async function getOrCreateSubdirectory(
   name: string,
 ): Promise<FileSystemDirectoryHandle> {
   try {
-    return await parent.getDirectoryHandle(sanitizeDirectoryName(name), {
+    return await parent.getDirectoryHandle(sanitizeBundleDirectoryName(name), {
       create: true,
     })
   } catch (error) {
@@ -62,7 +64,7 @@ async function writeFile(
   content: Blob | ArrayBuffer | Uint8Array,
 ): Promise<FileSystemFileHandle> {
   try {
-    const fileHandle = await directory.getFileHandle(sanitizeFileName(fileName), {
+    const fileHandle = await directory.getFileHandle(sanitizeBundleFileName(fileName), {
       create: true,
     })
 
@@ -144,31 +146,6 @@ function createError(
   originalError?: unknown,
 ): FileSystemServiceError {
   return { type, message, originalError }
-}
-
-/**
- * Sanitize a directory name for safe filesystem usage
- */
-function sanitizeDirectoryName(name: string): string {
-  return (
-    name
-      .replace(/[<>:"/\\|?*]/g, '_')
-      .replace(/\s+/g, '_')
-      .substring(0, 100)
-      .trim() || 'untitled'
-  )
-}
-
-/**
- * Sanitize a file name for safe filesystem usage
- */
-function sanitizeFileName(name: string): string {
-  return (
-    name
-      .replace(/[<>:"/\\|?*]/g, '_')
-      .substring(0, 200)
-      .trim() || 'unnamed'
-  )
 }
 
 /**

--- a/src/features/project-bundle/services/json-export-service.ts
+++ b/src/features/project-bundle/services/json-export-service.ts
@@ -16,6 +16,7 @@ import {
 } from '../types/snapshot'
 import { getProject, getProjectMediaIds } from '@/infrastructure/storage'
 import { mediaLibraryService } from '@/features/project-bundle/deps/media-library'
+import { computeSnapshotChecksum, sanitizeDownloadFilename } from './pure-utils'
 
 // App version - should be imported from a config
 const APP_VERSION = '1.0.0'
@@ -138,7 +139,7 @@ export function downloadSnapshotJson(snapshot: ProjectSnapshot, filename?: strin
   const blob = new Blob([json], { type: 'application/json' })
   const url = URL.createObjectURL(blob)
 
-  const safeName = sanitizeFilename(filename || snapshot.project.name)
+  const safeName = sanitizeDownloadFilename(filename || snapshot.project.name)
   const a = document.createElement('a')
   a.href = url
   a.download = `${safeName}.freecut.json`
@@ -179,20 +180,6 @@ export async function copyProjectToClipboard(
 }
 
 /**
- * Compute SHA-256 checksum for snapshot integrity
- */
-async function computeSnapshotChecksum(snapshot: ProjectSnapshot): Promise<string> {
-  // Create a copy without the checksum field for hashing
-  const dataForHash = { ...snapshot, checksum: undefined }
-  const json = JSON.stringify(dataForHash)
-  const buffer = new TextEncoder().encode(json)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer)
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-/**
  * Verify snapshot checksum
  */
 export async function verifySnapshotChecksum(snapshot: ProjectSnapshot): Promise<boolean> {
@@ -203,16 +190,6 @@ export async function verifySnapshotChecksum(snapshot: ProjectSnapshot): Promise
   const expectedChecksum = snapshot.checksum
   const actualChecksum = await computeSnapshotChecksum(snapshot)
   return expectedChecksum === actualChecksum
-}
-
-/**
- * Sanitize filename for safe download
- */
-function sanitizeFilename(name: string): string {
-  return name
-    .replace(/[<>:"/\\|?*]/g, '_')
-    .replace(/\s+/g, '_')
-    .substring(0, 100)
 }
 
 /**

--- a/src/features/project-bundle/services/pure-utils.test.ts
+++ b/src/features/project-bundle/services/pure-utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import {
+  computeBundleManifestChecksum,
+  computeSnapshotChecksum,
+  getUniqueBundleFileName,
+  sanitizeBundleDirectoryName,
+  sanitizeBundleFileName,
+  sanitizeDownloadFilename,
+} from './pure-utils'
+import type { BundleManifest } from '../types/bundle'
+import type { ProjectSnapshot } from '../types/snapshot'
+
+describe('project bundle pure utilities', () => {
+  it('preserves file-system sanitizer golden outputs', () => {
+    expect(sanitizeBundleDirectoryName('  My Project: Cut?/Final  ')).toBe(
+      '_My_Project__Cut__Final_',
+    )
+    expect(sanitizeBundleDirectoryName('')).toBe('untitled')
+    expect(sanitizeBundleDirectoryName('x'.repeat(120))).toBe('x'.repeat(100))
+
+    expect(sanitizeBundleFileName('  clip:01?.mp4  ')).toBe('clip_01_.mp4')
+    expect(sanitizeBundleFileName('')).toBe('unnamed')
+    expect(sanitizeBundleFileName('x'.repeat(220))).toBe('x'.repeat(200))
+  })
+
+  it('preserves download filename sanitizer golden outputs and fallback behavior', () => {
+    expect(sanitizeDownloadFilename('My Project: Cut?/Final')).toBe('My_Project__Cut__Final')
+    expect(sanitizeDownloadFilename('  spaced   project  ')).toBe('_spaced_project_')
+    expect(sanitizeDownloadFilename('', { fallback: 'untitled' })).toBe('untitled')
+    expect(sanitizeDownloadFilename('', { fallback: '' })).toBe('')
+    expect(sanitizeDownloadFilename('x'.repeat(120))).toBe('x'.repeat(100))
+  })
+
+  it('preserves unique bundle filename generation for duplicate hash/name pairs', () => {
+    const used = new Set(['hash-a/clip.mp4', 'hash-a/clip_1.mp4', 'hash-a/raw'])
+
+    expect(getUniqueBundleFileName(used, 'hash-a', 'clip.mp4')).toBe('clip_2.mp4')
+    expect(getUniqueBundleFileName(used, 'hash-a', 'raw')).toBe('raw_1')
+    expect(getUniqueBundleFileName(used, 'hash-b', 'clip.mp4')).toBe('clip.mp4')
+  })
+
+  it('preserves snapshot checksum golden output', async () => {
+    const snapshot = {
+      version: '1.0',
+      exportedAt: '2026-01-02T03:04:05.000Z',
+      editorVersion: '1.0.0',
+      project: {
+        id: 'project-1',
+        name: 'Golden Project',
+        duration: 120,
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      mediaReferences: [
+        {
+          id: 'media-1',
+          fileName: 'clip.mp4',
+          fileSize: 3,
+          mimeType: 'video/mp4',
+        },
+      ],
+      checksum: 'ignored-existing-checksum',
+    } as unknown as ProjectSnapshot
+
+    expect(await computeSnapshotChecksum(snapshot)).toBe(
+      '1c2ec83c618a3613358a9bf4136863005699d3ee9ff6d7e55ad2c2a4c743ea46',
+    )
+  })
+
+  it('preserves manifest order and checksum golden output', async () => {
+    const manifest: BundleManifest = {
+      version: '1.0',
+      createdAt: 1700000000000,
+      editorVersion: '1.0.0',
+      projectId: 'project-1',
+      projectName: 'Golden Project',
+      media: [
+        {
+          originalId: 'media-b',
+          relativePath: 'media/hash-b/b.mp4',
+          fileName: 'b.mp4',
+          fileSize: 2,
+          sha256: 'hash-b',
+          mimeType: 'video/mp4',
+          metadata: {
+            duration: 2,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            codec: 'h264',
+            bitrate: 2000,
+          },
+        },
+        {
+          originalId: 'media-a',
+          relativePath: 'media/hash-a/a.mp4',
+          fileName: 'a.mp4',
+          fileSize: 1,
+          sha256: 'hash-a',
+          mimeType: 'video/mp4',
+          metadata: {
+            duration: 1,
+            width: 1280,
+            height: 720,
+            fps: 24,
+            codec: 'h265',
+            bitrate: 1000,
+          },
+        },
+      ],
+      checksum: 'ignored-existing-checksum',
+    }
+
+    expect(manifest.media.map((entry) => entry.originalId)).toEqual(['media-b', 'media-a'])
+    expect(await computeBundleManifestChecksum(manifest)).toBe(
+      '68199f97eee3d0ba81524ee855fffb27ebd6fd0a7a21a428195ca3e5b79c2921',
+    )
+  })
+})

--- a/src/features/project-bundle/services/pure-utils.ts
+++ b/src/features/project-bundle/services/pure-utils.ts
@@ -1,0 +1,70 @@
+import type { BundleManifest } from '../types/bundle'
+import type { ProjectSnapshot } from '../types/snapshot'
+
+const HEX_RADIX = 16
+
+export function sanitizeBundleDirectoryName(name: string): string {
+  return (
+    name
+      .replace(/[<>:"/\\|?*]/g, '_')
+      .replace(/\s+/g, '_')
+      .substring(0, 100)
+      .trim() || 'untitled'
+  )
+}
+
+export function sanitizeBundleFileName(name: string): string {
+  return (
+    name
+      .replace(/[<>:"/\\|?*]/g, '_')
+      .substring(0, 200)
+      .trim() || 'unnamed'
+  )
+}
+
+export function sanitizeDownloadFilename(
+  name: string,
+  options: { fallback?: string } = {},
+): string {
+  const sanitized = name
+    .replace(/[<>:"/\\|?*]/g, '_')
+    .replace(/\s+/g, '_')
+    .substring(0, 100)
+  return sanitized || options.fallback || ''
+}
+
+export function getUniqueBundleFileName(
+  usedFilenames: ReadonlySet<string>,
+  hash: string,
+  fileName: string,
+): string {
+  let bundleFileName = fileName
+  let counter = 1
+  while (usedFilenames.has(`${hash}/${bundleFileName}`)) {
+    const ext = fileName.lastIndexOf('.')
+    if (ext > 0) {
+      bundleFileName = `${fileName.substring(0, ext)}_${counter}${fileName.substring(ext)}`
+    } else {
+      bundleFileName = `${fileName}_${counter}`
+    }
+    counter++
+  }
+  return bundleFileName
+}
+
+export async function computeSnapshotChecksum(snapshot: ProjectSnapshot): Promise<string> {
+  const dataForHash = { ...snapshot, checksum: undefined }
+  return sha256Hex(JSON.stringify(dataForHash))
+}
+
+export async function computeBundleManifestChecksum(manifest: BundleManifest): Promise<string> {
+  const manifestForHash = { ...manifest, checksum: '' }
+  return sha256Hex(JSON.stringify(manifestForHash))
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(HEX_RADIX).padStart(2, '0'))
+    .join('')
+}

--- a/src/features/project-bundle/services/pure-utils.ts
+++ b/src/features/project-bundle/services/pure-utils.ts
@@ -62,7 +62,7 @@ export async function computeBundleManifestChecksum(manifest: BundleManifest): P
   return sha256Hex(JSON.stringify(manifestForHash))
 }
 
-export async function sha256Hex(value: string): Promise<string> {
+async function sha256Hex(value: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
   return Array.from(new Uint8Array(hashBuffer))
     .map((byte) => byte.toString(HEX_RADIX).padStart(2, '0'))

--- a/src/infrastructure/storage/workspace-fs/paths.test.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { proxiesRoot, proxyDir, proxyFilePath, proxyMetaPath } from './paths'
+import {
+  mediaSourceByFileName,
+  proxiesRoot,
+  proxyDir,
+  proxyFilePath,
+  proxyMetaPath,
+  sanitizeWorkspaceFileName,
+} from './paths'
 
 describe('workspace proxy path builders', () => {
   it('preserves content-rooted proxy path segments byte-for-byte', () => {
@@ -17,5 +24,21 @@ describe('workspace proxy path builders', () => {
 
     expect(proxyFilePath(proxyKey).join('/')).toBe('content/proxies/h-deadbeef/proxy.mp4')
     expect(proxyMetaPath(proxyKey).join('/')).toBe('content/proxies/h-deadbeef/meta.json')
+  })
+})
+
+describe('workspace filename sanitizer', () => {
+  it('preserves Windows reserved-name, trailing-dot, and trailing-space golden outputs', () => {
+    expect(sanitizeWorkspaceFileName('CON')).toBe('CON_')
+    expect(sanitizeWorkspaceFileName('con.mp4')).toBe('con_.mp4')
+    expect(sanitizeWorkspaceFileName('LPT9.mov')).toBe('LPT9_.mov')
+    expect(sanitizeWorkspaceFileName('clip. ')).toBe('clip')
+    expect(sanitizeWorkspaceFileName(' clip name .mp4   ')).toBe('clip name .mp4')
+    expect(sanitizeWorkspaceFileName('bad<name>|?.mp4')).toBe('bad_name___.mp4')
+    expect(sanitizeWorkspaceFileName('     ')).toBe('source.bin')
+  })
+
+  it('preserves media source path strings after filename sanitization', () => {
+    expect(mediaSourceByFileName('media-1', ' con?.mp4  ').join('/')).toBe('media/media-1/con_.mp4')
   })
 })


### PR DESCRIPTION
## Summary
- Extract shared project-bundle pure utilities for bundle/file-system/download filename sanitization, bundle filename de-duping, and snapshot/manifest checksums
- Reuse those utilities from JSON export, bundle export, and file-system service without changing output formats
- Add golden coverage for workspace filename sanitization, project-bundle sanitizer outputs, checksum stability, and manifest order

## Test Plan
- npm run lint
- npm run test:run -- src/infrastructure/storage/workspace-fs/paths.test.ts src/features/project-bundle/services/json-import-service.test.ts src/features/project-bundle/services/test-fixtures.test.ts src/features/project-bundle/services/bundle-timeline.test.ts src/features/project-bundle/services/pure-utils.test.ts
- npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports
- git diff --check HEAD~1..HEAD