### PR TITLE
refactor(preview): extract render pump prewarm planners

### DIFF
--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -46,6 +46,10 @@ import {
   getVideoItemSourceTimeSeconds,
   resolvePausedVariableSpeedPrewarmPlan,
 } from '../utils/render-pump-preseek'
+import {
+  resolveBoundarySourcePrewarmCacheUpdate,
+  resolvePrewarmFrameQueueAfterEnqueue,
+} from '../utils/render-pump-prewarm-plan'
 import type { TransitionPreviewSessionTrace } from './use-preview-transition-session-controller'
 import { createLogger } from '@/shared/logging/logger'
 
@@ -417,17 +421,15 @@ export function usePreviewRenderPump({
 
       try {
         const enqueuePrewarmFrame = (frame: number) => {
-          if (frame < 0) return
-          if (scrubPrewarmQueuedSetRef.current.has(frame)) return
-          if (scrubPrewarmedFrameSetRef.current.has(frame)) return
-          scrubPrewarmQueuedSetRef.current.add(frame)
-          scrubPrewarmQueueRef.current.push(frame)
-          while (scrubPrewarmQueueRef.current.length > FAST_SCRUB_PREWARM_QUEUE_MAX) {
-            const dropped = scrubPrewarmQueueRef.current.shift()
-            if (dropped !== undefined) {
-              scrubPrewarmQueuedSetRef.current.delete(dropped)
-            }
-          }
+          const plan = resolvePrewarmFrameQueueAfterEnqueue({
+            frame,
+            queue: scrubPrewarmQueueRef.current,
+            queuedFrames: scrubPrewarmQueuedSetRef.current,
+            prewarmedFrames: scrubPrewarmedFrameSetRef.current,
+            maxQueueSize: FAST_SCRUB_PREWARM_QUEUE_MAX,
+          })
+          scrubPrewarmQueueRef.current = plan.queue
+          scrubPrewarmQueuedSetRef.current = plan.queuedFrames
         }
 
         const markPrewarmed = (frame: number) => {
@@ -459,37 +461,27 @@ export function usePreviewRenderPump({
           if (fastScrubBoundarySources.length === 0) return
 
           const pool = getGlobalVideoSourcePool()
-          const touchFrameMap = scrubPrewarmedSourceTouchFrameRef.current
           const markBoundarySourcePrewarmed = (src: string, currentFrame: number): boolean => {
-            const lastTouchedFrame = touchFrameMap.get(src)
-            if (
-              lastTouchedFrame !== undefined &&
-              Math.abs(currentFrame - lastTouchedFrame) < FAST_SCRUB_SOURCE_TOUCH_COOLDOWN_FRAMES
-            ) {
+            const plan = resolveBoundarySourcePrewarmCacheUpdate({
+              src,
+              currentFrame,
+              touchFrameEntries: Array.from(scrubPrewarmedSourceTouchFrameRef.current.entries()),
+              prewarmedSources: scrubPrewarmedSourcesRef.current,
+              prewarmedSourceOrder: scrubPrewarmedSourceOrderRef.current,
+              cooldownFrames: FAST_SCRUB_SOURCE_TOUCH_COOLDOWN_FRAMES,
+              maxSources: FAST_SCRUB_MAX_PREWARM_SOURCES,
+            })
+
+            if (!plan.touched) {
               return false
             }
-            touchFrameMap.set(src, currentFrame)
-            const prewarmedSet = scrubPrewarmedSourcesRef.current
-            const prewarmedOrder = scrubPrewarmedSourceOrderRef.current
-            const existingIndex = prewarmedOrder.indexOf(src)
-            if (existingIndex >= 0) {
-              prewarmedOrder.splice(existingIndex, 1)
-            } else {
-              prewarmedSet.add(src)
-            }
-            prewarmedOrder.push(src)
 
-            while (prewarmedOrder.length > FAST_SCRUB_MAX_PREWARM_SOURCES) {
-              const evicted = prewarmedOrder.shift()
-              if (evicted === undefined) break
-              if (prewarmedSet.delete(evicted)) {
-                touchFrameMap.delete(evicted)
-                previewPerfRef.current.fastScrubPrewarmSourceEvictions += 1
-              }
-            }
-
-            previewPerfRef.current.fastScrubPrewarmedSources = prewarmedSet.size
-            return true
+            scrubPrewarmedSourceTouchFrameRef.current = new Map(plan.touchFrameEntries)
+            scrubPrewarmedSourcesRef.current = plan.prewarmedSources
+            scrubPrewarmedSourceOrderRef.current = plan.prewarmedSourceOrder
+            previewPerfRef.current.fastScrubPrewarmSourceEvictions += plan.evictedSources.length
+            previewPerfRef.current.fastScrubPrewarmedSources = plan.prewarmedSources.size
+            return plan.touched
           }
           const selectedSources = selectBoundarySourcePrewarmSources({
             boundarySources: fastScrubBoundarySources,

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -465,7 +465,7 @@ export function usePreviewRenderPump({
             const plan = resolveBoundarySourcePrewarmCacheUpdate({
               src,
               currentFrame,
-              touchFrameEntries: Array.from(scrubPrewarmedSourceTouchFrameRef.current.entries()),
+              touchFrameMap: scrubPrewarmedSourceTouchFrameRef.current,
               prewarmedSources: scrubPrewarmedSourcesRef.current,
               prewarmedSourceOrder: scrubPrewarmedSourceOrderRef.current,
               cooldownFrames: FAST_SCRUB_SOURCE_TOUCH_COOLDOWN_FRAMES,
@@ -476,12 +476,12 @@ export function usePreviewRenderPump({
               return false
             }
 
-            scrubPrewarmedSourceTouchFrameRef.current = new Map(plan.touchFrameEntries)
+            scrubPrewarmedSourceTouchFrameRef.current = plan.touchFrameMap
             scrubPrewarmedSourcesRef.current = plan.prewarmedSources
             scrubPrewarmedSourceOrderRef.current = plan.prewarmedSourceOrder
             previewPerfRef.current.fastScrubPrewarmSourceEvictions += plan.evictedSources.length
             previewPerfRef.current.fastScrubPrewarmedSources = plan.prewarmedSources.size
-            return plan.touched
+            return true
           }
           const selectedSources = selectBoundarySourcePrewarmSources({
             boundarySources: fastScrubBoundarySources,

--- a/src/features/preview/utils/render-pump-prewarm-plan.test.ts
+++ b/src/features/preview/utils/render-pump-prewarm-plan.test.ts
@@ -34,14 +34,30 @@ describe('render pump prewarm planner helpers', () => {
     expect(resolvePrewarmFrameQueueAfterEnqueue({ ...base, frame: 12 }).enqueued).toBe(false)
   })
 
+  it('preserves frame queue references when rejecting duplicate prewarm frames', () => {
+    const queue = [10]
+    const queuedFrames = new Set([10])
+    const plan = resolvePrewarmFrameQueueAfterEnqueue({
+      frame: 10,
+      queue,
+      queuedFrames,
+      prewarmedFrames: new Set<number>(),
+      maxQueueSize: 3,
+    })
+
+    expect(plan.enqueued).toBe(false)
+    expect(plan.queue).toBe(queue)
+    expect(plan.queuedFrames).toBe(queuedFrames)
+  })
+
   it('touches boundary sources with LRU ordering and reports source evictions', () => {
     const next = resolveBoundarySourcePrewarmCacheUpdate({
       src: 'new.mp4',
       currentFrame: 120,
-      touchFrameEntries: [
+      touchFrameMap: new Map([
         ['old-a.mp4', 20],
         ['old-b.mp4', 30],
-      ],
+      ]),
       prewarmedSources: new Set(['old-a.mp4', 'old-b.mp4']),
       prewarmedSourceOrder: ['old-a.mp4', 'old-b.mp4'],
       cooldownFrames: 6,
@@ -52,10 +68,10 @@ describe('render pump prewarm planner helpers', () => {
       touched: true,
       wasAlreadyPrewarmed: false,
       evictedSources: ['old-a.mp4'],
-      touchFrameEntries: [
+      touchFrameMap: new Map([
         ['old-b.mp4', 30],
         ['new.mp4', 120],
-      ],
+      ]),
       prewarmedSources: new Set(['old-b.mp4', 'new.mp4']),
       prewarmedSourceOrder: ['old-b.mp4', 'new.mp4'],
     })
@@ -65,7 +81,7 @@ describe('render pump prewarm planner helpers', () => {
     const next = resolveBoundarySourcePrewarmCacheUpdate({
       src: 'clip.mp4',
       currentFrame: 24,
-      touchFrameEntries: [['clip.mp4', 20]],
+      touchFrameMap: new Map([['clip.mp4', 20]]),
       prewarmedSources: new Set(['clip.mp4']),
       prewarmedSourceOrder: ['clip.mp4'],
       cooldownFrames: 6,

--- a/src/features/preview/utils/render-pump-prewarm-plan.test.ts
+++ b/src/features/preview/utils/render-pump-prewarm-plan.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  resolveBoundarySourcePrewarmCacheUpdate,
+  resolvePrewarmFrameQueueAfterEnqueue,
+} from './render-pump-prewarm-plan'
+
+describe('render pump prewarm planner helpers', () => {
+  it('enqueues eligible prewarm frames and evicts oldest queued frames at the cap', () => {
+    const next = resolvePrewarmFrameQueueAfterEnqueue({
+      frame: 14,
+      queue: [10, 11, 12],
+      queuedFrames: new Set([10, 11, 12]),
+      prewarmedFrames: new Set([9]),
+      maxQueueSize: 3,
+    })
+
+    expect(next).toEqual({
+      enqueued: true,
+      queue: [11, 12, 14],
+      queuedFrames: new Set([11, 12, 14]),
+    })
+  })
+
+  it('does not enqueue negative, queued, or already prewarmed frames', () => {
+    const base = {
+      queue: [10],
+      queuedFrames: new Set([10]),
+      prewarmedFrames: new Set([12]),
+      maxQueueSize: 3,
+    }
+
+    expect(resolvePrewarmFrameQueueAfterEnqueue({ ...base, frame: -1 }).enqueued).toBe(false)
+    expect(resolvePrewarmFrameQueueAfterEnqueue({ ...base, frame: 10 }).enqueued).toBe(false)
+    expect(resolvePrewarmFrameQueueAfterEnqueue({ ...base, frame: 12 }).enqueued).toBe(false)
+  })
+
+  it('touches boundary sources with LRU ordering and reports source evictions', () => {
+    const next = resolveBoundarySourcePrewarmCacheUpdate({
+      src: 'new.mp4',
+      currentFrame: 120,
+      touchFrameEntries: [
+        ['old-a.mp4', 20],
+        ['old-b.mp4', 30],
+      ],
+      prewarmedSources: new Set(['old-a.mp4', 'old-b.mp4']),
+      prewarmedSourceOrder: ['old-a.mp4', 'old-b.mp4'],
+      cooldownFrames: 6,
+      maxSources: 2,
+    })
+
+    expect(next).toEqual({
+      touched: true,
+      wasAlreadyPrewarmed: false,
+      evictedSources: ['old-a.mp4'],
+      touchFrameEntries: [
+        ['old-b.mp4', 30],
+        ['new.mp4', 120],
+      ],
+      prewarmedSources: new Set(['old-b.mp4', 'new.mp4']),
+      prewarmedSourceOrder: ['old-b.mp4', 'new.mp4'],
+    })
+  })
+
+  it('skips boundary source touches inside the frame cooldown window', () => {
+    const next = resolveBoundarySourcePrewarmCacheUpdate({
+      src: 'clip.mp4',
+      currentFrame: 24,
+      touchFrameEntries: [['clip.mp4', 20]],
+      prewarmedSources: new Set(['clip.mp4']),
+      prewarmedSourceOrder: ['clip.mp4'],
+      cooldownFrames: 6,
+      maxSources: 2,
+    })
+
+    expect(next.touched).toBe(false)
+    expect(next.prewarmedSourceOrder).toEqual(['clip.mp4'])
+    expect(next.evictedSources).toEqual([])
+  })
+})

--- a/src/features/preview/utils/render-pump-prewarm-plan.ts
+++ b/src/features/preview/utils/render-pump-prewarm-plan.ts
@@ -1,0 +1,125 @@
+type ScrubPrewarmFrameQueueInput = {
+  frame: number
+  queue: number[]
+  queuedFrames: Set<number>
+  prewarmedFrames: Set<number>
+  maxQueueSize: number
+}
+
+type ScrubPrewarmFrameQueuePlan = {
+  enqueued: boolean
+  queue: number[]
+  queuedFrames: Set<number>
+}
+
+type BoundarySourcePrewarmCacheInput = {
+  src: string
+  currentFrame: number
+  touchFrameEntries: Array<[string, number]>
+  prewarmedSources: Set<string>
+  prewarmedSourceOrder: string[]
+  cooldownFrames: number
+  maxSources: number
+}
+
+type BoundarySourcePrewarmCachePlan = {
+  touched: boolean
+  wasAlreadyPrewarmed: boolean
+  evictedSources: string[]
+  touchFrameEntries: Array<[string, number]>
+  prewarmedSources: Set<string>
+  prewarmedSourceOrder: string[]
+}
+
+export function resolvePrewarmFrameQueueAfterEnqueue({
+  frame,
+  queue,
+  queuedFrames,
+  prewarmedFrames,
+  maxQueueSize,
+}: ScrubPrewarmFrameQueueInput): ScrubPrewarmFrameQueuePlan {
+  const nextQueue = [...queue]
+  const nextQueuedFrames = new Set(queuedFrames)
+
+  if (frame < 0 || nextQueuedFrames.has(frame) || prewarmedFrames.has(frame)) {
+    return {
+      enqueued: false,
+      queue: nextQueue,
+      queuedFrames: nextQueuedFrames,
+    }
+  }
+
+  nextQueuedFrames.add(frame)
+  nextQueue.push(frame)
+
+  while (nextQueue.length > maxQueueSize) {
+    const dropped = nextQueue.shift()
+    if (dropped !== undefined) {
+      nextQueuedFrames.delete(dropped)
+    }
+  }
+
+  return {
+    enqueued: true,
+    queue: nextQueue,
+    queuedFrames: nextQueuedFrames,
+  }
+}
+
+export function resolveBoundarySourcePrewarmCacheUpdate({
+  src,
+  currentFrame,
+  touchFrameEntries,
+  prewarmedSources,
+  prewarmedSourceOrder,
+  cooldownFrames,
+  maxSources,
+}: BoundarySourcePrewarmCacheInput): BoundarySourcePrewarmCachePlan {
+  const nextTouchFrameMap = new Map(touchFrameEntries)
+  const nextPrewarmedSources = new Set(prewarmedSources)
+  const nextPrewarmedSourceOrder = [...prewarmedSourceOrder]
+  const wasAlreadyPrewarmed = nextPrewarmedSources.has(src)
+
+  const lastTouchedFrame = nextTouchFrameMap.get(src)
+  if (
+    lastTouchedFrame !== undefined &&
+    Math.abs(currentFrame - lastTouchedFrame) < cooldownFrames
+  ) {
+    return {
+      touched: false,
+      wasAlreadyPrewarmed,
+      evictedSources: [],
+      touchFrameEntries: Array.from(nextTouchFrameMap.entries()),
+      prewarmedSources: nextPrewarmedSources,
+      prewarmedSourceOrder: nextPrewarmedSourceOrder,
+    }
+  }
+
+  nextTouchFrameMap.set(src, currentFrame)
+  const existingIndex = nextPrewarmedSourceOrder.indexOf(src)
+  if (existingIndex >= 0) {
+    nextPrewarmedSourceOrder.splice(existingIndex, 1)
+  } else {
+    nextPrewarmedSources.add(src)
+  }
+  nextPrewarmedSourceOrder.push(src)
+
+  const evictedSources: string[] = []
+  while (nextPrewarmedSourceOrder.length > maxSources) {
+    const evicted = nextPrewarmedSourceOrder.shift()
+    if (evicted === undefined) break
+    if (nextPrewarmedSources.delete(evicted)) {
+      nextTouchFrameMap.delete(evicted)
+      evictedSources.push(evicted)
+    }
+  }
+
+  return {
+    touched: true,
+    wasAlreadyPrewarmed,
+    evictedSources,
+    touchFrameEntries: Array.from(nextTouchFrameMap.entries()),
+    prewarmedSources: nextPrewarmedSources,
+    prewarmedSourceOrder: nextPrewarmedSourceOrder,
+  }
+}

--- a/src/features/preview/utils/render-pump-prewarm-plan.ts
+++ b/src/features/preview/utils/render-pump-prewarm-plan.ts
@@ -15,7 +15,7 @@ type ScrubPrewarmFrameQueuePlan = {
 type BoundarySourcePrewarmCacheInput = {
   src: string
   currentFrame: number
-  touchFrameEntries: Array<[string, number]>
+  touchFrameMap: Map<string, number>
   prewarmedSources: Set<string>
   prewarmedSourceOrder: string[]
   cooldownFrames: number
@@ -26,7 +26,7 @@ type BoundarySourcePrewarmCachePlan = {
   touched: boolean
   wasAlreadyPrewarmed: boolean
   evictedSources: string[]
-  touchFrameEntries: Array<[string, number]>
+  touchFrameMap: Map<string, number>
   prewarmedSources: Set<string>
   prewarmedSourceOrder: string[]
 }
@@ -38,16 +38,16 @@ export function resolvePrewarmFrameQueueAfterEnqueue({
   prewarmedFrames,
   maxQueueSize,
 }: ScrubPrewarmFrameQueueInput): ScrubPrewarmFrameQueuePlan {
-  const nextQueue = [...queue]
-  const nextQueuedFrames = new Set(queuedFrames)
-
-  if (frame < 0 || nextQueuedFrames.has(frame) || prewarmedFrames.has(frame)) {
+  if (frame < 0 || queuedFrames.has(frame) || prewarmedFrames.has(frame)) {
     return {
       enqueued: false,
-      queue: nextQueue,
-      queuedFrames: nextQueuedFrames,
+      queue,
+      queuedFrames,
     }
   }
+
+  const nextQueue = [...queue]
+  const nextQueuedFrames = new Set(queuedFrames)
 
   nextQueuedFrames.add(frame)
   nextQueue.push(frame)
@@ -69,18 +69,15 @@ export function resolvePrewarmFrameQueueAfterEnqueue({
 export function resolveBoundarySourcePrewarmCacheUpdate({
   src,
   currentFrame,
-  touchFrameEntries,
+  touchFrameMap,
   prewarmedSources,
   prewarmedSourceOrder,
   cooldownFrames,
   maxSources,
 }: BoundarySourcePrewarmCacheInput): BoundarySourcePrewarmCachePlan {
-  const nextTouchFrameMap = new Map(touchFrameEntries)
-  const nextPrewarmedSources = new Set(prewarmedSources)
-  const nextPrewarmedSourceOrder = [...prewarmedSourceOrder]
-  const wasAlreadyPrewarmed = nextPrewarmedSources.has(src)
+  const wasAlreadyPrewarmed = prewarmedSources.has(src)
 
-  const lastTouchedFrame = nextTouchFrameMap.get(src)
+  const lastTouchedFrame = touchFrameMap.get(src)
   if (
     lastTouchedFrame !== undefined &&
     Math.abs(currentFrame - lastTouchedFrame) < cooldownFrames
@@ -89,11 +86,15 @@ export function resolveBoundarySourcePrewarmCacheUpdate({
       touched: false,
       wasAlreadyPrewarmed,
       evictedSources: [],
-      touchFrameEntries: Array.from(nextTouchFrameMap.entries()),
-      prewarmedSources: nextPrewarmedSources,
-      prewarmedSourceOrder: nextPrewarmedSourceOrder,
+      touchFrameMap,
+      prewarmedSources,
+      prewarmedSourceOrder,
     }
   }
+
+  const nextTouchFrameMap = new Map(touchFrameMap)
+  const nextPrewarmedSources = new Set(prewarmedSources)
+  const nextPrewarmedSourceOrder = [...prewarmedSourceOrder]
 
   nextTouchFrameMap.set(src, currentFrame)
   const existingIndex = nextPrewarmedSourceOrder.indexOf(src)
@@ -118,7 +119,7 @@ export function resolveBoundarySourcePrewarmCacheUpdate({
     touched: true,
     wasAlreadyPrewarmed,
     evictedSources,
-    touchFrameEntries: Array.from(nextTouchFrameMap.entries()),
+    touchFrameMap: nextTouchFrameMap,
     prewarmedSources: nextPrewarmedSources,
     prewarmedSourceOrder: nextPrewarmedSourceOrder,
   }


### PR DESCRIPTION
## Summary
- Extract pure render-pump prewarm frame queue planning into a tested utility
- Extract boundary-source prewarm LRU/cooldown planning into a tested utility
- Keep the preview render-pump hook responsible for refs, renderer calls, and side effects

## Test Plan
- npm run test:run -- src/features/preview/utils/render-pump-prewarm-plan.test.ts src/features/preview/utils/render-pump-frame-plan.test.ts src/features/preview/utils/render-pump-preseek.test.ts src/features/preview/utils/render-pump-invariants.test.ts src/features/preview/hooks/use-preview-render-pump-controller.test.ts
- npm run check