### PR TITLE
refactor(preview): isolate transition prewarm guards

### DIFF
--- a/src/features/preview/hooks/use-preview-transition-session-controller.ts
+++ b/src/features/preview/hooks/use-preview-transition-session-controller.ts
@@ -8,6 +8,11 @@ import {
   snapSourceTime,
 } from '@/features/preview/deps/composition-runtime'
 import { createLogger, createOperationId } from '@/shared/logging/logger'
+import {
+  resolveTransitionPrerenderPlan,
+  selectUpcomingTransitionStartFrame,
+  shouldUsePausedTransitionOverlay,
+} from '../utils/transition-prewarm-guards'
 
 const logger = createLogger('VideoPreview')
 
@@ -390,22 +395,14 @@ export function usePreviewTransitionSessionController({
   )
 
   const getUpcomingTransitionStartFrame = useCallback(
-    (frame: number, maxLookaheadFrames: number, options?: { complexOnly?: boolean }) => {
-      const nextWindow = playbackTransitionWindows.find((window) => {
-        if (frame > window.startFrame) {
-          return false
-        }
-        if (options?.complexOnly && !playbackTransitionComplexStartFrames.has(window.startFrame)) {
-          return false
-        }
-        return true
-      })
-      if (!nextWindow) return null
-      if (nextWindow.startFrame - frame > maxLookaheadFrames) {
-        return null
-      }
-      return nextWindow.startFrame
-    },
+    (frame: number, maxLookaheadFrames: number, options?: { complexOnly?: boolean }) =>
+      selectUpcomingTransitionStartFrame({
+        frame,
+        maxLookaheadFrames,
+        windows: playbackTransitionWindows,
+        complexStartFrames: playbackTransitionComplexStartFrames,
+        complexOnly: options?.complexOnly,
+      }),
     [playbackTransitionComplexStartFrames, playbackTransitionWindows],
   )
 
@@ -425,12 +422,12 @@ export function usePreviewTransitionSessionController({
 
   const isPausedTransitionOverlayActive = useCallback(
     (frame: number, playbackState: { isPlaying: boolean; previewFrame: number | null }) => {
-      return (
-        !playbackState.isPlaying &&
-        playbackState.previewFrame === null &&
-        !forceFastScrubOverlay &&
-        getActiveTransitionWindowForFrame(frame) !== null
-      )
+      return shouldUsePausedTransitionOverlay({
+        isPlaying: playbackState.isPlaying,
+        previewFrame: playbackState.previewFrame,
+        forceFastScrubOverlay,
+        hasActiveTransition: getActiveTransitionWindowForFrame(frame) !== null,
+      })
     },
     [forceFastScrubOverlay, getActiveTransitionWindowForFrame],
   )
@@ -525,25 +522,28 @@ export function usePreviewTransitionSessionController({
           }
 
           const isComplexTransitionStart = playbackTransitionComplexStartFrames.has(targetFrame)
-          const shouldCachePlaybackRunway = usePlaybackStore.getState().isPlaying
-          const shouldRenderFullTargetFrame =
-            forceFastScrubOverlay || isComplexTransitionStart || shouldCachePlaybackRunway
-          if (shouldRenderFullTargetFrame) {
-            await renderer.renderFrame(targetFrame)
-            cacheTransitionSessionFrame(targetFrame)
+          const prerenderPlan = resolveTransitionPrerenderPlan({
+            targetFrame,
+            runwayFrames: playbackTransitionPrerenderRunwayFrames,
+            forceFastScrubOverlay,
+            isComplexTransitionStart,
+            isPlaying: usePlaybackStore.getState().isPlaying,
+          })
+          if (!prerenderPlan.renderTargetAfterRunway) {
+            await renderer.renderFrame(prerenderPlan.targetFrame.frame)
+            cacheTransitionSessionFrame(prerenderPlan.targetFrame.frame)
           }
-          for (let offset = 1; offset < playbackTransitionPrerenderRunwayFrames; offset += 1) {
-            const runwayFrame = targetFrame + offset
-            if (shouldCachePlaybackRunway || (forceFastScrubOverlay && !isComplexTransitionStart)) {
-              await renderer.renderFrame(runwayFrame)
-              cacheTransitionSessionFrame(runwayFrame)
+          for (const runwayFrame of prerenderPlan.runwayFrames) {
+            if (runwayFrame.action === 'render-and-cache') {
+              await renderer.renderFrame(runwayFrame.frame)
+              cacheTransitionSessionFrame(runwayFrame.frame)
             } else {
-              await renderer.prewarmFrame(runwayFrame)
+              await renderer.prewarmFrame(runwayFrame.frame)
             }
           }
-          if (!shouldRenderFullTargetFrame) {
-            await renderer.renderFrame(targetFrame)
-            cacheTransitionSessionFrame(targetFrame)
+          if (prerenderPlan.renderTargetAfterRunway) {
+            await renderer.renderFrame(prerenderPlan.targetFrame.frame)
+            cacheTransitionSessionFrame(prerenderPlan.targetFrame.frame)
           }
           if (!scrubMountedRef.current) return false
           scrubOffscreenRenderedFrameRef.current = targetFrame

--- a/src/features/preview/utils/transition-prewarm-guards.test.ts
+++ b/src/features/preview/utils/transition-prewarm-guards.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  resolveTransitionPrerenderPlan,
+  selectUpcomingTransitionStartFrame,
+  shouldUsePausedTransitionOverlay,
+} from './transition-prewarm-guards'
+
+describe('selectUpcomingTransitionStartFrame', () => {
+  const windows = [{ startFrame: 100 }, { startFrame: 180 }, { startFrame: 260 }]
+
+  it('selects the first transition at or after the current frame within lookahead', () => {
+    expect(
+      selectUpcomingTransitionStartFrame({
+        frame: 90,
+        maxLookaheadFrames: 20,
+        windows,
+      }),
+    ).toBe(100)
+  })
+
+  it('includes a transition that starts on the current frame', () => {
+    expect(
+      selectUpcomingTransitionStartFrame({
+        frame: 100,
+        maxLookaheadFrames: 0,
+        windows,
+      }),
+    ).toBe(100)
+  })
+
+  it('ignores transitions that already started before the current frame', () => {
+    expect(
+      selectUpcomingTransitionStartFrame({
+        frame: 101,
+        maxLookaheadFrames: 100,
+        windows,
+      }),
+    ).toBe(180)
+  })
+
+  it('returns null when the next transition is beyond the lookahead', () => {
+    expect(
+      selectUpcomingTransitionStartFrame({
+        frame: 50,
+        maxLookaheadFrames: 20,
+        windows,
+      }),
+    ).toBeNull()
+  })
+
+  it('can restrict selection to complex transition starts', () => {
+    expect(
+      selectUpcomingTransitionStartFrame({
+        frame: 90,
+        maxLookaheadFrames: 120,
+        windows,
+        complexStartFrames: new Set([180]),
+        complexOnly: true,
+      }),
+    ).toBe(180)
+  })
+})
+
+describe('shouldUsePausedTransitionOverlay', () => {
+  it('enables paused transition overlay only without playback, preview frame, or forced fast overlay', () => {
+    expect(
+      shouldUsePausedTransitionOverlay({
+        isPlaying: false,
+        previewFrame: null,
+        forceFastScrubOverlay: false,
+        hasActiveTransition: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('disables paused transition overlay for each existing guard condition', () => {
+    expect(
+      shouldUsePausedTransitionOverlay({
+        isPlaying: true,
+        previewFrame: null,
+        forceFastScrubOverlay: false,
+        hasActiveTransition: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldUsePausedTransitionOverlay({
+        isPlaying: false,
+        previewFrame: 10,
+        forceFastScrubOverlay: false,
+        hasActiveTransition: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldUsePausedTransitionOverlay({
+        isPlaying: false,
+        previewFrame: null,
+        forceFastScrubOverlay: true,
+        hasActiveTransition: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldUsePausedTransitionOverlay({
+        isPlaying: false,
+        previewFrame: null,
+        forceFastScrubOverlay: false,
+        hasActiveTransition: false,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('resolveTransitionPrerenderPlan', () => {
+  it('renders and caches the target frame for forced fast overlay', () => {
+    expect(
+      resolveTransitionPrerenderPlan({
+        targetFrame: 100,
+        runwayFrames: 4,
+        forceFastScrubOverlay: true,
+        isComplexTransitionStart: false,
+        isPlaying: false,
+      }),
+    ).toEqual({
+      targetFrame: { action: 'render-and-cache', frame: 100 },
+      runwayFrames: [
+        { action: 'render-and-cache', frame: 101 },
+        { action: 'render-and-cache', frame: 102 },
+        { action: 'render-and-cache', frame: 103 },
+      ],
+      renderTargetAfterRunway: false,
+    })
+  })
+
+  it('prewarms runway before rendering a complex target when not forced or playing', () => {
+    expect(
+      resolveTransitionPrerenderPlan({
+        targetFrame: 100,
+        runwayFrames: 3,
+        forceFastScrubOverlay: false,
+        isComplexTransitionStart: true,
+        isPlaying: false,
+      }),
+    ).toEqual({
+      targetFrame: { action: 'render-and-cache', frame: 100 },
+      runwayFrames: [
+        { action: 'prewarm', frame: 101 },
+        { action: 'prewarm', frame: 102 },
+      ],
+      renderTargetAfterRunway: false,
+    })
+  })
+
+  it('caches playback runway frames and renders the target before runway', () => {
+    expect(
+      resolveTransitionPrerenderPlan({
+        targetFrame: 100,
+        runwayFrames: 3,
+        forceFastScrubOverlay: false,
+        isComplexTransitionStart: false,
+        isPlaying: true,
+      }),
+    ).toEqual({
+      targetFrame: { action: 'render-and-cache', frame: 100 },
+      runwayFrames: [
+        { action: 'render-and-cache', frame: 101 },
+        { action: 'render-and-cache', frame: 102 },
+      ],
+      renderTargetAfterRunway: false,
+    })
+  })
+
+  it('prewarms runway and delays non-complex target render without forced overlay', () => {
+    expect(
+      resolveTransitionPrerenderPlan({
+        targetFrame: 100,
+        runwayFrames: 2,
+        forceFastScrubOverlay: false,
+        isComplexTransitionStart: false,
+        isPlaying: false,
+      }),
+    ).toEqual({
+      targetFrame: { action: 'render-and-cache', frame: 100 },
+      runwayFrames: [{ action: 'prewarm', frame: 101 }],
+      renderTargetAfterRunway: true,
+    })
+  })
+})

--- a/src/features/preview/utils/transition-prewarm-guards.test.ts
+++ b/src/features/preview/utils/transition-prewarm-guards.test.ts
@@ -130,6 +130,25 @@ describe('resolveTransitionPrerenderPlan', () => {
     })
   })
 
+  it('prewarms forced-overlay runway frames for complex transition starts', () => {
+    expect(
+      resolveTransitionPrerenderPlan({
+        targetFrame: 100,
+        runwayFrames: 3,
+        forceFastScrubOverlay: true,
+        isComplexTransitionStart: true,
+        isPlaying: false,
+      }),
+    ).toEqual({
+      targetFrame: { action: 'render-and-cache', frame: 100 },
+      runwayFrames: [
+        { action: 'prewarm', frame: 101 },
+        { action: 'prewarm', frame: 102 },
+      ],
+      renderTargetAfterRunway: false,
+    })
+  })
+
   it('prewarms runway before rendering a complex target when not forced or playing', () => {
     expect(
       resolveTransitionPrerenderPlan({

--- a/src/features/preview/utils/transition-prewarm-guards.ts
+++ b/src/features/preview/utils/transition-prewarm-guards.ts
@@ -15,19 +15,22 @@ export interface TransitionPrerenderPlan {
   renderTargetAfterRunway: boolean
 }
 
+type SelectUpcomingTransitionStartFrameParams = {
+  frame: number
+  maxLookaheadFrames: number
+  windows: readonly TransitionStartWindow[]
+} & (
+  | { complexOnly?: false; complexStartFrames?: ReadonlySet<number> }
+  | { complexOnly: true; complexStartFrames: ReadonlySet<number> }
+)
+
 export function selectUpcomingTransitionStartFrame({
   frame,
   maxLookaheadFrames,
   windows,
   complexStartFrames,
   complexOnly = false,
-}: {
-  frame: number
-  maxLookaheadFrames: number
-  windows: readonly TransitionStartWindow[]
-  complexStartFrames?: ReadonlySet<number>
-  complexOnly?: boolean
-}): number | null {
+}: SelectUpcomingTransitionStartFrameParams): number | null {
   const nextWindow = windows.find((window) => {
     if (frame > window.startFrame) {
       return false

--- a/src/features/preview/utils/transition-prewarm-guards.ts
+++ b/src/features/preview/utils/transition-prewarm-guards.ts
@@ -1,0 +1,88 @@
+export type TransitionStartWindow = {
+  startFrame: number
+}
+
+export type TransitionPrerenderAction = 'render-and-cache' | 'prewarm'
+
+export type TransitionPrerenderFramePlan = {
+  action: TransitionPrerenderAction
+  frame: number
+}
+
+export interface TransitionPrerenderPlan {
+  targetFrame: TransitionPrerenderFramePlan
+  runwayFrames: TransitionPrerenderFramePlan[]
+  renderTargetAfterRunway: boolean
+}
+
+export function selectUpcomingTransitionStartFrame({
+  frame,
+  maxLookaheadFrames,
+  windows,
+  complexStartFrames,
+  complexOnly = false,
+}: {
+  frame: number
+  maxLookaheadFrames: number
+  windows: readonly TransitionStartWindow[]
+  complexStartFrames?: ReadonlySet<number>
+  complexOnly?: boolean
+}): number | null {
+  const nextWindow = windows.find((window) => {
+    if (frame > window.startFrame) {
+      return false
+    }
+    if (complexOnly && !complexStartFrames?.has(window.startFrame)) {
+      return false
+    }
+    return true
+  })
+  if (!nextWindow) return null
+  if (nextWindow.startFrame - frame > maxLookaheadFrames) {
+    return null
+  }
+  return nextWindow.startFrame
+}
+
+export function shouldUsePausedTransitionOverlay({
+  isPlaying,
+  previewFrame,
+  forceFastScrubOverlay,
+  hasActiveTransition,
+}: {
+  isPlaying: boolean
+  previewFrame: number | null
+  forceFastScrubOverlay: boolean
+  hasActiveTransition: boolean
+}): boolean {
+  return !isPlaying && previewFrame === null && !forceFastScrubOverlay && hasActiveTransition
+}
+
+export function resolveTransitionPrerenderPlan({
+  targetFrame,
+  runwayFrames,
+  forceFastScrubOverlay,
+  isComplexTransitionStart,
+  isPlaying,
+}: {
+  targetFrame: number
+  runwayFrames: number
+  forceFastScrubOverlay: boolean
+  isComplexTransitionStart: boolean
+  isPlaying: boolean
+}): TransitionPrerenderPlan {
+  const shouldCachePlaybackRunway = isPlaying
+  const shouldRenderFullTargetFrame =
+    forceFastScrubOverlay || isComplexTransitionStart || shouldCachePlaybackRunway
+  const shouldRenderRunway =
+    shouldCachePlaybackRunway || (forceFastScrubOverlay && !isComplexTransitionStart)
+
+  return {
+    targetFrame: { action: 'render-and-cache', frame: targetFrame },
+    runwayFrames: Array.from({ length: Math.max(0, runwayFrames - 1) }, (_, index) => ({
+      action: shouldRenderRunway ? 'render-and-cache' : 'prewarm',
+      frame: targetFrame + index + 1,
+    })),
+    renderTargetAfterRunway: !shouldRenderFullTargetFrame,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract pure helpers for transition prewarm window selection, paused overlay eligibility, and prerender runway planning
- Wire the transition session controller through the helpers without changing media side effects or timing paths
- Add characterization coverage for the extracted guard decisions

## Test Plan
- npx -y node@22 node_modules/.bin/vp test run src/features/preview/utils/transition-prewarm-guards.test.ts src/features/preview/hooks/use-preview-transition-model.test.ts src/features/preview/utils/playback-transition-overlay.test.ts src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts
- npm run check