### PR TITLE
Changelog: close 2026.05.11, open week of 2026-05-18

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -56,10 +56,14 @@ The user invokes one of these explicitly. Default to asking which mode if unclea
 
 The user asks "draft changelog bullets for this week" or similar. Produce bullets from commits — do **not** write files yet, just show the user the curated list to approve.
 
-1. `git log --first-parent main --pretty=format:"%H|%ad|%s" --date=short <range>` — range usually `<last-rollup>..HEAD` or a date range the user gives.
-2. Apply curation rules (below). Drop noise, rewrite dev-speak into user language, dedupe revisits.
-3. Group into Added / Fixed / Improved.
-4. Show the result. Wait for approval before touching files.
+1. Pick the branch to read from:
+   - For the **current rolling week** (drafting bullets for `current`), query the **active development branch** — typically `develop`, not `main`. PRs target `staging`/`develop` first, so commits from earlier today or this week may not be on `main` yet. Confirm the branch with `git branch --show-current` if unsure, or `git log <branch> --no-merges` to see what's actually there.
+   - For **closed weeks** (rollup, backfill), `main` is usually fine — the week's PRs have merged by then. But if you're rolling up early Monday and the Sunday PRs haven't been promoted yet, fall back to `develop`.
+2. `git log <branch> --no-merges --pretty=format:"%H|%ad|%s" --date=short --since=<week-start> --until=<week-end>` — `--no-merges` filters out PR merge commits, which carry no useful subject. Range is usually `<last-rollup>..HEAD` or explicit `--since`/`--until`.
+3. Sanity-check: if the user just mentioned a specific commit you don't see in the output, you're on the wrong branch. Re-query.
+4. Apply curation rules (below). Drop noise, rewrite dev-speak into user language, dedupe revisits.
+5. Group into Added / Fixed / Improved.
+6. Show the result. Wait for approval before touching files.
 
 ### Append mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,24 @@ All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the 
 
 <!-- Entries below are generated via the `changelog` skill. Newest first. -->
 
-## [Current] — week of 2026-05-11
+## [Current] — week of 2026-05-18
+
+### Fixed
+- Rotated videos display the correct orientation in skim preview and exports
+- Scrub overlay stays aligned and the skim indicator sits flush on clip edges
+
+### Improved
+- Filmstrips and waveforms render smoother while zooming the timeline
+- Faster filmstrip reload from disk cache when reopening projects
+
+## [2026.05.11] — week of 2026-05-11 to 2026-05-17
 
 ### Added
 - Translated UI in 9 languages: English, Spanish, French, German, Portuguese (Brazil), Turkish, Japanese, Korean, and Chinese (Simplified)
 - Language picker in editor settings, with auto-detection from your browser
 - Effect names, timeline labels, and media library all translate alongside the rest of the UI
 - Supertonic voice engine added to AI text-to-speech
+- Install FreeCut as a desktop app, with prompts when new versions ship
 
 ## [2026.05.04] — week of 2026-05-04 to 2026-05-10
 

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,25 +1,50 @@
 {
   "current": {
     "version": "current",
-    "date": "2026-05-14",
+    "date": "2026-05-19",
     "groups": {
-      "added": [
+      "fixed": [
         {
-          "title": "Translated UI in 9 languages: English, Spanish, French, German, Portuguese (Brazil), Turkish, Japanese, Korean, and Chinese (Simplified)"
+          "title": "Rotated videos display the correct orientation in skim preview and exports"
         },
         {
-          "title": "Language picker in editor settings, with auto-detection from your browser"
+          "title": "Scrub overlay stays aligned and the skim indicator sits flush on clip edges"
+        }
+      ],
+      "improved": [
+        {
+          "title": "Filmstrips and waveforms render smoother while zooming the timeline"
         },
         {
-          "title": "Effect names, timeline labels, and media library all translate alongside the rest of the UI"
-        },
-        {
-          "title": "Supertonic voice engine added to AI text-to-speech"
+          "title": "Faster filmstrip reload from disk cache when reopening projects"
         }
       ]
     }
   },
   "releases": [
+    {
+      "version": "2026.05.11",
+      "date": "2026-05-11",
+      "groups": {
+        "added": [
+          {
+            "title": "Translated UI in 9 languages: English, Spanish, French, German, Portuguese (Brazil), Turkish, Japanese, Korean, and Chinese (Simplified)"
+          },
+          {
+            "title": "Language picker in editor settings, with auto-detection from your browser"
+          },
+          {
+            "title": "Effect names, timeline labels, and media library all translate alongside the rest of the UI"
+          },
+          {
+            "title": "Supertonic voice engine added to AI text-to-speech"
+          },
+          {
+            "title": "Install FreeCut as a desktop app, with prompts when new versions ship"
+          }
+        ]
+      }
+    },
     {
       "version": "2026.05.04",
       "date": "2026-05-04",

--- a/src/features/export/utils/canvas-video-extractor.ts
+++ b/src/features/export/utils/canvas-video-extractor.ts
@@ -392,7 +392,11 @@ export class VideoFrameExtractor {
       // Phone videos commonly store landscape pixels with 90/270 degree
       // rotation metadata. VideoSample.draw() honors that metadata, while a
       // raw VideoFrame draw does not.
-      sample.draw?.(ctx, x, y, width, height)
+      if (typeof sample.draw !== 'function') {
+        this.lastFailureKind = 'decode-error'
+        return false
+      }
+      sample.draw(ctx, x, y, width, height)
       return true
     } catch (error) {
       // Draw failed — discard the cached frame so next attempt gets a fresh one
@@ -453,8 +457,8 @@ export class VideoFrameExtractor {
       return null
     }
 
-    const width = Math.max(1, Math.round(this.videoTrack?.displayWidth ?? 0))
-    const height = Math.max(1, Math.round(this.videoTrack?.displayHeight ?? 0))
+    const width = Math.round(this.videoTrack?.displayWidth ?? 0)
+    const height = Math.round(this.videoTrack?.displayHeight ?? 0)
     if (width <= 0 || height <= 0) {
       return this.cloneCurrentVideoFrame()
     }
@@ -463,7 +467,8 @@ export class VideoFrameExtractor {
       const canvas = new OffscreenCanvas(width, height)
       const ctx = canvas.getContext('2d')
       if (!ctx) return this.cloneCurrentVideoFrame()
-      sample.draw?.(ctx, 0, 0, width, height)
+      if (typeof sample.draw !== 'function') return this.cloneCurrentVideoFrame()
+      sample.draw(ctx, 0, 0, width, height)
       return await createImageBitmap(canvas)
     } catch (error) {
       this.sampleLoopError = error
@@ -589,8 +594,10 @@ export class VideoFrameExtractor {
       for await (const sample of this.sink.samplesAtTimestamps(timestamps)) {
         if (!sample) continue
         try {
-          sample.draw?.(ctx, x, y, width, height)
-          decoded++
+          if (typeof sample.draw === 'function') {
+            sample.draw(ctx, x, y, width, height)
+            decoded++
+          }
         } finally {
           sample.close()
         }

--- a/src/features/preview/components/source-composition.tsx
+++ b/src/features/preview/components/source-composition.tsx
@@ -155,7 +155,6 @@ function VideoSource({
   const [strictDecodeReady, setStrictDecodeReady] = useState(false)
   const [hasDecodedFrame, setHasDecodedFrame] = useState(false)
   const [decodedFrameKey, setDecodedFrameKey] = useState<number | null>(null)
-  const [pausedRenderTargetKey, setPausedRenderTargetKey] = useState<number | null>(null)
   const shouldUseDecodedScrubFrame = forceFastScrub && strictDecodeReady && !useLegacyPausedSeek
 
   useEffect(() => {
@@ -208,7 +207,6 @@ function VideoSource({
     setUseLegacyPausedSeek(false)
     setHasDecodedFrame(false)
     setDecodedFrameKey(null)
-    setPausedRenderTargetKey(null)
     pausedRenderTargetKeyRef.current = null
     prewarmInFlightRef.current = false
     queuedPrewarmTimesRef.current = []
@@ -587,7 +585,6 @@ function VideoSource({
       ) {
         if (pausedRenderTargetKeyRef.current !== targetCacheKey) {
           pausedRenderTargetKeyRef.current = targetCacheKey
-          setPausedRenderTargetKey(targetCacheKey)
         }
         pendingTimeRef.current = targetTime
         if (decoderReadyRef.current) {
@@ -756,10 +753,7 @@ function VideoSource({
     strictDecodeReady &&
     hasDecodedFrame &&
     !useLegacyPausedSeek &&
-    decodedFrameKey !== null &&
-    decodedFrameKey === pausedRenderTargetKey
-  const hideNativeVideoForPendingDecodedScrub =
-    shouldUseDecodedScrubFrame && pausedRenderTargetKey !== decodedFrameKey
+    decodedFrameKey !== null
 
   return (
     <AbsoluteFill>
@@ -769,7 +763,7 @@ function VideoSource({
           width: '100%',
           height: '100%',
           position: 'relative',
-          display: showDecodedCanvas || hideNativeVideoForPendingDecodedScrub ? 'none' : 'block',
+          display: showDecodedCanvas ? 'none' : 'block',
         }}
       />
       <canvas

--- a/src/features/preview/workers/decoder-prewarm-worker.ts
+++ b/src/features/preview/workers/decoder-prewarm-worker.ts
@@ -311,76 +311,59 @@ function currentSampleCoversTimestamp(state: ExtractorState, timestamp: number):
   return sample.timestamp + sample.duration >= timestamp - TIMESTAMP_EPSILON
 }
 
-function getOrCreateCurrentVideoFrame(state: ExtractorState): VideoFrame | null {
+function getSampleDisplaySize(sample: WorkerSample): { width: number; height: number } | null {
+  const width = Number(sample?.displayWidth ?? 0)
+  const height = Number(sample?.displayHeight ?? 0)
+  if (Number.isFinite(width) && Number.isFinite(height) && width >= 1 && height >= 1) {
+    return { width: Math.round(width), height: Math.round(height) }
+  }
+
+  const videoFrame =
+    typeof sample?.toVideoFrame === 'function' ? sample.toVideoFrame() : (sample?.frame ?? null)
+  if (!videoFrame) {
+    return null
+  }
+
+  try {
+    const fallbackWidth = Number(videoFrame.displayWidth ?? videoFrame.width ?? 0)
+    const fallbackHeight = Number(videoFrame.displayHeight ?? videoFrame.height ?? 0)
+    if (
+      Number.isFinite(fallbackWidth) &&
+      Number.isFinite(fallbackHeight) &&
+      fallbackWidth >= 1 &&
+      fallbackHeight >= 1
+    ) {
+      return { width: Math.round(fallbackWidth), height: Math.round(fallbackHeight) }
+    }
+    return null
+  } finally {
+    try {
+      videoFrame.close?.()
+    } catch {
+      // Ignore close errors.
+    }
+  }
+}
+
+function renderSampleToBitmap(state: ExtractorState, sample: WorkerSample): ImageBitmap | null {
+  const size = getSampleDisplaySize(sample)
+  if (!size || typeof sample?.draw !== 'function') {
+    return null
+  }
+
+  state.canvas.width = size.width
+  state.canvas.height = size.height
+  sample.draw(state.ctx, 0, 0, size.width, size.height)
+  return state.canvas.transferToImageBitmap()
+}
+
+function renderCurrentSampleToBitmap(state: ExtractorState): ImageBitmap | null {
   const sample = state.currentSample
   if (!sample) {
     return null
   }
 
-  let videoFrame = state.cachedVideoFrame
-  if (!videoFrame || state.cachedVideoFrameSample !== sample) {
-    closeCachedVideoFrame(state)
-    if (typeof sample.toVideoFrame === 'function') {
-      videoFrame = sample.toVideoFrame()
-    } else {
-      videoFrame = sample.frame ?? null
-    }
-    if (!videoFrame) {
-      return null
-    }
-    state.cachedVideoFrame = videoFrame
-    state.cachedVideoFrameSample = sample
-  }
-
-  return videoFrame
-}
-
-function renderCurrentSampleToBitmap(state: ExtractorState): ImageBitmap | null {
-  const videoFrame = getOrCreateCurrentVideoFrame(state)
-  if (!videoFrame) {
-    return null
-  }
-
-  const visibleRect = (
-    videoFrame as VideoFrame & {
-      visibleRect?: { x: number; y: number; width: number; height: number }
-    }
-  ).visibleRect
-
-  const width =
-    visibleRect?.width && visibleRect.width > 0 ? visibleRect.width : videoFrame.displayWidth
-  const height =
-    visibleRect?.height && visibleRect.height > 0 ? visibleRect.height : videoFrame.displayHeight
-  if (width < 1 || height < 1) {
-    return null
-  }
-
-  state.canvas.width = width
-  state.canvas.height = height
-
-  if (
-    visibleRect &&
-    Number.isFinite(visibleRect.width) &&
-    Number.isFinite(visibleRect.height) &&
-    visibleRect.width > 0 &&
-    visibleRect.height > 0
-  ) {
-    state.ctx.drawImage(
-      videoFrame,
-      visibleRect.x,
-      visibleRect.y,
-      visibleRect.width,
-      visibleRect.height,
-      0,
-      0,
-      width,
-      height,
-    )
-  } else {
-    state.ctx.drawImage(videoFrame, 0, 0, width, height)
-  }
-
-  return state.canvas.transferToImageBitmap()
+  return renderSampleToBitmap(state, sample)
 }
 
 async function recoverAndPrime(
@@ -477,57 +460,8 @@ async function batchPreseek(
         i++
 
         try {
-          const videoFrame: VideoFrame | null =
-            typeof sample.toVideoFrame === 'function'
-              ? sample.toVideoFrame()
-              : (sample.frame ?? null)
-          if (!videoFrame) {
-            sample.close?.()
-            continue
-          }
-
-          const visibleRect = (
-            videoFrame as VideoFrame & {
-              visibleRect?: { x: number; y: number; width: number; height: number }
-            }
-          ).visibleRect
-
-          const width =
-            visibleRect?.width && visibleRect.width > 0
-              ? visibleRect.width
-              : videoFrame.displayWidth
-          const height =
-            visibleRect?.height && visibleRect.height > 0
-              ? visibleRect.height
-              : videoFrame.displayHeight
-          if (width < 1 || height < 1) {
-            videoFrame.close()
-            sample.close?.()
-            continue
-          }
-
-          state.canvas.width = width
-          state.canvas.height = height
-
-          if (visibleRect && visibleRect.width > 0 && visibleRect.height > 0) {
-            state.ctx.drawImage(
-              videoFrame,
-              visibleRect.x,
-              visibleRect.y,
-              visibleRect.width,
-              visibleRect.height,
-              0,
-              0,
-              width,
-              height,
-            )
-          } else {
-            state.ctx.drawImage(videoFrame, 0, 0, width, height)
-          }
-
-          videoFrame.close()
-          const bitmap = state.canvas.transferToImageBitmap()
-          results.set(ts, bitmap)
+          const bitmap = renderSampleToBitmap(state, sample)
+          if (bitmap) results.set(ts, bitmap)
         } finally {
           sample.close?.()
         }

--- a/src/features/timeline/components/clip-filmstrip/index.test.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.test.tsx
@@ -133,8 +133,6 @@ describe('ClipFilmstrip', () => {
         mediaId: 'media-1',
         blobUrl: 'blob:proxy',
         enabled: true,
-        targetFrameCount: expect.any(Number),
-        targetFrameIndices: expect.any(Array),
       }),
     )
   })
@@ -160,13 +158,16 @@ describe('ClipFilmstrip', () => {
         mediaId: 'media-1',
         blobUrl: 'blob:original',
         enabled: true,
-        targetFrameCount: expect.any(Number),
-        targetFrameIndices: expect.any(Array),
       }),
     )
   })
 
-  it('prioritizes the visible source slice instead of the clip start', () => {
+  it('does not vary extraction targeting with zoom-derived inputs', () => {
+    // Filmstrip used to recompute targetFrameCount/targetFrameIndices/priorityWindow
+    // from clipWidth + pixelsPerSecond + visibility ratios on every zoom step.
+    // That caused the cache to re-extract on zoom and briefly show "broken"
+    // tiles. The contract is now: those request fields are all stable
+    // (undefined / null) so the cache extracts default coverage once.
     render(
       <ClipFilmstrip
         mediaId="media-1"
@@ -184,17 +185,39 @@ describe('ClipFilmstrip', () => {
     )
 
     const latestCall = useFilmstripMock.mock.calls.at(-1)?.[0]
-    const priorityWindow = latestCall?.priorityWindow
-    expect(priorityWindow).toBeDefined()
-    expect(latestCall?.priorityWindow).toEqual(
-      expect.objectContaining({
-        startTime: expect.any(Number),
-        endTime: expect.any(Number),
-      }),
+    expect(latestCall?.priorityWindow).toBeNull()
+    expect(latestCall?.targetFrameCount).toBeUndefined()
+    expect(latestCall?.targetFrameIndices).toBeUndefined()
+  })
+
+  it('keeps tile media full width when the segment window is narrower than a thumbnail', async () => {
+    useFilmstripMock.mockReturnValue({
+      frames: [{ index: 0, timestamp: 0, url: 'blob:frame-0' }],
+      isLoading: false,
+      isComplete: true,
+      progress: 100,
+      error: null,
+    })
+
+    const { container } = render(
+      <ClipFilmstrip
+        mediaId="media-1"
+        clipWidth={40}
+        sourceStart={0}
+        sourceDuration={10}
+        trimStart={0}
+        speed={1}
+        fps={30}
+        isVisible
+        pixelsPerSecond={120}
+      />,
     )
-    expect(priorityWindow!.startTime).toBeGreaterThan(0)
-    expect(priorityWindow!.endTime).toBeGreaterThan(priorityWindow!.startTime)
-    expect(latestCall?.targetFrameIndices).toEqual(expect.arrayContaining([expect.any(Number)]))
+
+    await waitFor(() => {
+      const img = container.querySelector('img[src="blob:frame-0"]') as HTMLImageElement | null
+      expect(img).not.toBeNull()
+      expect(img!.style.width).toBe('107px')
+    })
   })
 
   it('refreshes a stale frame URL when a tile source errors', async () => {

--- a/src/features/timeline/components/clip-filmstrip/index.tsx
+++ b/src/features/timeline/components/clip-filmstrip/index.tsx
@@ -5,23 +5,9 @@ import { resolveMediaUrl, resolveProxyUrl } from '@/features/timeline/deps/media
 import { useMediaBlobUrl } from '../../hooks/use-media-blob-url'
 import { filmstripCache, THUMBNAIL_WIDTH } from '../../services/filmstrip-cache'
 import { createLogger } from '@/shared/logging/logger'
-import { computeFilmstripRenderWindow } from './render-window'
 import { useMediaLibraryStore } from '@/features/timeline/deps/media-library-store'
 
 const logger = createLogger('ClipFilmstrip')
-
-const ZOOM_SETTLE_MS = 80
-const PRIORITY_PAD_SECONDS = 0.75
-const MAX_PRIORITY_WINDOW_SECONDS = 60
-const MAX_TILES_DURING_ZOOM = 32
-const MAX_TILES_DURING_ZOOM_MID = 24
-const MAX_TILES_DURING_ZOOM_HIGH = 16
-const MAX_TILES_IDLE = 260
-const VIEWPORT_PAD_TILES = 2
-const VIEWPORT_PAD_TILES_INTERACTION = 1
-const VIEWPORT_PAD_PX = 600
-const MID_INTERACTION_PPS = 120
-const HIGH_INTERACTION_PPS = 170
 
 interface ClipFilmstripProps {
   /** Media ID from the timeline item */
@@ -53,17 +39,6 @@ interface ClipFilmstripProps {
   pixelsPerSecond: number
   /** Disable deferred width/zoom while active edit previews are running */
   preferImmediateRendering?: boolean
-}
-
-function getTileStep(tileCount: number, maxTiles: number): number {
-  if (tileCount <= maxTiles) return 1
-  return Math.ceil(tileCount / maxTiles)
-}
-
-function getInteractionMaxTiles(pixelsPerSecond: number): number {
-  if (pixelsPerSecond >= HIGH_INTERACTION_PPS) return MAX_TILES_DURING_ZOOM_HIGH
-  if (pixelsPerSecond >= MID_INTERACTION_PPS) return MAX_TILES_DURING_ZOOM_MID
-  return MAX_TILES_DURING_ZOOM
 }
 
 /**
@@ -98,16 +73,26 @@ const FilmstripTile = memo(function FilmstripTile({
   const canvasRefCallback: RefCallback<HTMLCanvasElement> = useCallback(
     (canvas: HTMLCanvasElement | null) => {
       if (!canvas || !bitmap || bitmap.width === 0 || bitmap.height === 0) return
-      if (canvas.width !== bitmap.width) canvas.width = bitmap.width
-      if (canvas.height !== bitmap.height) canvas.height = bitmap.height
+      const targetWidth = Math.max(1, Math.round(sourceWidth))
+      const targetHeight = Math.max(1, Math.round(height))
+      if (canvas.width !== targetWidth) canvas.width = targetWidth
+      if (canvas.height !== targetHeight) canvas.height = targetHeight
       const ctx = canvas.getContext('2d')
       try {
-        if (ctx) ctx.drawImage(bitmap, 0, 0)
+        if (ctx) {
+          const scale = Math.max(targetWidth / bitmap.width, targetHeight / bitmap.height)
+          const drawWidth = bitmap.width * scale
+          const drawHeight = bitmap.height * scale
+          const drawX = (targetWidth - drawWidth) * 0.5
+          const drawY = (targetHeight - drawHeight) * 0.5
+          ctx.clearRect(0, 0, targetWidth, targetHeight)
+          ctx.drawImage(bitmap, drawX, drawY, drawWidth, drawHeight)
+        }
       } catch {
         // Bitmap may have been closed/detached by the time React renders
       }
     },
-    [bitmap],
+    [bitmap, height, sourceWidth],
   )
 
   const handleError = useCallback(() => {
@@ -118,16 +103,25 @@ const FilmstripTile = memo(function FilmstripTile({
   // Bitmap path: render to canvas (instant, no JPEG decode)
   if (bitmap) {
     return (
-      <canvas
-        ref={canvasRefCallback}
+      <div
+        aria-hidden
         className="absolute top-0"
         style={{
           left: x,
           width,
           height,
-          objectFit: 'cover',
+          overflow: 'hidden',
         }}
-      />
+      >
+        <canvas
+          ref={canvasRefCallback}
+          className="absolute top-0 left-0"
+          style={{
+            width: sourceWidth,
+            height,
+          }}
+        />
+      </div>
     )
   }
 
@@ -165,20 +159,30 @@ const FilmstripTile = memo(function FilmstripTile({
   }
 
   return (
-    <img
-      src={src}
-      alt=""
-      loading="lazy"
-      decoding="async"
+    <div
+      aria-hidden
       className="absolute top-0"
-      onError={handleError}
       style={{
         left: x,
         width,
         height,
-        objectFit: 'cover',
+        overflow: 'hidden',
       }}
-    />
+    >
+      <img
+        src={src}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        className="absolute top-0 left-0"
+        onError={handleError}
+        style={{
+          width: sourceWidth,
+          height,
+          objectFit: 'cover',
+        }}
+      />
+    </div>
   )
 })
 
@@ -201,16 +205,11 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
   speed,
   isReversed = false,
   isVisible,
-  visibleStartRatio = 0,
-  visibleEndRatio = 1,
   pixelsPerSecond,
-  preferImmediateRendering = false,
 }: ClipFilmstripProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [height, setHeight] = useState(0)
   const { blobUrl, setBlobUrl, hasStartedLoadingRef, blobUrlVersion } = useMediaBlobUrl(mediaId)
-  const [isZooming, setIsZooming] = useState(false)
-  const zoomSettleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const refreshingFrameIndicesRef = useRef<Set<number>>(new Set())
   const proxyStatus = useMediaLibraryStore((s) => s.proxyStatus.get(mediaId) ?? null)
 
@@ -258,162 +257,15 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
       sourceEnd ?? effectiveStart + (visibleClipWidth / Math.max(1, renderPixelsPerSecond)) * speed,
     ),
   )
-  const getSourceTimeForX = useCallback(
-    (x: number) => {
-      const timelineSeconds = (x / Math.max(1, renderPixelsPerSecond)) * speed
-      return isReversed
-        ? Math.min(sourceDuration, Math.max(0, effectiveEnd - timelineSeconds))
-        : Math.min(sourceDuration, Math.max(0, effectiveStart + timelineSeconds))
-    },
-    [effectiveEnd, effectiveStart, isReversed, renderPixelsPerSecond, sourceDuration, speed],
-  )
-  const isInteractionLod = !preferImmediateRendering && isZooming
-  const viewportPadTiles = isInteractionLod ? VIEWPORT_PAD_TILES_INTERACTION : VIEWPORT_PAD_TILES
-
-  // Track active zoom interaction from pps changes. While active, keep
-  // extraction density conservative without decoupling visible tile geometry
-  // from the clip itself.
-  const lastPpsRef = useRef(pixelsPerSecond)
-  useEffect(() => {
-    if (preferImmediateRendering) return
-    if (lastPpsRef.current === pixelsPerSecond) return
-    lastPpsRef.current = pixelsPerSecond
-
-    setIsZooming(true)
-    if (zoomSettleTimeoutRef.current) {
-      clearTimeout(zoomSettleTimeoutRef.current)
-    }
-    zoomSettleTimeoutRef.current = setTimeout(() => {
-      setIsZooming(false)
-      zoomSettleTimeoutRef.current = null
-    }, ZOOM_SETTLE_MS)
-  }, [pixelsPerSecond, preferImmediateRendering])
-
-  // Keep unmount cleanup separate: the zoom-tracking effect above intentionally
-  // handles dependency-change behavior (including early returns), and returning
-  // cleanup there would run on every change. This effect only clears a pending
-  // timeout on unmount so it cannot leak during a settle window.
-  useEffect(() => {
-    return () => {
-      if (zoomSettleTimeoutRef.current) {
-        clearTimeout(zoomSettleTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const renderWindow = useMemo(
-    () =>
-      computeFilmstripRenderWindow({
-        renderWidth: renderClipWidth,
-        visibleWidth: visibleClipWidth,
-        tileWidth: thumbnailWidth,
-        visibleStartRatio,
-        visibleEndRatio,
-        minimumPadTiles: viewportPadTiles,
-        minimumPadPx: VIEWPORT_PAD_PX,
-      }),
-    [
-      renderClipWidth,
-      visibleClipWidth,
-      thumbnailWidth,
-      visibleStartRatio,
-      visibleEndRatio,
-      viewportPadTiles,
-    ],
-  )
-
-  // During active edit previews, prioritize the source window that actually
-  // maps to the current padded render window, not always the clip's left edge.
-  const priorityWindow = useMemo(() => {
-    if (isInteractionLod) {
-      return null
-    }
-    if (sourceDuration <= 0 || renderPixelsPerSecond <= 0 || renderClipWidth <= 0) {
-      return null
-    }
-    if (renderWindow.paddedEndX <= renderWindow.paddedStartX) {
-      return null
-    }
-
-    const windowStartTime = getSourceTimeForX(renderWindow.paddedStartX)
-    const windowEndTime = getSourceTimeForX(renderWindow.paddedEndX)
-    const unclampedStartTime = Math.max(
-      0,
-      Math.min(windowStartTime, windowEndTime) - PRIORITY_PAD_SECONDS,
-    )
-    const unclampedEndTime = Math.min(
-      sourceDuration,
-      Math.max(windowStartTime, windowEndTime) + PRIORITY_PAD_SECONDS,
-    )
-    if (unclampedEndTime <= unclampedStartTime) {
-      return null
-    }
-
-    const unclampedSpan = unclampedEndTime - unclampedStartTime
-    if (unclampedSpan <= MAX_PRIORITY_WINDOW_SECONDS) {
-      return { startTime: unclampedStartTime, endTime: unclampedEndTime }
-    }
-
-    const halfWindow = MAX_PRIORITY_WINDOW_SECONDS * 0.5
-    const centerTime = (unclampedStartTime + unclampedEndTime) * 0.5
-    const maxStartTime = Math.max(0, sourceDuration - MAX_PRIORITY_WINDOW_SECONDS)
-    const startTime = Math.min(maxStartTime, Math.max(0, centerTime - halfWindow))
-    const endTime = Math.min(sourceDuration, startTime + MAX_PRIORITY_WINDOW_SECONDS)
-    return endTime > startTime ? { startTime, endTime } : null
-  }, [
-    sourceDuration,
-    renderPixelsPerSecond,
-    renderClipWidth,
-    getSourceTimeForX,
-    isInteractionLod,
-    renderWindow,
-  ])
-
-  const targetFrameIndices = useMemo(() => {
-    if (thumbnailWidth === 0 || renderPixelsPerSecond <= 0) {
-      return undefined
-    }
-
-    const { startTile, endTile, paddedEndX } = renderWindow
-    const visibleTileCount = Math.max(0, endTile - startTile)
-    if (visibleTileCount <= 0) {
-      return undefined
-    }
-
-    const maxTiles = isInteractionLod
-      ? getInteractionMaxTiles(renderPixelsPerSecond)
-      : MAX_TILES_IDLE
-    const tileStep = getTileStep(visibleTileCount, maxTiles)
-    const indices = new Set<number>()
-
-    for (let tile = startTile; tile < endTile; tile += tileStep) {
-      const tileX = tile * thumbnailWidth
-      if (tileX >= paddedEndX) {
-        break
-      }
-
-      const tileWidth = Math.max(
-        1,
-        Math.min(renderClipWidth, Math.min((tile + tileStep) * thumbnailWidth, paddedEndX)) - tileX,
-      )
-      const tileCenterX = tileX + tileWidth * 0.5
-      const tileTime = getSourceTimeForX(tileCenterX)
-
-      indices.add(Math.max(0, Math.round(tileTime)))
-    }
-
-    const normalized = Array.from(indices).sort((a, b) => a - b)
-    return normalized.length > 0 ? normalized : undefined
-  }, [
-    thumbnailWidth,
-    renderPixelsPerSecond,
-    renderWindow,
-    isInteractionLod,
-    renderClipWidth,
-    getSourceTimeForX,
-  ])
-
-  const targetFrameCount = targetFrameIndices?.length
+  // No zoom-driven extraction targeting. Earlier we passed a priorityWindow +
+  // targetFrameIndices that flipped on every pps change, which made the cache
+  // mark frames as re-extracting and the tiles momentarily showed a "broken
+  // thumbnail" while the cache published refining state. Letting the cache
+  // extract its default 1fps coverage once per clip and never re-targeting on
+  // zoom keeps already-loaded thumbnails stable across every zoom step.
+  const priorityWindow = null
+  const targetFrameCount = undefined
+  const targetFrameIndices = undefined
 
   // Load blob URL lazily when visible, and retry after global invalidation.
   useEffect(() => {
@@ -477,28 +329,24 @@ export const ClipFilmstrip = memo(function ClipFilmstrip({
   // Pixel-aligned slot grid. Slots are at x = 0, thumbnailWidth, 2*thumbnailWidth, …
   // up to the clip's right edge. Each slot's content is the closest available
   // extracted frame for the source time at that slot's center — so extraction
-  // gaps (e.g. background-stride misses) are silently filled with the nearest
-  // frame instead of producing an alternating-size visual.
+  // gaps are silently filled with the nearest frame instead of producing an
+  // alternating-size visual.
   //
   // - Tile width is exactly thumbnailWidth — never stretched, squashed, or
-  //   merged. Every rendered tile is identical in size.
+  //   merged. Segment boundaries are handled by overflow clipping outside the
+  //   tile, so a short segment only reveals less of the full-size tile.
   // - key=slot is the integer slot index on the pixel grid. At fixed zoom the
   //   slot set never changes; scrolling can't refresh tiles, and a slot's
   //   frame prop updating as extraction lands doesn't remount its DOM.
-  // - Zoom changes the slot count (clip width grew/shrunk), which mounts or
-  //   unmounts tiles only at the clip's right edge — the visible portion's
-  //   slots stay stable.
   const tiles = useMemo(() => {
     if (!frames || frames.length === 0 || renderPixelsPerSecond <= 0) return []
     if (effectiveEnd <= effectiveStart) return []
 
     const pixelsPerSourceSecond = renderPixelsPerSecond / Math.max(0.0001, speed)
     const tileWidth = thumbnailWidth
-    const slotCount = Math.floor(renderClipWidth / tileWidth)
+    const slotCount = Math.ceil(renderClipWidth / tileWidth)
     if (slotCount === 0) return []
 
-    // frames is sorted by index in the cache; binary-search for the closest
-    // available frame to a target source time.
     const findClosestFrame = (targetTime: number): FilmstripFrame | null => {
       if (frames.length === 0) return null
       let lo = 0


### PR DESCRIPTION
## Summary
- Rolls i18n + PWA install into the `2026.05.11` release entry.
- Opens a fresh `current` for the week of 2026-05-18 with the rotation fix, scrub overlay alignment, and filmstrip/waveform zoom perf.
- Patches the `/changelog` skill to draft from the active dev branch (typically `develop`) so in-flight commits aren't missed.

## Test plan
- [ ] Open the "What's New" dialog and confirm the current week + 2026.05.11 entry render with the expected bullets.
- [ ] Verify `CHANGELOG.md` on GitHub displays the new headings correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video preview/export rendering problems and timeline rendering errors.

* **Improvements**
  * More reliable and accurate frame capture and transition handling during export.
  * Decoded-frame handling updated so native video and decoded canvases display more consistently.

* **Documentation**
  * Updated changelog dates and draft workflow guidance for weekly rollups and commit-collection steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->