### PR TITLE
fix(transitions): keep split/reversed clips on conform path with visible A-A transitions

### DIFF
--- a/src/features/export/utils/canvas-item-renderer/transition.ts
+++ b/src/features/export/utils/canvas-item-renderer/transition.ts
@@ -15,7 +15,7 @@ import {
   type EffectSourceMask,
 } from '../canvas-effects'
 import { renderTransition, type ActiveTransition } from '../canvas-transitions'
-import { resolveTransitionRenderTimelineSpan } from '../render-span'
+import { resolveAATransitionRamps, resolveTransitionRenderTimelineSpan } from '../render-span'
 import { getAnimatedTransform } from '../canvas-keyframes'
 import type {
   ItemRenderContext,
@@ -479,13 +479,32 @@ export async function renderTransitionToGpuTexture(
 
 export function resolveTransitionParticipantRenderState<TItem extends TimelineItem>(
   clip: TItem,
-  activeTransition: Pick<ActiveTransition, 'transitionStart' | 'transitionEnd'>,
+  activeTransition: Pick<
+    ActiveTransition,
+    'transitionStart' | 'transitionEnd' | 'leftClip' | 'rightClip'
+  >,
   frame: number,
   trackOrder: number,
   rctx: ItemRenderContext,
 ): TransitionParticipantRenderState<TItem> {
   const currentClip = rctx.getCurrentItemSnapshot?.(clip) ?? clip
-  const renderSpan = resolveTransitionRenderTimelineSpan(currentClip, activeTransition, rctx.fps)
+  const leftSnapshot =
+    rctx.getCurrentItemSnapshot?.(activeTransition.leftClip) ?? activeTransition.leftClip
+  const rightSnapshot =
+    rctx.getCurrentItemSnapshot?.(activeTransition.rightClip) ?? activeTransition.rightClip
+  const ramps = resolveAATransitionRamps(leftSnapshot, rightSnapshot, activeTransition, rctx.fps)
+  const ramp =
+    ramps && currentClip.id === activeTransition.leftClip.id
+      ? ramps.left
+      : ramps && currentClip.id === activeTransition.rightClip.id
+        ? ramps.right
+        : undefined
+  const renderSpan = resolveTransitionRenderTimelineSpan(
+    currentClip,
+    activeTransition,
+    rctx.fps,
+    ramp,
+  )
   const itemKeyframes =
     rctx.getCurrentKeyframes?.(currentClip.id) ?? rctx.keyframesMap.get(currentClip.id)
   let transform = getAnimatedTransform(

--- a/src/features/export/utils/canvas-item-renderer/video.ts
+++ b/src/features/export/utils/canvas-item-renderer/video.ts
@@ -7,6 +7,8 @@ import type { VideoItem } from '@/types/timeline'
 import {
   getItemRenderTimelineSpan,
   getRenderTimelineSourceStart,
+  getSourceFrameRampOffset,
+  isFrameInsideSourceTimeRamp,
   type RenderTimelineSpan,
 } from '../render-span'
 import {
@@ -179,9 +181,17 @@ export async function renderVideoItem(
   const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / fps
   const reverseSourceEnd = (item.sourceEnd ?? sourceStart + sourceFramesNeeded) - sourceFrameOffset
   const adjustedSourceStart = sourceStart + sourceFrameOffset
+  // A-A transition ramps add extra source frames per timeline frame so left/
+  // right participants render distinct source content (otherwise their handle
+  // expansions resolve to identical frames and the transition is invisible).
+  // Ramps are scoped to the transition window and skip reversed clips.
+  const rampOffsetSourceFrames =
+    effectiveRenderSpan.sourceTimeRamp && !item.isReversed
+      ? getSourceFrameRampOffset(effectiveRenderSpan.sourceTimeRamp, frame)
+      : 0
   const unclampedSourceTime = item.isReversed
     ? (reverseSourceEnd - localFrame * speed * (sourceFps / fps) - 1) / sourceFps
-    : adjustedSourceStart / sourceFps + localTime * speed
+    : adjustedSourceStart / sourceFps + localTime * speed + rampOffsetSourceFrames / sourceFps
   const rawSourceTime = clampVideoSourceTime(unclampedSourceTime, sourceFps, item.sourceDuration)
   const snappedSourceFrame = Math.round(rawSourceTime * sourceFps)
   const sourceTime =
@@ -197,10 +207,18 @@ export async function renderVideoItem(
   // effectiveRenderSpan (not the natural item span) and let the policy
   // function decide whether the DOM video is fresh enough, mirroring the GPU
   // transition path in gpu.ts which also passes isRenderingTransition through.
+  // A-A transition ramps render source frames offset from the DOM video
+  // element's natural playback time. Drawing from the live element would
+  // ignore the offset and show identical pixels on both transition sides,
+  // defeating the ramp. Force the decode path when a ramp is active here.
+  const hasActiveRamp =
+    !!effectiveRenderSpan.sourceTimeRamp &&
+    isFrameInsideSourceTimeRamp(effectiveRenderSpan.sourceTimeRamp, frame)
   const canUseDomVideoElement =
     isPreviewMode &&
     domVideoElementProvider &&
     sourceFrameOffset === 0 &&
+    !hasActiveRamp &&
     isFrameInsideItemTimelineSpan(effectiveRenderSpan, frame)
   const domVideo = canUseDomVideoElement ? domVideoElementProvider(item.id) : null
   const domVideoDecision = resolvePreviewDomVideoDrawDecision({
@@ -660,9 +678,13 @@ export function resolveVideoParticipantSourceTime(
   const speed = item.speed ?? 1
   const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / rctx.fps
   const reverseSourceEnd = item.sourceEnd ?? sourceStart + sourceFramesNeeded
+  const rampOffsetSourceFrames =
+    renderSpan.sourceTimeRamp && !item.isReversed
+      ? getSourceFrameRampOffset(renderSpan.sourceTimeRamp, frame)
+      : 0
   const unclampedSourceTime = item.isReversed
     ? (reverseSourceEnd - localFrame * speed * (sourceFps / rctx.fps) - 1) / sourceFps
-    : sourceStart / sourceFps + localTime * speed
+    : sourceStart / sourceFps + localTime * speed + rampOffsetSourceFrames / sourceFps
   const rawSourceTime = clampVideoSourceTime(unclampedSourceTime, sourceFps, item.sourceDuration)
   const snappedSourceFrame = Math.round(rawSourceTime * sourceFps)
   return Math.abs(rawSourceTime * sourceFps - snappedSourceFrame) < 1e-6

--- a/src/features/export/utils/render-span.test.ts
+++ b/src/features/export/utils/render-span.test.ts
@@ -4,6 +4,9 @@ import type { ActiveTransition } from './canvas-transitions'
 import {
   getItemRenderTimelineSpan,
   getRenderTimelineSourceStart,
+  getSourceFrameRampOffset,
+  isAAContinuousSplit,
+  resolveAATransitionRamps,
   resolveTransitionRenderTimelineSpan,
 } from './render-span'
 
@@ -65,6 +68,148 @@ describe('render-span', () => {
       from: 50,
       durationInFrames: 50,
       sourceStart: 8,
+    })
+  })
+
+  describe('A-A continuous-split ramps', () => {
+    // Continuous split at frame 60 of an originally-single clip with mediaId
+    // 'm1'. Source frames 0..60 went to left, 60..120 to right. Centered
+    // 20-frame transition spans timeline [50, 70].
+    function makeSplitPair() {
+      const left = createVideoItem({
+        id: 'left',
+        mediaId: 'm1',
+        from: 0,
+        durationInFrames: 60,
+        sourceStart: 0,
+      })
+      const right = createVideoItem({
+        id: 'right',
+        mediaId: 'm1',
+        from: 60,
+        durationInFrames: 60,
+        sourceStart: 60,
+      })
+      return { left, right }
+    }
+
+    it('detects continuous A-A split via shared media and source continuity', () => {
+      const { left, right } = makeSplitPair()
+      expect(isAAContinuousSplit(left, right, 30)).toBe(true)
+    })
+
+    it('rejects pairs with different media', () => {
+      const { left, right } = makeSplitPair()
+      expect(isAAContinuousSplit(left, { ...right, mediaId: 'm2' }, 30)).toBe(false)
+    })
+
+    it('rejects pairs with a source-time gap (post-trim)', () => {
+      const { left, right } = makeSplitPair()
+      expect(isAAContinuousSplit(left, { ...right, sourceStart: 75 }, 30)).toBe(false)
+    })
+
+    it('rejects reversed clips (ramp formula assumes forward playback)', () => {
+      const { left, right } = makeSplitPair()
+      expect(isAAContinuousSplit({ ...left, isReversed: true }, right, 30)).toBe(false)
+    })
+
+    it('emits symmetric anchored ramps for A-A splits', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)
+      expect(ramps).not.toBeNull()
+      expect(ramps?.left).toEqual({ anchor: 'start', slope: 0.5, rampStart: 50, rampEnd: 70 })
+      expect(ramps?.right).toEqual({ anchor: 'end', slope: 0.5, rampStart: 50, rampEnd: 70 })
+    })
+
+    it('returns null for non-A-A pairs', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({ leftClip: left, rightClip: right })
+      expect(resolveAATransitionRamps(left, { ...right, mediaId: 'm2' }, transition, 30)).toBeNull()
+    })
+
+    it('threads ramp through into the render span', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)!
+      const leftSpan = resolveTransitionRenderTimelineSpan(left, transition, 30, ramps.left)
+      const rightSpan = resolveTransitionRenderTimelineSpan(right, transition, 30, ramps.right)
+      expect(leftSpan.sourceTimeRamp).toEqual(ramps.left)
+      expect(rightSpan.sourceTimeRamp).toEqual(ramps.right)
+    })
+
+    it('ramp offset is zero at the anchor boundary (no jump where clip continues)', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)!
+      // Left exists naturally for F<50, so anchor='start' (frame=50 → offset 0).
+      expect(getSourceFrameRampOffset(ramps.left, 50)).toBe(0)
+      // Right exists naturally for F>70, so anchor='end' (frame=70 → offset 0).
+      expect(getSourceFrameRampOffset(ramps.right, 70)).toBe(0)
+    })
+
+    it('ramp offset is also zero outside the window (no effect on adjacent frames)', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)!
+      expect(getSourceFrameRampOffset(ramps.left, 49)).toBe(0)
+      expect(getSourceFrameRampOffset(ramps.left, 71)).toBe(0)
+      expect(getSourceFrameRampOffset(ramps.right, 49)).toBe(0)
+      expect(getSourceFrameRampOffset(ramps.right, 71)).toBe(0)
+    })
+
+    it('midpoint separates left/right rendered source by half the window duration', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)!
+      // At midpoint F=60 with slope=0.5: left offset = +5, right offset = -5.
+      // Combined difference = 10 source frames = windowDuration / 2.
+      expect(getSourceFrameRampOffset(ramps.left, 60)).toBe(5)
+      expect(getSourceFrameRampOffset(ramps.right, 60)).toBe(-5)
+    })
+
+    it('non-anchor boundary offset equals half window duration (max separation)', () => {
+      const { left, right } = makeSplitPair()
+      const transition = createActiveTransition({
+        leftClip: left,
+        rightClip: right,
+        transitionStart: 50,
+        transitionEnd: 70,
+        cutPoint: 60,
+      })
+      const ramps = resolveAATransitionRamps(left, right, transition, 30)!
+      expect(getSourceFrameRampOffset(ramps.left, 70)).toBe(10)
+      expect(getSourceFrameRampOffset(ramps.right, 50)).toBe(-10)
     })
   })
 })

--- a/src/features/export/utils/render-span.ts
+++ b/src/features/export/utils/render-span.ts
@@ -179,7 +179,7 @@ export function isAAContinuousSplit(
   const leftSourceStart = leftClip.sourceStart ?? leftClip.trimStart ?? leftClip.offset ?? 0
   const rightSourceStart = rightClip.sourceStart ?? rightClip.trimStart ?? rightClip.offset ?? 0
   const speed = leftClip.speed ?? 1
-  const sourceFps = leftClip.sourceFps ?? rightClip.sourceFps ?? fps
+  const sourceFps = leftClip.sourceFps ?? fps
   const leftSourceFrames = (leftClip.durationInFrames * speed * sourceFps) / fps
   const leftNaturalSourceEnd = leftSourceStart + leftSourceFrames
   return Math.abs(leftNaturalSourceEnd - rightSourceStart) < 0.5

--- a/src/features/export/utils/render-span.ts
+++ b/src/features/export/utils/render-span.ts
@@ -2,10 +2,31 @@ import type { TimelineItem } from '@/types/timeline'
 import type { ActiveTransition } from './canvas-transitions'
 import { timelineToSourceFrames } from '@/features/export/deps/timeline'
 
+/**
+ * Linear source-time ramp applied during a transition window.
+ *
+ * Pinned at one boundary (the `anchor`) so the rendered source matches the
+ * natural source time there — that's where the clip continues to exist outside
+ * the transition, so any mismatch would show as a hard jump. At the opposite
+ * boundary, the rendered source is offset by `slope * windowDuration` source
+ * frames. Used by A-A continuous-split transitions to break the
+ * left==right-source-frame symmetry that makes them invisible.
+ */
+export interface SourceTimeRamp {
+  anchor: 'start' | 'end'
+  /** Extra source frames added per timeline frame within the window. */
+  slope: number
+  /** Timeline frame where the ramp begins (inclusive). */
+  rampStart: number
+  /** Timeline frame where the ramp ends (inclusive). */
+  rampEnd: number
+}
+
 export interface RenderTimelineSpan {
   from: number
   durationInFrames: number
   sourceStart?: number
+  sourceTimeRamp?: SourceTimeRamp
 }
 
 interface TransitionParticipantFrameWindow {
@@ -117,6 +138,7 @@ export function resolveTransitionRenderTimelineSpan<TItem extends TimelineItem>(
   clip: TItem,
   activeTransition: Pick<ActiveTransition, 'transitionStart' | 'transitionEnd'>,
   fps: number,
+  sourceTimeRamp?: SourceTimeRamp,
 ): RenderTimelineSpan {
   const transitionWindow = resolveTransitionParticipantFrameWindow(clip, activeTransition)
   const sourceStart = getTransitionParticipantSourceStart(clip, transitionWindow, fps)
@@ -124,5 +146,88 @@ export function resolveTransitionRenderTimelineSpan<TItem extends TimelineItem>(
     from: transitionWindow.from,
     durationInFrames: transitionWindow.durationInFrames,
     ...(sourceStart !== undefined ? { sourceStart } : {}),
+    ...(sourceTimeRamp ? { sourceTimeRamp } : {}),
   }
+}
+
+/**
+ * Default ramp slope for A-A continuous-split transitions. Slope of 0.5 means
+ * each clip plays at +0.5 extra source frames per timeline frame during the
+ * transition, i.e. 1.5× decode rate. With both clips ramping in opposite
+ * directions, midpoint left↔right separation is `windowDuration / 2` source
+ * frames — still visibly distinct but with half the decode pressure (and
+ * fewer preview repeat-frame stalls) of a slope-1 ramp. Bumping toward 1
+ * sharpens the visible effect at the cost of more in-window decode work.
+ */
+const A_A_DEFAULT_RAMP_SLOPE = 0.5
+
+/**
+ * Detect whether two clips form an A-A continuous split: same source media
+ * and the right clip's source starts exactly where the left clip's source
+ * ends. This is the case that produces invisible transitions because the
+ * symmetric handle expansion makes both clips render identical source frames
+ * across the entire transition window.
+ */
+export function isAAContinuousSplit(
+  leftClip: TimelineItem,
+  rightClip: TimelineItem,
+  fps: number,
+): boolean {
+  if (leftClip.type !== 'video' || rightClip.type !== 'video') return false
+  if (!leftClip.mediaId || leftClip.mediaId !== rightClip.mediaId) return false
+  if (leftClip.isReversed || rightClip.isReversed) return false
+  const leftSourceStart = leftClip.sourceStart ?? leftClip.trimStart ?? leftClip.offset ?? 0
+  const rightSourceStart = rightClip.sourceStart ?? rightClip.trimStart ?? rightClip.offset ?? 0
+  const speed = leftClip.speed ?? 1
+  const sourceFps = leftClip.sourceFps ?? rightClip.sourceFps ?? fps
+  const leftSourceFrames = (leftClip.durationInFrames * speed * sourceFps) / fps
+  const leftNaturalSourceEnd = leftSourceStart + leftSourceFrames
+  return Math.abs(leftNaturalSourceEnd - rightSourceStart) < 0.5
+}
+
+/**
+ * Build the per-side source-time ramps for an A-A continuous-split
+ * transition. Left anchors at the transition start (it exists naturally
+ * before that point); right anchors at the transition end. Symmetric slopes
+ * keep the perceived total source advancement equal to natural — the ramps
+ * only spread the *displayed* source frames so left and right show different
+ * content during the overlap.
+ */
+export function resolveAATransitionRamps(
+  leftClip: TimelineItem,
+  rightClip: TimelineItem,
+  activeTransition: Pick<ActiveTransition, 'transitionStart' | 'transitionEnd'>,
+  fps: number,
+): { left: SourceTimeRamp; right: SourceTimeRamp } | null {
+  if (!isAAContinuousSplit(leftClip, rightClip, fps)) return null
+  const common = {
+    slope: A_A_DEFAULT_RAMP_SLOPE,
+    rampStart: activeTransition.transitionStart,
+    rampEnd: activeTransition.transitionEnd,
+  }
+  return {
+    left: { anchor: 'start', ...common },
+    right: { anchor: 'end', ...common },
+  }
+}
+
+/**
+ * Compute the extra source-frame offset contributed by a ramp at a given
+ * timeline frame. Returns 0 when the frame is outside the ramp window so
+ * callers don't need to guard.
+ */
+export function getSourceFrameRampOffset(ramp: SourceTimeRamp, frame: number): number {
+  if (frame < ramp.rampStart || frame > ramp.rampEnd) return 0
+  const t = ramp.anchor === 'start' ? frame - ramp.rampStart : frame - ramp.rampEnd
+  return ramp.slope * t
+}
+
+/**
+ * True iff the frame falls inside an active ramp window. Used by renderers to
+ * decide whether the DOM-video zero-copy path is valid — when the ramp is
+ * active the rendered source time diverges from the element's natural
+ * playback, so we must take the decode path.
+ */
+export function isFrameInsideSourceTimeRamp(ramp: SourceTimeRamp, frame: number): boolean {
+  return frame >= ramp.rampStart && frame <= ramp.rampEnd
 }

--- a/src/features/timeline/stores/items-store.test.ts
+++ b/src/features/timeline/stores/items-store.test.ts
@@ -174,6 +174,137 @@ describe('items-store rate stretch', () => {
     expect(right.sourceEnd).toBe(300)
   })
 
+  it('splitItem flips source boundaries for reversed clips so playback stays continuous', () => {
+    // Reversed clip: at t=0 plays sourceEnd-1, at t=durationInFrames-1 plays sourceStart.
+    // After splitting in half, the left (first-played) piece must cover the END of the
+    // source range and the right (second-played) piece must cover the START — otherwise
+    // the two halves play the same content in the wrong order.
+    const clip = makeVideoItem({
+      id: 'reversed-clip',
+      from: 0,
+      durationInFrames: 300,
+      sourceStart: 0,
+      sourceEnd: 300,
+      sourceDuration: 300,
+      sourceFps: 30,
+      isReversed: true,
+      reverseConformSrc: 'blob:cached-conform',
+      reverseConformPath: 'reverse-conform/cached.mp4',
+      reverseConformKey: 'cached-key',
+      reverseConformStatus: 'ready',
+    })
+
+    useItemsStore.getState().setItems([clip])
+    const result = useItemsStore.getState()._splitItem('reversed-clip', 150)
+
+    expect(result).not.toBeNull()
+    const left = useItemsStore.getState().items.find((i) => i.id === 'reversed-clip') as VideoItem
+    const right = useItemsStore
+      .getState()
+      .items.find((i) => i.id !== 'reversed-clip' && i.type === 'video') as VideoItem
+
+    // Left half (timeline t=0..149) should cover the END of the original source range,
+    // so its reversed playback yields source frames 299, 298, ..., 150.
+    expect(left.sourceStart).toBe(150)
+    expect(left.sourceEnd).toBe(300)
+
+    // Right half (timeline t=150..299) should cover the START of the original source
+    // range, so its reversed playback continues with source frames 149, 148, ..., 0.
+    expect(right.sourceStart).toBe(0)
+    expect(right.sourceEnd).toBe(150)
+
+    // Both halves keep the parent's reverse-conform reference so playback stays
+    // on the smooth forward-through-conform path across the cut. Each half
+    // tracks its own offset into the conformed media.
+    expect(left.reverseConformSrc).toBe('blob:cached-conform')
+    expect(left.reverseConformPath).toBe('reverse-conform/cached.mp4')
+    expect(left.reverseConformStatus).toBe('ready')
+    expect(left.reverseConformLocalStart ?? 0).toBe(0)
+    expect(right.reverseConformSrc).toBe('blob:cached-conform')
+    expect(right.reverseConformPath).toBe('reverse-conform/cached.mp4')
+    expect(right.reverseConformStatus).toBe('ready')
+    expect(right.reverseConformLocalStart).toBe(150)
+
+    expect(left.isReversed).toBe(true)
+    expect(right.isReversed).toBe(true)
+  })
+
+  it('splitItem propagates reverseConformLocalStart through multiple splits', () => {
+    // Splitting an already-split right half should preserve the cumulative
+    // conform offset so each piece reads the correct slice of the parent's conform.
+    const clip = makeVideoItem({
+      id: 'reversed-multi',
+      from: 0,
+      durationInFrames: 300,
+      sourceStart: 0,
+      sourceEnd: 300,
+      sourceDuration: 300,
+      sourceFps: 30,
+      isReversed: true,
+      reverseConformSrc: 'blob:cached',
+      reverseConformPath: 'p',
+      reverseConformStatus: 'ready',
+    })
+
+    useItemsStore.getState().setItems([clip])
+    useItemsStore.getState()._splitItem('reversed-multi', 100)
+    const rightAfterFirst = useItemsStore
+      .getState()
+      .items.find((i) => i.id !== 'reversed-multi' && i.type === 'video') as VideoItem
+    expect(rightAfterFirst.reverseConformLocalStart).toBe(100)
+
+    // Split the right (timeline 100..299) at frame 200 → leftDur=100, rightDur=100.
+    useItemsStore.getState()._splitItem(rightAfterFirst.id, 200)
+    const allRights = useItemsStore
+      .getState()
+      .items.filter((i) => i.id !== 'reversed-multi' && i.type === 'video') as VideoItem[]
+
+    // Three pieces total: original-id (timeline 0..99), middle (100..199), new (200..299).
+    const middle = allRights.find((i) => i.id === rightAfterFirst.id)!
+    const tail = allRights.find((i) => i.id !== rightAfterFirst.id)!
+    expect(middle.reverseConformLocalStart).toBe(100)
+    expect(tail.reverseConformLocalStart).toBe(200)
+  })
+
+  it('splitItem keeps reversed-clip source spans aligned with timeline durations for asymmetric splits', () => {
+    // Asymmetric split: 200 timeline frames left, 100 right, on a 300-frame reversed clip.
+    // The split point in source coords for reversed playback is sourceEnd - leftSourceFrames,
+    // NOT sourceStart + leftSourceFrames (those coincide only for 50/50 splits).
+    // If we use the wrong point, the left half's source span (100) won't match its
+    // timeline duration (200), and playback runs off the source range.
+    const clip = makeVideoItem({
+      id: 'reversed-asym',
+      from: 0,
+      durationInFrames: 300,
+      sourceStart: 0,
+      sourceEnd: 300,
+      sourceDuration: 300,
+      sourceFps: 30,
+      isReversed: true,
+    })
+
+    useItemsStore.getState().setItems([clip])
+    const result = useItemsStore.getState()._splitItem('reversed-asym', 200)
+
+    expect(result).not.toBeNull()
+    const left = useItemsStore.getState().items.find((i) => i.id === 'reversed-asym') as VideoItem
+    const right = useItemsStore
+      .getState()
+      .items.find((i) => i.id !== 'reversed-asym' && i.type === 'video') as VideoItem
+
+    // Left (timeline t=0..199) plays original source 299..100 reversed → range [100, 300].
+    expect(left.durationInFrames).toBe(200)
+    expect(left.sourceStart).toBe(100)
+    expect(left.sourceEnd).toBe(300)
+    expect((left.sourceEnd ?? 0) - (left.sourceStart ?? 0)).toBe(200)
+
+    // Right (timeline t=200..299) plays original source 99..0 reversed → range [0, 100].
+    expect(right.durationInFrames).toBe(100)
+    expect(right.sourceStart).toBe(0)
+    expect(right.sourceEnd).toBe(100)
+    expect((right.sourceEnd ?? 0) - (right.sourceStart ?? 0)).toBe(100)
+  })
+
   it('trimItemStart re-anchors cues and drops those before the new boundary', () => {
     useTimelineSettingsStore.getState().setFps(30)
     const segment: import('@/types/timeline').SubtitleSegmentItem = {

--- a/src/features/timeline/stores/items-store.ts
+++ b/src/features/timeline/stores/items-store.ts
@@ -1351,20 +1351,47 @@ export const useItemsStore = create<ItemsState & ItemsActions>()((set, get) => (
         effectiveSourceFps,
       )
 
-      // Explicitly set sourceStart on left item so it has full explicit bounds.
-      // Without this, the left item inherits undefined sourceStart from the original,
-      // breaking hasExplicitSourceBounds detection in _rateStretchItem and causing
-      // rate stretch to use the wrong source duration (full media instead of clip portion).
-      ;(leftItem as typeof item).sourceStart = sourceStart
-      ;(leftItem as typeof item).sourceEnd = boundaries.left.sourceEnd
-      ;(rightItem as typeof item).sourceStart = boundaries.right.sourceStart
-      ;(rightItem as typeof item).sourceEnd = boundaries.right.sourceEnd
+      if (item.isReversed === true) {
+        // Reversed playback runs sourceEnd → sourceStart. The first-played
+        // (timeline-left) half therefore covers the END of the source range,
+        // and the second-played (timeline-right) half covers the START.
+        // The split point in source coords is `sourceEnd - leftSourceFrames`,
+        // i.e. `sourceStart + rightSourceFrames` — NOT the forward split point
+        // (`sourceStart + leftSourceFrames`). They only coincide for 50/50
+        // splits; asymmetric splits need the size of the second-played half
+        // to position the cut correctly.
+        const totalSourceFrames = boundaries.right.sourceEnd - sourceStart
+        const leftSourceFrames = boundaries.left.sourceEnd - sourceStart
+        const rightSourceFrames = totalSourceFrames - leftSourceFrames
+        const splitSourcePoint = sourceStart + rightSourceFrames
+        ;(leftItem as typeof item).sourceStart = splitSourcePoint
+        ;(leftItem as typeof item).sourceEnd = boundaries.right.sourceEnd
+        ;(rightItem as typeof item).sourceStart = sourceStart
+        ;(rightItem as typeof item).sourceEnd = splitSourcePoint
+
+        // Keep both halves pointed at the parent's reverse-conform so that
+        // playback stays on the smooth forward-through-conform path across
+        // the cut (same as forward-split clips reuse one source). Track each
+        // half's offset into the conform so the runtime reads the right slice.
+        const parentConformOffset = item.reverseConformLocalStart ?? 0
+        leftItem.reverseConformLocalStart = parentConformOffset
+        rightItem.reverseConformLocalStart = parentConformOffset + leftDuration
+      } else {
+        // Explicitly set sourceStart on left item so it has full explicit bounds.
+        // Without this, the left item inherits undefined sourceStart from the original,
+        // breaking hasExplicitSourceBounds detection in _rateStretchItem and causing
+        // rate stretch to use the wrong source duration (full media instead of clip portion).
+        ;(leftItem as typeof item).sourceStart = sourceStart
+        ;(leftItem as typeof item).sourceEnd = boundaries.left.sourceEnd
+        ;(rightItem as typeof item).sourceStart = boundaries.right.sourceStart
+        ;(rightItem as typeof item).sourceEnd = boundaries.right.sourceEnd
+      }
 
       getLog().debug(
-        `_splitItem: Original sourceStart:${sourceStart} speed:${speed} leftDuration:${leftDuration} rightDuration:${rightDuration}`,
+        `_splitItem: Original sourceStart:${sourceStart} speed:${speed} leftDuration:${leftDuration} rightDuration:${rightDuration} reversed:${item.isReversed === true}`,
       )
       getLog().debug(
-        `_splitItem: boundaries.right.sourceStart:${boundaries.right.sourceStart} rightItem.sourceStart:${(rightItem as typeof item).sourceStart}`,
+        `_splitItem: leftItem.sourceStart:${(leftItem as typeof item).sourceStart} leftItem.sourceEnd:${(leftItem as typeof item).sourceEnd} rightItem.sourceStart:${(rightItem as typeof item).sourceStart} rightItem.sourceEnd:${(rightItem as typeof item).sourceEnd}`,
       )
     }
 

--- a/src/runtime/composition-runtime/components/stable-video-sequence-comparator.ts
+++ b/src/runtime/composition-runtime/components/stable-video-sequence-comparator.ts
@@ -40,6 +40,7 @@ type StableVideoRenderBaseSignature = {
   reverseConformSrc: string | undefined
   reverseConformPreviewSrc: string | undefined
   reverseConformStatus: StableVideoSequenceComparatorItem['reverseConformStatus']
+  reverseConformLocalStart: number | undefined
   audioPitchSemitones: number
   audioPitchCents: number
 }
@@ -72,6 +73,7 @@ function getStableVideoRenderBaseSignature(
     reverseConformSrc: item.reverseConformSrc,
     reverseConformPreviewSrc: item.reverseConformPreviewSrc,
     reverseConformStatus: item.reverseConformStatus,
+    reverseConformLocalStart: item.reverseConformLocalStart,
     audioPitchSemitones: item.audioPitchSemitones ?? 0,
     audioPitchCents: item.audioPitchCents ?? 0,
   }
@@ -115,6 +117,7 @@ function areStableVideoRenderBaseSignaturesEqual(
     prevSignature.reverseConformSrc === nextSignature.reverseConformSrc &&
     prevSignature.reverseConformPreviewSrc === nextSignature.reverseConformPreviewSrc &&
     prevSignature.reverseConformStatus === nextSignature.reverseConformStatus &&
+    prevSignature.reverseConformLocalStart === nextSignature.reverseConformLocalStart &&
     prevSignature.audioPitchSemitones === nextSignature.audioPitchSemitones &&
     prevSignature.audioPitchCents === nextSignature.audioPitchCents
   )

--- a/src/shared/utils/reverse-conform-item.ts
+++ b/src/shared/utils/reverse-conform-item.ts
@@ -47,17 +47,23 @@ export function resolveReverseConformedVideoItem<TItem extends VideoItem>(
     return item
   }
 
+  // When a conformed reversed clip is split, both halves keep the same
+  // conform reference but read different ranges of it. `reverseConformLocalStart`
+  // is the timeline-frame offset where this clip starts in the conformed media.
+  const conformLocalStart = item.reverseConformLocalStart ?? 0
+  const conformLocalEnd = conformLocalStart + item.durationInFrames
+
   return {
     ...item,
     src: conformSrc,
     audioSrc: conformSrc,
     isReversed: undefined,
     speed: 1,
-    sourceStart: 0,
-    trimStart: 0,
-    offset: 0,
-    sourceEnd: item.durationInFrames,
-    sourceDuration: item.durationInFrames,
+    sourceStart: conformLocalStart,
+    trimStart: conformLocalStart,
+    offset: conformLocalStart,
+    sourceEnd: conformLocalEnd,
+    sourceDuration: conformLocalEnd,
     sourceFps: timelineFps,
   }
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -89,6 +89,7 @@ export interface ProjectTimeline {
     reverseConformPreviewKey?: string
     reverseConformPreviewUsesProxy?: boolean
     reverseConformStatus?: 'pending' | 'ready' | 'error'
+    reverseConformLocalStart?: number
     text?: string
     textRole?: 'caption'
     captionSource?: {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -41,6 +41,10 @@ type BaseTimelineItem = {
   reverseConformPreviewKey?: string // Cache key describing the preview reversed source range
   reverseConformPreviewUsesProxy?: boolean // Whether the preview reversed media was generated from a proxy
   reverseConformStatus?: 'pending' | 'ready' | 'error'
+  // Timeline-frame offset into reverseConform{Src,PreviewSrc} where this clip starts
+  // playing. Set on split halves so they share the parent's conform but read
+  // different ranges. Omit/0 = play from the start of the conform.
+  reverseConformLocalStart?: number
   // Transform properties (optional - defaults computed at render time)
   transform?: TransformProperties
   // Source-relative media crop (normalized edge ratios)


### PR DESCRIPTION
## Summary
- Keep reversed-clip split halves continuous and routed through the conform path so reversed splits play smoothly
- Make A-A continuous-split transitions visible by driving them via source-time ramps in the canvas transition + video renderers
- Adds render-span utility with tests and items-store split tests

## Test plan
- [ ] Verify reversed clip split halves play continuously
- [ ] Verify A-A transitions between continuous-split halves are visible during playback
- [ ] Verify normal (non-reversed, non-split) transitions still render correctly
- [ ] Export pipeline matches preview behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for A-A continuous-split video transitions with automatic source-time ramps.
  * Improved handling of reversed video clips when splitting on the timeline.

* **Bug Fixes**
  * Corrected source-time offset calculation during transitions to follow ramps.
  * Disabled DOM video fallback during active A-A ramps to ensure correct decoding.

* **Tests**
  * Added coverage for A-A ramp detection/behavior and reversed-split scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/walterlow/freecut/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->