### PR TITLE
refactor(media-library): introduce storage facade

### DIFF
--- a/src/features/media-library/deps/README.md
+++ b/src/features/media-library/deps/README.md
@@ -13,3 +13,6 @@ Media-library-local adapters for external feature dependencies.
   above. Prefer importing the more specific module directly in new code.
 - `projects.ts`: the preferred entry point for media-library modules that need
   project metadata/state stores.
+- `storage.ts`: the preferred entry point for media-library modules that need
+  workspace-backed storage APIs; keep direct `workspace-fs/*` imports out of
+  services.

--- a/src/features/media-library/deps/storage.ts
+++ b/src/features/media-library/deps/storage.ts
@@ -1,0 +1,37 @@
+// Media-library-local adapter for workspace-backed storage APIs.
+//
+// Keep direct workspace-fs imports out of media-library services; this facade is
+// intentionally thin and behavior-preserving.
+export {
+  associateMediaWithProject,
+  createMedia,
+  decrementContentRef,
+  deleteCaptions,
+  deleteContent,
+  deleteMedia,
+  deleteScenes,
+  deleteThumbnailsByMediaId,
+  deleteTranscript,
+  getAllMedia,
+  getMedia,
+  getMediaForProject,
+  getProjectMediaIds,
+  getProjectsUsingMedia,
+  getThumbnailByMediaId,
+  hasMediaSource,
+  incrementContentRef,
+  mirrorBlobToWorkspace,
+  mirrorJsonToWorkspace,
+  proxyDir,
+  proxyFilePath,
+  proxyMetaPath,
+  readAiOutput,
+  readMediaSource,
+  readWorkspaceBlob,
+  removeMediaFromProject,
+  removeWorkspaceCacheEntry,
+  saveCaptions,
+  saveThumbnail,
+  updateMedia,
+  writeMediaSource,
+} from '@/infrastructure/storage'

--- a/src/features/media-library/services/media-asset-helpers.ts
+++ b/src/features/media-library/services/media-asset-helpers.ts
@@ -6,9 +6,9 @@ import {
   deleteMedia as deleteMediaDB,
   deleteThumbnailsByMediaId,
   saveThumbnail as saveThumbnailDB,
-} from '@/infrastructure/storage'
+  writeMediaSource,
+} from '@/features/media-library/deps/storage'
 import { opfsService } from '@/features/media-library/services/opfs-service'
-import { writeMediaSource } from '@/infrastructure/storage/workspace-fs/media-source'
 
 const logger = createLogger('MediaAssetHelpers')
 

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -19,12 +19,18 @@ const indexedDbMocks = vi.hoisted(() => ({
   getMediaForProject: vi.fn(),
   deleteTranscript: vi.fn(),
   readAiOutput: vi.fn(),
-}))
-
-const captionsStorageMocks = vi.hoisted(() => ({
   saveCaptions: vi.fn(async () => []),
   deleteCaptions: vi.fn(async () => undefined),
+  deleteScenes: vi.fn(async () => undefined),
+  hasMediaSource: vi.fn(async () => false),
+  readMediaSource: vi.fn(async () => null),
+  writeMediaSource: vi.fn(async () => undefined),
 }))
+
+const captionsStorageMocks = {
+  saveCaptions: indexedDbMocks.saveCaptions,
+  deleteCaptions: indexedDbMocks.deleteCaptions,
+}
 
 const opfsMocks = vi.hoisted(() => ({
   saveFile: vi.fn(),
@@ -78,8 +84,6 @@ const backgroundMediaWorkMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/infrastructure/storage', () => indexedDbMocks)
-
-vi.mock('@/infrastructure/storage/workspace-fs/captions', () => captionsStorageMocks)
 
 vi.mock('./opfs-service', () => ({
   opfsService: opfsMocks,

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -59,6 +59,9 @@ import {
   saveCaptions,
   deleteCaptions,
   deleteScenes,
+  hasMediaSource,
+  readMediaSource,
+  writeMediaSource,
 } from '@/features/media-library/deps/storage'
 import {
   filmstripCache,
@@ -69,11 +72,6 @@ import { opfsService } from './opfs-service'
 import { proxyService } from './proxy-service'
 import { ensureFileHandlePermission, FileAccessError } from './file-access'
 import { enqueueBackgroundMediaWork } from './background-media-work'
-import {
-  hasMediaSource,
-  readMediaSource,
-  writeMediaSource,
-} from '@/features/media-library/deps/storage'
 import {
   buildGeneratedMediaOpfsPath,
   getGeneratedImageDimensions,

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -56,9 +56,10 @@ import {
   getMediaForProject as getMediaForProjectDB,
   deleteTranscript,
   readAiOutput,
-} from '@/infrastructure/storage'
-import { saveCaptions, deleteCaptions } from '@/infrastructure/storage/workspace-fs/captions'
-import { deleteScenes } from '@/infrastructure/storage/workspace-fs/scenes'
+  saveCaptions,
+  deleteCaptions,
+  deleteScenes,
+} from '@/features/media-library/deps/storage'
 import {
   filmstripCache,
   gifFrameCache,
@@ -72,7 +73,7 @@ import {
   hasMediaSource,
   readMediaSource,
   writeMediaSource,
-} from '@/infrastructure/storage/workspace-fs/media-source'
+} from '@/features/media-library/deps/storage'
 import {
   buildGeneratedMediaOpfsPath,
   getGeneratedImageDimensions,

--- a/src/features/media-library/services/proxy-service.ts
+++ b/src/features/media-library/services/proxy-service.ts
@@ -25,10 +25,12 @@ import { isVideoProxyCandidate } from '@/config/proxy-generation'
 import {
   mirrorBlobToWorkspace,
   mirrorJsonToWorkspace,
+  proxyDir,
+  proxyFilePath,
+  proxyMetaPath,
   readWorkspaceBlob,
   removeWorkspaceCacheEntry,
-} from '@/infrastructure/storage/workspace-fs/cache-mirror'
-import { proxyDir, proxyFilePath, proxyMetaPath } from '@/infrastructure/storage/workspace-fs/paths'
+} from '@/features/media-library/deps/storage'
 import {
   PROXY_DIR,
   PROXY_FILE_NAME,

--- a/src/infrastructure/storage/index.ts
+++ b/src/infrastructure/storage/index.ts
@@ -109,6 +109,24 @@ export {
   getCaptionImageEmbeddings,
 } from '@/infrastructure/storage/workspace-fs/captions'
 
+// Media source files
+export {
+  hasMediaSource,
+  readMediaSource,
+  writeMediaSource,
+} from '@/infrastructure/storage/workspace-fs/media-source'
+
+// Workspace cache mirror helpers
+export {
+  mirrorBlobToWorkspace,
+  mirrorJsonToWorkspace,
+  readWorkspaceBlob,
+  removeWorkspaceCacheEntry,
+} from '@/infrastructure/storage/workspace-fs/cache-mirror'
+
+// Workspace cache path helpers
+export { proxyDir, proxyFilePath, proxyMetaPath } from '@/infrastructure/storage/workspace-fs/paths'
+
 // Embedded text-subtitle track cache (parsed once per source fingerprint)
 export {
   getEmbeddedSubtitleSidecar,


### PR DESCRIPTION
## Summary
- add a media-library-local storage facade backed by the infrastructure storage barrel
- route media-library service, generated asset helper, and proxy storage imports through the facade
- expose the needed media source/cache mirror/path helpers from the storage barrel and adjust service mocks

## Verification
- npm run test:run -- src/features/media-library/services/media-library-service.test.ts src/features/media-library/services/proxy-service.test.ts
- npm run lint
- npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports && npm run check:deps-wrapper-health
- npm run build
- git push pre-push quality checks: check:boundaries, check:deps-contracts, check:legacy-lib-imports, check:deps-wrapper-health, check:edge-budgets, vp check --no-fmt src vite.config.ts --silent