### PR TITLE
fix(timeline): persisted freeze-frame media missing thumbnail link

### DIFF
--- a/src/features/timeline/stores/actions/edit/freeze-frame-actions.ts
+++ b/src/features/timeline/stores/actions/edit/freeze-frame-actions.ts
@@ -152,10 +152,11 @@ export async function insertFreezeFrame(itemId: string, playheadFrame: number): 
       getLogger().warn('[insertFreezeFrame] Failed to mirror frame to workspace', error)
     })
 
-    await createMedia(mediaMetadata)
-    await associateMediaWithProject(currentProjectId, frameMediaId)
-
-    // Save thumbnail (reuse the frame blob)
+    // Save thumbnail first so we can persist the metadata with its
+    // thumbnailId in a single write — createMedia serializes the metadata
+    // verbatim, so setting thumbnailId after createMedia would only update
+    // the in-memory copy and leave the on-disk record without a thumbnail
+    // association (visible after project reload).
     const thumbnailId = crypto.randomUUID()
     const thumbnailData: ThumbnailData = {
       id: thumbnailId,
@@ -168,15 +169,18 @@ export async function insertFreezeFrame(itemId: string, playheadFrame: number): 
     await saveThumbnail(thumbnailData)
     mediaMetadata.thumbnailId = thumbnailId
 
-    // Add to media library store
-    useMediaLibraryStore.getState().prependMediaItem(mediaMetadata)
+    await createMedia(mediaMetadata)
+    await associateMediaWithProject(currentProjectId, frameMediaId)
 
-    // Step 4: Perform timeline mutations atomically (split + insert + shift)
+    // Step 4: Perform timeline mutations atomically (split + insert + shift).
+    // Prepend the media item to the store only after execute() succeeds so a
+    // failed _splitItem (e.g. the source clip was removed between validation
+    // and execute) doesn't leave an orphaned entry in the media library UI.
     const freezeDurationFrames = Math.round(fps * 2) // 2 seconds
 
-    execute(
+    const success = execute<boolean>(
       'INSERT_FREEZE_FRAME',
-      () => {
+      (): boolean => {
         // Split the video at playhead
         const splitResult = useItemsStore.getState()._splitItem(itemId, playheadFrame)
         if (!splitResult) {
@@ -239,10 +243,16 @@ export async function insertFreezeFrame(itemId: string, playheadFrame: number): 
         useSelectionStore.getState().selectItems([freezeFrameItem.id])
 
         useTimelineSettingsStore.getState().markDirty()
+        return true
       },
       { itemId, playheadFrame, freezeDurationFrames },
     )
 
+    if (!success) {
+      return false
+    }
+
+    useMediaLibraryStore.getState().prependMediaItem(mediaMetadata)
     return true
   } catch (error) {
     getLogger().error('[insertFreezeFrame] Failed:', error)


### PR DESCRIPTION
## Summary

Three correlated bugs in `insertFreezeFrame` (surfaced by line-by-line review of the recently-split code):

1. **Persisted freeze-frame media missing thumbnail link.** `createMedia(mediaMetadata)` was called before `mediaMetadata.thumbnailId` was set. `createMedia` serializes the metadata verbatim to disk via `writeJsonAtomic`, so the on-disk record had no thumbnail association. After project reload, the freeze frame appeared in the library with no thumbnail. **Fix:** save the thumbnail and stamp the id onto `mediaMetadata` first, then persist.

2. **Orphaned media library entry on failure.** `prependMediaItem(mediaMetadata)` ran before `execute('INSERT_FREEZE_FRAME', …)`. If the inner `_splitItem` returned null (e.g. source clip deleted between validation and execute), the timeline mutation aborted but the media library was left holding an orphan visible in the UI. **Fix:** move the prepend to after `execute()` reports success.

3. **Function always returned `true`.** Callers couldn't distinguish success from the orphan-leaving failure mode. **Fix:** capture `execute<boolean>`'s return and propagate it.

## What this PR is NOT

The reviewer also flagged \"stale itemId after \`_splitItem()\`\" in three places (freeze-frame transition rewrite, `split-actions.ts:149-210`, `range-removal-actions.ts:244-279`). I verified these against the code and tests:

- `_splitItem` **keeps the original id on the LEFT half** by design (`items-store.ts:1286` comment: *\"keeps original ID for minimal disruption\"*; `items-store.test.ts:165` explicitly depends on it).
- `splitItemAtFrames` and the range-removal loop **sort frames descending** (`split-actions.ts:149` comment: *\"Splits from last to first so the original item ID stays valid\"*), so the original id always points to the leftmost remaining segment for the next iteration.
- Freeze-frame's transition rewrite (`leftClipId === itemId → rightItem.id`) is correct: any `rightClipId === itemId` transition still validly references the left half, whose id is unchanged.

Those reviewer concerns are based on a misreading of `_splitItem`'s contract — no change needed.

## Test plan

- [x] tsc clean
- [x] oxlint 0 warnings, 0 errors
- [x] `npm run test:run -- src/features/timeline` — 113 files / 645 tests pass
- [ ] Manual: open a project, scrub to mid-clip, Insert > Freeze Frame, reload the project, confirm the freeze-frame thumbnail still shows in the media library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved freeze-frame thumbnail persistence and association reliability. Enhanced error handling to prevent UI updates when operations fail, ensuring consistent media library state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->