### PR TITLE
fix(export): re-enable zero-copy DOM video on the canvas transition path

### DIFF
--- a/src/features/export/utils/canvas-item-renderer/shared.test.ts
+++ b/src/features/export/utils/canvas-item-renderer/shared.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { isFrameInsideItemTimelineSpan } from './shared'
+
+describe('isFrameInsideItemTimelineSpan', () => {
+  it('returns true for frames inside the half-open span [from, from+duration)', () => {
+    const span = { from: 10, durationInFrames: 5 }
+    expect(isFrameInsideItemTimelineSpan(span, 10)).toBe(true)
+    expect(isFrameInsideItemTimelineSpan(span, 14)).toBe(true)
+  })
+
+  it('returns false at the exclusive end frame', () => {
+    expect(isFrameInsideItemTimelineSpan({ from: 10, durationInFrames: 5 }, 15)).toBe(false)
+  })
+
+  it('returns false before from', () => {
+    expect(isFrameInsideItemTimelineSpan({ from: 10, durationInFrames: 5 }, 9)).toBe(false)
+  })
+
+  // The DOM-video gate in video.ts passes a RenderTimelineSpan here so that
+  // transition participants — whose effective span is wider than the natural
+  // item span during a transition zone — are still recognized as in-range.
+  it('accepts an extended RenderTimelineSpan from a transition participant', () => {
+    const itemSpan = { from: 0, durationInFrames: 100 }
+    const transitionExtendedSpan = { from: 0, durationInFrames: 110, sourceStart: 0 }
+    expect(isFrameInsideItemTimelineSpan(itemSpan, 105)).toBe(false)
+    expect(isFrameInsideItemTimelineSpan(transitionExtendedSpan, 105)).toBe(true)
+  })
+})

--- a/src/features/export/utils/canvas-item-renderer/shared.ts
+++ b/src/features/export/utils/canvas-item-renderer/shared.ts
@@ -51,8 +51,11 @@ export function applyItemTransformToContext(
   ctx.translate(-centerX, -centerY)
 }
 
-export function isFrameInsideItemTimelineSpan(item: TimelineItem, frame: number): boolean {
-  return frame >= item.from && frame < item.from + item.durationInFrames
+export function isFrameInsideItemTimelineSpan(
+  span: { from: number; durationInFrames: number },
+  frame: number,
+): boolean {
+  return frame >= span.from && frame < span.from + span.durationInFrames
 }
 
 export function applyAnimatedCropToItem<TItem extends TimelineItem>(

--- a/src/features/export/utils/canvas-item-renderer/video.ts
+++ b/src/features/export/utils/canvas-item-renderer/video.ts
@@ -190,12 +190,18 @@ export async function renderVideoItem(
       : rawSourceTime
   const tier2ToleranceSeconds = getTier2VideoFrameToleranceSeconds(sourceFps)
   const domVideoElementProvider = rctx.domVideoElementProvider
+  // During transitions, frame can lie outside item's natural span (the
+  // participant's renderSpan is extended to cover the transition zone), and
+  // the policy function below is already transition-aware: it returns a wider
+  // drift threshold and inspects `data-transition-hold`. Check against
+  // effectiveRenderSpan (not the natural item span) and let the policy
+  // function decide whether the DOM video is fresh enough, mirroring the GPU
+  // transition path in gpu.ts which also passes isRenderingTransition through.
   const canUseDomVideoElement =
     isPreviewMode &&
     domVideoElementProvider &&
     sourceFrameOffset === 0 &&
-    !rctx.isRenderingTransition &&
-    isFrameInsideItemTimelineSpan(item, frame)
+    isFrameInsideItemTimelineSpan(effectiveRenderSpan, frame)
   const domVideo = canUseDomVideoElement ? domVideoElementProvider(item.id) : null
   const domVideoDecision = resolvePreviewDomVideoDrawDecision({
     domVideo,


### PR DESCRIPTION
## Summary

The DOM-video fast path in \`renderVideoItem\` was gated off whenever \`rctx.isRenderingTransition\` was set. This excluded the optimization from the exact case it was designed for: during a transition the participant clip is still playing in a real \`<video>\` element (kept alive via the \`data-transition-hold\` dance described in CLAUDE.md), and drawing from that element costs **~1ms** vs **~170ms** for a mediabunny decode stall.

Two pieces of evidence that the exclusion was an oversight:

1. \`resolvePreviewDomVideoDrawDecision\` (\`frame-source-policy.ts\`) is built to handle transitions — it returns a **1s** drift tolerance instead of 0.2s when \`isRenderingTransition\` is true, and inspects \`data-transition-hold\`. None of that fires when the upstream gate excludes transitions outright.
2. The sibling GPU transition prepare path (\`gpu.ts:269\`) passes \`isRenderingTransition\` *through* to the decision function instead of excluding transitions upstream. The canvas path now matches.

Also switched the frame-in-range check from the natural item span to the participant's \`effectiveRenderSpan\`. During a transition that span is wider than the natural item span (the outgoing clip continues drawing into the transition zone past its natural end) — the natural-span check would still have blocked the optimization for the exact frames it targets, even after dropping the \`!isRenderingTransition\` guard.

\`isFrameInsideItemTimelineSpan\`'s parameter widened from \`TimelineItem\` to \`{ from; durationInFrames }\` so \`RenderTimelineSpan\` callers fit structurally. No callers needed updating beyond the gate itself.

## Test plan

- [x] tsc clean
- [x] oxlint 0 warnings, 0 errors
- [x] New test \`shared.test.ts\` covers the helper for both natural item spans and transition-extended \`RenderTimelineSpan\`s
- [x] Full suite: 366 files / 2251 tests pass
- [ ] Manual: scrub through a clip-to-clip transition during playback and confirm no visible stall (the 170ms freezes should be gone)

## Risk

Behavioral change in the preview path during transitions. The CLAUDE.md note on \"Transition participant video hold\" documents that DOM video elements are *expected* to be playing during transitions, so the infrastructure is already in place. The drift threshold (1s) is generous enough that occasional staleness is invisible; CLAUDE.md's own comment in \`video.ts:229-233\` calls this out: *\"a 1-2 frame-old frame is invisible; a 170ms freeze is not.\"*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video rendering accuracy during transitions in the export feature.
  * Enhanced timeline frame handling for more precise transition-aware rendering.

* **Tests**
  * Added comprehensive unit tests for timeline span validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->