### PR TITLE
refactor(composition-runtime): extract audio scene derivation

### DIFF
--- a/src/features/composition-runtime/compositions/main-composition.tsx
+++ b/src/features/composition-runtime/compositions/main-composition.tsx
@@ -33,6 +33,7 @@ import {
   type VideoAudioSegment,
 } from '../utils/audio-scene'
 import {
+  deriveCompositionAudioScene,
   resolveCompositionRenderPlan,
   type AudioTrackItem,
   type ShapeMaskWithTrackOrder,
@@ -48,7 +49,6 @@ import {
 import {
   getManagedLinkedAudioTransitions,
   hasLinkedAudioCompanion,
-  isCompositionAudioItem,
 } from '@/shared/utils/linked-media'
 import {
   appendResolvedAudioEqSources,
@@ -190,17 +190,6 @@ export const MainComposition: React.FC<MainCompositionProps> = ({
   // This prevents audio from being affected by visual layer changes (mask add/delete, item moves)
   // Use ALL tracks for stable DOM structure, with trackVisible for conditional playback
   const audioItems: EnrichedAudioItem[] = renderPlan.audioItems
-  const compoundAudioItems = useMemo(
-    () =>
-      audioItems.filter((item): item is EnrichedAudioItem & { compositionId: string } =>
-        isCompositionAudioItem(item),
-      ),
-    [audioItems],
-  )
-  const directSourceAudioItems = useMemo(
-    () => audioItems.filter((item) => !isCompositionAudioItem(item)),
-    [audioItems],
-  )
 
   const managedLinkedAudioTransitions = useMemo(
     () =>
@@ -210,73 +199,25 @@ export const MainComposition: React.FC<MainCompositionProps> = ({
       ),
     [tracks, transitions],
   )
-  const managedLinkedAudioIds = useMemo(() => {
-    const ids = new Set<string>()
-    for (const managed of managedLinkedAudioTransitions) {
-      ids.add(managed.leftAudio.id)
-      ids.add(managed.rightAudio.id)
-    }
-    return ids
-  }, [managedLinkedAudioTransitions])
-  const managedLinkedAudioItems = useMemo(
-    () => directSourceAudioItems.filter((item) => managedLinkedAudioIds.has(item.id)),
-    [directSourceAudioItems, managedLinkedAudioIds],
-  )
-  const standaloneAudioItems = useMemo(
-    () => directSourceAudioItems.filter((item) => !managedLinkedAudioIds.has(item.id)),
-    [directSourceAudioItems, managedLinkedAudioIds],
-  )
-  const managedCompoundAudioItems = useMemo(
-    () => compoundAudioItems.filter((item) => managedLinkedAudioIds.has(item.id)),
-    [compoundAudioItems, managedLinkedAudioIds],
-  )
-  const standaloneCompoundAudioItems = useMemo(
-    () => compoundAudioItems.filter((item) => !managedLinkedAudioIds.has(item.id)),
-    [compoundAudioItems, managedLinkedAudioIds],
-  )
-  const managedLinkedAudioItemsById = useMemo(
-    () => new Map(managedLinkedAudioItems.map((item) => [item.id, item])),
-    [managedLinkedAudioItems],
-  )
-  const managedLinkedAudioTransitionDefs = useMemo(
+  const audioScene = useMemo(
     () =>
-      managedLinkedAudioTransitions.flatMap(({ transition, leftAudio, rightAudio }) => {
-        const left = managedLinkedAudioItemsById.get(leftAudio.id)
-        const right = managedLinkedAudioItemsById.get(rightAudio.id)
-        if (!left || !right) return []
-
-        return [
-          {
-            ...transition,
-            leftClipId: left.id,
-            rightClipId: right.id,
-            trackId: left.trackId,
-          },
-        ]
+      deriveCompositionAudioScene({
+        audioItems,
+        managedLinkedAudioTransitions,
       }),
-    [managedLinkedAudioItemsById, managedLinkedAudioTransitions],
+    [audioItems, managedLinkedAudioTransitions],
   )
+  const {
+    managedLinkedAudioItems,
+    standaloneAudioItems,
+    managedCompoundAudioItems,
+    standaloneCompoundAudioItems,
+    managedLinkedAudioTransitionDefs,
+    managedCompoundAudioTransitionDefs,
+  } = audioScene
   const managedCompoundAudioItemsById = useMemo(
     () => new Map(managedCompoundAudioItems.map((item) => [item.id, item])),
     [managedCompoundAudioItems],
-  )
-  const managedCompoundAudioTransitionDefs = useMemo(
-    () =>
-      managedLinkedAudioTransitions.flatMap(({ transition, leftAudio, rightAudio }) => {
-        const left = managedCompoundAudioItemsById.get(leftAudio.id)
-        const right = managedCompoundAudioItemsById.get(rightAudio.id)
-        if (!left || !right) return []
-
-        return [
-          {
-            ...transition,
-            leftClipId: left.id,
-            rightClipId: right.id,
-            trackId: left.trackId,
-          },
-        ]
-      }),
-    [managedCompoundAudioItemsById, managedLinkedAudioTransitions],
   )
 
   // Merge continuous split audio clips into single segments to prevent

--- a/src/features/composition-runtime/utils/scene-assembly.test.ts
+++ b/src/features/composition-runtime/utils/scene-assembly.test.ts
@@ -138,6 +138,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'source.wav',
       label: 'Source audio',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
     } as const
     const managedLeft = {
       id: 'managed-left',
@@ -147,6 +150,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'left.wav',
       label: 'Managed left',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
     } as const
     const managedRight = {
       id: 'managed-right',
@@ -156,6 +162,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'right.wav',
       label: 'Managed right',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
     } as const
     const standaloneCompound = {
       id: 'standalone-compound',
@@ -165,6 +174,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'compound.wav',
       label: 'Standalone compound',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
       compositionId: 'composition-a',
     } as const
     const managedCompoundLeft = {
@@ -175,6 +187,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'compound-left.wav',
       label: 'Managed compound left',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
       compositionId: 'composition-b',
     } as const
     const managedCompoundRight = {
@@ -185,6 +200,9 @@ describe('scene assembly', () => {
       durationInFrames: 30,
       src: 'compound-right.wav',
       label: 'Managed compound right',
+      muted: false,
+      trackVolumeDb: 0,
+      trackVisible: true,
       compositionId: 'composition-b',
     } as const
     const audioItems = [
@@ -194,7 +212,7 @@ describe('scene assembly', () => {
       standaloneCompound,
       managedCompoundLeft,
       managedCompoundRight,
-    ] as AudioTrackItem[]
+    ] satisfies AudioTrackItem[]
     const transition = {
       id: 'transition-direct',
       type: 'crossfade',

--- a/src/features/composition-runtime/utils/scene-assembly.test.ts
+++ b/src/features/composition-runtime/utils/scene-assembly.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vite-plus/test'
 import type { TimelineTrack } from '@/types/timeline'
+import type { Transition } from '@/types/transition'
 import {
   buildStableDomTracks,
   buildItemIdMap,
   buildFrameRenderTasks,
   collectAudioTrackItems,
+  type AudioTrackItem,
   collectFrameVideoCandidates,
   collectTransitionClipItems,
   collectVisualTrackItems,
@@ -12,6 +14,7 @@ import {
   collectVisibleShapeMasks,
   collectVisibleTextFontFamilies,
   groupTransitionsByTrackOrder,
+  deriveCompositionAudioScene,
   resolveCompositionRenderPlan,
   resolveTransitionWindowsForItems,
   resolveFrameRenderScene,
@@ -124,6 +127,135 @@ describe('scene assembly', () => {
     expect(
       collectVisibleAdjustmentLayers(visibleState.visibleTracks).map(({ layer }) => layer.id),
     ).toEqual(['adj-visible'])
+  })
+
+  it('derives direct and compound audio scene partitions with managed transition defs', () => {
+    const sourceAudio = {
+      id: 'source-audio',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 0,
+      durationInFrames: 30,
+      src: 'source.wav',
+      label: 'Source audio',
+    } as const
+    const managedLeft = {
+      id: 'managed-left',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 0,
+      durationInFrames: 30,
+      src: 'left.wav',
+      label: 'Managed left',
+    } as const
+    const managedRight = {
+      id: 'managed-right',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 24,
+      durationInFrames: 30,
+      src: 'right.wav',
+      label: 'Managed right',
+    } as const
+    const standaloneCompound = {
+      id: 'standalone-compound',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 60,
+      durationInFrames: 30,
+      src: 'compound.wav',
+      label: 'Standalone compound',
+      compositionId: 'composition-a',
+    } as const
+    const managedCompoundLeft = {
+      id: 'managed-compound-left',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 90,
+      durationInFrames: 30,
+      src: 'compound-left.wav',
+      label: 'Managed compound left',
+      compositionId: 'composition-b',
+    } as const
+    const managedCompoundRight = {
+      id: 'managed-compound-right',
+      type: 'audio',
+      trackId: 'audio-track',
+      from: 114,
+      durationInFrames: 30,
+      src: 'compound-right.wav',
+      label: 'Managed compound right',
+      compositionId: 'composition-b',
+    } as const
+    const audioItems = [
+      sourceAudio,
+      managedLeft,
+      managedRight,
+      standaloneCompound,
+      managedCompoundLeft,
+      managedCompoundRight,
+    ] as AudioTrackItem[]
+    const transition = {
+      id: 'transition-direct',
+      type: 'crossfade',
+      presentation: 'fade',
+      timing: 'linear',
+      leftClipId: 'video-left',
+      rightClipId: 'video-right',
+      trackId: 'video-track',
+      durationInFrames: 6,
+    } satisfies Transition
+    const compoundTransition = {
+      id: 'transition-compound',
+      type: 'crossfade',
+      presentation: 'fade',
+      timing: 'linear',
+      leftClipId: 'composition-left',
+      rightClipId: 'composition-right',
+      trackId: 'composition-track',
+      durationInFrames: 6,
+    } satisfies Transition
+
+    const scene = deriveCompositionAudioScene({
+      audioItems,
+      managedLinkedAudioTransitions: [
+        { transition, leftAudio: managedLeft, rightAudio: managedRight },
+        {
+          transition: compoundTransition,
+          leftAudio: managedCompoundLeft,
+          rightAudio: managedCompoundRight,
+        },
+      ],
+    })
+
+    expect(scene.standaloneAudioItems.map((item) => item.id)).toEqual(['source-audio'])
+    expect(scene.managedLinkedAudioItems.map((item) => item.id)).toEqual([
+      'managed-left',
+      'managed-right',
+    ])
+    expect(scene.standaloneCompoundAudioItems.map((item) => item.id)).toEqual([
+      'standalone-compound',
+    ])
+    expect(scene.managedCompoundAudioItems.map((item) => item.id)).toEqual([
+      'managed-compound-left',
+      'managed-compound-right',
+    ])
+    expect(scene.managedLinkedAudioTransitionDefs).toEqual([
+      {
+        ...transition,
+        leftClipId: 'managed-left',
+        rightClipId: 'managed-right',
+        trackId: 'audio-track',
+      },
+    ])
+    expect(scene.managedCompoundAudioTransitionDefs).toEqual([
+      {
+        ...compoundTransition,
+        leftClipId: 'managed-compound-left',
+        rightClipId: 'managed-compound-right',
+        trackId: 'audio-track',
+      },
+    ])
   })
 
   it('collects stable-dom visual and audio items with track metadata', () => {

--- a/src/features/composition-runtime/utils/scene-assembly.ts
+++ b/src/features/composition-runtime/utils/scene-assembly.ts
@@ -58,15 +58,9 @@ export type AudioTrackItem = AudioItem & {
 
 export type CompoundAudioTrackItem = AudioTrackItem & { compositionId: string }
 
-export type ManagedAudioTransitionDef = Transition & {
-  leftClipId: string
-  rightClipId: string
-  trackId: string
-}
+export type ManagedAudioTransitionDef = Transition
 
 export interface CompositionAudioScene {
-  directSourceAudioItems: AudioTrackItem[]
-  compoundAudioItems: CompoundAudioTrackItem[]
   managedLinkedAudioItems: AudioTrackItem[]
   standaloneAudioItems: AudioTrackItem[]
   managedCompoundAudioItems: CompoundAudioTrackItem[]
@@ -340,8 +334,6 @@ export function deriveCompositionAudioScene({
   )
 
   return {
-    directSourceAudioItems,
-    compoundAudioItems,
     managedLinkedAudioItems,
     standaloneAudioItems,
     managedCompoundAudioItems,

--- a/src/features/composition-runtime/utils/scene-assembly.ts
+++ b/src/features/composition-runtime/utils/scene-assembly.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/types/timeline'
 import type { AudioEqSettings } from '@/types/audio'
 import type { Transition } from '@/types/transition'
+import type { ManagedLinkedAudioTransition } from '@/shared/utils/linked-media'
 import {
   resolveTransitionWindows,
   type ResolvedTransitionWindow,
@@ -53,6 +54,25 @@ export type AudioTrackItem = AudioItem & {
   trackVolumeDb: number
   trackAudioEq?: AudioEqSettings
   trackVisible: boolean
+}
+
+export type CompoundAudioTrackItem = AudioTrackItem & { compositionId: string }
+
+export type ManagedAudioTransitionDef = Transition & {
+  leftClipId: string
+  rightClipId: string
+  trackId: string
+}
+
+export interface CompositionAudioScene {
+  directSourceAudioItems: AudioTrackItem[]
+  compoundAudioItems: CompoundAudioTrackItem[]
+  managedLinkedAudioItems: AudioTrackItem[]
+  standaloneAudioItems: AudioTrackItem[]
+  managedCompoundAudioItems: CompoundAudioTrackItem[]
+  standaloneCompoundAudioItems: CompoundAudioTrackItem[]
+  managedLinkedAudioTransitionDefs: ManagedAudioTransitionDef[]
+  managedCompoundAudioTransitionDefs: ManagedAudioTransitionDef[]
 }
 
 export type StableDomTrack = TimelineTrack & {
@@ -248,6 +268,93 @@ export function collectAudioTrackItems({
         trackVisible: visibleTrackIds.has(track.id),
       })),
   )
+}
+
+function hasCompositionAudioId(item: AudioTrackItem): boolean {
+  return (
+    'compositionId' in item &&
+    typeof item.compositionId === 'string' &&
+    item.compositionId.length > 0
+  )
+}
+
+function isCompoundAudioTrackItem(item: AudioTrackItem): item is CompoundAudioTrackItem {
+  return hasCompositionAudioId(item)
+}
+
+function buildManagedAudioTransitionDefs<TItem extends AudioTrackItem>({
+  managedAudioItems,
+  managedLinkedAudioTransitions,
+}: {
+  managedAudioItems: TItem[]
+  managedLinkedAudioTransitions: ManagedLinkedAudioTransition[]
+}): ManagedAudioTransitionDef[] {
+  const itemsById = new Map<string, TItem>()
+  for (const item of managedAudioItems) {
+    itemsById.set(item.id, item)
+  }
+
+  return managedLinkedAudioTransitions.flatMap(({ transition, leftAudio, rightAudio }) => {
+    const left = itemsById.get(leftAudio.id)
+    const right = itemsById.get(rightAudio.id)
+    if (!left || !right) return []
+
+    return [
+      {
+        ...transition,
+        leftClipId: left.id,
+        rightClipId: right.id,
+        trackId: left.trackId,
+      },
+    ]
+  })
+}
+
+export function deriveCompositionAudioScene({
+  audioItems,
+  managedLinkedAudioTransitions,
+}: {
+  audioItems: AudioTrackItem[]
+  managedLinkedAudioTransitions: ManagedLinkedAudioTransition[]
+}): CompositionAudioScene {
+  const compoundAudioItems = audioItems.filter(isCompoundAudioTrackItem)
+  const directSourceAudioItems = audioItems.filter((item) => !hasCompositionAudioId(item))
+  const managedLinkedAudioIds = new Set<string>()
+
+  for (const managed of managedLinkedAudioTransitions) {
+    managedLinkedAudioIds.add(managed.leftAudio.id)
+    managedLinkedAudioIds.add(managed.rightAudio.id)
+  }
+
+  const managedLinkedAudioItems = directSourceAudioItems.filter((item) =>
+    managedLinkedAudioIds.has(item.id),
+  )
+  const standaloneAudioItems = directSourceAudioItems.filter(
+    (item) => !managedLinkedAudioIds.has(item.id),
+  )
+  const managedCompoundAudioItems = compoundAudioItems.filter((item) =>
+    managedLinkedAudioIds.has(item.id),
+  )
+  const standaloneCompoundAudioItems = compoundAudioItems.filter(
+    (item) => !managedLinkedAudioIds.has(item.id),
+  )
+
+  return {
+    directSourceAudioItems,
+    compoundAudioItems,
+    managedLinkedAudioItems,
+    standaloneAudioItems,
+    managedCompoundAudioItems,
+    standaloneCompoundAudioItems,
+    managedLinkedAudioTransitionDefs: buildManagedAudioTransitionDefs({
+      managedAudioItems: managedLinkedAudioItems,
+      managedLinkedAudioTransitions,
+    }),
+    managedCompoundAudioTransitionDefs: buildManagedAudioTransitionDefs({
+      managedAudioItems: managedCompoundAudioItems,
+      managedLinkedAudioTransitions,
+    }),
+  }
 }
 
 export function buildStableDomTracks({


### PR DESCRIPTION
## Summary
- Extract pure composition audio scene derivation into scene-assembly helpers
- Keep MainComposition rendering/wiring intact while replacing inline partition logic
- Add characterization coverage for direct/compound managed audio partition and transition-def derivation

## Test Plan
- npx -y node@22 node_modules/.bin/vp test run src/features/composition-runtime/utils/scene-assembly.test.ts
- npx -y node@22 node_modules/.bin/vp check --no-fmt src vite.config.ts
- npx -y node@22 node_modules/.bin/vp fmt --check src/features/composition-runtime/compositions/main-composition.tsx src/features/composition-runtime/utils/scene-assembly.ts src/features/composition-runtime/utils/scene-assembly.test.ts