### PR TITLE
fix(update): reload current location on app shell update

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -42,6 +42,12 @@ function rememberAcceptedAppUpdate(signature?: string) {
   }
 }
 
+function reloadCurrentLocationWithUpdateCacheBust() {
+  const nextUrl = new URL(window.location.href)
+  nextUrl.searchParams.set('__freecut_updated', Date.now().toString())
+  window.location.assign(`${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`)
+}
+
 async function showUpdateAvailableToast(
   applyUpdate: () => void = () => window.location.reload(),
   updateSignature?: string,
@@ -128,9 +134,10 @@ async function checkForAppShellUpdate() {
       nextBuildAssetSignature !== currentBuildAssetSignature &&
       nextBuildAssetSignature !== acceptedUpdateSignature
     ) {
-      await showUpdateAvailableToast(() => {
-        window.location.assign(`/?__freecut_updated=${Date.now()}`)
-      }, nextBuildAssetSignature)
+      await showUpdateAvailableToast(
+        reloadCurrentLocationWithUpdateCacheBust,
+        nextBuildAssetSignature,
+      )
     }
   } catch (error) {
     log.warn('App update check failed:', error)


### PR DESCRIPTION
## Summary
- App-shell update toast now reloads the **current** location (preserving path, query, and hash) with a cache-bust param, instead of always redirecting to `/`.

## Details
Adds `reloadCurrentLocationWithUpdateCacheBust()` in `src/main.tsx`, which builds the next URL from `window.location.href`, sets `__freecut_updated=<timestamp>`, and assigns it — keeping the user on the page they were on when they accept an update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app update reload behavior to preserve your current location and page state when reloading after an app update becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->