### PR TITLE
test(preview): characterize render pump planner invariants

### DIFF
--- a/src/features/preview/utils/render-pump-frame-plan.test.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.test.ts
@@ -41,6 +41,26 @@ describe('render pump frame plan', () => {
     expect(target).toBe(100)
   })
 
+  it('uses current frame for paused transition overlay requests', () => {
+    const target = resolveRenderPumpTargetFrame({
+      state: makeState({ previewFrame: null, currentFrame: 142 }),
+      forceFastScrubOverlay: false,
+      isPausedInsideTransition: true,
+    })
+
+    expect(target).toBe(142)
+  })
+
+  it('keeps preview frame ahead of paused transition fallback', () => {
+    const target = resolveRenderPumpTargetFrame({
+      state: makeState({ previewFrame: 151, currentFrame: 142 }),
+      forceFastScrubOverlay: false,
+      isPausedInsideTransition: true,
+    })
+
+    expect(target).toBe(151)
+  })
+
   it('detects atomic preview targets', () => {
     expect(
       isAtomicPreviewTarget(
@@ -165,6 +185,17 @@ describe('render pump frame plan', () => {
     expect(frames).toEqual([100, 101, 102, 107, 108, 109])
   })
 
+  it('falls back to nearest boundary frames when direction has no candidates', () => {
+    const frames = selectBoundaryPrewarmFrames({
+      boundaryFrames: [91, 94, 96],
+      targetFrame: 100,
+      direction: 1,
+      fps: 30,
+    })
+
+    expect(frames).toEqual([95, 96, 97, 93, 94])
+  })
+
   it('selects nearby boundary sources and caps total sources', () => {
     const sources = selectBoundarySourcePrewarmSources({
       boundarySources: [
@@ -178,5 +209,19 @@ describe('render pump frame plan', () => {
     })
 
     expect(sources).toEqual(['d', 'e', 'f', 'g', 'h', 'i'])
+  })
+
+  it('uses directional boundary source fallback and preserves selected entry ordering', () => {
+    const sources = selectBoundarySourcePrewarmSources({
+      boundarySources: [
+        { frame: 94, srcs: ['a'] },
+        { frame: 96, srcs: ['b', 'c'] },
+      ],
+      targetFrame: 100,
+      direction: 1,
+      fps: 30,
+    })
+
+    expect(sources).toEqual(['b', 'c', 'a'])
   })
 })

--- a/src/features/preview/utils/render-pump-invariants.test.ts
+++ b/src/features/preview/utils/render-pump-invariants.test.ts
@@ -231,6 +231,20 @@ describe('render pump invariants', () => {
     expect(sim.renderedFrames).toContain(100)
   })
 
+  it('stale generation suppresses background prewarm after a priority frame', async () => {
+    sim.renderDelayMs = 10
+    sim.setRequestedFrame(100)
+    const p = sim.pump()
+
+    sim.bumpGeneration()
+    sim.setRequestedFrame(101)
+    await p
+
+    expect(sim.renderedFrames).toEqual([100])
+    expect(sim.inFlight).toBe(true)
+    expect(sim.staleFinallyReleases).toBe(1)
+  })
+
   it('lock is released after pump completes with matching generation', async () => {
     sim.setRequestedFrame(100)
     await sim.pump()

--- a/src/features/preview/utils/render-pump-preseek.test.ts
+++ b/src/features/preview/utils/render-pump-preseek.test.ts
@@ -267,6 +267,79 @@ describe('render pump preseek helpers', () => {
     })
   })
 
+  it('uses the earliest visibility frame across paused variable-speed candidates', () => {
+    const tracks = [
+      {
+        ...makeTrack([
+          makeVideoItem({
+            id: 'top-occluder',
+            from: 90,
+            durationInFrames: 25,
+            speed: 1,
+          }),
+        ]),
+        id: 'top',
+        order: 0,
+      },
+      {
+        ...makeTrack([
+          makeVideoItem({
+            id: 'middle-candidate',
+            from: 112,
+            durationInFrames: 30,
+            speed: 1.25,
+            src: 'middle.mp4',
+          }),
+        ]),
+        id: 'middle',
+        order: 1,
+      },
+      {
+        ...makeTrack([
+          makeVideoItem({
+            id: 'bottom-candidate',
+            from: 118,
+            durationInFrames: 30,
+            speed: 1.5,
+            src: 'bottom.mp4',
+          }),
+        ]),
+        id: 'bottom',
+        order: 2,
+      },
+    ]
+
+    expect(resolvePausedVariableSpeedPrewarmPlan(tracks, 100, 30)).toEqual({
+      itemIds: ['middle-candidate', 'bottom-candidate'],
+      visibilityFrame: 115,
+      preseekFrame: 114,
+    })
+  })
+
+  it('keeps paused variable-speed preseek at the current frame when already visible', () => {
+    const tracks = [
+      {
+        ...makeTrack([
+          makeVideoItem({
+            id: 'visible-soon',
+            from: 104,
+            durationInFrames: 30,
+            speed: 1.5,
+            src: 'visible.mp4',
+          }),
+        ]),
+        id: 'top',
+        order: 0,
+      },
+    ]
+
+    expect(resolvePausedVariableSpeedPrewarmPlan(tracks, 100, 30)).toEqual({
+      itemIds: ['visible-soon'],
+      visibilityFrame: 100,
+      preseekFrame: 100,
+    })
+  })
+
   it('returns null when there are no paused variable-speed candidates', () => {
     const tracks = [
       makeTrack([


### PR DESCRIPTION
## Summary
- Add render-pump characterization coverage for paused transition target selection and scrub stale-generation suppression.
- Pin frame-plan boundary prewarm directional fallback/source ordering behavior.
- Extend paused variable-speed prewarm coverage for multiple candidates and already-visible candidates.

## Verification
- npm run test:run -- src/features/preview/utils/render-pump-invariants.test.ts src/features/preview/utils/render-pump-preseek.test.ts src/features/preview/utils/render-pump-frame-plan.test.ts src/features/preview/utils/playback-transition-overlay.test.ts
- npm run lint
- npm run format:check
- npm run check:boundaries && npm run check:deps-contracts && npm run check:legacy-lib-imports && npm run check:deps-wrapper-health
- git push pre-push quality checks: check:boundaries, check:deps-contracts, check:legacy-lib-imports, check:deps-wrapper-health, check:edge-budgets, vp check --no-fmt src vite.config.ts --silent