### PR TITLE
fix(timeline): stabilize project-load visual readiness

### DIFF
--- a/src/features/media-library/stores/media-delete-actions.test.ts
+++ b/src/features/media-library/stores/media-delete-actions.test.ts
@@ -80,6 +80,7 @@ function createMockState(overrides: DeleteState = {}): MediaLibraryState & Media
     mediaItems: [makeMedia('media-1'), makeMedia('media-2')],
     mediaById: {},
     isLoading: false,
+    loadingProjectId: null,
     importingIds: [],
     error: null,
     errorLink: null,

--- a/src/features/media-library/stores/media-import-actions.test.ts
+++ b/src/features/media-library/stores/media-import-actions.test.ts
@@ -117,6 +117,7 @@ function createMockState(overrides: ImportState = {}): MediaLibraryState & Media
     mediaItems: [],
     mediaById: {},
     isLoading: false,
+    loadingProjectId: null,
     importingIds: [],
     error: null,
     errorLink: null,

--- a/src/features/media-library/stores/media-library-store.test.ts
+++ b/src/features/media-library/stores/media-library-store.test.ts
@@ -123,6 +123,7 @@ function resetStore(): void {
     mediaItems: [],
     mediaById: {},
     isLoading: false,
+    loadingProjectId: null,
     importingIds: [],
     error: null,
     errorLink: null,
@@ -161,6 +162,7 @@ describe('useMediaLibraryStore', () => {
     await useMediaLibraryStore.getState().loadMediaItems()
 
     expect(useMediaLibraryStore.getState().isLoading).toBe(false)
+    expect(useMediaLibraryStore.getState().loadingProjectId).toBeNull()
     expect(mediaLibraryServiceMocks.getMediaForProject).not.toHaveBeenCalled()
   })
 
@@ -188,6 +190,7 @@ describe('useMediaLibraryStore', () => {
 
     const state = useMediaLibraryStore.getState()
     expect(state.isLoading).toBe(false)
+    expect(state.loadingProjectId).toBeNull()
     expect(state.mediaItems).toEqual([video, audio])
     expect(state.mediaById['video-1']).toEqual(video)
     expect(state.mediaById['audio-1']).toEqual(audio)
@@ -212,6 +215,51 @@ describe('useMediaLibraryStore', () => {
     expect(state.transcriptStatus.get('video-1')).toBe('idle')
     expect(proxyServiceMocks.loadExistingProxies).toHaveBeenCalledWith(['video-1'])
     expect(proxyServiceMocks.generateProxy).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale media load completion after switching projects', async () => {
+    let resolveProjectOne!: (items: MediaMetadata[]) => void
+    const projectOnePromise = new Promise<MediaMetadata[]>((resolve) => {
+      resolveProjectOne = resolve
+    })
+    const projectTwoMedia = makeMedia({ id: 'project-2-media', fileName: 'project-2.mp4' })
+
+    mediaLibraryServiceMocks.getMediaForProject
+      .mockReturnValueOnce(projectOnePromise)
+      .mockResolvedValueOnce([projectTwoMedia])
+    indexedDbMocks.getTranscriptMediaIds.mockResolvedValue(new Set())
+    proxyServiceMocks.canGenerateProxy.mockReturnValue(false)
+
+    useMediaLibraryStore.setState({ currentProjectId: 'project-1' })
+    const projectOneLoad = useMediaLibraryStore.getState().loadMediaItems()
+    expect(useMediaLibraryStore.getState().loadingProjectId).toBe('project-1')
+
+    useMediaLibraryStore.getState().setCurrentProject('project-2')
+    const projectTwoLoad = useMediaLibraryStore.getState().loadMediaItems()
+
+    resolveProjectOne([makeMedia({ id: 'stale-project-1-media', fileName: 'project-1.mp4' })])
+    await Promise.all([projectOneLoad, projectTwoLoad])
+
+    const state = useMediaLibraryStore.getState()
+    expect(state.currentProjectId).toBe('project-2')
+    expect(state.isLoading).toBe(false)
+    expect(state.loadingProjectId).toBeNull()
+    expect(state.mediaItems).toEqual([projectTwoMedia])
+    expect(state.mediaById['stale-project-1-media']).toBeUndefined()
+  })
+
+  it('clears active project loading state when media load fails', async () => {
+    const error = new Error('load failed')
+    mediaLibraryServiceMocks.getMediaForProject.mockRejectedValue(error)
+
+    useMediaLibraryStore.setState({ currentProjectId: 'project-1' })
+    await expect(useMediaLibraryStore.getState().loadMediaItems()).rejects.toThrow(error)
+
+    const state = useMediaLibraryStore.getState()
+    expect(state.currentProjectId).toBe('project-1')
+    expect(state.isLoading).toBe(false)
+    expect(state.loadingProjectId).toBeNull()
+    expect(state.error).toBe('load failed')
   })
 
   it('clears proxy status and progress when proxy generation is cancelled', () => {

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -99,6 +99,7 @@ const newStore: MediaLibraryStoreApi =
         mediaItems: [],
         mediaById: {},
         isLoading: false, // Only load once a project context is available
+        loadingProjectId: null,
         importingIds: [],
         error: null,
         errorLink: null,
@@ -152,6 +153,7 @@ const newStore: MediaLibraryStoreApi =
             selectedMediaIds: [],
             selectedCompositionIds: [],
             isLoading: !!projectId, // Set loading if switching to a project
+            loadingProjectId: projectId,
             proxyStatus: new Map(),
             proxyProgress: new Map(),
             transcriptStatus: new Map(),
@@ -169,11 +171,11 @@ const newStore: MediaLibraryStoreApi =
 
           // Don't load without project context; ensure loading state is cleared.
           if (!currentProjectId) {
-            set({ isLoading: false })
+            set({ isLoading: false, loadingProjectId: null })
             return
           }
 
-          set({ isLoading: true, error: null })
+          set({ isLoading: true, loadingProjectId: currentProjectId, error: null })
 
           const opId = createOperationId()
           const event = logger.startEvent('loadMediaItems', opId)
@@ -183,15 +185,26 @@ const newStore: MediaLibraryStoreApi =
             // v3: Load project-scoped media only
             const mediaItems = await mediaLibraryService.getMediaForProject(currentProjectId)
 
+            if (get().currentProjectId !== currentProjectId) {
+              event.set('stale', true)
+              return
+            }
+
             set({
               mediaItems,
               mediaById: buildMediaById(mediaItems),
               isLoading: false,
+              loadingProjectId: null,
             })
 
             event.set('mediaCount', mediaItems.length)
 
             const transcriptStatus = await loadTranscriptStatusMap(mediaItems)
+            if (get().currentProjectId !== currentProjectId) {
+              event.set('staleTranscriptStatus', true)
+              return
+            }
+
             set({
               transcriptStatus,
               transcriptProgress: new Map(),
@@ -209,11 +222,18 @@ const newStore: MediaLibraryStoreApi =
               logger.warn('[MediaLibraryStore] Proxy initialization failed:', error)
             }
 
+            if (get().currentProjectId !== currentProjectId) {
+              event.set('staleProxyState', true)
+              return
+            }
+
             event.success({ mediaCount: mediaItems.length })
           } catch (error) {
             event.failure(error instanceof Error ? error : new Error(String(error)))
             const errorMessage = error instanceof Error ? error.message : 'Failed to load media'
-            set({ error: errorMessage, isLoading: false })
+            if (get().currentProjectId === currentProjectId) {
+              set({ error: errorMessage, isLoading: false, loadingProjectId: null })
+            }
             throw error
           }
         },

--- a/src/features/media-library/types.ts
+++ b/src/features/media-library/types.ts
@@ -57,6 +57,7 @@ export interface MediaLibraryState {
   mediaItems: MediaMetadata[]
   mediaById: Record<string, MediaMetadata>
   isLoading: boolean
+  loadingProjectId: string | null
   importingIds: string[] // IDs of media items currently being imported
   error: string | null
   errorLink: string | null

--- a/src/features/timeline/components/timeline-item/clip-content.test.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.test.tsx
@@ -4,6 +4,8 @@ import type { TimelineItem } from '@/types/timeline'
 import { useSettingsStore } from '@/features/timeline/deps/settings'
 import { useMediaLibraryStore } from '@/features/timeline/deps/media-library-store'
 import { useItemsStore } from '../../stores/items-store'
+import { useCompositionsStore } from '../../stores/compositions-store'
+import { useTimelineSettingsStore } from '../../stores/timeline-settings-store'
 import { useTimelineStore } from '../../stores/timeline-store'
 import { useZoomStore, _resetZoomStoreForTest } from '../../stores/zoom-store'
 import { ClipContent } from './clip-content'
@@ -47,9 +49,16 @@ describe('ClipContent', () => {
       showFilmstrips: false,
       showWaveforms: false,
     })
+    useTimelineSettingsStore.setState({
+      isTimelineLoading: false,
+      loadingProjectId: null,
+      loadedProjectId: 'project-1',
+    })
     useMediaLibraryStore.setState({
+      currentProjectId: 'project-1',
       mediaItems: [],
       mediaById: {},
+      isLoading: false,
       brokenMediaIds: [],
       selectedMediaIds: [],
       notification: null,
@@ -169,5 +178,149 @@ describe('ClipContent', () => {
     )
 
     expect(screen.getByTestId('clip-waveform')).toHaveAttribute('data-pps', '180')
+  })
+
+  it('defers heavy video visuals while the timeline is hydrating', () => {
+    useSettingsStore.setState({
+      showFilmstrips: true,
+      showWaveforms: true,
+    })
+    useTimelineSettingsStore.setState({
+      isTimelineLoading: true,
+      loadingProjectId: 'project-1',
+      loadedProjectId: null,
+    })
+
+    const item: TimelineItem = {
+      id: 'video-1',
+      type: 'video',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Hydrating video clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+    } as TimelineItem
+
+    render(<ClipContent item={item} clipLeftFrames={0} clipWidthFrames={96} fps={30} />)
+
+    expect(screen.getByText('Hydrating video clip')).toBeInTheDocument()
+    expect(screen.queryByTestId('clip-filmstrip')).not.toBeInTheDocument()
+  })
+
+  it('defers heavy audio visuals while media metadata is still loading for the current project', () => {
+    useSettingsStore.setState({
+      showFilmstrips: true,
+      showWaveforms: true,
+    })
+    useMediaLibraryStore.setState({
+      currentProjectId: 'project-1',
+      isLoading: true,
+    })
+
+    const item: TimelineItem = {
+      id: 'audio-1',
+      type: 'audio',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Loading audio clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+    } as TimelineItem
+
+    render(<ClipContent item={item} clipLeftFrames={0} clipWidthFrames={96} fps={30} />)
+
+    expect(screen.getByText('Loading audio clip')).toBeInTheDocument()
+    expect(screen.queryByTestId('clip-waveform')).not.toBeInTheDocument()
+  })
+
+  it('defers compound clip visual segment filmstrips while media metadata is loading', () => {
+    useSettingsStore.setState({
+      showFilmstrips: true,
+      showWaveforms: true,
+    })
+    useMediaLibraryStore.setState({
+      currentProjectId: 'project-1',
+      isLoading: true,
+    })
+    useCompositionsStore.getState().setCompositions([
+      {
+        id: 'composition-1',
+        name: 'Compound',
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        durationInFrames: 60,
+        transitions: [],
+        keyframes: [],
+        tracks: [
+          {
+            id: 'sub-track-1',
+            name: 'Video',
+            kind: 'video',
+            order: 0,
+            height: 60,
+            locked: false,
+            visible: true,
+            muted: false,
+            solo: false,
+            items: [],
+          },
+        ],
+        items: [
+          {
+            id: 'sub-video-1',
+            type: 'video',
+            trackId: 'sub-track-1',
+            from: 0,
+            durationInFrames: 60,
+            label: 'Nested video',
+            mediaId: 'media-1',
+            src: 'blob:test',
+            sourceStart: 0,
+            sourceDuration: 60,
+          } as TimelineItem,
+        ],
+      },
+    ])
+
+    const item: TimelineItem = {
+      id: 'composition-item-1',
+      type: 'composition',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Compound shell',
+      compositionId: 'composition-1',
+    } as TimelineItem
+
+    render(<ClipContent item={item} clipLeftFrames={0} clipWidthFrames={96} fps={30} />)
+
+    expect(screen.getByText('Compound shell')).toBeInTheDocument()
+    expect(screen.queryByTestId('clip-filmstrip')).not.toBeInTheDocument()
+  })
+
+  it('mounts heavy visuals after timeline hydration and media loading have settled', () => {
+    useSettingsStore.setState({
+      showFilmstrips: true,
+      showWaveforms: true,
+    })
+
+    const item: TimelineItem = {
+      id: 'video-1',
+      type: 'video',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Settled video clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+    } as TimelineItem
+
+    render(<ClipContent item={item} clipLeftFrames={0} clipWidthFrames={96} fps={30} />)
+
+    expect(screen.getByText('Settled video clip')).toBeInTheDocument()
+    expect(screen.getByTestId('clip-filmstrip')).toBeInTheDocument()
   })
 })

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo } from 'react'
 import { Link2 } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
 import type { TimelineItem } from '@/types/timeline'
 import { ClipFilmstrip } from '../clip-filmstrip'
 import { ImageFilmstrip } from '../clip-filmstrip/image-filmstrip'
@@ -9,6 +10,7 @@ import { useSettingsStore } from '@/features/timeline/deps/settings'
 import { useMediaLibraryStore } from '@/features/timeline/deps/media-library-store'
 import { useCompositionsStore } from '../../stores/compositions-store'
 import { useItemsStore } from '../../stores/items-store'
+import { useTimelineSettingsStore } from '../../stores/timeline-settings-store'
 import { useClipVisibility } from '../../hooks/use-clip-visibility'
 import { useZoomStore } from '../../stores/zoom-store'
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/app/editor-layout'
@@ -53,14 +55,19 @@ function CompositionFilmstripSegment({
   isReversed = false,
 }: CompositionFilmstripSegmentProps) {
   const mediaId = segment.mediaId
-  const mediaFps = useMediaLibraryStore(
-    useCallback(
-      (s) => s.mediaById[mediaId]?.fps || segment.sourceFps,
-      [mediaId, segment.sourceFps],
+  const mediaStats = useMediaLibraryStore(
+    useShallow(
+      useCallback(
+        (s) => {
+          const media = s.mediaById[mediaId]
+          return {
+            fps: media?.fps || segment.sourceFps,
+            duration: media?.duration || 0,
+          }
+        },
+        [mediaId, segment.sourceFps],
+      ),
     ),
-  )
-  const mediaDuration = useMediaLibraryStore(
-    useCallback((s) => s.mediaById[mediaId]?.duration || 0, [mediaId]),
   )
 
   const wrapperSpan = Math.max(1, wrapperDurationFrames)
@@ -70,11 +77,13 @@ function CompositionFilmstripSegment({
   const segmentRenderWidth = Math.max(0, widthFraction * wrapperRenderWidthPx)
 
   const sourceDurationSeconds =
-    mediaDuration > 0 ? mediaDuration : segment.sourceDurationFrames / Math.max(1, mediaFps)
+    mediaStats.duration > 0
+      ? mediaStats.duration
+      : segment.sourceDurationFrames / Math.max(1, mediaStats.fps)
   const sourceStartSeconds =
-    mediaDuration > 0 && segment.sourceDurationFrames > 0
-      ? (segment.sourceStart / segment.sourceDurationFrames) * mediaDuration
-      : segment.sourceStart / Math.max(1, mediaFps)
+    mediaStats.duration > 0 && segment.sourceDurationFrames > 0
+      ? (segment.sourceStart / segment.sourceDurationFrames) * mediaStats.duration
+      : segment.sourceStart / Math.max(1, mediaStats.fps)
   const sourceEndSeconds =
     sourceStartSeconds + (segment.durationInFrames / Math.max(1, fps)) * segment.speed
 
@@ -166,6 +175,11 @@ export const ClipContent = memo(function ClipContent({
   const pixelsPerSecond = useZoomStore((s) => s.pixelsPerSecond)
   const showWaveforms = useSettingsStore((s) => s.showWaveforms)
   const showFilmstrips = useSettingsStore((s) => s.showFilmstrips)
+  const timelineVisualsSettled = useTimelineSettingsStore(
+    useCallback((s) => !s.isTimelineLoading, []),
+  )
+  const mediaVisualsSettled = useMediaLibraryStore(useCallback((s) => !s.isLoading, []))
+  const shouldRenderHeavyVisuals = timelineVisualsSettled && mediaVisualsSettled
   const clipLeftPx = useMemo(
     () => (fps > 0 ? (clipLeftFrames / fps) * pixelsPerSecond : 0),
     [clipLeftFrames, fps, pixelsPerSecond],
@@ -270,24 +284,21 @@ export const ClipContent = memo(function ClipContent({
 
   // sourceStart/sourceDuration are stored in source-frame units. Prefer duration-ratio
   // mapping so rendering remains stable even if media FPS metadata changes after drop.
-  const sourceFps = useMediaLibraryStore(
-    useCallback(
-      (s) => {
-        if (!effectiveMediaId) return fps
-        const media = s.mediaById[effectiveMediaId]
-        return media?.fps || fps
-      },
-      [effectiveMediaId, fps],
-    ),
-  )
-  const mediaDuration = useMediaLibraryStore(
-    useCallback(
-      (s) => {
-        if (!effectiveMediaId) return 0
-        const media = s.mediaById[effectiveMediaId]
-        return media?.duration || 0
-      },
-      [effectiveMediaId],
+  const mediaStats = useMediaLibraryStore(
+    useShallow(
+      useCallback(
+        (s) => {
+          if (!effectiveMediaId) {
+            return { fps, duration: 0 }
+          }
+          const media = s.mediaById[effectiveMediaId]
+          return {
+            fps: media?.fps || fps,
+            duration: media?.duration || 0,
+          }
+        },
+        [effectiveMediaId, fps],
+      ),
     ),
   )
 
@@ -306,18 +317,19 @@ export const ClipContent = memo(function ClipContent({
       : sourceStartFrames,
   )
 
-  const sourceDuration = mediaDuration > 0 ? mediaDuration : sourceDurationFrames / sourceFps
+  const sourceDuration =
+    mediaStats.duration > 0 ? mediaStats.duration : sourceDurationFrames / mediaStats.fps
   const sourceStart =
-    mediaDuration > 0
-      ? (sourceStartFrames / sourceDurationFrames) * mediaDuration
-      : sourceStartFrames / sourceFps
+    mediaStats.duration > 0
+      ? (sourceStartFrames / sourceDurationFrames) * mediaStats.duration
+      : sourceStartFrames / mediaStats.fps
   const sourceEndFrames = item.sourceEnd
   const sourceEnd =
     sourceEndFrames === undefined
       ? undefined
-      : mediaDuration > 0
-        ? (sourceEndFrames / sourceDurationFrames) * mediaDuration
-        : sourceEndFrames / sourceFps
+      : mediaStats.duration > 0
+        ? (sourceEndFrames / sourceDurationFrames) * mediaStats.duration
+        : sourceEndFrames / mediaStats.fps
 
   const trimStart = (item.trimStart ?? 0) / fps
   const speed = item.speed ?? 1
@@ -363,7 +375,7 @@ export const ClipContent = memo(function ClipContent({
         {/* Row 2: Filmstrip - flex-1 to fill remaining space */}
         {showVisualContent && (
           <div className="relative overflow-hidden flex-1 min-h-0">
-            {showFilmstrips && (
+            {shouldRenderHeavyVisuals && showFilmstrips && (
               <ClipFilmstrip
                 mediaId={item.mediaId}
                 clipWidth={clipWidth}
@@ -403,7 +415,7 @@ export const ClipContent = memo(function ClipContent({
           {renderTitleText(item.label)}
         </div>
         {/* Row 2: Waveform - fills remaining space */}
-        {showVisualContent && showWaveforms && (
+        {showVisualContent && shouldRenderHeavyVisuals && showWaveforms && (
           <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
             <div
               className="absolute inset-0"
@@ -439,7 +451,7 @@ export const ClipContent = memo(function ClipContent({
     return (
       <div className="absolute inset-0 flex flex-col">
         {renderCompoundClipLabel(item.label || 'Compound Clip')}
-        {showVisualContent && showWaveforms && (
+        {showVisualContent && shouldRenderHeavyVisuals && showWaveforms && (
           <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
             <CompoundClipWaveform
               composition={composition}
@@ -480,7 +492,8 @@ export const ClipContent = memo(function ClipContent({
             <>
               {/* Row 2: Filmstrip stack - flex-1 */}
               <div className="relative overflow-hidden flex-1 min-h-0">
-                {showFilmstrips &&
+                {shouldRenderHeavyVisuals &&
+                  showFilmstrips &&
                   visualSegments.map((segment) => (
                     <CompositionFilmstripSegment
                       key={segment.itemId}
@@ -499,7 +512,7 @@ export const ClipContent = memo(function ClipContent({
                   ))}
               </div>
               {/* Row 3: Waveform */}
-              {showCompositionWaveform && composition && (
+              {shouldRenderHeavyVisuals && showCompositionWaveform && composition && (
                 <div
                   className="relative overflow-hidden bg-waveform-gradient"
                   style={{ height: EDITOR_LAYOUT_CSS_VALUES.timelineWaveformRowHeight }}
@@ -526,7 +539,7 @@ export const ClipContent = memo(function ClipContent({
       return (
         <div className="absolute inset-0 flex flex-col">
           {renderCompoundClipLabel(item.label || 'Compound Clip')}
-          {showVisualContent && showWaveforms && (
+          {showVisualContent && shouldRenderHeavyVisuals && showWaveforms && (
             <div className="relative overflow-hidden bg-waveform-gradient flex-1 min-h-0">
               <CompoundClipWaveform
                 composition={composition}
@@ -604,7 +617,7 @@ export const ClipContent = memo(function ClipContent({
         </div>
         {showVisualContent && (
           <div className="relative overflow-hidden flex-1 min-h-0">
-            {showFilmstrips && (
+            {shouldRenderHeavyVisuals && showFilmstrips && (
               <ImageFilmstrip
                 mediaId={item.mediaId}
                 isAnimated={isAnimated}

--- a/src/features/timeline/components/timeline-item/clip-content.tsx
+++ b/src/features/timeline/components/timeline-item/clip-content.tsx
@@ -178,7 +178,12 @@ export const ClipContent = memo(function ClipContent({
   const timelineVisualsSettled = useTimelineSettingsStore(
     useCallback((s) => !s.isTimelineLoading, []),
   )
-  const mediaVisualsSettled = useMediaLibraryStore(useCallback((s) => !s.isLoading, []))
+  const mediaVisualsSettled = useMediaLibraryStore(
+    useCallback(
+      (s) => !s.isLoading || (s.loadingProjectId !== null && s.loadingProjectId !== s.currentProjectId),
+      [],
+    ),
+  )
   const shouldRenderHeavyVisuals = timelineVisualsSettled && mediaVisualsSettled
   const clipLeftPx = useMemo(
     () => (fps > 0 ? (clipLeftFrames / fps) * pixelsPerSecond : 0),

--- a/src/features/timeline/components/timeline-item/index.tsx
+++ b/src/features/timeline/components/timeline-item/index.tsx
@@ -316,8 +316,7 @@ export const TimelineItem = memo(
     )
     const mediaFileName = useMediaLibraryStore(
       useCallback(
-        (s) =>
-          item.mediaId ? (s.mediaItems.find((m) => m.id === item.mediaId)?.fileName ?? '') : '',
+        (s) => (item.mediaId ? (s.mediaById[item.mediaId]?.fileName ?? '') : ''),
         [item.mediaId],
       ),
     )
@@ -399,7 +398,7 @@ export const TimelineItem = memo(
 
     const mediaForItem = useMediaLibraryStore(
       useCallback(
-        (s) => (item.mediaId ? (s.mediaItems.find((m) => m.id === item.mediaId) ?? null) : null),
+        (s) => (item.mediaId ? (s.mediaById[item.mediaId] ?? null) : null),
         [item.mediaId],
       ),
     )

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -38,6 +38,7 @@ import { clearMediaDragData } from '@/features/timeline/deps/media-library-resol
 import { useNewTrackZonePreviewStore } from '../stores/new-track-zone-preview-store'
 import { useTrackDropPreviewStore } from '../stores/track-drop-preview-store'
 import { clearAllTimelineDropPreviewOwners } from '../utils/drop-preview-owner'
+import { useProjectStore } from '../deps/projects'
 import {
   isDragEventOverTimelineDropTarget,
   isExternalTimelineDragEvent,
@@ -141,6 +142,15 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
   const toggleColorScopesOpen = useEditorStore((s) => s.toggleColorScopesOpen)
   const toggleKeyframeEditorOpen = useEditorStore((s) => s.toggleKeyframeEditorOpen)
   const setTimelineTracks = useTimelineStore((s) => s.setTracks)
+  const currentProjectId = useProjectStore((s) => s.currentProject?.id ?? null)
+  const isTimelineLoading = useTimelineSettingsStore((s) => s.isTimelineLoading)
+  const loadingProjectId = useTimelineSettingsStore((s) => s.loadingProjectId)
+  const loadedProjectId = useTimelineSettingsStore((s) => s.loadedProjectId)
+  const isTimelineHydratingCurrentProject =
+    !!currentProjectId &&
+    (loadingProjectId === currentProjectId ||
+      isTimelineLoading ||
+      loadedProjectId !== currentProjectId)
 
   useEffect(() => {
     const clearExternalDropPreviews = () => {
@@ -876,107 +886,119 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
         className="flex-1 flex overflow-hidden min-h-0"
         onMouseDown={handleTimelineAreaMouseDown}
       >
-        {/* Track Headers Sidebar */}
-        <div
-          className="border-r border-border panel-bg flex-shrink-0 flex flex-col overflow-x-hidden"
-          style={{ width: EDITOR_LAYOUT_CSS_VALUES.timelineSidebarWidth }}
-        >
-          {/* Tracks label with controls */}
-          <div
-            className="flex items-center justify-between px-3 border-b border-border bg-secondary/20 flex-shrink-0"
-            style={{ height: EDITOR_LAYOUT_CSS_VALUES.timelineTracksHeaderHeight }}
-          >
-            <span className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
-              Tracks
-            </span>
-            <div className="flex items-center gap-1">
-              {/* Add track button */}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6"
-                onClick={handleAddTrack}
-                title={
-                  nextTrackKind === 'audio'
-                    ? 'Add audio track to audio section'
-                    : 'Add video track at top'
-                }
-              >
-                <Plus className="w-3 h-3" />
-              </Button>
-              {/* Remove track button */}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6"
-                onClick={handleRemoveTracks}
-                disabled={tracks.length === 0 || (!activeTrackId && selectedTrackIds.length === 0)}
-                title={
-                  tracks.length === 0
-                    ? 'No tracks to remove'
-                    : !activeTrackId && selectedTrackIds.length === 0
-                      ? 'Select a track to remove'
-                      : selectedTrackIds.length > 0
-                        ? `Remove ${selectedTrackIds.length} selected track(s)`
-                        : 'Remove active track'
-                }
-              >
-                <Minus className="w-3 h-3" />
-              </Button>
-            </div>
+        {isTimelineHydratingCurrentProject ? (
+          <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+            Loading timeline…
           </div>
+        ) : (
+          <>
+            {/* Track Headers Sidebar */}
+            <div
+              className="border-r border-border panel-bg flex-shrink-0 flex flex-col overflow-x-hidden"
+              style={{ width: EDITOR_LAYOUT_CSS_VALUES.timelineSidebarWidth }}
+            >
+              {/* Tracks label with controls */}
+              <div
+                className="flex items-center justify-between px-3 border-b border-border bg-secondary/20 flex-shrink-0"
+                style={{ height: EDITOR_LAYOUT_CSS_VALUES.timelineTracksHeaderHeight }}
+              >
+                <span className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
+                  Tracks
+                </span>
+                <div className="flex items-center gap-1">
+                  {/* Add track button */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={handleAddTrack}
+                    title={
+                      nextTrackKind === 'audio'
+                        ? 'Add audio track to audio section'
+                        : 'Add video track at top'
+                    }
+                  >
+                    <Plus className="w-3 h-3" />
+                  </Button>
+                  {/* Remove track button */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={handleRemoveTracks}
+                    disabled={
+                      tracks.length === 0 || (!activeTrackId && selectedTrackIds.length === 0)
+                    }
+                    title={
+                      tracks.length === 0
+                        ? 'No tracks to remove'
+                        : !activeTrackId && selectedTrackIds.length === 0
+                          ? 'Select a track to remove'
+                          : selectedTrackIds.length > 0
+                            ? `Remove ${selectedTrackIds.length} selected track(s)`
+                            : 'Remove active track'
+                    }
+                  >
+                    <Minus className="w-3 h-3" />
+                  </Button>
+                </div>
+              </div>
 
-          {/* Track labels - synced scroll (no scrollbar) */}
-          <div ref={trackHeadersViewportRef} className="flex-1 overflow-hidden relative">
-            <div ref={trackHeadersRootRef} className="flex h-full min-h-0 flex-col">
-              {hasTrackSections ? (
-                <>
-                  {renderTrackHeadersSection(videoTracks, {
-                    section: 'video',
-                    height: videoPaneHeight,
-                    zoneHeight: videoZoneHeight,
-                    scrollRef: videoTrackHeadersScrollRef,
-                    dropIndicatorLocalIndex: videoDropIndicatorIndex,
-                    showTopDividerForFirstTrack: true,
-                  })}
-                  <TrackSectionDivider onMouseDown={handleSectionDividerMouseDown} />
-                  {renderTrackHeadersSection(audioTracks, {
-                    section: 'audio',
-                    height: audioPaneHeight,
-                    zoneHeight: audioZoneHeight,
-                    scrollRef: audioTrackHeadersScrollRef,
-                    dropIndicatorLocalIndex: audioDropIndicatorIndex,
-                    showTopDividerForFirstTrack: false,
-                  })}
-                </>
-              ) : (
-                renderTrackHeadersSection(singleSectionTracks, {
-                  section: singleSectionKind,
-                  height: singleSectionHeight,
-                  zoneHeight: singleSectionZoneHeight,
-                  scrollRef: allTrackHeadersScrollRef,
-                  dropIndicatorLocalIndex: singleDropIndicatorIndex,
-                  showTopDividerForFirstTrack: true,
-                })
-              )}
+              {/* Track labels - synced scroll (no scrollbar) */}
+              <div ref={trackHeadersViewportRef} className="flex-1 overflow-hidden relative">
+                <div ref={trackHeadersRootRef} className="flex h-full min-h-0 flex-col">
+                  {hasTrackSections ? (
+                    <>
+                      {renderTrackHeadersSection(videoTracks, {
+                        section: 'video',
+                        height: videoPaneHeight,
+                        zoneHeight: videoZoneHeight,
+                        scrollRef: videoTrackHeadersScrollRef,
+                        dropIndicatorLocalIndex: videoDropIndicatorIndex,
+                        showTopDividerForFirstTrack: true,
+                      })}
+                      <TrackSectionDivider onMouseDown={handleSectionDividerMouseDown} />
+                      {renderTrackHeadersSection(audioTracks, {
+                        section: 'audio',
+                        height: audioPaneHeight,
+                        zoneHeight: audioZoneHeight,
+                        scrollRef: audioTrackHeadersScrollRef,
+                        dropIndicatorLocalIndex: audioDropIndicatorIndex,
+                        showTopDividerForFirstTrack: false,
+                      })}
+                    </>
+                  ) : (
+                    renderTrackHeadersSection(singleSectionTracks, {
+                      section: singleSectionKind,
+                      height: singleSectionHeight,
+                      zoneHeight: singleSectionZoneHeight,
+                      scrollRef: allTrackHeadersScrollRef,
+                      dropIndicatorLocalIndex: singleDropIndicatorIndex,
+                      showTopDividerForFirstTrack: true,
+                    })
+                  )}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
 
-        {/* Timeline Canvas */}
-        <TimelineContent
-          duration={duration}
-          tracks={visibleTracks}
-          scrollRef={timelineContentRef}
-          allTracksScrollRef={allTrackContentScrollRef}
-          videoTracksScrollRef={videoTrackContentScrollRef}
-          audioTracksScrollRef={audioTrackContentScrollRef}
-          videoPaneHeight={videoPaneHeight}
-          audioPaneHeight={audioPaneHeight}
-          onSectionDividerMouseDown={hasTrackSections ? handleSectionDividerMouseDown : undefined}
-          onZoomHandlersReady={setZoomHandlers}
-          onMetricsChange={setTimelineMetrics}
-        />
+            {/* Timeline Canvas */}
+            <TimelineContent
+              duration={duration}
+              tracks={visibleTracks}
+              scrollRef={timelineContentRef}
+              allTracksScrollRef={allTrackContentScrollRef}
+              videoTracksScrollRef={videoTrackContentScrollRef}
+              audioTracksScrollRef={audioTrackContentScrollRef}
+              videoPaneHeight={videoPaneHeight}
+              audioPaneHeight={audioPaneHeight}
+              onSectionDividerMouseDown={
+                hasTrackSections ? handleSectionDividerMouseDown : undefined
+              }
+              onZoomHandlersReady={setZoomHandlers}
+              onMetricsChange={setTimelineMetrics}
+            />
+          </>
+        )}
       </div>
 
       <div className="flex flex-shrink-0 overflow-hidden">

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -851,8 +851,18 @@ export async function loadTimeline(
   projectId: string,
   options: LoadTimelineOptions = {},
 ): Promise<void> {
-  // Mark loading started - used to coordinate initial player sync
-  useTimelineSettingsStore.getState().setTimelineLoading(true)
+  // Mark loading before any UI-visible state swap, then clear stale timeline
+  // content so old-project clips cannot flash while the new project hydrates.
+  useTimelineSettingsStore.getState().beginTimelineHydration(projectId)
+  useItemsStore.getState().setTracks([])
+  useItemsStore.getState().setItems([])
+  useTransitionsStore.getState().setTransitions([])
+  useKeyframesStore.getState().setKeyframes([])
+  useMarkersStore.getState().setMarkers([])
+  useMarkersStore.getState().setInPoint(null)
+  useMarkersStore.getState().setOutPoint(null)
+  useCompositionsStore.getState().setCompositions([])
+  useCompositionNavigationStore.getState().resetToRoot()
 
   try {
     const rawProject = await getProject(projectId)
@@ -1028,12 +1038,13 @@ export async function loadTimeline(
       useMediaLibraryStore.getState().setOrphanedClips([])
     }
 
-    // Mark loading complete - signals player sync can proceed
-    useTimelineSettingsStore.getState().setTimelineLoading(false)
+    // Mark loading complete only after all stores are restored and media references validated.
+    useTimelineSettingsStore.getState().completeTimelineHydration(projectId)
   } catch (error) {
     logger.error('Failed to load timeline:', error)
-    // Still mark loading complete on error so UI isn't stuck
-    useTimelineSettingsStore.getState().setTimelineLoading(false)
+    // Still mark loading complete on error so UI isn't stuck; keep loadedProjectId
+    // null so project-specific gates do not show stale clips as current.
+    useTimelineSettingsStore.getState().failTimelineHydration(projectId)
     throw error
   }
 }

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -853,7 +853,9 @@ export async function loadTimeline(
 ): Promise<void> {
   // Mark loading before any UI-visible state swap, then clear stale timeline
   // content so old-project clips cannot flash while the new project hydrates.
-  useTimelineSettingsStore.getState().beginTimelineHydration(projectId)
+  const hydrationRequestId = useTimelineSettingsStore.getState().beginTimelineHydration(projectId)
+  const isCurrentHydration = () =>
+    useTimelineSettingsStore.getState().isTimelineHydrationCurrent(projectId, hydrationRequestId)
   useItemsStore.getState().setTracks([])
   useItemsStore.getState().setItems([])
   useTransitionsStore.getState().setTransitions([])
@@ -866,6 +868,7 @@ export async function loadTimeline(
 
   try {
     const rawProject = await getProject(projectId)
+    if (!isCurrentHydration()) return
     if (!rawProject) {
       throw new Error(`Project not found: ${projectId}`)
     }
@@ -881,6 +884,7 @@ export async function loadTimeline(
     // Run migrations and normalization
     const migrationResult = migrateProject(rawProject)
     const repairedLegacyLayouts = await repairLegacyProjectAvLayouts(migrationResult.project)
+    if (!isCurrentHydration()) return
     const sanitizedTimeline = repairedLegacyLayouts.project.timeline
       ? sanitizeTimelineEphemeralFields(repairedLegacyLayouts.project.timeline)
       : { timeline: repairedLegacyLayouts.project.timeline, cleaned: false }
@@ -911,6 +915,7 @@ export async function loadTimeline(
         ...project,
         schemaVersion: CURRENT_SCHEMA_VERSION,
       })
+      if (!isCurrentHydration()) return
       logger.debug('Saved migrated project to storage')
     }
 
@@ -945,6 +950,7 @@ export async function loadTimeline(
       const hydratedItems = await reverseConformService.hydrateItems(
         (t.items || []) as TimelineItem[],
       )
+      if (!isCurrentHydration()) return
       useItemsStore.getState().setTracks(sortedTracks as TimelineTrack[])
       useItemsStore.getState().setItems(hydratedItems)
       useTransitionsStore.getState().setTransitions((t.transitions || []) as Transition[])
@@ -974,6 +980,7 @@ export async function loadTimeline(
             ...(c.busAudioEq && { busAudioEq: c.busAudioEq }),
           })),
         )
+        if (!isCurrentHydration()) return
         useCompositionsStore.getState().setCompositions(hydratedCompositions)
       } else {
         useCompositionsStore.getState().setCompositions([])
@@ -1029,6 +1036,7 @@ export async function loadTimeline(
       compositions: useCompositionsStore.getState().compositions,
       projectId,
     })
+    if (!isCurrentHydration()) return
     if (orphans.length > 0) {
       logger.warn(`Found ${orphans.length} orphaned clip(s) referencing deleted media`)
       useMediaLibraryStore.getState().setOrphanedClips(orphans)
@@ -1039,12 +1047,12 @@ export async function loadTimeline(
     }
 
     // Mark loading complete only after all stores are restored and media references validated.
-    useTimelineSettingsStore.getState().completeTimelineHydration(projectId)
+    useTimelineSettingsStore.getState().completeTimelineHydration(projectId, hydrationRequestId)
   } catch (error) {
     logger.error('Failed to load timeline:', error)
     // Still mark loading complete on error so UI isn't stuck; keep loadedProjectId
     // null so project-specific gates do not show stale clips as current.
-    useTimelineSettingsStore.getState().failTimelineHydration(projectId)
+    useTimelineSettingsStore.getState().failTimelineHydration(projectId, hydrationRequestId)
     throw error
   }
 }

--- a/src/features/timeline/stores/timeline-settings-store.ts
+++ b/src/features/timeline/stores/timeline-settings-store.ts
@@ -16,6 +16,8 @@ interface TimelineSettingsState {
   loadingProjectId: string | null
   /** Last project whose timeline stores were fully restored and are safe to display. */
   loadedProjectId: string | null
+  /** Monotonic token for the currently active loadTimeline() request. */
+  timelineHydrationRequestId: number
 }
 
 interface TimelineSettingsActions {
@@ -27,9 +29,10 @@ interface TimelineSettingsActions {
   markDirty: () => void
   markClean: () => void
   setTimelineLoading: (loading: boolean) => void
-  beginTimelineHydration: (projectId: string) => void
-  completeTimelineHydration: (projectId: string) => void
-  failTimelineHydration: (projectId: string) => void
+  beginTimelineHydration: (projectId: string) => number
+  isTimelineHydrationCurrent: (projectId: string, requestId: number) => boolean
+  completeTimelineHydration: (projectId: string, requestId: number) => void
+  failTimelineHydration: (projectId: string, requestId: number) => void
   resetTimelineHydration: () => void
 }
 
@@ -43,6 +46,7 @@ export const useTimelineSettingsStore = create<TimelineSettingsState & TimelineS
     isTimelineLoading: true, // Start true - set false after loadTimeline completes
     loadingProjectId: null,
     loadedProjectId: null,
+    timelineHydrationRequestId: 0,
 
     // Actions
     setFps: (fps) => set({ fps }),
@@ -59,28 +63,53 @@ export const useTimelineSettingsStore = create<TimelineSettingsState & TimelineS
         isTimelineLoading: loading,
         loadingProjectId: loading ? state.loadingProjectId : null,
       })),
-    beginTimelineHydration: (projectId) =>
+    beginTimelineHydration: (projectId) => {
+      const requestId = get().timelineHydrationRequestId + 1
       set({
         isTimelineLoading: true,
         loadingProjectId: projectId,
         loadedProjectId: null,
+        timelineHydrationRequestId: requestId,
+      })
+      return requestId
+    },
+    isTimelineHydrationCurrent: (projectId, requestId) => {
+      const state = get()
+      return state.loadingProjectId === projectId && state.timelineHydrationRequestId === requestId
+    },
+    completeTimelineHydration: (projectId, requestId) =>
+      set((state) => {
+        if (
+          state.loadingProjectId !== projectId ||
+          state.timelineHydrationRequestId !== requestId
+        ) {
+          return state
+        }
+        return {
+          isTimelineLoading: false,
+          loadingProjectId: null,
+          loadedProjectId: projectId,
+        }
       }),
-    completeTimelineHydration: (projectId) =>
-      set({
-        isTimelineLoading: false,
-        loadingProjectId: null,
-        loadedProjectId: projectId,
+    failTimelineHydration: (projectId, requestId) =>
+      set((state) => {
+        if (
+          state.loadingProjectId !== projectId ||
+          state.timelineHydrationRequestId !== requestId
+        ) {
+          return state
+        }
+        return {
+          isTimelineLoading: false,
+          loadingProjectId: null,
+        }
       }),
-    failTimelineHydration: (projectId) =>
-      set((state) => ({
-        isTimelineLoading: false,
-        loadingProjectId: state.loadingProjectId === projectId ? null : state.loadingProjectId,
-      })),
     resetTimelineHydration: () =>
       set({
         isTimelineLoading: true,
         loadingProjectId: null,
         loadedProjectId: null,
+        timelineHydrationRequestId: 0,
       }),
   }),
 )

--- a/src/features/timeline/stores/timeline-settings-store.ts
+++ b/src/features/timeline/stores/timeline-settings-store.ts
@@ -12,6 +12,10 @@ interface TimelineSettingsState {
   isDirty: boolean
   /** True while loadTimeline() is in progress - used to coordinate initial player sync */
   isTimelineLoading: boolean
+  /** Project currently being restored into the timeline stores, if any. */
+  loadingProjectId: string | null
+  /** Last project whose timeline stores were fully restored and are safe to display. */
+  loadedProjectId: string | null
 }
 
 interface TimelineSettingsActions {
@@ -23,6 +27,10 @@ interface TimelineSettingsActions {
   markDirty: () => void
   markClean: () => void
   setTimelineLoading: (loading: boolean) => void
+  beginTimelineHydration: (projectId: string) => void
+  completeTimelineHydration: (projectId: string) => void
+  failTimelineHydration: (projectId: string) => void
+  resetTimelineHydration: () => void
 }
 
 export const useTimelineSettingsStore = create<TimelineSettingsState & TimelineSettingsActions>()(
@@ -33,6 +41,8 @@ export const useTimelineSettingsStore = create<TimelineSettingsState & TimelineS
     snapEnabled: true,
     isDirty: false,
     isTimelineLoading: true, // Start true - set false after loadTimeline completes
+    loadingProjectId: null,
+    loadedProjectId: null,
 
     // Actions
     setFps: (fps) => set({ fps }),
@@ -44,6 +54,33 @@ export const useTimelineSettingsStore = create<TimelineSettingsState & TimelineS
       if (!get().isDirty) set({ isDirty: true })
     },
     markClean: () => set({ isDirty: false }),
-    setTimelineLoading: (loading) => set({ isTimelineLoading: loading }),
+    setTimelineLoading: (loading) =>
+      set((state) => ({
+        isTimelineLoading: loading,
+        loadingProjectId: loading ? state.loadingProjectId : null,
+      })),
+    beginTimelineHydration: (projectId) =>
+      set({
+        isTimelineLoading: true,
+        loadingProjectId: projectId,
+        loadedProjectId: null,
+      }),
+    completeTimelineHydration: (projectId) =>
+      set({
+        isTimelineLoading: false,
+        loadingProjectId: null,
+        loadedProjectId: projectId,
+      }),
+    failTimelineHydration: (projectId) =>
+      set((state) => ({
+        isTimelineLoading: false,
+        loadingProjectId: state.loadingProjectId === projectId ? null : state.loadingProjectId,
+      })),
+    resetTimelineHydration: () =>
+      set({
+        isTimelineLoading: true,
+        loadingProjectId: null,
+        loadedProjectId: null,
+      }),
   }),
 )

--- a/src/features/timeline/stores/timeline-store-facade.test.ts
+++ b/src/features/timeline/stores/timeline-store-facade.test.ts
@@ -1091,7 +1091,7 @@ describe('TimelineStoreFacade', () => {
     })
 
     it('marks timeline hydration as loading for the requested project before state is restored', async () => {
-      useTimelineSettingsStore.getState().completeTimelineHydration('old-project')
+      useTimelineSettingsStore.getState().completeTimelineHydration('old-project', 0)
       useItemsStore.getState().setTracks([
         {
           id: 'old-track',
@@ -1129,6 +1129,110 @@ describe('TimelineStoreFacade', () => {
         timeline: null,
       })
       await loadPromise
+    })
+
+    it('ignores stale concurrent loadTimeline completions when a newer project finishes first', async () => {
+      let resolveProjectA!: (project: unknown) => void
+      let resolveProjectB!: (project: unknown) => void
+      indexedDbMocks.getProject.mockImplementation((projectId: string) => {
+        if (projectId === 'project-a') {
+          return new Promise((resolve) => {
+            resolveProjectA = resolve
+          })
+        }
+        if (projectId === 'project-b') {
+          return new Promise((resolve) => {
+            resolveProjectB = resolve
+          })
+        }
+        return Promise.resolve(null)
+      })
+      mediaValidationMocks.validateProjectMediaReferences.mockResolvedValue([])
+
+      const loadProjectA = useTimelineStore.getState().loadTimeline('project-a')
+      const loadProjectB = useTimelineStore.getState().loadTimeline('project-b')
+
+      resolveProjectB({
+        id: 'project-b',
+        metadata: { fps: 30 },
+        timeline: {
+          tracks: [
+            {
+              id: 'track-b',
+              name: 'Project B Track',
+              order: 0,
+              height: 80,
+              locked: false,
+              visible: true,
+              muted: false,
+              solo: false,
+            },
+          ],
+          items: [
+            {
+              id: 'item-b',
+              type: 'video',
+              trackId: 'track-b',
+              from: 0,
+              durationInFrames: 100,
+              label: 'project-b.mp4',
+            },
+          ],
+          keyframes: [],
+          transitions: [],
+          markers: [],
+        },
+      })
+      await loadProjectB
+
+      expect(useTimelineSettingsStore.getState()).toMatchObject({
+        isTimelineLoading: false,
+        loadingProjectId: null,
+        loadedProjectId: 'project-b',
+      })
+      expect(useItemsStore.getState().tracks.map((track) => track.id)).toEqual(['track-b'])
+      expect(useItemsStore.getState().items.map((item) => item.id)).toEqual(['item-b'])
+
+      resolveProjectA({
+        id: 'project-a',
+        metadata: { fps: 30 },
+        timeline: {
+          tracks: [
+            {
+              id: 'track-a',
+              name: 'Project A Track',
+              order: 0,
+              height: 80,
+              locked: false,
+              visible: true,
+              muted: false,
+              solo: false,
+            },
+          ],
+          items: [
+            {
+              id: 'item-a',
+              type: 'video',
+              trackId: 'track-a',
+              from: 0,
+              durationInFrames: 100,
+              label: 'project-a.mp4',
+            },
+          ],
+          keyframes: [],
+          transitions: [],
+          markers: [],
+        },
+      })
+      await loadProjectA
+
+      expect(useTimelineSettingsStore.getState()).toMatchObject({
+        isTimelineLoading: false,
+        loadingProjectId: null,
+        loadedProjectId: 'project-b',
+      })
+      expect(useItemsStore.getState().tracks.map((track) => track.id)).toEqual(['track-b'])
+      expect(useItemsStore.getState().items.map((item) => item.id)).toEqual(['item-b'])
     })
 
     it('marks timeline as loaded for the project after completion', async () => {

--- a/src/features/timeline/stores/timeline-store-facade.test.ts
+++ b/src/features/timeline/stores/timeline-store-facade.test.ts
@@ -133,6 +133,7 @@ describe('TimelineStoreFacade', () => {
     useTimelineSettingsStore.getState().setScrollPosition(0)
     useTimelineSettingsStore.getState().setSnapEnabled(true)
     useTimelineSettingsStore.getState().markClean()
+    useTimelineSettingsStore.getState().resetTimelineHydration()
     useCompositionsStore.getState().setCompositions([])
     useCompositionNavigationStore.getState().resetToRoot()
     useTimelineCommandStore.getState().clearHistory()
@@ -1089,7 +1090,48 @@ describe('TimelineStoreFacade', () => {
       )
     })
 
-    it('marks timeline as not loading after completion', async () => {
+    it('marks timeline hydration as loading for the requested project before state is restored', async () => {
+      useTimelineSettingsStore.getState().completeTimelineHydration('old-project')
+      useItemsStore.getState().setTracks([
+        {
+          id: 'old-track',
+          name: 'Old Project Track',
+          order: 0,
+          height: 80,
+          locked: false,
+          visible: true,
+          muted: false,
+          solo: false,
+          items: [],
+        },
+      ])
+
+      let resolveProject!: (project: unknown) => void
+      indexedDbMocks.getProject.mockReturnValue(
+        new Promise((resolve) => {
+          resolveProject = resolve
+        }),
+      )
+      mediaValidationMocks.validateProjectMediaReferences.mockResolvedValue([])
+
+      const loadPromise = useTimelineStore.getState().loadTimeline('project-1')
+
+      expect(useTimelineSettingsStore.getState()).toMatchObject({
+        isTimelineLoading: true,
+        loadingProjectId: 'project-1',
+        loadedProjectId: null,
+      })
+      expect(useItemsStore.getState().tracks).toHaveLength(0)
+
+      resolveProject({
+        id: 'project-1',
+        metadata: { fps: 30 },
+        timeline: null,
+      })
+      await loadPromise
+    })
+
+    it('marks timeline as loaded for the project after completion', async () => {
       indexedDbMocks.getProject.mockResolvedValue({
         id: 'project-1',
         metadata: { fps: 30 },
@@ -1099,7 +1141,25 @@ describe('TimelineStoreFacade', () => {
 
       await useTimelineStore.getState().loadTimeline('project-1')
 
-      expect(useTimelineSettingsStore.getState().isTimelineLoading).toBe(false)
+      expect(useTimelineSettingsStore.getState()).toMatchObject({
+        isTimelineLoading: false,
+        loadingProjectId: null,
+        loadedProjectId: 'project-1',
+      })
+    })
+
+    it('clears loading without marking the failed project as loaded on load errors', async () => {
+      indexedDbMocks.getProject.mockRejectedValue(new Error('storage unavailable'))
+
+      await expect(useTimelineStore.getState().loadTimeline('project-1')).rejects.toThrow(
+        'storage unavailable',
+      )
+
+      expect(useTimelineSettingsStore.getState()).toMatchObject({
+        isTimelineLoading: false,
+        loadingProjectId: null,
+        loadedProjectId: null,
+      })
     })
 
     it('repairs legacy AV track layout inside compound clips on load', async () => {

--- a/src/features/timeline/stores/timeline-store-facade.ts
+++ b/src/features/timeline/stores/timeline-store-facade.ts
@@ -48,6 +48,9 @@ let lastFpsRef: unknown = null
 let lastScrollPositionRef: unknown = null
 let lastSnapEnabledRef: unknown = null
 let lastIsDirtyRef: unknown = null
+let lastIsTimelineLoadingRef: unknown = null
+let lastLoadingProjectIdRef: unknown = null
+let lastLoadedProjectIdRef: unknown = null
 
 /**
  * Get cached snapshot, rebuilding only if underlying state changed.
@@ -71,7 +74,10 @@ function getSnapshot(): TimelineState & TimelineActions {
     lastFpsRef !== settingsState.fps ||
     lastScrollPositionRef !== settingsState.scrollPosition ||
     lastSnapEnabledRef !== settingsState.snapEnabled ||
-    lastIsDirtyRef !== settingsState.isDirty
+    lastIsDirtyRef !== settingsState.isDirty ||
+    lastIsTimelineLoadingRef !== settingsState.isTimelineLoading ||
+    lastLoadingProjectIdRef !== settingsState.loadingProjectId ||
+    lastLoadedProjectIdRef !== settingsState.loadedProjectId
 
   if (!cachedSnapshot || stateChanged) {
     // Update tracked references
@@ -86,6 +92,9 @@ function getSnapshot(): TimelineState & TimelineActions {
     lastScrollPositionRef = settingsState.scrollPosition
     lastSnapEnabledRef = settingsState.snapEnabled
     lastIsDirtyRef = settingsState.isDirty
+    lastIsTimelineLoadingRef = settingsState.isTimelineLoading
+    lastLoadingProjectIdRef = settingsState.loadingProjectId
+    lastLoadedProjectIdRef = settingsState.loadedProjectId
 
     // Rebuild cached snapshot
     cachedSnapshot = {
@@ -101,6 +110,9 @@ function getSnapshot(): TimelineState & TimelineActions {
       scrollPosition: settingsState.scrollPosition,
       snapEnabled: settingsState.snapEnabled,
       isDirty: settingsState.isDirty,
+      isTimelineLoading: settingsState.isTimelineLoading,
+      loadingProjectId: settingsState.loadingProjectId,
+      loadedProjectId: settingsState.loadedProjectId,
 
       // Actions (static references, never change)
       setTracks: timelineActions.setTracks,

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -47,6 +47,9 @@ export interface TimelineState {
   inPoint: number | null
   outPoint: number | null
   isDirty: boolean // Track unsaved changes
+  isTimelineLoading: boolean
+  loadingProjectId: string | null
+  loadedProjectId: string | null
 }
 
 export interface TimelineActions {


### PR DESCRIPTION
## Summary
- Gate timeline project hydration so the editor waits for the selected project restore path instead of racing stale load completions.
- Defer heavy timeline clip visuals (filmstrips, waveforms, compound segments) during project/media load while keeping clip shells and labels visible.
- Make media-library visual readiness project-aware so stale or unrelated media loads cannot prematurely show or hide visuals after project switches.

## Verification
- `npx -y node@22 node_modules/.bin/vp test run src/features/media-library/stores/media-library-store.test.ts src/features/timeline/components/timeline-item/clip-content.test.tsx`
- `npx -y node@22 node_modules/.bin/vp lint src/features/media-library/stores/media-library-store.ts src/features/media-library/stores/media-library-store.test.ts src/features/timeline/components/timeline-item/clip-content.tsx src/features/timeline/components/timeline-item/clip-content.test.tsx`
- `npx -y node@22 node_modules/.bin/vp build`

## Notes
- This PR packages the completed local FreeCut Kanban work currently ahead of `origin/develop`.
- System Node is v18.19.1; verification used Node 22 because Vite/vite-plus require newer Node APIs.
