### PR TITLE
test(composition-runtime): characterize transition participants

### DIFF
--- a/src/features/composition-runtime/components/stable-video-sequence.test.tsx
+++ b/src/features/composition-runtime/components/stable-video-sequence.test.tsx
@@ -545,7 +545,6 @@ describe('StableVideoSequence', () => {
 
   it('keeps the left participant rendered after the cut while syncing the right shadow', () => {
     sequenceContextValue.localFrame = 42
-    mediaLibraryMock.state.mediaItems = [{ id: 'media-1', fps: 24 }]
     const renderItem = vi.fn((item: { id: string; _sharedTransitionSync?: boolean }) => (
       <div
         data-testid={`render-${item.id}`}

--- a/src/features/composition-runtime/components/stable-video-sequence.test.tsx
+++ b/src/features/composition-runtime/components/stable-video-sequence.test.tsx
@@ -19,10 +19,18 @@ vi.mock('../hooks/use-transition-participant-sync', () => ({
   useTransitionParticipantSync: vi.fn(),
 }))
 
+type MediaLibraryMockState = { mediaItems: Array<{ id: string; fps: number }> }
+const mediaLibraryMock = vi.hoisted(() => {
+  const state: MediaLibraryMockState = { mediaItems: [] }
+  const store = Object.assign(
+    (selector: (state: MediaLibraryMockState) => unknown) => selector(state),
+    { getState: () => state },
+  )
+  return { state, store }
+})
+
 vi.mock('@/features/composition-runtime/deps/stores', () => ({
-  useMediaLibraryStore: (
-    selector: (state: { mediaItems: Array<{ id: string; fps: number }> }) => unknown,
-  ) => selector({ mediaItems: [] }),
+  useMediaLibraryStore: mediaLibraryMock.store,
 }))
 
 vi.mock('./video-content', () => ({
@@ -37,6 +45,7 @@ import {
   areGroupPropsEqual,
   getStableVideoRenderSignature,
 } from './stable-video-sequence-comparator'
+import { useTransitionParticipantSync } from '../hooks/use-transition-participant-sync'
 import type { StableVideoGroup } from '../utils/video-scene'
 
 const renderComparatorItem = (
@@ -264,6 +273,8 @@ describe('areGroupPropsEqual', () => {
 describe('StableVideoSequence', () => {
   beforeEach(() => {
     ensureReadyLanesMock.mockClear()
+    vi.mocked(useTransitionParticipantSync).mockClear()
+    mediaLibraryMock.state.mediaItems = []
     sequenceContextValue.localFrame = 28
   })
 
@@ -530,5 +541,70 @@ describe('StableVideoSequence', () => {
 
     expect(screen.getByTestId('render-left')).toHaveAttribute('data-softness', '0.25')
     expect(screen.getByTestId('shadow-video-right')).toHaveAttribute('data-softness', '0.25')
+  })
+
+  it('keeps the left participant rendered after the cut while syncing the right shadow', () => {
+    sequenceContextValue.localFrame = 42
+    mediaLibraryMock.state.mediaItems = [{ id: 'media-1', fps: 24 }]
+    const renderItem = vi.fn((item: { id: string; _sharedTransitionSync?: boolean }) => (
+      <div
+        data-testid={`render-${item.id}`}
+        data-transition-sync={String(item._sharedTransitionSync)}
+      >
+        {item.id}
+      </div>
+    ))
+
+    render(
+      <StableVideoSequence
+        items={[
+          renderComparatorItem({ id: 'left', from: 0, durationInFrames: 60, sourceStart: 48 }),
+          renderComparatorItem({ id: 'right', from: 30, durationInFrames: 60, sourceStart: 96 }),
+        ]}
+        transitionWindows={[
+          {
+            startFrame: 30,
+            endFrame: 50,
+            durationInFrames: 20,
+            leftClip: { id: 'left' },
+            rightClip: { id: 'right' },
+            leftPortion: 0.5,
+            rightPortion: 0.5,
+            cutPoint: 40,
+            transition: {
+              id: 'transition-1',
+              leftClipId: 'left',
+              rightClipId: 'right',
+              timing: 'linear',
+            },
+          } as never,
+        ]}
+        renderItem={renderItem}
+      />,
+    )
+
+    expect(screen.getByTestId('render-left')).toHaveAttribute('data-transition-sync', 'true')
+    expect(screen.getByTestId('shadow-video-right')).toBeInTheDocument()
+    expect(screen.queryByTestId('render-right')).not.toBeInTheDocument()
+    expect(useTransitionParticipantSync).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          poolClipId: 'group-media-1-origin-1-left',
+          safeTrimBefore: 48,
+          sourceFps: 30,
+          sequenceFrameOffset: 0,
+          role: 'leader',
+        }),
+        expect.objectContaining({
+          poolClipId: 'shadow-right',
+          safeTrimBefore: 60,
+          sourceFps: 30,
+          sequenceFrameOffset: 30,
+          role: 'follower',
+        }),
+      ],
+      0,
+      30,
+    )
   })
 })

--- a/src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts
+++ b/src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts
@@ -25,8 +25,16 @@ import {
   type TransitionSyncParticipant,
 } from './use-transition-participant-sync'
 
-function SyncHarness({ participants }: { participants: TransitionSyncParticipant[] }) {
-  useTransitionParticipantSync(participants, 10, 30)
+function SyncHarness({
+  participants,
+  groupMinFrom,
+  timelineFps,
+}: {
+  participants: TransitionSyncParticipant[]
+  groupMinFrom: number
+  timelineFps: number
+}) {
+  useTransitionParticipantSync(participants, groupMinFrom, timelineFps)
   return null
 }
 
@@ -102,6 +110,8 @@ describe('useTransitionParticipantSync', () => {
             role: 'follower',
           },
         ],
+        groupMinFrom: 10,
+        timelineFps: 30,
       }),
     )
 
@@ -139,6 +149,8 @@ describe('useTransitionParticipantSync', () => {
             role: 'follower',
           },
         ],
+        groupMinFrom: 10,
+        timelineFps: 30,
       }),
     )
 

--- a/src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts
+++ b/src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts
@@ -1,5 +1,50 @@
-import { describe, expect, it } from 'vite-plus/test'
-import { getTransitionSyncPlaybackRate } from './use-transition-participant-sync'
+import * as React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test'
+import { render } from '@testing-library/react'
+
+const getClipElementMock = vi.fn()
+const onFrameChangeMock = vi.fn(() => vi.fn())
+const clockMock = {
+  currentFrame: 0,
+  onFrameChange: onFrameChangeMock,
+}
+let isPlayingMock = true
+
+vi.mock('@/features/composition-runtime/deps/player', () => ({
+  useClock: () => clockMock,
+  useVideoSourcePool: () => ({ getClipElement: getClipElementMock }),
+}))
+
+vi.mock('./use-player-compat', () => ({
+  useIsPlaying: () => isPlayingMock,
+}))
+
+import {
+  getTransitionSyncPlaybackRate,
+  useTransitionParticipantSync,
+  type TransitionSyncParticipant,
+} from './use-transition-participant-sync'
+
+function SyncHarness({ participants }: { participants: TransitionSyncParticipant[] }) {
+  useTransitionParticipantSync(participants, 10, 30)
+  return null
+}
+
+const createVideo = (overrides: Partial<HTMLVideoElement> = {}) => {
+  const video = document.createElement('video')
+  Object.defineProperties(video, {
+    duration: { configurable: true, value: overrides.duration ?? 100 },
+    paused: { configurable: true, writable: true, value: overrides.paused ?? false },
+    readyState: { configurable: true, value: overrides.readyState ?? 4 },
+  })
+  video.currentTime = overrides.currentTime ?? 0
+  video.playbackRate = overrides.playbackRate ?? 1
+  video.pause = vi.fn(() => {
+    Object.defineProperty(video, 'paused', { configurable: true, value: true })
+  })
+  video.play = vi.fn(() => Promise.resolve())
+  return video
+}
 
 describe('getTransitionSyncPlaybackRate', () => {
   it('keeps the leader on the nominal playback rate', () => {
@@ -17,5 +62,89 @@ describe('getTransitionSyncPlaybackRate', () => {
   it('clamps follower correction to a bounded range', () => {
     expect(getTransitionSyncPlaybackRate(1, 10, 'follower')).toBeGreaterThanOrEqual(0.94)
     expect(getTransitionSyncPlaybackRate(1, -10, 'follower')).toBeLessThanOrEqual(1.06)
+  })
+})
+
+describe('useTransitionParticipantSync', () => {
+  beforeEach(() => {
+    clockMock.currentFrame = 10
+    getClipElementMock.mockReset()
+    onFrameChangeMock.mockClear()
+    isPlayingMock = true
+  })
+
+  it('does not pause or seek premount participants held by a transition session', () => {
+    clockMock.currentFrame = 20
+    const heldVideo = createVideo({ currentTime: 1.5, paused: false })
+    heldVideo.dataset.transitionHold = '1'
+    const freeVideo = createVideo({ currentTime: 1.5, paused: false })
+    getClipElementMock.mockImplementation((clipId: string) =>
+      clipId === 'held' ? heldVideo : freeVideo,
+    )
+
+    render(
+      React.createElement(SyncHarness, {
+        participants: [
+          {
+            poolClipId: 'held',
+            safeTrimBefore: 48,
+            sourceFps: 24,
+            playbackRate: 1,
+            sequenceFrameOffset: 20,
+            role: 'leader',
+          },
+          {
+            poolClipId: 'free',
+            safeTrimBefore: 48,
+            sourceFps: 24,
+            playbackRate: 1,
+            sequenceFrameOffset: 20,
+            role: 'follower',
+          },
+        ],
+      }),
+    )
+
+    expect(heldVideo.pause).not.toHaveBeenCalled()
+    expect(heldVideo.currentTime).toBe(1.5)
+    expect(freeVideo.pause).toHaveBeenCalledTimes(1)
+    expect(freeVideo.currentTime).toBe(2)
+  })
+
+  it('syncs participants against source-native FPS and per-item sequence offsets', () => {
+    clockMock.currentFrame = 25
+    const leader = createVideo({ currentTime: 0, paused: true })
+    const follower = createVideo({ currentTime: 0, paused: true })
+    getClipElementMock.mockImplementation((clipId: string) =>
+      clipId === 'leader' ? leader : follower,
+    )
+
+    render(
+      React.createElement(SyncHarness, {
+        participants: [
+          {
+            poolClipId: 'leader',
+            safeTrimBefore: 48,
+            sourceFps: 24,
+            playbackRate: 1,
+            sequenceFrameOffset: 0,
+            role: 'leader',
+          },
+          {
+            poolClipId: 'follower',
+            safeTrimBefore: 120,
+            sourceFps: 60,
+            playbackRate: 1,
+            sequenceFrameOffset: 10,
+            role: 'follower',
+          },
+        ],
+      }),
+    )
+
+    expect(leader.currentTime).toBeCloseTo(2.5)
+    expect(follower.currentTime).toBeCloseTo(2 + 5 / 30)
+    expect(leader.play).toHaveBeenCalledTimes(1)
+    expect(follower.play).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- add hook-level characterization for transition-held premount participants
- cover participant sync timing with source-native FPS and sequence offsets
- characterize StableVideoSequence post-cut rendering of left participant plus synced right shadow

## Test Plan
- npm run test:run -- src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts src/features/composition-runtime/components/stable-video-sequence.test.tsx src/features/composition-runtime/utils/transition-scene.test.ts src/features/composition-runtime/utils/transition-shadow-warmup.test.ts
- npm run check
- pre-push: check:boundaries, check:deps-contracts, check:legacy-lib-imports, check:deps-wrapper-health, check:edge-budgets, check