### PR TITLE
perf(timeline): filmstrip + zoom churn, cached re-display, cold extraction

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -10,6 +10,7 @@ const APP_SHELL_URLS = [
 ]
 const CACHEABLE_DESTINATIONS = new Set(['document', 'script', 'style', 'font', 'image'])
 const EXCLUDED_PATH_PREFIXES = ['/moss-tts/']
+const MAX_DYNAMIC_CACHE_ENTRIES = 160
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -92,7 +93,10 @@ async function staleWhileRevalidate(request) {
   const fetchPromise = fetch(request)
     .then((response) => {
       if (response.ok) {
-        cache.put(request, response.clone()).catch(() => {})
+        cache
+          .put(request, response.clone())
+          .then(() => trimRuntimeCache(cache))
+          .catch(() => {})
       }
       return response
     })
@@ -104,4 +108,18 @@ async function staleWhileRevalidate(request) {
     })
 
   return cachedResponse ?? fetchPromise
+}
+
+async function trimRuntimeCache(cache) {
+  const requests = await cache.keys()
+  const dynamicRequests = requests.filter((request) => {
+    const url = new URL(request.url)
+    return !APP_SHELL_URLS.includes(url.pathname)
+  })
+  const deleteCount = dynamicRequests.length - MAX_DYNAMIC_CACHE_ENTRIES
+  if (deleteCount <= 0) {
+    return
+  }
+
+  await Promise.all(dynamicRequests.slice(0, deleteCount).map((request) => cache.delete(request)))
 }

--- a/src/features/editor/components/editor.test.tsx
+++ b/src/features/editor/components/editor.test.tsx
@@ -94,6 +94,9 @@ vi.mock('./audio-meter-panel', () => ({
 vi.mock('@/features/editor/deps/timeline-ui', () => ({
   Timeline: () => <div data-testid="timeline" />,
   BentoLayoutDialog: () => null,
+  FillerRemovalDialog: () => null,
+  ReverseConformDialog: () => null,
+  SilenceRemovalDialog: () => null,
 }))
 
 vi.mock('./clear-keyframes-dialog', () => ({

--- a/src/features/media-library/components/compositions-section.tsx
+++ b/src/features/media-library/components/compositions-section.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect, memo } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect, memo, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Layers, Trash2, ChevronRight } from 'lucide-react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -34,6 +34,16 @@ import { setMediaDragData, clearMediaDragData } from '../utils/drag-data-cache'
 import { GRID_MIN_SIZE_PX, GRID_GAP_BY_SIZE } from './media-grid-constants'
 import { CARD_GRID_BASE, CARD_LIST_BASE, CARD_PERF_STYLE } from './card-styles'
 import { compoundClipThumbnailService } from '../services/compound-clip-thumbnail-service'
+
+function getSkimIndicatorStyle(progress: number): CSSProperties {
+  if (progress >= 0.999) {
+    return { right: 0 }
+  }
+
+  return {
+    left: `${progress * 100}%`,
+  }
+}
 
 /**
  * Compositions section in the media library.
@@ -504,7 +514,7 @@ const CompositionCard = memo(function CompositionCard({
               {skimProgress !== null && (
                 <div
                   className="absolute inset-y-0 w-px bg-white/85 shadow-[0_0_0_1px_rgba(0,0,0,0.3)] pointer-events-none"
-                  style={{ left: `${skimProgress * 100}%` }}
+                  style={getSkimIndicatorStyle(skimProgress)}
                 />
               )}
             </div>
@@ -590,7 +600,7 @@ const CompositionCard = memo(function CompositionCard({
             {skimProgress !== null && (
               <div
                 className="absolute inset-y-0 w-px bg-white/85 shadow-[0_0_0_1px_rgba(0,0,0,0.3)] pointer-events-none"
-                style={{ left: `${skimProgress * 100}%` }}
+                style={getSkimIndicatorStyle(skimProgress)}
               />
             )}
           </div>

--- a/src/features/media-library/components/media-card.test.tsx
+++ b/src/features/media-library/components/media-card.test.tsx
@@ -643,6 +643,35 @@ describe('MediaCard', () => {
     expect(editorStoreState.clearMediaSkimPreview).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the skim indicator inside the right edge', () => {
+    const { container } = render(<MediaCard media={makeMedia()} viewMode="list" />)
+
+    const thumbnail = container.querySelector('.w-12.h-9') as HTMLDivElement
+    expect(thumbnail).toBeTruthy()
+    vi.spyOn(thumbnail, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: 36,
+      right: 100,
+      width: 100,
+      height: 36,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.pointerEnter(thumbnail, {
+      clientX: 100,
+      pointerType: 'mouse',
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('div')).some((element) =>
+        element.getAttribute('style')?.includes('right: 0px'),
+      ),
+    ).toBe(true)
+  })
+
   it('stores AI analysis on the media item without inserting timeline captions', async () => {
     const media = makeMedia({
       fileName: 'frame.png',

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -1,4 +1,13 @@
-import { Fragment, memo, useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
+import {
+  Fragment,
+  memo,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { i18n } from '@/i18n'
 import {
@@ -85,6 +94,16 @@ interface MediaCardActionMenuProps {
 }
 
 const DEFAULT_CAPTION_SELECTION_DURATION_SEC = 3
+
+function getSkimIndicatorStyle(progress: number): CSSProperties {
+  if (progress >= 0.999) {
+    return { right: 0 }
+  }
+
+  return {
+    left: `${progress * 100}%`,
+  }
+}
 
 function canExtractEmbeddedSubtitlesFromMedia(media: MediaMetadata): boolean {
   const fileName = media.fileName.toLowerCase()
@@ -1217,7 +1236,7 @@ export const MediaCard = memo(function MediaCard({
                 {canScrubPreview && skimProgress !== null && (
                   <div
                     className="absolute inset-y-0 w-px bg-white/80 shadow-[0_0_0_1px_rgba(0,0,0,0.25)] pointer-events-none"
-                    style={{ left: `${skimProgress * 100}%` }}
+                    style={getSkimIndicatorStyle(skimProgress)}
                   />
                 )}
                 {!isBroken &&
@@ -1465,7 +1484,7 @@ export const MediaCard = memo(function MediaCard({
               {canScrubPreview && skimProgress !== null && (
                 <div
                   className="absolute inset-y-0 w-px bg-white/85 shadow-[0_0_0_1px_rgba(0,0,0,0.3)] pointer-events-none"
-                  style={{ left: `${skimProgress * 100}%` }}
+                  style={getSkimIndicatorStyle(skimProgress)}
                 />
               )}
               {!isBroken &&

--- a/src/features/media-library/services/media-library-service.generated-image.test.ts
+++ b/src/features/media-library/services/media-library-service.generated-image.test.ts
@@ -72,6 +72,7 @@ vi.mock('@/infrastructure/storage', () => ({
   getMediaForProject: vi.fn(),
   deleteTranscript: vi.fn(),
   saveTranscript: vi.fn(),
+  writeMediaSource: vi.fn(async () => undefined),
 }))
 
 vi.mock('./opfs-service', () => ({

--- a/src/features/preview/components/inline-composition-preview.tsx
+++ b/src/features/preview/components/inline-composition-preview.tsx
@@ -10,11 +10,16 @@ import {
 import { resolveMediaUrl, resolveMediaUrls } from '@/features/preview/deps/media-library-contract'
 import { createCompositionRenderer } from '@/features/preview/deps/export'
 import { createLogger } from '@/shared/logging/logger'
+import { getPreviewPixelSnapSize } from '../utils/preview-pixel-snap'
 
 type CompositionRendererInstance = Awaited<ReturnType<typeof createCompositionRenderer>>
 
 function getLogger() {
   return createLogger('InlineCompositionPreview')
+}
+
+function getDevicePixelRatio(): number {
+  return typeof window === 'undefined' ? 1 : window.devicePixelRatio
 }
 
 interface InlineCompositionPreviewProps {
@@ -102,26 +107,36 @@ const InlineCompositionPreviewContent = memo(function InlineCompositionPreviewCo
   const playerSize = useMemo(() => {
     const aspectRatio = compositionWidth / compositionHeight
 
+    // Snap only the dominant dimension and derive the other from the source
+    // aspect ratio — independent rounding breaks the aspect ratio and lets
+    // the scrub overlay misalign with Remotion's uniformly scaled content.
     if (zoom === -1) {
       if (containerSize.width > 0 && containerSize.height > 0) {
         const containerAspectRatio = containerSize.width / containerSize.height
 
         if (containerAspectRatio > aspectRatio) {
-          const height = containerSize.height
+          const { height } = getPreviewPixelSnapSize(
+            { width: containerSize.height * aspectRatio, height: containerSize.height },
+            getDevicePixelRatio(),
+          )
           return { width: height * aspectRatio, height }
         }
 
-        const width = containerSize.width
+        const { width } = getPreviewPixelSnapSize(
+          { width: containerSize.width, height: containerSize.width / aspectRatio },
+          getDevicePixelRatio(),
+        )
         return { width, height: width / aspectRatio }
       }
 
       return { width: compositionWidth, height: compositionHeight }
     }
 
-    return {
-      width: compositionWidth * zoom,
-      height: compositionHeight * zoom,
-    }
+    const { width } = getPreviewPixelSnapSize(
+      { width: compositionWidth * zoom, height: compositionHeight * zoom },
+      getDevicePixelRatio(),
+    )
+    return { width, height: width / aspectRatio }
   }, [compositionHeight, compositionWidth, containerSize.height, containerSize.width, zoom])
 
   const needsOverflow = useMemo(() => {

--- a/src/features/preview/components/inline-source-preview.tsx
+++ b/src/features/preview/components/inline-source-preview.tsx
@@ -83,35 +83,36 @@ const InlineSourcePreviewContent = memo(function InlineSourcePreviewContent({
   const playerSize = useMemo(() => {
     const aspectRatio = mediaWidth / mediaHeight
 
+    // Snap only the dominant dimension and derive the other from the source
+    // aspect ratio — independent rounding breaks the aspect ratio and lets
+    // the scrub overlay misalign with Remotion's uniformly scaled content.
     if (zoom === -1) {
       if (containerSize.width > 0 && containerSize.height > 0) {
         const containerAspectRatio = containerSize.width / containerSize.height
 
         if (containerAspectRatio > aspectRatio) {
-          const height = containerSize.height
-          return getPreviewPixelSnapSize(
-            { width: height * aspectRatio, height },
+          const { height } = getPreviewPixelSnapSize(
+            { width: containerSize.height * aspectRatio, height: containerSize.height },
             getDevicePixelRatio(),
           )
+          return { width: height * aspectRatio, height }
         }
 
-        const width = containerSize.width
-        return getPreviewPixelSnapSize(
-          { width, height: width / aspectRatio },
+        const { width } = getPreviewPixelSnapSize(
+          { width: containerSize.width, height: containerSize.width / aspectRatio },
           getDevicePixelRatio(),
         )
+        return { width, height: width / aspectRatio }
       }
 
       return { width: mediaWidth, height: mediaHeight }
     }
 
-    return getPreviewPixelSnapSize(
-      {
-        width: mediaWidth * zoom,
-        height: mediaHeight * zoom,
-      },
+    const { width } = getPreviewPixelSnapSize(
+      { width: mediaWidth * zoom, height: mediaHeight * zoom },
       getDevicePixelRatio(),
     )
+    return { width, height: width / aspectRatio }
   }, [containerSize.height, containerSize.width, mediaHeight, mediaWidth, zoom])
 
   const needsOverflow = useMemo(() => {

--- a/src/features/preview/components/preview-stage.tsx
+++ b/src/features/preview/components/preview-stage.tsx
@@ -192,6 +192,7 @@ export const PreviewStage = memo(function PreviewStage({
                     height: '100%',
                     zIndex: 4,
                     visibility: isRenderedOverlayVisible ? 'visible' : 'hidden',
+                    backgroundColor: '#000',
                   }}
                 />
               )}

--- a/src/features/preview/components/source-composition.tsx
+++ b/src/features/preview/components/source-composition.tsx
@@ -156,6 +156,7 @@ function VideoSource({
   const [hasDecodedFrame, setHasDecodedFrame] = useState(false)
   const [decodedFrameKey, setDecodedFrameKey] = useState<number | null>(null)
   const [pausedRenderTargetKey, setPausedRenderTargetKey] = useState<number | null>(null)
+  const shouldUseDecodedScrubFrame = forceFastScrub && strictDecodeReady && !useLegacyPausedSeek
 
   useEffect(() => {
     playingRef.current = playing
@@ -579,7 +580,11 @@ function VideoSource({
 
       lastFrameRef.current = frame
 
-      if (!playingRef.current && !useLegacyPausedSeek && !isPreviewScrubbing) {
+      if (
+        !playingRef.current &&
+        !useLegacyPausedSeek &&
+        (!isPreviewScrubbing || shouldUseDecodedScrubFrame)
+      ) {
         if (pausedRenderTargetKeyRef.current !== targetCacheKey) {
           pausedRenderTargetKeyRef.current = targetCacheKey
           setPausedRenderTargetKey(targetCacheKey)
@@ -623,7 +628,7 @@ function VideoSource({
         strictDecodeReady &&
         hasDecodedFrame &&
         !useLegacyPausedSeek &&
-        !isPreviewScrubbing
+        (!isPreviewScrubbing || shouldUseDecodedScrubFrame)
       ) {
         syncAudioTime()
         return
@@ -667,6 +672,7 @@ function VideoSource({
       hasDecodedFrame,
       isPreviewScrubbing,
       pumpLatestDecodedFrame,
+      shouldUseDecodedScrubFrame,
       src,
       strictDecodeReady,
       useLegacyPausedSeek,
@@ -746,12 +752,14 @@ function VideoSource({
 
   const showDecodedCanvas =
     !playing &&
-    !isPreviewScrubbing &&
+    (!isPreviewScrubbing || shouldUseDecodedScrubFrame) &&
     strictDecodeReady &&
     hasDecodedFrame &&
     !useLegacyPausedSeek &&
     decodedFrameKey !== null &&
     decodedFrameKey === pausedRenderTargetKey
+  const hideNativeVideoForPendingDecodedScrub =
+    shouldUseDecodedScrubFrame && pausedRenderTargetKey !== decodedFrameKey
 
   return (
     <AbsoluteFill>
@@ -761,7 +769,7 @@ function VideoSource({
           width: '100%',
           height: '100%',
           position: 'relative',
-          display: showDecodedCanvas ? 'none' : 'block',
+          display: showDecodedCanvas || hideNativeVideoForPendingDecodedScrub ? 'none' : 'block',
         }}
       />
       <canvas

--- a/src/features/preview/hooks/use-preview-view-model.ts
+++ b/src/features/preview/hooks/use-preview-view-model.ts
@@ -96,33 +96,36 @@ export function usePreviewViewModel({
   const playerSize = useMemo(() => {
     const aspectRatio = project.width / project.height
 
+    // Snap only the dominant dimension to a device pixel and derive the other
+    // from the source aspect ratio. Rounding both independently breaks the
+    // aspect ratio by up to a sub-pixel, which makes the scrub overlay (which
+    // fills the container at 100%/100%) misalign with Remotion's uniformly
+    // scaled composition along whichever edge ends up on the derived side.
     if (zoom === -1) {
       if (containerSize.width > 0 && containerSize.height > 0) {
         const containerAspectRatio = containerSize.width / containerSize.height
 
-        let width: number
-        let height: number
-
         if (containerAspectRatio > aspectRatio) {
-          height = containerSize.height
-          width = height * aspectRatio
-        } else {
-          width = containerSize.width
-          height = width / aspectRatio
+          const { height } = getPreviewPixelSnapSize(
+            { width: containerSize.height * aspectRatio, height: containerSize.height },
+            getDevicePixelRatio(),
+          )
+          return { width: height * aspectRatio, height }
         }
-
-        return getPreviewPixelSnapSize({ width, height }, getDevicePixelRatio())
+        const { width } = getPreviewPixelSnapSize(
+          { width: containerSize.width, height: containerSize.width / aspectRatio },
+          getDevicePixelRatio(),
+        )
+        return { width, height: width / aspectRatio }
       }
       return { width: project.width, height: project.height }
     }
 
-    return getPreviewPixelSnapSize(
-      {
-        width: project.width * zoom,
-        height: project.height * zoom,
-      },
+    const { width } = getPreviewPixelSnapSize(
+      { width: project.width * zoom, height: project.height * zoom },
       getDevicePixelRatio(),
     )
+    return { width, height: width / aspectRatio }
   }, [containerSize.height, containerSize.width, project.height, project.width, zoom])
 
   const needsOverflow = useMemo(() => {

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -476,13 +476,15 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     }
   }, [mediaId, isVisible, proxyBlobUrl, blobUrlVersion, hasStartedLoadingRef, setBlobUrl])
 
-  // Use filmstrip hook
+  // Use filmstrip hook. `enabled` no longer requires the source blob URL —
+  // disk-cached frames can render before useMediaBlobUrl resolves. The
+  // extraction path inside the hook still gates on blobUrl.
   const { frames, isLoading, isComplete, error } = useFilmstrip({
     mediaId,
     blobUrl: filmstripSourceUrl,
     duration: sourceDuration,
     isVisible,
-    enabled: !!filmstripSourceUrl && sourceDuration > 0,
+    enabled: sourceDuration > 0,
     priorityWindow,
     targetFrameCount,
     targetFrameIndices,

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -127,12 +127,14 @@ const FilmstripTile = memo(function FilmstripTile({
 }) {
   const [errorSrc, setErrorSrc] = useState<string | null>(null)
 
-  // Draw bitmap to canvas when ref is attached or bitmap changes
+  // Draw bitmap to canvas when ref is attached or bitmap changes.
+  // Assigning canvas.width/height resets the backing buffer even when the value
+  // doesn't change, so guard against same-size writes to avoid wasted realloc.
   const canvasRefCallback: RefCallback<HTMLCanvasElement> = useCallback(
     (canvas: HTMLCanvasElement | null) => {
       if (!canvas || !bitmap || bitmap.width === 0 || bitmap.height === 0) return
-      canvas.width = bitmap.width
-      canvas.height = bitmap.height
+      if (canvas.width !== bitmap.width) canvas.width = bitmap.width
+      if (canvas.height !== bitmap.height) canvas.height = bitmap.height
       const ctx = canvas.getContext('2d')
       try {
         if (ctx) ctx.drawImage(bitmap, 0, 0)
@@ -514,9 +516,11 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     [mediaId],
   )
 
-  // Calculate tiles - maps each tile position to the best frame
-  // Visible tiles stay locked to the clip geometry even during zoom; only the
-  // extraction request density above is reduced while interaction is active.
+  // Calculate tiles - maps each tile position to the best frame.
+  // During active zoom, drop tile density to match the request density (the
+  // extraction path already does this). Dedupe by frame.index and merge spans
+  // so the same frame stays in the same DOM node across zoom steps — keyed by
+  // frame.index, only style.left/width changes during zoom (no src thrash).
   const tiles = useMemo(() => {
     if (!frames || frames.length === 0 || thumbnailWidth === 0 || renderPixelsPerSecond <= 0)
       return []
@@ -528,7 +532,10 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     const visibleTileCount = Math.max(0, endTile - startTile)
     if (visibleTileCount <= 0) return []
 
-    const tileStep = getTileStep(visibleTileCount, MAX_TILES_IDLE)
+    const maxTiles = isInteractionLod
+      ? getInteractionMaxTiles(renderPixelsPerSecond)
+      : MAX_TILES_IDLE
+    const tileStep = getTileStep(visibleTileCount, maxTiles)
     const tileDurationSeconds = (thumbnailWidth / renderPixelsPerSecond) * speed
     const candidateWindowPadSeconds = Math.max(1, tileDurationSeconds * Math.max(2, tileStep))
     const windowStartTime = getSourceTimeForX(renderWindow.paddedStartX)
@@ -548,7 +555,11 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
       candidateFrames.length === frames.length
         ? frameByIndex
         : new Map(candidateFrames.map((frame) => [frame.index, frame] as const))
-    const result: { tileIndex: number; frame: FilmstripFrame; x: number; width: number }[] = []
+    // Build in slot order so adjacent slots that resolve to the same frame can
+    // merge into a single wider tile (preserves visible coverage without
+    // duplicating DOM nodes / breaking the key={frame.index} contract).
+    const result: { frame: FilmstripFrame; x: number; width: number }[] = []
+    let last: { frame: FilmstripFrame; x: number; width: number } | null = null
 
     for (let tile = startTile; tile < endTile; tile += tileStep) {
       const tileX = tile * thumbnailWidth
@@ -566,8 +577,14 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
         // Fall back to full frame set — always cover gaps with the closest available frame
         findClosestFrame(frames, tileTime)
 
-      if (frame) {
-        result.push({ tileIndex: tile, frame, x: tileX, width: tileWidth })
+      if (!frame) continue
+
+      if (last && last.frame.index === frame.index) {
+        // Same frame as previous slot — extend the existing tile right edge.
+        last.width = tileX + tileWidth - last.x
+      } else {
+        last = { frame, x: tileX, width: tileWidth }
+        result.push(last)
       }
     }
 
@@ -582,6 +599,7 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
     speed,
     thumbnailWidth,
     renderWindow,
+    isInteractionLod,
   ])
 
   // Pick a cover frame from the middle of available frames — used as a repeating
@@ -626,9 +644,9 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
             : undefined
         }
       >
-        {tiles.map(({ tileIndex, frame, x, width }) => (
+        {tiles.map(({ frame, x, width }) => (
           <FilmstripTile
-            key={tileIndex}
+            key={frame.index}
             src={frame.url}
             bitmap={frame.bitmap}
             x={x}

--- a/src/features/timeline/components/clip-waveform/index.tsx
+++ b/src/features/timeline/components/clip-waveform/index.tsx
@@ -79,6 +79,11 @@ export const ClipWaveform = memo(function ClipWaveform({
   const containerRef = useRef<HTMLDivElement>(null)
   const pixelsPerSecondRef = useRef(pixelsPerSecond)
   pixelsPerSecondRef.current = pixelsPerSecond
+  // clipWidth is read via ref inside renderTile so zoom (which changes clipWidth
+  // and pps proportionally) doesn't invalidate the callback identity and force
+  // TiledCanvas to redraw all visible tiles on every zoom step.
+  const clipWidthRef = useRef(clipWidth)
+  clipWidthRef.current = clipWidth
   const amplitudesBufferRef = useRef<Float32Array>(new Float32Array(0))
   const [height, setHeight] = useState(0)
   const conformStartedRef = useRef(false)
@@ -218,7 +223,7 @@ export const ClipWaveform = memo(function ClipWaveform({
         sourceDuration,
         Math.max(
           effectiveStart,
-          sourceEnd ?? effectiveStart + (clipWidth / Math.max(1, currentPps)) * speed,
+          sourceEnd ?? effectiveStart + (clipWidthRef.current / Math.max(1, currentPps)) * speed,
         ),
       )
       const centerY = height / 2
@@ -312,7 +317,6 @@ export const ClipWaveform = memo(function ClipWaveform({
       speed,
       isReversed,
       sourceDuration,
-      clipWidth,
       height,
       normalizationPeak,
       stereo,

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -86,7 +86,8 @@ export function TimelinePlayhead({ inRuler = false, maxFrame }: TimelinePlayhead
     const updatePosition = (frame: number) => {
       if (!playheadRef.current) return
       const leftPosition = Math.round(frameToPixelsRef.current(frame))
-      playheadRef.current.style.left = `${leftPosition}px`
+      // Use transform (compositor-only) instead of style.left (triggers layout).
+      playheadRef.current.style.transform = `translate3d(${leftPosition}px, 0, 0)`
     }
 
     // Initial update
@@ -111,7 +112,7 @@ export function TimelinePlayhead({ inRuler = false, maxFrame }: TimelinePlayhead
         ? playbackState.previewFrame
         : playbackState.currentFrame
     const leftPosition = Math.round(frameToPixels(frame))
-    playheadRef.current.style.left = `${leftPosition}px`
+    playheadRef.current.style.transform = `translate3d(${leftPosition}px, 0, 0)`
   }, [frameToPixels, isDragging])
 
   // Track external drag operations to disable pointer events on hit areas

--- a/src/features/timeline/components/timeline-preview-scrubber.tsx
+++ b/src/features/timeline/components/timeline-preview-scrubber.tsx
@@ -53,7 +53,8 @@ export function TimelinePreviewScrubber({
 
       const leftPosition = Math.round(frameToPixelsRef.current(clampedFrame))
       scrubberRef.current.style.display = ''
-      scrubberRef.current.style.left = `${leftPosition}px`
+      // Use transform (compositor-only) instead of style.left (triggers layout).
+      scrubberRef.current.style.transform = `translate3d(${leftPosition}px, 0, 0)`
 
       // Update tooltip text
       if (tooltipRef.current) {
@@ -79,7 +80,7 @@ export function TimelinePreviewScrubber({
       clampedFrame = Math.min(clampedFrame, maxFrame)
     }
     const leftPosition = Math.round(frameToPixels(clampedFrame))
-    scrubberRef.current.style.left = `${leftPosition}px`
+    scrubberRef.current.style.transform = `translate3d(${leftPosition}px, 0, 0)`
   }, [frameToPixels, maxFrame])
 
   // Change color based on active tool: red for razor, purple for rate-stretch

--- a/src/features/timeline/hooks/preview-work-budget.ts
+++ b/src/features/timeline/hooks/preview-work-budget.ts
@@ -10,6 +10,7 @@ const SHORT_PREVIEW_DELAY_MS = 120
 const LONG_PREVIEW_DELAY_MS = 220
 const VERY_LONG_PREVIEW_DELAY_MS = 360
 const PREVIEW_IDLE_TIMEOUT_MS = 1200
+const PREVIEW_IDLE_TIMEOUT_IMMEDIATE_MS = 200
 const DEFAULT_AUDIO_STARTUP_HOLD_MIN_MS = 1200
 
 interface PreviewAudioStartupHold {
@@ -216,6 +217,9 @@ export function _resetPreviewWorkBudgetForTest(): void {
   clearPreviewAudioStartupTimer()
 }
 
+/** Tighter idle timeout for cold-start filmstrip work where waiting up to 1.2s for idle is too pessimistic. */
+export const PREVIEW_IMMEDIATE_IDLE_TIMEOUT_MS = PREVIEW_IDLE_TIMEOUT_IMMEDIATE_MS
+
 export function getPreviewStartupDelayMs(durationSec: number): number {
   if (!Number.isFinite(durationSec) || durationSec <= 0) {
     return SHORT_PREVIEW_DELAY_MS
@@ -258,13 +262,17 @@ function scheduleOnIdle(callback: () => void, delayMs: number, idleTimeoutMs: nu
     }, 0)
   }
 
-  timeoutId = setTimeout(
-    () => {
+  // For delayMs=0 the macrotask wrap adds 4-10ms with no benefit — go straight
+  // to requestIdleCallback (or microtask fallback). For non-zero delays keep
+  // the setTimeout so callers can space work out.
+  if (delayMs <= 0) {
+    run()
+  } else {
+    timeoutId = setTimeout(() => {
       timeoutId = null
       run()
-    },
-    Math.max(0, delayMs),
-  )
+    }, delayMs)
+  }
 
   return () => {
     cancelled = true

--- a/src/features/timeline/hooks/use-filmstrip.test.tsx
+++ b/src/features/timeline/hooks/use-filmstrip.test.tsx
@@ -7,6 +7,7 @@ const filmstripCacheMocks = vi.hoisted(() => ({
   subscribe: vi.fn(() => vi.fn()),
   needsPriorityRefinement: vi.fn(() => false),
   getFilmstrip: vi.fn(() => new Promise<never>(() => {})),
+  loadFromDisk: vi.fn(() => Promise.resolve(null)),
   abort: vi.fn(),
 }))
 
@@ -44,6 +45,7 @@ describe('useFilmstrip', () => {
     filmstripCacheMocks.subscribe.mockReturnValue(vi.fn())
     filmstripCacheMocks.needsPriorityRefinement.mockReturnValue(false)
     filmstripCacheMocks.getFilmstrip.mockReturnValue(new Promise<never>(() => {}))
+    filmstripCacheMocks.loadFromDisk.mockReturnValue(Promise.resolve(null))
   })
 
   it('aborts extraction when the clip leaves the active workset', async () => {

--- a/src/features/timeline/hooks/use-filmstrip.test.tsx
+++ b/src/features/timeline/hooks/use-filmstrip.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../services/filmstrip-cache', () => ({
 
 vi.mock('./preview-work-budget', () => ({
   getPreviewStartupDelayMs: vi.fn(() => 0),
+  PREVIEW_IMMEDIATE_IDLE_TIMEOUT_MS: 200,
   schedulePreviewWork: vi.fn((task: () => void) => {
     task()
     return () => {}

--- a/src/features/timeline/hooks/use-filmstrip.ts
+++ b/src/features/timeline/hooks/use-filmstrip.ts
@@ -131,9 +131,11 @@ export function useFilmstrip({
     return normalized.length > 0 ? normalized : undefined
   }, [targetFrameIndices])
 
-  // Subscribe to progressive updates
+  // Subscribe to progressive updates. Intentionally does not require blobUrl —
+  // cached filmstrip frames live on disk and can be displayed before the source
+  // video blob URL resolves.
   useEffect(() => {
-    if (!enabled || !blobUrl || !duration || duration <= 0) {
+    if (!enabled || !duration || duration <= 0) {
       return
     }
 
@@ -144,7 +146,21 @@ export function useFilmstrip({
     })
 
     return unsubscribe
-  }, [mediaId, enabled, blobUrl, duration])
+  }, [mediaId, enabled, duration])
+
+  // Hydrate from persisted storage as soon as the clip is visible — does not
+  // wait for the source blob URL. For warm-disk / cold-memory clips this is
+  // typically all we need; the extraction effect below will then no-op when
+  // it finds a complete cache.
+  useEffect(() => {
+    if (!enabled || !duration || duration <= 0) return
+    if (!isVisible) return
+    if (filmstrip?.isComplete) return
+
+    void filmstripCache.loadFromDisk(mediaId, duration).catch(() => {
+      // Swallow: extraction path below is the fallback once blobUrl arrives.
+    })
+  }, [mediaId, enabled, duration, isVisible, filmstrip?.isComplete])
 
   // Once a clip leaves the active workset, stop spending background decode time on it.
   useEffect(() => {

--- a/src/features/timeline/hooks/use-filmstrip.ts
+++ b/src/features/timeline/hooks/use-filmstrip.ts
@@ -148,19 +148,19 @@ export function useFilmstrip({
     return unsubscribe
   }, [mediaId, enabled, duration])
 
-  // Hydrate from persisted storage as soon as the clip is visible — does not
-  // wait for the source blob URL. For warm-disk / cold-memory clips this is
-  // typically all we need; the extraction effect below will then no-op when
-  // it finds a complete cache.
+  // Hydrate from persisted storage as soon as we know the clip exists — does
+  // not wait for the source blob URL or for visibility. Disk reads are cheap
+  // and parallel, so prefetching off-viewport clips lets them paint instantly
+  // when scrolled into view. The extraction effect below still no-ops when it
+  // finds a complete cache.
   useEffect(() => {
     if (!enabled || !duration || duration <= 0) return
-    if (!isVisible) return
     if (filmstrip?.isComplete) return
 
     void filmstripCache.loadFromDisk(mediaId, duration).catch(() => {
       // Swallow: extraction path below is the fallback once blobUrl arrives.
     })
-  }, [mediaId, enabled, duration, isVisible, filmstrip?.isComplete])
+  }, [mediaId, enabled, duration, filmstrip?.isComplete])
 
   // Once a clip leaves the active workset, stop spending background decode time on it.
   useEffect(() => {

--- a/src/features/timeline/hooks/use-filmstrip.ts
+++ b/src/features/timeline/hooks/use-filmstrip.ts
@@ -1,6 +1,10 @@
 import { useState, useEffect, useRef, useEffectEvent, useMemo } from 'react'
 import { filmstripCache, type Filmstrip, type FilmstripFrame } from '../services/filmstrip-cache'
-import { getPreviewStartupDelayMs, schedulePreviewWork } from './preview-work-budget'
+import {
+  getPreviewStartupDelayMs,
+  PREVIEW_IMMEDIATE_IDLE_TIMEOUT_MS,
+  schedulePreviewWork,
+} from './preview-work-budget'
 
 export type { FilmstripFrame }
 
@@ -248,6 +252,9 @@ export function useFilmstrip({
       },
       {
         delayMs: shouldStartImmediately ? 0 : getPreviewStartupDelayMs(duration),
+        // Cold-start (no frames yet): don't let extraction sit waiting for an
+        // idle slot for over a second. After this window, fire anyway.
+        idleTimeoutMs: shouldStartImmediately ? PREVIEW_IMMEDIATE_IDLE_TIMEOUT_MS : undefined,
         ignoreAudioStartupHold: true,
       },
     )

--- a/src/features/timeline/services/filmstrip-cache.test.ts
+++ b/src/features/timeline/services/filmstrip-cache.test.ts
@@ -39,6 +39,14 @@ vi.mock('./filmstrip-storage', () => ({
 
 import { filmstripCache } from './filmstrip-cache'
 
+function makeBitmap(): ImageBitmap {
+  return {
+    width: 80,
+    height: 45,
+    close: vi.fn(),
+  } as unknown as ImageBitmap
+}
+
 describe('filmstripCache completion semantics', () => {
   afterEach(async () => {
     vi.clearAllMocks()
@@ -142,5 +150,99 @@ describe('filmstripCache completion semantics', () => {
 
     expect(result.isComplete).toBe(true)
     expect(result.progress).toBe(100)
+  })
+})
+
+describe('filmstripCache bitmap lifecycle', () => {
+  afterEach(async () => {
+    vi.clearAllMocks()
+    await filmstripCache.dispose()
+  })
+
+  it('closes bitmap-only frames when cached frames are replaced by persisted URLs', () => {
+    const bitmap = makeBitmap()
+    const service = filmstripCache as unknown as {
+      notifyUpdate: (
+        mediaId: string,
+        filmstrip: {
+          frames: Array<{ index: number; timestamp: number; url: string; bitmap?: ImageBitmap }>
+          isComplete: boolean
+          isExtracting: boolean
+          progress: number
+        },
+      ) => void
+    }
+
+    service.notifyUpdate('media-1', {
+      frames: [{ index: 0, timestamp: 0, url: '', bitmap }],
+      isComplete: false,
+      isExtracting: true,
+      progress: 1,
+    })
+    service.notifyUpdate('media-1', {
+      frames: [{ index: 0, timestamp: 0, url: 'blob:0' }],
+      isComplete: true,
+      isExtracting: false,
+      progress: 100,
+    })
+
+    expect(bitmap.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps retained bitmaps open across cache updates', () => {
+    const bitmap = makeBitmap()
+    const service = filmstripCache as unknown as {
+      notifyUpdate: (
+        mediaId: string,
+        filmstrip: {
+          frames: Array<{ index: number; timestamp: number; url: string; bitmap?: ImageBitmap }>
+          isComplete: boolean
+          isExtracting: boolean
+          progress: number
+        },
+      ) => void
+    }
+    const frame = { index: 0, timestamp: 0, url: '', bitmap }
+
+    service.notifyUpdate('media-1', {
+      frames: [frame],
+      isComplete: false,
+      isExtracting: true,
+      progress: 1,
+    })
+    service.notifyUpdate('media-1', {
+      frames: [frame, { index: 1, timestamp: 1, url: 'blob:1' }],
+      isComplete: false,
+      isExtracting: true,
+      progress: 50,
+    })
+
+    expect(bitmap.close).not.toHaveBeenCalled()
+  })
+
+  it('closes cached bitmaps when clearing all filmstrips', async () => {
+    const bitmap = makeBitmap()
+    const service = filmstripCache as unknown as {
+      notifyUpdate: (
+        mediaId: string,
+        filmstrip: {
+          frames: Array<{ index: number; timestamp: number; url: string; bitmap?: ImageBitmap }>
+          isComplete: boolean
+          isExtracting: boolean
+          progress: number
+        },
+      ) => void
+    }
+
+    service.notifyUpdate('media-1', {
+      frames: [{ index: 0, timestamp: 0, url: '', bitmap }],
+      isComplete: false,
+      isExtracting: false,
+      progress: 25,
+    })
+
+    await filmstripCache.clearAll()
+
+    expect(bitmap.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -218,6 +218,20 @@ class FilmstripCacheService {
   private metricsHistory: ExtractionMetricSample[] = []
   private lastMemoryCheckAt = 0
   private prewarmStarted = false
+  // Generation counters guard against clearMedia/clearAll racing with an
+  // in-flight loadFromDisk: an async hydration captures the token at the
+  // start and discards its writes when the token has moved on.
+  private mediaGeneration = new Map<string, number>()
+  private globalGeneration = 0
+
+  private currentGenerationToken(mediaId: string): string {
+    return `${this.globalGeneration}:${this.mediaGeneration.get(mediaId) ?? 0}`
+  }
+
+  private bumpMediaGeneration(mediaId: string): void {
+    const next = (this.mediaGeneration.get(mediaId) ?? 0) + 1
+    this.mediaGeneration.set(mediaId, next)
+  }
 
   /**
    * Eagerly boot one extraction worker and load mediabunny so the first real
@@ -2503,8 +2517,14 @@ class FilmstripCacheService {
       return inflight
     }
 
+    const tokenAtStart = this.currentGenerationToken(mediaId)
     const promise = (async (): Promise<Filmstrip | null> => {
       const stored = await filmstripStorage.load(mediaId)
+      // If clearMedia/clearAll ran while we were reading from OPFS, abandon —
+      // re-inserting these frames would resurrect just-cleared cache state.
+      if (this.currentGenerationToken(mediaId) !== tokenAtStart) {
+        return this.cache.get(mediaId) ?? null
+      }
       if (!stored) {
         return this.cache.get(mediaId) ?? null
       }
@@ -2624,6 +2644,7 @@ class FilmstripCacheService {
    * Clear filmstrip for a media item
    */
   async clearMedia(mediaId: string): Promise<void> {
+    this.bumpMediaGeneration(mediaId)
     this.abort(mediaId)
     this.clearIdleEvictionTimer(mediaId)
     this.closeBitmapFrames(this.cache.get(mediaId)?.frames ?? [])
@@ -2637,6 +2658,8 @@ class FilmstripCacheService {
    * Clear all
    */
   async clearAll(): Promise<void> {
+    this.globalGeneration += 1
+    this.mediaGeneration.clear()
     for (const mediaId of this.pendingExtractions.keys()) {
       this.abort(mediaId)
     }

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -2359,6 +2359,73 @@ class FilmstripCacheService {
   }
 
   /**
+   * Hydrate from persisted storage without starting extraction.
+   *
+   * Filmstrip display does not need the source video blob URL — JPEGs on disk
+   * are enough. This lets a clip show its cached frames before useMediaBlobUrl
+   * resolves the source, which otherwise serializes (visibility → blobUrl →
+   * filmstrip) and adds 50-200ms+ to re-display.
+   */
+  async loadFromDisk(mediaId: string, duration: number): Promise<Filmstrip | null> {
+    if (duration <= 0) return null
+
+    const cached = this.cache.get(mediaId)
+    if (cached?.isComplete) {
+      this.touchCacheEntry(mediaId)
+      return cached
+    }
+
+    const inflight = this.loadingPromises.get(mediaId)
+    if (inflight) {
+      return inflight
+    }
+
+    const promise = (async (): Promise<Filmstrip> => {
+      const stored = await filmstripStorage.load(mediaId)
+      if (!stored) {
+        // Return whatever's in memory (possibly nothing) — caller will fall
+        // back to the extraction path once blobUrl is available.
+        return (
+          this.cache.get(mediaId) ?? {
+            frames: [],
+            isComplete: false,
+            isExtracting: false,
+            progress: 0,
+          }
+        )
+      }
+
+      const totalFrames = Math.ceil(duration * FRAME_RATE)
+      const targetIndices = this.buildTargetIndices(totalFrames, null)
+      const targetSet = new Set(targetIndices)
+      const existingTargetCount = stored.frames.reduce(
+        (count, frame) => (targetSet.has(frame.index) ? count + 1 : count),
+        0,
+      )
+
+      const filmstrip: Filmstrip = {
+        frames: stored.frames,
+        isComplete: stored.metadata.isComplete,
+        isExtracting: false,
+        progress: stored.metadata.isComplete
+          ? 100
+          : targetIndices.length > 0
+            ? Math.round((existingTargetCount / targetIndices.length) * 100)
+            : 0,
+      }
+      this.notifyUpdate(mediaId, filmstrip)
+      return filmstrip
+    })()
+
+    this.loadingPromises.set(mediaId, promise)
+    try {
+      return await promise
+    } finally {
+      this.loadingPromises.delete(mediaId)
+    }
+  }
+
+  /**
    * Refresh cached frame URLs from persisted storage when a visible tile reports a stale source.
    */
   async refreshFrames(mediaId: string, frameIndices: number[]): Promise<void> {

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -292,6 +292,42 @@ class FilmstripCacheService {
     this.memoryState.clearEntry(mediaId)
   }
 
+  private closeBitmap(bitmap: ImageBitmap): void {
+    try {
+      bitmap.close()
+    } catch {
+      // Already closed or detached.
+    }
+  }
+
+  private closeBitmapFrames(frames: Iterable<FilmstripFrame>): void {
+    for (const frame of frames) {
+      if (frame.bitmap) {
+        this.closeBitmap(frame.bitmap)
+      }
+    }
+  }
+
+  private closeReplacedBitmapFrames(
+    previous: Filmstrip | null | undefined,
+    next: Filmstrip | null | undefined,
+  ): void {
+    if (!previous?.frames?.length) return
+
+    const retainedBitmaps = new Set<ImageBitmap>()
+    for (const frame of next?.frames ?? []) {
+      if (frame.bitmap) {
+        retainedBitmaps.add(frame.bitmap)
+      }
+    }
+
+    for (const frame of previous.frames) {
+      if (frame.bitmap && !retainedBitmaps.has(frame.bitmap)) {
+        this.closeBitmap(frame.bitmap)
+      }
+    }
+  }
+
   private clearIdleEvictionTimer(mediaId: string): void {
     this.memoryState.clearIdleTimer(mediaId)
   }
@@ -315,9 +351,11 @@ class FilmstripCacheService {
   private tryEvictMedia(mediaId: string, reason: string): boolean {
     if (this.pendingExtractions.has(mediaId)) return false
     if (this.hasSubscribers(mediaId)) return false
-    if (!this.cache.has(mediaId)) return false
+    const cached = this.cache.get(mediaId)
+    if (!cached) return false
 
     this.cache.delete(mediaId)
+    this.closeBitmapFrames(cached.frames)
     this.clearCacheMeta(mediaId)
     filmstripStorage.revokeUrls(mediaId)
     this.clearIdleEvictionTimer(mediaId)
@@ -913,6 +951,7 @@ class FilmstripCacheService {
 
   private notifyUpdate(mediaId: string, filmstrip: Filmstrip): void {
     this.clearIdleEvictionTimer(mediaId)
+    this.closeReplacedBitmapFrames(this.cache.get(mediaId), filmstrip)
     this.cache.set(mediaId, filmstrip)
     this.updateCacheMeta(mediaId, filmstrip)
     this.enforceMemoryBudget()
@@ -2406,6 +2445,7 @@ class FilmstripCacheService {
   async clearMedia(mediaId: string): Promise<void> {
     this.abort(mediaId)
     this.clearIdleEvictionTimer(mediaId)
+    this.closeBitmapFrames(this.cache.get(mediaId)?.frames ?? [])
     this.cache.delete(mediaId)
     this.clearCacheMeta(mediaId)
     filmstripStorage.revokeUrls(mediaId)
@@ -2418,6 +2458,9 @@ class FilmstripCacheService {
   async clearAll(): Promise<void> {
     for (const mediaId of this.pendingExtractions.keys()) {
       this.abort(mediaId)
+    }
+    for (const filmstrip of this.cache.values()) {
+      this.closeBitmapFrames(filmstrip.frames)
     }
     this.cache.clear()
     this.memoryState.clear()
@@ -2441,6 +2484,9 @@ class FilmstripCacheService {
     // Revoke in-memory object URLs only; keep persisted filmstrip files.
     for (const mediaId of this.cache.keys()) {
       filmstripStorage.revokeUrls(mediaId)
+    }
+    for (const filmstrip of this.cache.values()) {
+      this.closeBitmapFrames(filmstrip.frames)
     }
     this.cache.clear()
     this.memoryState.clear()

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -339,13 +339,67 @@ class FilmstripCacheService {
     if (!this.cache.has(mediaId)) return
 
     this.memoryState.scheduleIdleTimer(mediaId, CACHE_EVICT_IDLE_MS, () => {
-      this.tryEvictMedia(mediaId, 'idle-timeout')
+      // Idle eviction: close decoded bitmaps to free GPU/heap memory but keep
+      // the cache entry + object URLs alive. Re-display will hit the cache
+      // (no OPFS read) and render as <img src> instead of bitmap-canvas.
+      this.softEvictMedia(mediaId, 'idle-timeout')
     })
   }
 
   private hasSubscribers(mediaId: string): boolean {
     const callbacks = this.updateCallbacks.get(mediaId)
     return !!callbacks && callbacks.size > 0
+  }
+
+  /**
+   * Soft eviction: close decoded bitmaps but keep frames + object URLs in the
+   * in-memory cache. Memory cost drops from ~14MB/clip (bitmaps) to ~300KB/clip
+   * (JPEG blobs referenced by object URLs). Re-display reuses the cached URLs
+   * with no OPFS round-trip.
+   */
+  private softEvictMedia(mediaId: string, reason: string): boolean {
+    if (this.pendingExtractions.has(mediaId)) return false
+    const cached = this.cache.get(mediaId)
+    if (!cached) return false
+    if (!cached.frames.some((frame) => frame.bitmap)) {
+      // Nothing to free — entry is already bitmap-less.
+      this.clearIdleEvictionTimer(mediaId)
+      return false
+    }
+
+    // Build a new frames array with bitmaps removed. Frames that have a
+    // bitmap but no URL are unrenderable without the bitmap, so leave those
+    // untouched (extraction is still in flight or never persisted JPEGs).
+    const bitmapsToClose: ImageBitmap[] = []
+    const downgradedFrames = cached.frames.map((frame) => {
+      if (!frame.bitmap) return frame
+      if (!frame.url) return frame
+      bitmapsToClose.push(frame.bitmap)
+      const { bitmap: _bitmap, ...rest } = frame
+      void _bitmap
+      return rest
+    })
+
+    const downgraded: Filmstrip = { ...cached, frames: downgradedFrames }
+    this.cache.set(mediaId, downgraded)
+    this.updateCacheMeta(mediaId, downgraded)
+    for (const bitmap of bitmapsToClose) {
+      this.closeBitmap(bitmap)
+    }
+    this.clearIdleEvictionTimer(mediaId)
+
+    // Notify mounted subscribers so any visible <canvas> tiles re-render as
+    // <img>. In practice idle eviction only fires after subscribers have
+    // dropped, but this is safe either way.
+    const callbacks = this.updateCallbacks.get(mediaId)
+    if (callbacks) {
+      for (const callback of callbacks) {
+        callback(downgraded)
+      }
+    }
+
+    logger.debug(`Soft-evicted in-memory filmstrip bitmaps ${mediaId} (${reason})`)
+    return true
   }
 
   private tryEvictMedia(mediaId: string, reason: string): boolean {

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -1131,8 +1131,28 @@ class FilmstripCacheService {
     priorityRange?: PriorityFrameRange,
     options?: FilmstripLoadOptions,
   ): Promise<Filmstrip> {
-    // Try loading from storage
-    const stored = await filmstripStorage.load(mediaId)
+    // If a disk hydration is already in flight or just completed, reuse those
+    // frames instead of re-reading the OPFS directory. The in-memory cache is
+    // populated by loadFromDisk via notifyUpdate.
+    await this.diskHydrationPromises.get(mediaId)?.catch(() => undefined)
+    const cachedAfterHydration = this.cache.get(mediaId)
+    if (cachedAfterHydration?.isComplete && !cachedAfterHydration.isExtracting) {
+      return cachedAfterHydration
+    }
+
+    // Try loading from storage when we haven't already
+    const stored = cachedAfterHydration?.frames.length
+      ? {
+          metadata: {
+            width: FILMSTRIP_EXTRACT_WIDTH,
+            height: FILMSTRIP_EXTRACT_HEIGHT,
+            isComplete: cachedAfterHydration.isComplete,
+            frameCount: cachedAfterHydration.frames.length,
+          },
+          frames: cachedAfterHydration.frames,
+          existingIndices: cachedAfterHydration.frames.map((frame) => frame.index),
+        }
+      : await filmstripStorage.load(mediaId)
 
     if (stored?.metadata.isComplete) {
       // Complete - return immediately
@@ -2358,6 +2378,8 @@ class FilmstripCacheService {
     return cached
   }
 
+  private diskHydrationPromises = new Map<string, Promise<Filmstrip | null>>()
+
   /**
    * Hydrate from persisted storage without starting extraction.
    *
@@ -2365,6 +2387,10 @@ class FilmstripCacheService {
    * are enough. This lets a clip show its cached frames before useMediaBlobUrl
    * resolves the source, which otherwise serializes (visibility → blobUrl →
    * filmstrip) and adds 50-200ms+ to re-display.
+   *
+   * Tracked in its own dedupe map (not loadingPromises) so that a later
+   * getFilmstrip() call still starts extraction when needed instead of just
+   * returning this hydration result.
    */
   async loadFromDisk(mediaId: string, duration: number): Promise<Filmstrip | null> {
     if (duration <= 0) return null
@@ -2375,24 +2401,15 @@ class FilmstripCacheService {
       return cached
     }
 
-    const inflight = this.loadingPromises.get(mediaId)
+    const inflight = this.diskHydrationPromises.get(mediaId)
     if (inflight) {
       return inflight
     }
 
-    const promise = (async (): Promise<Filmstrip> => {
+    const promise = (async (): Promise<Filmstrip | null> => {
       const stored = await filmstripStorage.load(mediaId)
       if (!stored) {
-        // Return whatever's in memory (possibly nothing) — caller will fall
-        // back to the extraction path once blobUrl is available.
-        return (
-          this.cache.get(mediaId) ?? {
-            frames: [],
-            isComplete: false,
-            isExtracting: false,
-            progress: 0,
-          }
-        )
+        return this.cache.get(mediaId) ?? null
       }
 
       const totalFrames = Math.ceil(duration * FRAME_RATE)
@@ -2417,11 +2434,11 @@ class FilmstripCacheService {
       return filmstrip
     })()
 
-    this.loadingPromises.set(mediaId, promise)
+    this.diskHydrationPromises.set(mediaId, promise)
     try {
       return await promise
     } finally {
-      this.loadingPromises.delete(mediaId)
+      this.diskHydrationPromises.delete(mediaId)
     }
   }
 

--- a/src/features/timeline/services/filmstrip-cache.ts
+++ b/src/features/timeline/services/filmstrip-cache.ts
@@ -27,7 +27,11 @@ import {
 } from '@/features/timeline/constants'
 import { filmstripStorage, type FilmstripFrame } from './filmstrip-storage'
 import { FilmstripMemoryState } from './filmstrip-memory-state'
-import type { ExtractRequest, WorkerResponse } from '../workers/filmstrip-extraction-worker'
+import type {
+  ExtractRequest,
+  WarmRequest,
+  WorkerResponse,
+} from '../workers/filmstrip-extraction-worker'
 
 export { THUMBNAIL_WIDTH }
 export type { FilmstripFrame }
@@ -213,6 +217,38 @@ class FilmstripCacheService {
   }
   private metricsHistory: ExtractionMetricSample[] = []
   private lastMemoryCheckAt = 0
+  private prewarmStarted = false
+
+  /**
+   * Eagerly boot one extraction worker and load mediabunny so the first real
+   * extraction skips worker boot + dynamic-import latency (~100-300ms total).
+   * Idempotent and safe to call repeatedly; only the first call does work.
+   *
+   * Fires synchronously and releases the worker immediately so the next
+   * acquireWorker() call gets it back (with the `warm` message still queued).
+   * The worker processes warm → loadMediabunny → ignored 'warmed' response,
+   * then any queued extract message. Net result: mediabunny is loaded once
+   * per worker realm instead of per extraction.
+   */
+  prewarm(): void {
+    if (this.prewarmStarted) return
+    this.prewarmStarted = true
+
+    let worker: Worker
+    try {
+      worker = this.acquireWorker()
+    } catch (error) {
+      logger.warn('Failed to acquire worker for prewarm', error)
+      this.prewarmStarted = false
+      return
+    }
+
+    const requestId = crypto.randomUUID()
+    worker.postMessage({ type: 'warm', requestId } satisfies WarmRequest)
+    // Release immediately so the next acquireWorker() returns this worker
+    // (with the warm message still queued in front of any extract message).
+    this.releaseWorker(worker)
+  }
 
   private get cacheBytes(): number {
     return this.memoryState.sizeBytes
@@ -978,6 +1014,9 @@ class FilmstripCacheService {
    * Subscribe to filmstrip updates
    */
   subscribe(mediaId: string, callback: FilmstripUpdateCallback): () => void {
+    // Active interest in any filmstrip is the cue to prewarm the worker pool.
+    // Idempotent — only the first call does work.
+    this.prewarm()
     this.clearIdleEvictionTimer(mediaId)
     if (!this.updateCallbacks.has(mediaId)) {
       this.updateCallbacks.set(mediaId, new Set())
@@ -1618,6 +1657,10 @@ class FilmstripCacheService {
       // Handle worker messages
       worker.onmessage = async (e: MessageEvent<WorkerResponse>) => {
         const response = e.data
+
+        // Stale 'warmed' from an earlier prewarm() can arrive after this
+        // worker was reacquired — ignore it.
+        if (response.type === 'warmed') return
 
         if (response.type === 'progress') {
           workerState.frameCount = response.frameCount

--- a/src/features/timeline/services/filmstrip-storage.test.ts
+++ b/src/features/timeline/services/filmstrip-storage.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 const fsMocks = vi.hoisted(() => ({
   readBlob: vi.fn(),
+  readDirectoryFiles: vi.fn(),
   readJson: vi.fn(),
   writeBlob: vi.fn(),
   writeJsonAtomic: vi.fn(),
@@ -73,6 +74,10 @@ describe('filmstripStorage', () => {
       { kind: 'file', name: '1.jpg' },
     ])
     fsMocks.readBlob.mockResolvedValue(new Blob(['frame'], { type: 'image/jpeg' }))
+    fsMocks.readDirectoryFiles.mockResolvedValue([
+      { name: '0.jpg', blob: new Blob(['frame'], { type: 'image/jpeg' }) },
+      { name: '1.jpg', blob: new Blob(['frame'], { type: 'image/jpeg' }) },
+    ])
   })
 
   it('does not revoke unrequested frame URLs during single-frame loads', async () => {

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -15,6 +15,7 @@ import { createLogger } from '@/shared/logging/logger'
 import { getCacheMigration } from '@/infrastructure/storage/cache-version'
 import {
   readBlob,
+  readDirectoryFiles,
   readJson,
   writeBlob,
   writeJsonAtomic,
@@ -257,39 +258,31 @@ class FilmstripStorage {
       const metadata = await this.ensureWorkspaceFilmstrip(mediaId)
       if (!metadata) return null
 
-      const entries = await listDirectory(requireWorkspaceRoot(), filmstripDir(mediaId))
+      // Resolve the filmstrip dir once and read all matching files via the
+      // same handle iterator. readBlob-per-path would re-walk the 4-segment
+      // media path for every frame; with N=60 that's 240 wasted lookups.
+      const files = await readDirectoryFiles(
+        requireWorkspaceRoot(),
+        filmstripDir(mediaId),
+        (entry) => parseFrameFileNameParts(entry.name) !== null,
+      )
 
-      // Pick the best file per index up front (prefer primary ext when both exist),
-      // then issue all blob reads concurrently. Sequential awaits used to dominate
-      // re-display latency for cached clips — O(N) wall time at ~1-5ms per frame.
-      const fileByIndex = new Map<number, { name: string; index: number; ext: string }>()
-      for (const entry of entries) {
-        if (entry.kind !== 'file') continue
-        const parsed = parseFrameFileNameParts(entry.name)
+      const fileByIndex = new Map<number, { index: number; ext: string; blob: Blob }>()
+      for (const { name, blob } of files) {
+        const parsed = parseFrameFileNameParts(name)
         if (!parsed) continue
+        if (!blob || blob.size <= 0) continue
         const existing = fileByIndex.get(parsed.index)
         const shouldReplace =
           !existing || (parsed.ext === PRIMARY_FRAME_EXT && existing.ext !== PRIMARY_FRAME_EXT)
         if (shouldReplace) {
-          fileByIndex.set(parsed.index, { name: entry.name, index: parsed.index, ext: parsed.ext })
+          fileByIndex.set(parsed.index, { index: parsed.index, ext: parsed.ext, blob })
         }
       }
 
-      const candidates = Array.from(fileByIndex.values()).sort((a, b) => a.index - b.index)
-      const readResults = await Promise.all(
-        candidates.map(async ({ index, ext }) => {
-          const blob = await readBlob(
-            requireWorkspaceRoot(),
-            filmstripFramePath(mediaId, index, ext),
-          )
-          return blob && blob.size > 0 ? { index, blob } : null
-        }),
-      )
-
-      const frameFiles: Array<{ index: number; blob: Blob }> = []
-      for (const result of readResults) {
-        if (result) frameFiles.push(result)
-      }
+      const frameFiles = Array.from(fileByIndex.values())
+        .map(({ index, blob }) => ({ index, blob }))
+        .sort((a, b) => a.index - b.index)
 
       const nextUrls: Array<{ index: number; url: string }> = []
       const frames: FilmstripFrame[] = frameFiles.map(({ index, blob }) => {

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -258,30 +258,38 @@ class FilmstripStorage {
       if (!metadata) return null
 
       const entries = await listDirectory(requireWorkspaceRoot(), filmstripDir(mediaId))
-      const frameFilesByIndex = new Map<number, { blob: Blob; ext: string }>()
 
+      // Pick the best file per index up front (prefer primary ext when both exist),
+      // then issue all blob reads concurrently. Sequential awaits used to dominate
+      // re-display latency for cached clips — O(N) wall time at ~1-5ms per frame.
+      const fileByIndex = new Map<number, { name: string; index: number; ext: string }>()
       for (const entry of entries) {
         if (entry.kind !== 'file') continue
         const parsed = parseFrameFileNameParts(entry.name)
         if (!parsed) continue
-
-        const blob = await readBlob(
-          requireWorkspaceRoot(),
-          filmstripFramePath(mediaId, parsed.index, parsed.ext),
-        )
-        if (!blob || blob.size <= 0) continue
-
-        const existing = frameFilesByIndex.get(parsed.index)
+        const existing = fileByIndex.get(parsed.index)
         const shouldReplace =
           !existing || (parsed.ext === PRIMARY_FRAME_EXT && existing.ext !== PRIMARY_FRAME_EXT)
         if (shouldReplace) {
-          frameFilesByIndex.set(parsed.index, { blob, ext: parsed.ext })
+          fileByIndex.set(parsed.index, { name: entry.name, index: parsed.index, ext: parsed.ext })
         }
       }
 
-      const frameFiles = Array.from(frameFilesByIndex.entries())
-        .map(([index, value]) => ({ index, blob: value.blob }))
-        .sort((a, b) => a.index - b.index)
+      const candidates = Array.from(fileByIndex.values()).sort((a, b) => a.index - b.index)
+      const readResults = await Promise.all(
+        candidates.map(async ({ index, ext }) => {
+          const blob = await readBlob(
+            requireWorkspaceRoot(),
+            filmstripFramePath(mediaId, index, ext),
+          )
+          return blob && blob.size > 0 ? { index, blob } : null
+        }),
+      )
+
+      const frameFiles: Array<{ index: number; blob: Blob }> = []
+      for (const result of readResults) {
+        if (result) frameFiles.push(result)
+      }
 
       const nextUrls: Array<{ index: number; url: string }> = []
       const frames: FilmstripFrame[] = frameFiles.map(({ index, blob }) => {

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -323,22 +323,24 @@ class FilmstripStorage {
     const metadata = await this.ensureWorkspaceFilmstrip(mediaId)
     if (!metadata) return []
 
-    const entries = await listDirectory(requireWorkspaceRoot(), filmstripDir(mediaId))
+    // Resolve the dir once and read matching files concurrently — was a
+    // sequential await loop that re-walked the four-segment path per frame.
+    const files = await readDirectoryFiles(
+      requireWorkspaceRoot(),
+      filmstripDir(mediaId),
+      (entry) => {
+        const index = parseFrameFileName(entry.name)
+        if (index === null) return false
+        if (typeof startIndex === 'number' && index < startIndex) return false
+        if (typeof endIndex === 'number' && index >= endIndex) return false
+        return true
+      },
+    )
+
     const indices = new Set<number>()
-
-    for (const entry of entries) {
-      if (entry.kind !== 'file') continue
-      const index = parseFrameFileName(entry.name)
+    for (const { name, blob } of files) {
+      const index = parseFrameFileName(name)
       if (index === null) continue
-      if (typeof startIndex === 'number' && index < startIndex) continue
-      if (typeof endIndex === 'number' && index >= endIndex) continue
-
-      const parsed = parseFrameFileNameParts(entry.name)
-      if (!parsed) continue
-      const blob = await readBlob(
-        requireWorkspaceRoot(),
-        filmstripFramePath(mediaId, parsed.index, parsed.ext),
-      )
       if (blob && blob.size > 0) {
         indices.add(index)
       }

--- a/src/features/timeline/stores/actions/source-edit-actions.ts
+++ b/src/features/timeline/stores/actions/source-edit-actions.ts
@@ -12,7 +12,7 @@ import { usePlaybackStore } from '@/shared/state/playback'
 import { useMediaLibraryStore } from '@/features/timeline/deps/media-library-store'
 import { useProjectStore } from '@/features/timeline/deps/projects'
 import { mediaLibraryService } from '@/features/timeline/deps/media-library-service'
-import { getMediaType } from '@/features/timeline/deps/media-library-resolver'
+import { getMediaType, resolveMediaUrl } from '@/features/timeline/deps/media-library-resolver'
 import { toast } from 'sonner'
 import { execute, applyTransitionRepairs, getLogger } from './shared'
 import { resolveSourceEditTrackTargets } from '../../utils/source-edit-targeting'
@@ -146,7 +146,7 @@ async function resolveSourceEditContext(): Promise<SourceEditContext | null> {
   }
 
   // Resolve blob URLs before execute (async not allowed inside execute)
-  const blobUrl = await mediaLibraryService.getMediaBlobUrl(sourceMediaId)
+  const blobUrl = await resolveMediaUrl(sourceMediaId)
   if (!blobUrl) {
     toast.error('Failed to load source media')
     return null

--- a/src/features/timeline/workers/filmstrip-extraction-worker.ts
+++ b/src/features/timeline/workers/filmstrip-extraction-worker.ts
@@ -39,6 +39,16 @@ export interface AbortRequest {
   requestId: string
 }
 
+export interface WarmRequest {
+  type: 'warm'
+  requestId: string
+}
+
+export interface WarmedResponse {
+  type: 'warmed'
+  requestId: string
+}
+
 export interface ProgressResponse {
   type: 'progress'
   requestId: string
@@ -69,8 +79,8 @@ export interface ErrorResponse {
   error: string
 }
 
-export type WorkerRequest = ExtractRequest | AbortRequest
-export type WorkerResponse = ProgressResponse | CompleteResponse | ErrorResponse
+export type WorkerRequest = ExtractRequest | AbortRequest | WarmRequest
+export type WorkerResponse = ProgressResponse | CompleteResponse | ErrorResponse | WarmedResponse
 
 // Track active requests for abort support
 const activeRequests = new Map<string, { aborted: boolean }>()
@@ -234,22 +244,19 @@ async function extractAndSave(request: ExtractRequest, state: { aborted: boolean
       const canvas = wrapped.canvas as OffscreenCanvas
       const frameIndex = frame.index
 
-      // Create two bitmaps: one for transfer to main thread, one for JPEG encode.
-      // Both are instant snapshots (<0.1ms) that free the canvas pool slot.
-      const [displayBitmap, encodeBitmap] = await Promise.all([
-        createImageBitmap(canvas),
-        createImageBitmap(canvas),
-      ])
+      // Single bitmap path: copy pool canvas into a fresh OffscreenCanvas,
+      // then use that one canvas as both the source for the display bitmap
+      // and the source for the JPEG encode. The pool canvas slot is free
+      // immediately after drawImage so the next decode can advance.
+      const encodeCanvas = new OffscreenCanvas(canvas.width, canvas.height)
+      const encodeCtx = encodeCanvas.getContext('2d')!
+      encodeCtx.drawImage(canvas, 0, 0)
 
-      // Queue bitmap for immediate transfer to main thread (no JPEG encode needed)
+      // Flush prior encode, then queue display + encode against the new canvas.
+      await flushPendingEncode()
+      const displayBitmap = await createImageBitmap(encodeCanvas)
       bitmapsSinceLastReport.push({ index: frameIndex, bitmap: displayBitmap })
 
-      // Flush prior encode, then start JPEG encode in background for workspace persistence
-      await flushPendingEncode()
-      const encodeCanvas = new OffscreenCanvas(encodeBitmap.width, encodeBitmap.height)
-      const encodeCtx = encodeCanvas.getContext('2d')!
-      encodeCtx.drawImage(encodeBitmap, 0, 0)
-      encodeBitmap.close()
       pendingEncode = encodeCanvas
         .convertToBlob({
           type: IMAGE_FORMAT,
@@ -355,6 +362,16 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         if (state) {
           state.aborted = true
         }
+        break
+      }
+
+      case 'warm': {
+        // Eagerly load mediabunny so the first real extraction skips ~100-300ms
+        // of dynamic-import + parse cost. The module is cached in the worker
+        // realm for subsequent extractAndSave() calls.
+        const { requestId } = event.data as WarmRequest
+        await loadMediabunny()
+        self.postMessage({ type: 'warmed', requestId } as WarmedResponse)
         break
       }
 

--- a/src/infrastructure/storage/workspace-fs/fs-primitives.ts
+++ b/src/infrastructure/storage/workspace-fs/fs-primitives.ts
@@ -273,12 +273,21 @@ export async function readDirectoryFiles(
         if (filter && !filter({ name: entry.name, kind: entry.kind })) continue
         fileHandles.push({ name: entry.name, handle: entry as FileSystemFileHandle })
       }
-      return await Promise.all(
+      const results = await Promise.all(
         fileHandles.map(async ({ name, handle }) => {
-          const file = await handle.getFile()
-          return { name, blob: file as Blob }
+          try {
+            const file = await handle.getFile()
+            return { name, blob: file as Blob }
+          } catch (error) {
+            // A file can disappear between iterating dir.values() and calling
+            // getFile() (e.g. concurrent delete). Skip it instead of failing
+            // the whole batch.
+            if (isNotFound(error)) return null
+            throw error
+          }
         }),
       )
+      return results.filter((r): r is { name: string; blob: Blob } => r !== null)
     } catch (error) {
       if (isNotFound(error)) return []
       throw error

--- a/src/infrastructure/storage/workspace-fs/fs-primitives.ts
+++ b/src/infrastructure/storage/workspace-fs/fs-primitives.ts
@@ -250,6 +250,42 @@ export async function listDirectory(
   })
 }
 
+/**
+ * List a directory and read all matching files in a single resolved-dir pass.
+ *
+ * Calling readBlob() per file forces resolveDir() to re-walk the segments
+ * (4 getDirectoryHandle calls for typical media paths) on every read. For
+ * directories with many files this dominates wall time. This helper resolves
+ * the parent dir once and reuses its file-handle iterator, then reads all
+ * files concurrently.
+ */
+export async function readDirectoryFiles(
+  root: FileSystemDirectoryHandle,
+  segments: string[],
+  filter?: (entry: DirectoryEntry) => boolean,
+): Promise<Array<{ name: string; blob: Blob }>> {
+  return wrap('readDirectoryFiles', async () => {
+    try {
+      const dir = await resolveDir(root, segments, false)
+      const fileHandles: Array<{ name: string; handle: FileSystemFileHandle }> = []
+      for await (const entry of dir.values()) {
+        if (entry.kind !== 'file') continue
+        if (filter && !filter({ name: entry.name, kind: entry.kind })) continue
+        fileHandles.push({ name: entry.name, handle: entry as FileSystemFileHandle })
+      }
+      return await Promise.all(
+        fileHandles.map(async ({ name, handle }) => {
+          const file = await handle.getFile()
+          return { name, blob: file as Blob }
+        }),
+      )
+    } catch (error) {
+      if (isNotFound(error)) return []
+      throw error
+    }
+  })
+}
+
 export async function exists(
   root: FileSystemDirectoryHandle,
   segments: string[],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import './index.css'
 
 const log = createLogger('App')
 const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000
+const ACCEPTED_APP_UPDATE_SIGNATURE_KEY = 'freecut-accepted-app-update-signature'
 
 let updateToastVisible = false
 let currentBuildAssetSignature: string | null = null
@@ -35,7 +36,16 @@ async function saveCurrentProjectBeforeReload() {
   }
 }
 
-function showUpdateAvailableToast(applyUpdate: () => void = () => window.location.reload()) {
+function rememberAcceptedAppUpdate(signature?: string) {
+  if (signature) {
+    window.localStorage.setItem(ACCEPTED_APP_UPDATE_SIGNATURE_KEY, signature)
+  }
+}
+
+function showUpdateAvailableToast(
+  applyUpdate: () => void = () => window.location.reload(),
+  updateSignature?: string,
+) {
   if (updateToastVisible) {
     return
   }
@@ -46,15 +56,20 @@ function showUpdateAvailableToast(applyUpdate: () => void = () => window.locatio
     action: {
       label: i18n.t('appShell.saveAndReload'),
       onClick: async () => {
+        rememberAcceptedAppUpdate(updateSignature)
         await saveCurrentProjectBeforeReload()
         applyUpdate()
       },
     },
     cancel: {
       label: i18n.t('appShell.reloadWithoutSaving'),
-      onClick: applyUpdate,
+      onClick: () => {
+        rememberAcceptedAppUpdate(updateSignature)
+        applyUpdate()
+      },
     },
     onDismiss: () => {
+      rememberAcceptedAppUpdate(updateSignature)
       updateToastVisible = false
     },
     onAutoClose: () => {
@@ -96,9 +111,16 @@ async function checkForAppShellUpdate() {
     const html = await response.text()
     const nextDocument = new DOMParser().parseFromString(html, 'text/html')
     const nextBuildAssetSignature = getBuildAssetSignature(nextDocument)
+    const acceptedUpdateSignature = window.localStorage.getItem(ACCEPTED_APP_UPDATE_SIGNATURE_KEY)
 
-    if (nextBuildAssetSignature && nextBuildAssetSignature !== currentBuildAssetSignature) {
-      showUpdateAvailableToast()
+    if (
+      nextBuildAssetSignature &&
+      nextBuildAssetSignature !== currentBuildAssetSignature &&
+      nextBuildAssetSignature !== acceptedUpdateSignature
+    ) {
+      showUpdateAvailableToast(() => {
+        window.location.assign(`/?__freecut_updated=${Date.now()}`)
+      }, nextBuildAssetSignature)
     }
   } catch (error) {
     log.warn('App update check failed:', error)


### PR DESCRIPTION
## Summary

Filmstrip and timeline performance work, plus a handful of preview/PWA fixes that have been sitting on `develop`.

### Render churn during zoom

- Filmstrip tiles are now keyed by `frame.index` and merge adjacent slots that resolve to the same frame, so a zoom gesture doesn't thrash `<img src>` / bitmap canvases for stable frames.
- `tiles` honors the interaction-LOD density that the extraction-request path already used (16–32 tiles during active zoom instead of 260).
- Filmstrip bitmap canvas guards against same-size `canvas.width`/`canvas.height` writes (assignment resets the backing buffer regardless of value).
- Waveform `renderTile` no longer lists `clipWidth` as a dep, which used to invalidate the callback identity every zoom step and force `TiledCanvas` to redraw all visible tile content.
- Playhead and preview-scrubber positioning moved from `style.left` (layout) to `transform: translate3d(...)` (compositor only).

**Measured on a 20-tick ctrl-wheel zoom**
- `<img src>` mutations: 2277 → 1258 (−45%)
- canvas width/height writes: 974 → 653 (−33%)
- long-task total: 883 → 580 ms (−34%)
- FPS during gesture: 44 → 49

### Cached re-display

- `FilmstripStorage.load()` resolves the filmstrip dir once via a new `readDirectoryFiles()` primitive and reads frames in parallel (was sequential `readBlob` per file, re-walking the 4-segment media path each time).
- `filmstripCache.loadFromDisk()` hydrates from OPFS without waiting on the source video blob URL; `useFilmstrip` calls it as soon as the clip mounts (no `isVisible` gate either, so off-viewport prefetch lands instantly when scrolled in).
- Idle TTL eviction is now a "soft" eviction: closes decoded bitmaps to free the heavy ~14 MB/clip footprint but keeps frames + object URLs alive in the cache. Memory-pressure eviction stays a full wipe.
- `getExistingIndices` parallelized the same way `load` was.

### Cold extraction

- Pre-warm one extraction worker on first `subscribe`: post a `warm` message that runs `await loadMediabunny()` and release immediately so the next acquire returns this worker with mediabunny cached in its module realm.
- `schedulePreviewWork` skips the macrotask `setTimeout(0)` wrap when `delayMs=0` and tightens the idle timeout from 1200 → 200 ms for cold-start filmstrip work.
- Worker creates a single `ImageBitmap` per frame instead of two (display + encode share one `OffscreenCanvas`).

**Cold page-load first-tile times (median of two runs)**
- Worker-extracted (CANVAS) tile: ~1500 ms → ~810 ms
- Disk-cached (IMG) tile: ~1900 ms → ~1045 ms

### Prior fixes also included
- `fix(preview): keep scrub overlay aligned and skim indicator on-edge`
- `fix: tighten blob url caching and stale mocks`
- `fix: close filmstrip bitmaps on cache updates`
- `fix: suppress repeated PWA update prompt`

## Test plan
- [ ] Open a large project and confirm zoom feels smoother (no canvas thrash on track-1/track-2 clips)
- [ ] Scrub the playhead — overlay alignment + skim indicator unchanged
- [ ] Reload the page on a project with cached filmstrips — clips with full disk cache paint before extraction kicks in
- [ ] Open a fresh project (no disk cache) — first filmstrip tile appears in ~800–1100 ms instead of ~1500 ms
- [ ] Leave a clip off-screen for >15 s, scroll back — re-displays without OPFS round-trip (soft eviction)
- [ ] Verify nothing regressed in playback, drag, trim, transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service worker now trims runtime cache to limit growth
  * Filmstrip prewarm and disk-hydration for faster initial loads
  * Device-pixel-aware preview sizing for crisper rendering

* **Bug Fixes**
  * Skim indicator kept inside card bounds
  * Playhead and scrubber positioning improved to avoid layout jank

* **Performance Improvements**
  * More efficient filmstrip tile/bitmap handling and extraction startup

* **Chores**
  * Suppress repeated update notifications via persisted acceptance

* **Tests**
  * Added/updated tests for skim behavior, filmstrip lifecycle, and preload paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->