### PR TITLE
fix(export): occlusion check honors preview effect overrides

### DIFF
--- a/src/features/export/utils/canvas-item-renderer/composition.ts
+++ b/src/features/export/utils/canvas-item-renderer/composition.ts
@@ -411,7 +411,15 @@ export function isSubCompFullyOccludingItem(
   if (item.type !== 'video' && item.type !== 'image') return false
   if (item.blendMode && item.blendMode !== 'normal') return false
   if (hasCornerPin(item.cornerPin)) return false
-  if ((item.effects ?? []).some((effect) => effect.enabled !== false)) return false
+  // Use the same preview-override path as the renderer above. Otherwise a
+  // preview-only effect can flip this check the wrong way (e.g. a clean clip
+  // with a transparency-producing override would be falsely treated as fully
+  // occluding) and underlying layers would be skipped from the preview.
+  const itemEffects =
+    (rctx.renderMode === 'preview' ? rctx.getPreviewEffectsOverride?.(item.id) : undefined) ??
+    item.effects ??
+    []
+  if (itemEffects.some((effect) => effect.enabled !== false)) return false
   const adjustmentEffects = getAdjustmentLayerEffects(
     trackOrder,
     adjustmentLayers,


### PR DESCRIPTION
## Summary

`isSubCompFullyOccludingItem` in `canvas-item-renderer/composition.ts` reads `item.effects` directly. Its sibling renderer path two screens earlier (composition.ts:202-205) reads the preview override first, falling back to `item.effects` only when no override is set:

\`\`\`ts
const itemEffects =
  (rctx.renderMode === 'preview'
    ? rctx.getPreviewEffectsOverride?.(subItem.id)
    : undefined) ?? subItem.effects
\`\`\`

The asymmetry means a preview-only effect change can flip the occlusion verdict the wrong way. The occlusion check is a perf optimization: if a clip is opaque and effect-free, the layers underneath it can be skipped. With this bug, a transparency-producing preview override on a clip with no persisted effects would make the optimization think the clip still fully covers what's underneath, and underlying layers would be skipped from the preview.

Fix: mirror the renderer's lookup at line 414 so the optimization sees the same effects the renderer is about to apply.

## What this PR is NOT

Several other PR-review comments adjacent to this one were verified and found to be **invalid for current code**:

- **\"Pooled scratch canvas not cleared\" in `media-draw.ts` and `video.ts`** — `CanvasPool.acquire()` at `canvas-pool.ts:61` already calls `clearRect(0, 0, width, height)` before returning. The `if (!pooledCanvas) { clearRect }` you see is just belt-and-suspenders for the fresh-`OffscreenCanvas` fallback (which is already empty anyway).
- **\"GPU-direct path skips CPU-only effects\" in `transition.ts`** — `VisualEffect = GpuEffect` is the only effect type in the codebase (`src/types/effects.ts:9`). There are no CPU effects to skip.
- **\"`renderTransitionToGpuTexture` drops `trackMasks`\"** — the call site at `client-render-engine.ts:1982` guards the GPU path with `transitionMasks.length === 0`, so masks never reach it in practice. The asymmetric signature is a minor API smell, not a live bug.

These are all skipped — they're not user-visible issues today.

## Test plan

- [x] tsc clean
- [x] oxlint 0 warnings, 0 errors
- [x] \`npm run test:run -- src/features/export\` — 19 files / 100 tests pass
- [ ] Manual: add a brightness override via preview to a clip stacked over another, confirm the clip below still renders (instead of being skipped by the occlusion optimization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved occlusion handling in composition rendering to properly evaluate preview-only effects when determining item visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->