### PR TITLE
refactor(media-library): share pending worker cleanup

### DIFF
--- a/src/features/media-library/services/media-processor-service.ts
+++ b/src/features/media-library/services/media-processor-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '@/shared/logging/logger'
-import { createManagedWorker } from '@/shared/utils/managed-worker'
+import { createManagedWorker, rejectAndDeletePendingRequests } from '@/shared/utils/managed-worker'
 import type {
   ProcessMediaRequest,
   ProcessMediaResponse,
@@ -47,10 +47,10 @@ class MediaProcessorService {
         logger.error('Media processor worker error:', event.message)
         this.workerManager.terminate()
 
-        for (const [id, pending] of this.pendingRequests) {
-          pending.reject(new Error(`Worker error: ${event.message}`))
-          this.pendingRequests.delete(id)
-        }
+        rejectAndDeletePendingRequests(
+          this.pendingRequests,
+          new Error(`Worker error: ${event.message}`),
+        )
       }
 
       return () => {
@@ -122,10 +122,7 @@ class MediaProcessorService {
       // would hang forever waiting on a worker that no longer exists.
       const timeout = setTimeout(() => {
         const timeoutError = new Error('Media processing timeout')
-        for (const [, pending] of this.pendingRequests) {
-          pending.reject(timeoutError)
-        }
-        this.pendingRequests.clear()
+        rejectAndDeletePendingRequests(this.pendingRequests, timeoutError)
         this.workerManager.terminate()
         reject(timeoutError)
       }, PROCESS_MEDIA_TIMEOUT_MS)
@@ -232,10 +229,7 @@ class MediaProcessorService {
     this.workerManager.terminate()
 
     // Reject all pending requests
-    for (const [id, pending] of this.pendingRequests) {
-      pending.reject(new Error('Worker disposed'))
-      this.pendingRequests.delete(id)
-    }
+    rejectAndDeletePendingRequests(this.pendingRequests, new Error('Worker disposed'))
   }
 }
 

--- a/src/shared/utils/managed-worker.test.ts
+++ b/src/shared/utils/managed-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { createManagedWorker } from './managed-worker'
+import { createManagedWorker, rejectAndDeletePendingRequests } from './managed-worker'
 
 type MockWorker = {
   terminate: ReturnType<typeof vi.fn>
@@ -79,5 +79,23 @@ describe('createManagedWorker', () => {
 
     expect(createWorker).not.toHaveBeenCalled()
     expect(managedWorker.peekWorker()).toBeNull()
+  })
+})
+
+describe('rejectAndDeletePendingRequests', () => {
+  it('rejects each pending request with the same error and deletes it from the map', () => {
+    const firstReject = vi.fn()
+    const secondReject = vi.fn()
+    const pendingRequests = new Map([
+      ['first', { reject: firstReject }],
+      ['second', { reject: secondReject }],
+    ])
+    const error = new Error('Worker disposed')
+
+    rejectAndDeletePendingRequests(pendingRequests, error)
+
+    expect(firstReject).toHaveBeenCalledWith(error)
+    expect(secondReject).toHaveBeenCalledWith(error)
+    expect(pendingRequests.size).toBe(0)
   })
 })

--- a/src/shared/utils/managed-worker.ts
+++ b/src/shared/utils/managed-worker.ts
@@ -17,10 +17,10 @@ export function rejectAndDeletePendingRequests<TPending extends RejectablePendin
   pendingRequests: Map<string, TPending>,
   error: Error,
 ): void {
-  pendingRequests.forEach((pending, id) => {
+  pendingRequests.forEach((pending) => {
     pending.reject(error)
-    pendingRequests.delete(id)
   })
+  pendingRequests.clear()
 }
 
 export function createManagedWorker<TWorker extends Worker = Worker>(

--- a/src/shared/utils/managed-worker.ts
+++ b/src/shared/utils/managed-worker.ts
@@ -9,6 +9,20 @@ export interface ManagedWorkerOptions<TWorker extends Worker = Worker> {
   setupWorker?: (worker: TWorker) => void | (() => void)
 }
 
+export interface RejectablePendingRequest {
+  reject(error: Error): void
+}
+
+export function rejectAndDeletePendingRequests<TPending extends RejectablePendingRequest>(
+  pendingRequests: Map<string, TPending>,
+  error: Error,
+): void {
+  pendingRequests.forEach((pending, id) => {
+    pending.reject(error)
+    pendingRequests.delete(id)
+  })
+}
+
 export function createManagedWorker<TWorker extends Worker = Worker>(
   options: ManagedWorkerOptions<TWorker>,
 ): ManagedWorker<TWorker> {


### PR DESCRIPTION
## Summary
- adds a tiny shared helper beside managed worker utilities for rejecting and deleting pending worker requests
- applies it only to media processor worker timeout/error/dispose cleanup paths
- leaves OPFS MessageChannel and proxy progress-streaming semantics untouched

## Risk
Low: behavior-preserving refactor of existing cleanup loops; no message shapes, timeout durations, logging, worker lifecycle, or public APIs changed.

## Verification
- npm run test:run -- src/shared/utils/managed-worker.test.ts src/features/media-library/services/proxy-service.test.ts src/features/media-library/services/media-library-service.test.ts
- npm run lint
- npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports && npm run check:deps-wrapper-health
- npm run format:check
- npm run build