### PR TITLE
refactor(timeline): share edit preview defaults

### DIFF
--- a/src/features/timeline/stores/edit-preview-defaults.test.ts
+++ b/src/features/timeline/stores/edit-preview-defaults.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { withPreviewDefaults } from './edit-preview-defaults'
+
+describe('withPreviewDefaults', () => {
+  it('fills only omitted preview fields with defaults', () => {
+    const preview = withPreviewDefaults(
+      { itemId: 'clip-1', minDelta: -12, maxDelta: undefined },
+      { minDelta: 0, maxDelta: 0, constrained: false },
+    )
+
+    expect(preview).toEqual({
+      itemId: 'clip-1',
+      minDelta: -12,
+      maxDelta: 0,
+      constrained: false,
+    })
+  })
+
+  it('preserves explicit false and zero preview values', () => {
+    const preview = withPreviewDefaults(
+      { neighborDelta: 0, constrained: false },
+      { neighborDelta: 10, constrained: true },
+    )
+
+    expect(preview).toEqual({ neighborDelta: 0, constrained: false })
+  })
+})

--- a/src/features/timeline/stores/edit-preview-defaults.test.ts
+++ b/src/features/timeline/stores/edit-preview-defaults.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vite-plus/test'
 import { withPreviewDefaults } from './edit-preview-defaults'
 
 describe('withPreviewDefaults', () => {
-  it('fills only omitted preview fields with defaults', () => {
+  it('fills undefined and missing preview fields with defaults', () => {
     const preview = withPreviewDefaults(
       { itemId: 'clip-1', minDelta: -12, maxDelta: undefined },
       { minDelta: 0, maxDelta: 0, constrained: false },
@@ -14,6 +14,15 @@ describe('withPreviewDefaults', () => {
       maxDelta: 0,
       constrained: false,
     })
+  })
+
+  it('fills null preview fields with defaults', () => {
+    const preview = withPreviewDefaults(
+      { itemId: 'clip-1', leftNeighborId: null },
+      { leftNeighborId: 'left-clip' },
+    )
+
+    expect(preview).toEqual({ itemId: 'clip-1', leftNeighborId: 'left-clip' })
   })
 
   it('preserves explicit false and zero preview values', () => {

--- a/src/features/timeline/stores/edit-preview-defaults.ts
+++ b/src/features/timeline/stores/edit-preview-defaults.ts
@@ -1,0 +1,16 @@
+type PreviewDefaults<Defaults extends object> = {
+  [Key in keyof Defaults]-?: Exclude<Defaults[Key], undefined>
+}
+
+export function withPreviewDefaults<PreviewParams extends object, Defaults extends object>(
+  params: PreviewParams,
+  defaults: PreviewDefaults<Defaults>,
+): PreviewParams & PreviewDefaults<Defaults> {
+  const normalized = { ...params } as Record<string, unknown>
+
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    normalized[key] = normalized[key] ?? defaultValue
+  }
+
+  return normalized as PreviewParams & PreviewDefaults<Defaults>
+}

--- a/src/features/timeline/stores/rolling-edit-preview-store.ts
+++ b/src/features/timeline/stores/rolling-edit-preview-store.ts
@@ -1,3 +1,4 @@
+import { withPreviewDefaults } from './edit-preview-defaults'
 import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface RollingEditPreviewState {
@@ -39,7 +40,7 @@ export const useRollingEditPreviewStore = createEditPreviewStore<
   Pick<RollingEditPreviewActions, 'setNeighborDelta'>
 >({
   initialState: createInitialState,
-  normalizePreview: (params) => ({ ...params, constrained: params.constrained ?? false }),
+  normalizePreview: (params) => withPreviewDefaults(params, { constrained: false }),
   createActions: (set) => ({
     setNeighborDelta: (neighborDelta, constrained) =>
       set({ neighborDelta, constrained: constrained ?? false }),

--- a/src/features/timeline/stores/slide-edit-preview-store.ts
+++ b/src/features/timeline/stores/slide-edit-preview-store.ts
@@ -1,3 +1,4 @@
+import { withPreviewDefaults } from './edit-preview-defaults'
 import { createEditPreviewStore } from './edit-preview-store-factory'
 
 interface SlideEditPreviewState {
@@ -48,11 +49,7 @@ export const useSlideEditPreviewStore = createEditPreviewStore<
   Pick<SlideEditPreviewActions, 'setSlideDelta' | 'setSlideRange'>
 >({
   initialState: createInitialState,
-  normalizePreview: (params) => ({
-    ...params,
-    minDelta: params.minDelta ?? 0,
-    maxDelta: params.maxDelta ?? 0,
-  }),
+  normalizePreview: (params) => withPreviewDefaults(params, { minDelta: 0, maxDelta: 0 }),
   createActions: (set) => ({
     setSlideDelta: (slideDelta) => set({ slideDelta }),
     setSlideRange: (minDelta, maxDelta) => set({ minDelta, maxDelta }),


### PR DESCRIPTION
## Summary
- add a small pure helper for applying edit-preview defaults without overriding explicit values
- use it in rolling and slide preview store normalization
- cover the helper with focused characterization tests

## Test Plan
- npx -y node@22 node_modules/.bin/vp test run src/features/timeline/stores/edit-preview-defaults.test.ts
- npx -y node@22 node_modules/.bin/vp check --no-fmt src vite.config.ts
- npx -y node@22 $(command -v npm) run check
- git push pre-push quality checks