### PR TITLE
refactor(opfs): add infrastructure file access facade

### DIFF
--- a/src/features/media-library/services/opfs-service.ts
+++ b/src/features/media-library/services/opfs-service.ts
@@ -1,4 +1,5 @@
 import type { OPFSWorkerMessage, OPFSWorkerResponse, UploadProgress } from '../workers/opfs-worker'
+import { getOpfsFileBlob } from '@/infrastructure/browser/opfs-file-access'
 import { createManagedWorker } from '@/shared/utils/managed-worker'
 import { formatBytes } from '@/shared/utils/format-utils'
 
@@ -19,31 +20,6 @@ class OPFSService {
    * Maps file path to pending Promise
    */
   private pendingReads = new Map<string, Promise<ArrayBuffer>>()
-
-  private async getFileHandle(path: string): Promise<FileSystemFileHandle> {
-    const root = await navigator.storage.getDirectory()
-    const parts = path.split('/').filter((part) => part)
-
-    if (parts.length === 0) {
-      throw new Error('Invalid path')
-    }
-
-    let dir = root
-    for (let index = 0; index < parts.length - 1; index += 1) {
-      const part = parts[index]
-      if (!part) {
-        continue
-      }
-      dir = await dir.getDirectoryHandle(part)
-    }
-
-    const fileName = parts[parts.length - 1]
-    if (!fileName) {
-      throw new Error('Invalid path: missing filename')
-    }
-
-    return dir.getFileHandle(fileName)
-  }
 
   /**
    * Initialize the OPFS worker
@@ -116,8 +92,10 @@ class OPFSService {
    * file objects directly instead of forcing a full ArrayBuffer read first.
    */
   async getFileBlob(path: string): Promise<Blob> {
-    const fileHandle = await this.getFileHandle(path)
-    return fileHandle.getFile()
+    return getOpfsFileBlob(path, {
+      invalidPath: 'Invalid path',
+      missingFileName: 'Invalid path: missing filename',
+    })
   }
 
   /**

--- a/src/infrastructure/browser/mediabunny-input-source.ts
+++ b/src/infrastructure/browser/mediabunny-input-source.ts
@@ -3,6 +3,7 @@ import {
   getObjectUrlSourceMetadata,
   type ObjectUrlSourceMetadata,
 } from './object-url-registry'
+import { getOpfsFileBlob } from './opfs-file-access'
 
 type MediabunnyModule = typeof import('mediabunny')
 
@@ -27,31 +28,6 @@ function canUseDirectFileAccess(
   return Boolean(metadata.fileHandle || metadata.opfsPath)
 }
 
-async function getOpfsFileHandle(path: string): Promise<FileSystemFileHandle> {
-  const root = await navigator.storage.getDirectory()
-  const parts = path.split('/').filter((part) => part)
-
-  if (parts.length === 0) {
-    throw new Error('Invalid OPFS path')
-  }
-
-  let dir = root
-  for (let index = 0; index < parts.length - 1; index += 1) {
-    const part = parts[index]
-    if (!part) {
-      continue
-    }
-    dir = await dir.getDirectoryHandle(part)
-  }
-
-  const fileName = parts[parts.length - 1]
-  if (!fileName) {
-    throw new Error('Invalid OPFS path: missing filename')
-  }
-
-  return dir.getFileHandle(fileName)
-}
-
 function createBrowserFileStreamSource(
   mb: MediabunnyModule,
   metadata: ObjectUrlSourceMetadata & ({ fileHandle: FileSystemFileHandle } | { opfsPath: string }),
@@ -67,8 +43,7 @@ function createBrowserFileStreamSource(
         }
 
         if (metadata.opfsPath) {
-          const handle = await getOpfsFileHandle(metadata.opfsPath)
-          return handle.getFile()
+          return getOpfsFileBlob(metadata.opfsPath)
         }
 
         throw new Error('Missing file-backed source metadata')

--- a/src/infrastructure/browser/opfs-file-access.test.ts
+++ b/src/infrastructure/browser/opfs-file-access.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { getOpfsFileBlob, getOpfsFileHandle } from './opfs-file-access'
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('opfs-file-access', () => {
+  it('resolves nested OPFS paths through navigator.storage', async () => {
+    const fileHandle = {
+      getFile: vi.fn().mockResolvedValue(new Blob(['file-data'])),
+    } as unknown as FileSystemFileHandle
+    const getDirectoryHandle = vi.fn()
+    const contentDirectory = {
+      getDirectoryHandle,
+      getFileHandle: vi.fn(),
+    }
+    const hashDirectory = {
+      getDirectoryHandle: vi.fn(),
+      getFileHandle: vi.fn().mockResolvedValue(fileHandle),
+    }
+
+    getDirectoryHandle.mockResolvedValueOnce(contentDirectory).mockResolvedValueOnce(hashDirectory)
+
+    const root = {
+      getDirectoryHandle,
+      getFileHandle: vi.fn(),
+    }
+    const getDirectory = vi.fn().mockResolvedValue(root)
+
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory,
+      },
+    })
+
+    await expect(getOpfsFileHandle('content/aa/proxy.mp4')).resolves.toBe(fileHandle)
+
+    expect(getDirectory).toHaveBeenCalledTimes(1)
+    expect(getDirectoryHandle).toHaveBeenNthCalledWith(1, 'content')
+    expect(getDirectoryHandle).toHaveBeenNthCalledWith(2, 'aa')
+    expect(hashDirectory.getFileHandle).toHaveBeenCalledWith('proxy.mp4')
+  })
+
+  it('returns OPFS file blobs from resolved handles', async () => {
+    const file = new Blob(['blob-data'])
+    const fileHandle = {
+      getFile: vi.fn().mockResolvedValue(file),
+    }
+    const root = {
+      getFileHandle: vi.fn().mockResolvedValue(fileHandle),
+    }
+
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: vi.fn().mockResolvedValue(root),
+      },
+    })
+
+    await expect(getOpfsFileBlob('clip.mp4')).resolves.toBe(file)
+    expect(fileHandle.getFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects empty OPFS paths', async () => {
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: vi.fn().mockResolvedValue({}),
+      },
+    })
+
+    await expect(getOpfsFileHandle('///')).rejects.toThrow('Invalid OPFS path')
+  })
+})

--- a/src/infrastructure/browser/opfs-file-access.ts
+++ b/src/infrastructure/browser/opfs-file-access.ts
@@ -1,0 +1,52 @@
+interface OpfsFileAccessErrorMessages {
+  invalidPath: string
+  missingFileName: string
+}
+
+const DEFAULT_ERROR_MESSAGES: OpfsFileAccessErrorMessages = {
+  invalidPath: 'Invalid OPFS path',
+  missingFileName: 'Invalid OPFS path: missing filename',
+}
+
+/**
+ * Narrow browser OPFS file access helpers.
+ *
+ * This facade intentionally only covers direct FileSystemHandle access used by
+ * browser infrastructure consumers. Media-library keeps ownership of the OPFS
+ * worker singleton, message protocol, directory layout, and upload/read APIs.
+ */
+export async function getOpfsFileHandle(
+  path: string,
+  errorMessages: OpfsFileAccessErrorMessages = DEFAULT_ERROR_MESSAGES,
+): Promise<FileSystemFileHandle> {
+  const root = await navigator.storage.getDirectory()
+  const parts = path.split('/').filter((part) => part)
+
+  if (parts.length === 0) {
+    throw new Error(errorMessages.invalidPath)
+  }
+
+  let dir = root
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const part = parts[index]
+    if (!part) {
+      continue
+    }
+    dir = await dir.getDirectoryHandle(part)
+  }
+
+  const fileName = parts[parts.length - 1]
+  if (!fileName) {
+    throw new Error(errorMessages.missingFileName)
+  }
+
+  return dir.getFileHandle(fileName)
+}
+
+export async function getOpfsFileBlob(
+  path: string,
+  errorMessages?: OpfsFileAccessErrorMessages,
+): Promise<Blob> {
+  const fileHandle = await getOpfsFileHandle(path, errorMessages)
+  return fileHandle.getFile()
+}


### PR DESCRIPTION
## Summary
- Add a narrow infrastructure/browser OPFS file access facade for resolving OPFS paths to file handles/blobs.
- Route Mediabunny direct OPFS reads and media-library getFileBlob through the shared facade.
- Add focused characterization tests for OPFS path traversal and blob resolution.

## Invariants
- OPFS worker location, worker URL, message protocol, MessageChannel usage, directory layout, and persisted paths are unchanged.
- Existing media-library service APIs and OPFS singleton ownership are preserved.
- Pending read de-dupe and upload progress behavior are unchanged.

## Verification
- npm run test:run -- src/infrastructure/browser/opfs-file-access.test.ts src/infrastructure/browser/mediabunny-input-source.test.ts src/features/media-library/services/media-library-service.test.ts src/features/media-library/services/proxy-service.test.ts
- npm run lint (passes with existing timeline hook warnings)
- npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports && npm run check:deps-wrapper-health
- npm run build