### PR TITLE
feat(settings): improve shortcut editor ux

### DIFF
--- a/src/config/hotkeys.test.ts
+++ b/src/config/hotkeys.test.ts
@@ -157,6 +157,24 @@ describe('createHotkeyExportDocument', () => {
       }),
     )
   })
+
+  it('exports explicitly unassigned commands as custom blank bindings', () => {
+    const exportDocument = createHotkeyExportDocument({
+      DELETE_SELECTED: '',
+    })
+
+    expect(exportDocument.overrides).toEqual({
+      DELETE_SELECTED: '',
+    })
+    expect(exportDocument.commands).toContainEqual(
+      expect.objectContaining({
+        id: 'DELETE_SELECTED',
+        binding: '',
+        defaultBinding: 'delete',
+        isCustom: true,
+      }),
+    )
+  })
 })
 
 describe('parseHotkeyImportDocument', () => {

--- a/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
+++ b/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
@@ -17,6 +17,16 @@ function click(element: Element) {
   element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
 }
 
+function keyDown(key: string, code: string = key) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, code, bubbles: true, cancelable: true }))
+}
+
+function changeInput(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  valueSetter?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+}
+
 function getButton(name: string): HTMLButtonElement {
   const button = [...document.querySelectorAll('button')].find(
     (candidate) => candidate.textContent?.trim() === name,
@@ -40,6 +50,18 @@ async function waitForText(text: string): Promise<HTMLElement> {
   }
 
   throw new Error(`Text not found: ${text}`)
+}
+
+async function waitForBodyText(text: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (document.body.textContent?.includes(text)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  throw new Error(`Body text not found: ${text}`)
 }
 
 describe('HotkeyEditor reset all confirmation', () => {
@@ -81,5 +103,40 @@ describe('HotkeyEditor reset all confirmation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(useSettingsStore.getState().hotkeyOverrides).toEqual({})
+  })
+
+  it('overwrites the shown conflicting shortcut by unbinding that action', async () => {
+    click(getButton('Record'))
+    await waitForText('Listening')
+    keyDown('ArrowRight', 'ArrowRight')
+
+    await waitForBodyText('Conflicts with Next frame')
+    click(getButton('Overwrite'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({
+      NEXT_FRAME: '',
+      PLAY_PAUSE: 'right',
+    })
+  })
+
+  it('keeps unbind explicit and disables it once the selected command is unassigned', async () => {
+    click(getButton('Unbind'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({ PLAY_PAUSE: '' })
+    expect(getButton('Unbind').disabled).toBe(true)
+    await waitForText('Unassigned')
+  })
+
+  it('shows a localized search result count while filtering shortcuts', async () => {
+    const searchInput = document.querySelector(
+      'input[placeholder="Search commands or shortcuts"]',
+    ) as HTMLInputElement | null
+
+    expect(searchInput).toBeTruthy()
+    changeInput(searchInput!, 'export')
+
+    await waitForText('1 result')
   })
 })

--- a/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
+++ b/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
@@ -120,6 +120,37 @@ describe('HotkeyEditor reset all confirmation', () => {
     })
   })
 
+  it('restores partial conflict overwrites when capture is cancelled', async () => {
+    useSettingsStore.setState({
+      hotkeyOverrides: {
+        PLAY_PAUSE: 'shift+k',
+        PREVIOUS_FRAME: 'right',
+      },
+    })
+
+    click(getButton('Record'))
+    await waitForText('Listening')
+    keyDown('ArrowRight', 'ArrowRight')
+
+    await waitForBodyText('Conflicts with Previous frame')
+    await waitForBodyText('Conflicts with Next frame')
+    click(getButton('Overwrite'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useSettingsStore.getState().hotkeyOverrides).not.toEqual({
+      PLAY_PAUSE: 'shift+k',
+      PREVIOUS_FRAME: 'right',
+    })
+
+    keyDown('Escape', 'Escape')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({
+      PLAY_PAUSE: 'shift+k',
+      PREVIOUS_FRAME: 'right',
+    })
+  })
+
   it('keeps unbind explicit and disables it once the selected command is unassigned', async () => {
     click(getButton('Unbind'))
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
+++ b/src/features/settings/components/hotkey-editor-reset-dialog.test.tsx
@@ -1,0 +1,85 @@
+import { createElement } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test'
+import { HotkeyEditor } from './hotkey-editor'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { useSettingsStore } from '../stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+function setCustomHotkeyOverride() {
+  useSettingsStore.setState({ hotkeyOverrides: { PLAY_PAUSE: 'shift+k' } })
+}
+
+function click(element: Element) {
+  element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+}
+
+function getButton(name: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.trim() === name,
+  )
+
+  expect(button).toBeTruthy()
+  return button as HTMLButtonElement
+}
+
+async function waitForText(text: string): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const element = [...document.querySelectorAll('body *')].find(
+      (candidate) => candidate.textContent?.trim() === text,
+    )
+
+    if (element instanceof HTMLElement) {
+      return element
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  throw new Error(`Text not found: ${text}`)
+}
+
+describe('HotkeyEditor reset all confirmation', () => {
+  beforeEach(async () => {
+    setCustomHotkeyOverride()
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    root.render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(DialogPrimitive.Root, { open: true }, createElement(HotkeyEditor)),
+      ),
+    )
+    await waitForText('Reset All')
+  })
+
+  afterEach(() => {
+    root.unmount()
+    container.remove()
+    useSettingsStore.setState({ hotkeyOverrides: {} })
+  })
+
+  it('does not reset custom shortcuts until the destructive reset is confirmed', async () => {
+    click(getButton('Reset All'))
+
+    await waitForText('Reset all shortcuts?')
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({ PLAY_PAUSE: 'shift+k' })
+
+    click(getButton('Cancel'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(document.body.textContent).not.toContain('Reset all shortcuts?')
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({ PLAY_PAUSE: 'shift+k' })
+
+    click(getButton('Reset All'))
+    await waitForText('Reset all shortcuts?')
+    click(getButton('Reset all'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useSettingsStore.getState().hotkeyOverrides).toEqual({})
+  })
+})

--- a/src/features/settings/components/hotkey-editor-search.test.ts
+++ b/src/features/settings/components/hotkey-editor-search.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { HOTKEYS } from '@/config/hotkeys'
+import { HOTKEY_EDITOR_SECTIONS, getHotkeyEditorSearchResults } from './hotkey-editor-sections'
+
+describe('getHotkeyEditorSearchResults', () => {
+  it('filters commands by localized label', () => {
+    const results = getHotkeyEditorSearchResults({
+      query: 'ripple',
+      sections: HOTKEY_EDITOR_SECTIONS,
+      hotkeys: HOTKEYS,
+      translate: (key) =>
+        key.endsWith('rippleDeleteSelectedItems') ? 'Ripple delete selected items' : key,
+    })
+
+    expect(results.map((result) => result.item.labelKey)).toEqual([
+      'projects.settings.hotkeys.items.rippleDeleteSelectedItems',
+    ])
+  })
+
+  it('filters commands by current shortcut binding', () => {
+    const results = getHotkeyEditorSearchResults({
+      query: 'mod+shift+e',
+      sections: HOTKEY_EDITOR_SECTIONS,
+      hotkeys: HOTKEYS,
+      translate: (key) => (key.endsWith('exportVideo') ? 'Export video' : key),
+    })
+
+    expect(results.map((result) => result.item.labelKey)).toEqual([
+      'projects.settings.hotkeys.items.exportVideo',
+    ])
+  })
+})

--- a/src/features/settings/components/hotkey-editor-search.test.ts
+++ b/src/features/settings/components/hotkey-editor-search.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { HOTKEYS } from '@/config/hotkeys'
-import { HOTKEY_EDITOR_SECTIONS, getHotkeyEditorSearchResults } from './hotkey-editor-sections'
+import {
+  HOTKEY_EDITOR_SECTIONS,
+  getHotkeyBindingDisplayLabel,
+  getHotkeyEditorSearchResults,
+} from './hotkey-editor-sections'
 
 describe('getHotkeyEditorSearchResults', () => {
   it('filters commands by localized label', () => {
@@ -28,5 +32,15 @@ describe('getHotkeyEditorSearchResults', () => {
     expect(results.map((result) => result.item.labelKey)).toEqual([
       'projects.settings.hotkeys.items.exportVideo',
     ])
+  })
+})
+
+describe('getHotkeyBindingDisplayLabel', () => {
+  it('shows an explicit unassigned label for blank bindings', () => {
+    expect(getHotkeyBindingDisplayLabel('', 'Unassigned')).toBe('Unassigned')
+  })
+
+  it('formats non-empty bindings normally', () => {
+    expect(getHotkeyBindingDisplayLabel('mod+shift+e', 'Unassigned')).toBe('Ctrl + Shift + E')
   })
 })

--- a/src/features/settings/components/hotkey-editor-sections.ts
+++ b/src/features/settings/components/hotkey-editor-sections.ts
@@ -1,4 +1,4 @@
-import type { HotkeyKey } from '@/config/hotkeys'
+import { normalizeHotkeyBinding, type HotkeyBindingMap, type HotkeyKey } from '@/config/hotkeys'
 
 export interface HotkeyEditorItem {
   /** i18n key for the command label */
@@ -12,6 +12,55 @@ export interface HotkeyEditorSection {
   /** i18n key for the section blurb */
   blurbKey: string
   items: readonly HotkeyEditorItem[]
+}
+
+export interface HotkeyEditorSearchResult {
+  section: HotkeyEditorSection
+  item: HotkeyEditorItem
+}
+
+interface HotkeyEditorSearchOptions {
+  query: string
+  sections: readonly HotkeyEditorSection[]
+  hotkeys: HotkeyBindingMap
+  translate: (key: string) => string
+}
+
+export function getHotkeyEditorSearchResults({
+  query,
+  sections,
+  hotkeys,
+  translate,
+}: HotkeyEditorSearchOptions): HotkeyEditorSearchResult[] {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  if (!normalizedQuery) {
+    return []
+  }
+
+  const normalizedBindingQuery = normalizeHotkeyBinding(normalizedQuery)
+
+  return sections.flatMap((section) => {
+    const sectionLabel = translate(section.titleKey).toLowerCase()
+
+    return section.items
+      .filter((item) => {
+        const itemLabel = translate(item.labelKey).toLowerCase()
+        const bindings = item.keys.map((key) => hotkeys[key].toLowerCase())
+
+        return (
+          itemLabel.includes(normalizedQuery) ||
+          sectionLabel.includes(normalizedQuery) ||
+          item.keys.some((key) => key.toLowerCase().includes(normalizedQuery)) ||
+          bindings.some(
+            (binding) =>
+              binding.includes(normalizedQuery) ||
+              (normalizedBindingQuery.length > 0 && binding === normalizedBindingQuery),
+          )
+        )
+      })
+      .map((item) => ({ section, item }))
+  })
 }
 
 export const HOTKEY_EDITOR_SECTIONS: readonly HotkeyEditorSection[] = [

--- a/src/features/settings/components/hotkey-editor-sections.ts
+++ b/src/features/settings/components/hotkey-editor-sections.ts
@@ -1,4 +1,9 @@
-import { normalizeHotkeyBinding, type HotkeyBindingMap, type HotkeyKey } from '@/config/hotkeys'
+import {
+  formatHotkeyBinding,
+  normalizeHotkeyBinding,
+  type HotkeyBindingMap,
+  type HotkeyKey,
+} from '@/config/hotkeys'
 
 export interface HotkeyEditorItem {
   /** i18n key for the command label */
@@ -24,6 +29,10 @@ interface HotkeyEditorSearchOptions {
   sections: readonly HotkeyEditorSection[]
   hotkeys: HotkeyBindingMap
   translate: (key: string) => string
+}
+
+export function getHotkeyBindingDisplayLabel(binding: string, unassignedLabel: string): string {
+  return binding ? formatHotkeyBinding(binding) : unassignedLabel
 }
 
 export function getHotkeyEditorSearchResults({

--- a/src/features/settings/components/hotkey-editor.tsx
+++ b/src/features/settings/components/hotkey-editor.tsx
@@ -416,6 +416,7 @@ export function HotkeyEditor() {
   const selectedItem = HOTKEY_ITEM_BY_KEY[selectedKey]
   const selectedSlotLabel = t(getSlotLabelKey(selectedItem, selectedKey))
   const isSelectedCustom = selectedKey in hotkeyOverrides
+  const isSelectedUnassigned = hotkeys[selectedKey] === ''
   const customCount = Object.keys(hotkeyOverrides).length
   const isCapturingSelectedKey = captureKey === selectedKey
   const activePreviewBinding = isCapturingSelectedKey
@@ -565,7 +566,21 @@ export function HotkeyEditor() {
     stopCapture()
   }
 
-  const overwriteConflictingHotkeys = () => {
+  const overwriteConflictingHotkey = (conflictKey: HotkeyKey) => {
+    if (!captureKey || !draftBinding || !hasHotkeyPrimaryToken(draftBinding)) {
+      return
+    }
+
+    const remainingConflicts = captureConflicts.filter((key) => key !== conflictKey)
+    unbindHotkeyBinding(conflictKey)
+
+    if (remainingConflicts.length === 0) {
+      setHotkeyBinding(captureKey, normalizeHotkeyBinding(draftBinding))
+      stopCapture()
+    }
+  }
+
+  const overwriteAllConflictingHotkeys = () => {
     if (!captureKey || !draftBinding || !hasHotkeyPrimaryToken(draftBinding)) {
       return
     }
@@ -734,51 +749,54 @@ export function HotkeyEditor() {
               />
             </div>
             {hasSearchQuery ? (
-              <div
-                role="list"
-                aria-label={t('projects.settings.hotkeys.searchResults')}
-                className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1"
-              >
-                {searchResults.length > 0 ? (
-                  searchResults.map(({ section, item }) => {
-                    const resultKey = item.keys.join('|')
-                    const isSelectedResult = item.keys.includes(selectedKey)
+              <div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1">
+                <div className="px-1 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  {t('projects.settings.hotkeys.searchResultCount', {
+                    count: searchResults.length,
+                  })}
+                </div>
+                <div role="list" aria-label={t('projects.settings.hotkeys.searchResults')}>
+                  {searchResults.length > 0 ? (
+                    searchResults.map(({ section, item }) => {
+                      const resultKey = item.keys.join('|')
+                      const isSelectedResult = item.keys.includes(selectedKey)
 
-                    return (
-                      <div key={resultKey} role="listitem">
-                        <button
-                          type="button"
-                          onClick={() => selectSearchResult(item)}
-                          className={cn(
-                            'w-full rounded-lg px-2.5 py-2 text-left transition-colors duration-150 ease-out motion-reduce:transition-none',
-                            isSelectedResult
-                              ? 'bg-primary/15 text-primary'
-                              : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
-                          )}
-                        >
-                          <div className="text-[11px] font-medium leading-4 text-foreground">
-                            {t(item.labelKey)}
-                          </div>
-                          <div className="mt-0.5 truncate text-[10px] uppercase tracking-[0.14em]">
-                            {t(section.titleKey)} ·{' '}
-                            {item.keys
-                              .map((key) =>
-                                getHotkeyBindingDisplayLabel(
-                                  hotkeys[key],
-                                  t('projects.settings.hotkeys.unassigned'),
-                                ),
-                              )
-                              .join(' / ')}
-                          </div>
-                        </button>
-                      </div>
-                    )
-                  })
-                ) : (
-                  <div className="rounded-lg border border-white/8 bg-white/4 px-2.5 py-2 text-xs leading-4 text-muted-foreground">
-                    {t('projects.settings.hotkeys.noSearchResults')}
-                  </div>
-                )}
+                      return (
+                        <div key={resultKey} role="listitem">
+                          <button
+                            type="button"
+                            onClick={() => selectSearchResult(item)}
+                            className={cn(
+                              'w-full rounded-lg px-2.5 py-2 text-left transition-colors duration-150 ease-out motion-reduce:transition-none',
+                              isSelectedResult
+                                ? 'bg-primary/15 text-primary'
+                                : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
+                            )}
+                          >
+                            <div className="text-[11px] font-medium leading-4 text-foreground">
+                              {t(item.labelKey)}
+                            </div>
+                            <div className="mt-0.5 truncate text-[10px] uppercase tracking-[0.14em]">
+                              {t(section.titleKey)} ·{' '}
+                              {item.keys
+                                .map((key) =>
+                                  getHotkeyBindingDisplayLabel(
+                                    hotkeys[key],
+                                    t('projects.settings.hotkeys.unassigned'),
+                                  ),
+                                )
+                                .join(' / ')}
+                            </div>
+                          </button>
+                        </div>
+                      )
+                    })
+                  ) : (
+                    <div className="rounded-lg border border-white/8 bg-white/4 px-2.5 py-2 text-xs leading-4 text-muted-foreground">
+                      {t('projects.settings.hotkeys.noSearchResults')}
+                    </div>
+                  )}
+                </div>
               </div>
             ) : (
               <>
@@ -929,7 +947,7 @@ export function HotkeyEditor() {
                     variant="outline"
                     className="w-full"
                     onClick={unbindSelectedHotkey}
-                    disabled={!hotkeys[selectedKey]}
+                    disabled={isSelectedUnassigned}
                   >
                     {t('projects.settings.hotkeys.unbind')}
                   </Button>
@@ -985,21 +1003,36 @@ export function HotkeyEditor() {
                       const hotkeyItem = HOTKEY_ITEM_BY_KEY[key]
 
                       return (
-                        <div key={key} className="text-xs text-foreground/88">
-                          {t('projects.settings.hotkeys.conflictsWith', {
-                            action: t(hotkeyItem.labelKey),
-                          })}
+                        <div
+                          key={key}
+                          className="flex items-center justify-between gap-2 text-xs text-foreground/88"
+                        >
+                          <span className="min-w-0 flex-1">
+                            {t('projects.settings.hotkeys.conflictsWith', {
+                              action: t(hotkeyItem.labelKey),
+                            })}
+                          </span>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            className="h-6 shrink-0 px-2 text-[10px]"
+                            onClick={() => overwriteConflictingHotkey(key)}
+                          >
+                            {t('projects.settings.hotkeys.overwrite')}
+                          </Button>
                         </div>
                       )
                     })}
-                    <Button
-                      size="sm"
-                      variant="destructive"
-                      className="h-7 w-full px-2 text-[11px]"
-                      onClick={overwriteConflictingHotkeys}
-                    >
-                      {t('projects.settings.hotkeys.overwriteAll')}
-                    </Button>
+                    {captureConflicts.length > 1 ? (
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="h-7 w-full px-2 text-[11px]"
+                        onClick={overwriteAllConflictingHotkeys}
+                      >
+                        {t('projects.settings.hotkeys.overwriteAll')}
+                      </Button>
+                    ) : null}
                   </div>
                 ) : null}
                 {pendingBrowserHotkey ? (

--- a/src/features/settings/components/hotkey-editor.tsx
+++ b/src/features/settings/components/hotkey-editor.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { AlertTriangle, Download, Keyboard, RotateCcw, Upload, X } from 'lucide-react'
+import { AlertTriangle, Download, Keyboard, RotateCcw, Search, Upload, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/shared/ui/cn'
 import {
@@ -22,6 +23,7 @@ import {
 } from '@/config/hotkeys'
 import {
   HOTKEY_EDITOR_SECTIONS,
+  getHotkeyEditorSearchResults,
   type HotkeyEditorItem,
   type HotkeyEditorSection,
 } from './hotkey-editor-sections'
@@ -397,6 +399,7 @@ export function HotkeyEditor() {
   const [captureKey, setCaptureKey] = useState<HotkeyKey | null>(null)
   const [draftBinding, setDraftBinding] = useState('')
   const [previewBinding, setPreviewBinding] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
 
   const selectedItem = HOTKEY_ITEM_BY_KEY[selectedKey]
   const selectedSlotLabel = t(getSlotLabelKey(selectedItem, selectedKey))
@@ -421,6 +424,17 @@ export function HotkeyEditor() {
   const selectedBrowserHotkey = getBrowserHostileHotkey(hotkeys[selectedKey])
   const pendingBrowserHotkey =
     captureKey && draftBinding ? getBrowserHostileHotkey(draftBinding) : null
+  const searchResults = useMemo(
+    () =>
+      getHotkeyEditorSearchResults({
+        query: searchQuery,
+        sections: HOTKEY_EDITOR_SECTIONS,
+        hotkeys,
+        translate: t,
+      }),
+    [hotkeys, searchQuery, t],
+  )
+  const hasSearchQuery = searchQuery.trim().length > 0
 
   useEffect(() => {
     if (!captureKey) {
@@ -590,6 +604,11 @@ export function HotkeyEditor() {
     }
   }
 
+  const selectSearchResult = (item: HotkeyEditorItem) => {
+    stopCapture()
+    setSelectedKey(item.keys[0]!)
+  }
+
   const exportHotkeys = () => {
     try {
       const exportDocument = createHotkeyExportDocument(hotkeyOverrides)
@@ -686,42 +705,95 @@ export function HotkeyEditor() {
       <div className="px-4 pb-3 md:px-5">
         <div className="flex min-h-[380px] overflow-hidden rounded-lg border border-white/7 bg-[#0d0d0f]/90">
           {/* Section layers sidebar */}
-          <div className="flex shrink-0 flex-col gap-0.5 border-r border-white/6 p-2">
-            <button
-              type="button"
-              onClick={() => {
-                stopCapture()
-                setActiveLayer(null)
-              }}
-              className={cn(
-                'rounded-lg px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.16em] transition-colors duration-150 ease-out motion-reduce:transition-none',
-                activeLayer === null
-                  ? 'bg-primary/15 text-primary'
-                  : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
-              )}
-            >
-              {t('projects.settings.hotkeys.all')}
-            </button>
-            <div className="my-1 border-t border-white/6" />
-            {HOTKEY_EDITOR_SECTIONS.map((section) => (
-              <button
-                key={section.titleKey}
-                type="button"
-                onClick={() => {
-                  stopCapture()
-                  setActiveLayer(section)
-                  setSelectedKey(section.items[0]!.keys[0]!)
-                }}
-                className={cn(
-                  'rounded-lg px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.16em] transition-colors duration-150 ease-out motion-reduce:transition-none',
-                  activeLayer === section
-                    ? 'bg-primary/15 text-primary'
-                    : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
-                )}
+          <div className="flex w-52 shrink-0 flex-col gap-0.5 border-r border-white/6 p-2">
+            <div className="relative mb-2">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder={t('projects.settings.hotkeys.searchPlaceholder')}
+                className="h-8 border-white/10 bg-white/5 pl-8 pr-2 text-xs"
+              />
+            </div>
+            {hasSearchQuery ? (
+              <div
+                role="list"
+                aria-label={t('projects.settings.hotkeys.searchResults')}
+                className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1"
               >
-                {t(section.titleKey)}
-              </button>
-            ))}
+                {searchResults.length > 0 ? (
+                  searchResults.map(({ section, item }) => {
+                    const resultKey = item.keys.join('|')
+                    const isSelectedResult = item.keys.includes(selectedKey)
+
+                    return (
+                      <div key={resultKey} role="listitem">
+                        <button
+                          type="button"
+                          onClick={() => selectSearchResult(item)}
+                          className={cn(
+                            'w-full rounded-lg px-2.5 py-2 text-left transition-colors duration-150 ease-out motion-reduce:transition-none',
+                            isSelectedResult
+                              ? 'bg-primary/15 text-primary'
+                              : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
+                          )}
+                        >
+                          <div className="text-[11px] font-medium leading-4 text-foreground">
+                            {t(item.labelKey)}
+                          </div>
+                          <div className="mt-0.5 truncate text-[10px] uppercase tracking-[0.14em]">
+                            {t(section.titleKey)} ·{' '}
+                            {item.keys.map((key) => formatHotkeyBinding(hotkeys[key])).join(' / ')}
+                          </div>
+                        </button>
+                      </div>
+                    )
+                  })
+                ) : (
+                  <div className="rounded-lg border border-white/8 bg-white/4 px-2.5 py-2 text-xs leading-4 text-muted-foreground">
+                    {t('projects.settings.hotkeys.noSearchResults')}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    stopCapture()
+                    setActiveLayer(null)
+                  }}
+                  className={cn(
+                    'rounded-lg px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.16em] transition-colors duration-150 ease-out motion-reduce:transition-none',
+                    activeLayer === null
+                      ? 'bg-primary/15 text-primary'
+                      : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
+                  )}
+                >
+                  {t('projects.settings.hotkeys.all')}
+                </button>
+                <div className="my-1 border-t border-white/6" />
+                {HOTKEY_EDITOR_SECTIONS.map((section) => (
+                  <button
+                    key={section.titleKey}
+                    type="button"
+                    onClick={() => {
+                      stopCapture()
+                      setActiveLayer(section)
+                      setSelectedKey(section.items[0]!.keys[0]!)
+                    }}
+                    className={cn(
+                      'rounded-lg px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.16em] transition-colors duration-150 ease-out motion-reduce:transition-none',
+                      activeLayer === section
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:bg-white/5 hover:text-foreground/80',
+                    )}
+                  >
+                    {t(section.titleKey)}
+                  </button>
+                ))}
+              </>
+            )}
           </div>
           {/* Keyboard */}
           <div className="flex min-w-0 flex-1 flex-col justify-center p-4 md:p-5">

--- a/src/features/settings/components/hotkey-editor.tsx
+++ b/src/features/settings/components/hotkey-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { AlertTriangle, Download, Keyboard, RotateCcw, Search, Upload, X } from 'lucide-react'
@@ -402,6 +402,7 @@ export function HotkeyEditor() {
   const resetHotkeyBinding = useSettingsStore((state) => state.resetHotkeyBinding)
   const resetHotkeys = useSettingsStore((state) => state.resetHotkeys)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const partialConflictOverrideSnapshotRef = useRef<typeof hotkeyOverrides | null>(null)
 
   const [selectedKey, setSelectedKey] = useState<HotkeyKey>('PLAY_PAUSE')
   const [activeLayer, setActiveLayer] = useState<HotkeyEditorSection | null>(null)
@@ -449,6 +450,22 @@ export function HotkeyEditor() {
   )
   const hasSearchQuery = searchQuery.trim().length > 0
 
+  const stopCapture = useCallback(
+    ({ restorePartialOverwrites = true } = {}) => {
+      const snapshot = partialConflictOverrideSnapshotRef.current
+      partialConflictOverrideSnapshotRef.current = null
+
+      if (restorePartialOverwrites && snapshot) {
+        replaceHotkeyOverrides(snapshot)
+      }
+
+      setCaptureKey(null)
+      setDraftBinding('')
+      setPreviewBinding('')
+    },
+    [replaceHotkeyOverrides],
+  )
+
   useEffect(() => {
     if (!captureKey) {
       return undefined
@@ -457,9 +474,7 @@ export function HotkeyEditor() {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault()
-        setCaptureKey(null)
-        setDraftBinding('')
-        setPreviewBinding('')
+        stopCapture()
         return
       }
 
@@ -484,19 +499,23 @@ export function HotkeyEditor() {
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
     }
-  }, [captureKey])
+  }, [captureKey, stopCapture])
+
+  useEffect(() => {
+    return () => {
+      const snapshot = partialConflictOverrideSnapshotRef.current
+      partialConflictOverrideSnapshotRef.current = null
+
+      if (snapshot) {
+        replaceHotkeyOverrides(snapshot)
+      }
+    }
+  }, [replaceHotkeyOverrides])
 
   const startCapture = (key: HotkeyKey) => {
+    stopCapture()
     setSelectedKey(key)
     setCaptureKey(key)
-    setDraftBinding('')
-    setPreviewBinding('')
-  }
-
-  const stopCapture = () => {
-    setCaptureKey(null)
-    setDraftBinding('')
-    setPreviewBinding('')
   }
 
   const layerTokens = useMemo(() => {
@@ -563,7 +582,7 @@ export function HotkeyEditor() {
     }
 
     setHotkeyBinding(captureKey, normalizeHotkeyBinding(draftBinding))
-    stopCapture()
+    stopCapture({ restorePartialOverwrites: false })
   }
 
   const overwriteConflictingHotkey = (conflictKey: HotkeyKey) => {
@@ -571,12 +590,18 @@ export function HotkeyEditor() {
       return
     }
 
+    if (!partialConflictOverrideSnapshotRef.current) {
+      partialConflictOverrideSnapshotRef.current = {
+        ...useSettingsStore.getState().hotkeyOverrides,
+      }
+    }
+
     const remainingConflicts = captureConflicts.filter((key) => key !== conflictKey)
     unbindHotkeyBinding(conflictKey)
 
     if (remainingConflicts.length === 0) {
       setHotkeyBinding(captureKey, normalizeHotkeyBinding(draftBinding))
-      stopCapture()
+      stopCapture({ restorePartialOverwrites: false })
     }
   }
 
@@ -589,22 +614,22 @@ export function HotkeyEditor() {
       unbindHotkeyBinding(conflictKey)
     }
     setHotkeyBinding(captureKey, normalizeHotkeyBinding(draftBinding))
-    stopCapture()
+    stopCapture({ restorePartialOverwrites: false })
   }
 
   const unbindSelectedHotkey = () => {
     unbindHotkeyBinding(selectedKey)
-    stopCapture()
+    stopCapture({ restorePartialOverwrites: false })
   }
 
   const resetSelectedHotkey = () => {
     resetHotkeyBinding(selectedKey)
-    stopCapture()
+    stopCapture({ restorePartialOverwrites: false })
   }
 
   const confirmResetAllHotkeys = () => {
     resetHotkeys()
-    stopCapture()
+    stopCapture({ restorePartialOverwrites: false })
     toast.success(t('projects.settings.hotkeys.resetAllToast'))
   }
 
@@ -659,7 +684,7 @@ export function HotkeyEditor() {
       const importResult = parseHotkeyImportDocument(JSON.parse(contents))
 
       replaceHotkeyOverrides(importResult.overrides)
-      stopCapture()
+      stopCapture({ restorePartialOverwrites: false })
 
       const messages = [
         t('projects.settings.hotkeys.importedCommands', {
@@ -933,7 +958,12 @@ export function HotkeyEditor() {
                   >
                     {t('common.save')}
                   </Button>
-                  <Button size="sm" variant="outline" className="w-full" onClick={stopCapture}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => stopCapture()}
+                  >
                     {t('common.cancel')}
                   </Button>
                 </>

--- a/src/features/settings/components/hotkey-editor.tsx
+++ b/src/features/settings/components/hotkey-editor.tsx
@@ -3,6 +3,16 @@ import { useTranslation } from 'react-i18next'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { AlertTriangle, Download, Keyboard, RotateCcw, Search, Upload, X } from 'lucide-react'
 import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -23,6 +33,7 @@ import {
 } from '@/config/hotkeys'
 import {
   HOTKEY_EDITOR_SECTIONS,
+  getHotkeyBindingDisplayLabel,
   getHotkeyEditorSearchResults,
   type HotkeyEditorItem,
   type HotkeyEditorSection,
@@ -400,6 +411,7 @@ export function HotkeyEditor() {
   const [draftBinding, setDraftBinding] = useState('')
   const [previewBinding, setPreviewBinding] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
+  const [isResetAllDialogOpen, setIsResetAllDialogOpen] = useState(false)
 
   const selectedItem = HOTKEY_ITEM_BY_KEY[selectedKey]
   const selectedSlotLabel = t(getSlotLabelKey(selectedItem, selectedKey))
@@ -575,6 +587,12 @@ export function HotkeyEditor() {
     stopCapture()
   }
 
+  const confirmResetAllHotkeys = () => {
+    resetHotkeys()
+    stopCapture()
+    toast.success(t('projects.settings.hotkeys.resetAllToast'))
+  }
+
   const handleTokenClick = (token: string) => {
     if (token === 'mod' || token === 'alt' || token === 'shift') return
     stopCapture()
@@ -743,7 +761,14 @@ export function HotkeyEditor() {
                           </div>
                           <div className="mt-0.5 truncate text-[10px] uppercase tracking-[0.14em]">
                             {t(section.titleKey)} ·{' '}
-                            {item.keys.map((key) => formatHotkeyBinding(hotkeys[key])).join(' / ')}
+                            {item.keys
+                              .map((key) =>
+                                getHotkeyBindingDisplayLabel(
+                                  hotkeys[key],
+                                  t('projects.settings.hotkeys.unassigned'),
+                                ),
+                              )
+                              .join(' / ')}
                           </div>
                         </button>
                       </div>
@@ -833,7 +858,10 @@ export function HotkeyEditor() {
                   {t('projects.settings.hotkeys.current')}
                 </div>
                 <div className="mt-1 font-medium text-foreground">
-                  {formatHotkeyBinding(hotkeys[selectedKey])}
+                  {getHotkeyBindingDisplayLabel(
+                    hotkeys[selectedKey],
+                    t('projects.settings.hotkeys.unassigned'),
+                  )}
                 </div>
               </div>
               <div>
@@ -992,19 +1020,37 @@ export function HotkeyEditor() {
             </p>
 
             <div className="border-t border-white/6 pt-3">
-              <Button
-                variant="destructive"
-                size="sm"
-                className="w-full gap-1.5"
-                onClick={() => {
-                  resetHotkeys()
-                  stopCapture()
-                }}
-                disabled={customCount === 0}
-              >
-                <RotateCcw className="h-3.5 w-3.5" />
-                {t('projects.settings.hotkeys.resetAll')}
-              </Button>
+              <AlertDialog open={isResetAllDialogOpen} onOpenChange={setIsResetAllDialogOpen}>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="w-full gap-1.5"
+                  onClick={() => setIsResetAllDialogOpen(true)}
+                  disabled={customCount === 0}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  {t('projects.settings.hotkeys.resetAll')}
+                </Button>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      {t('projects.settings.hotkeys.resetAllConfirmTitle')}
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t('projects.settings.hotkeys.resetAllConfirmDescription')}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      onClick={confirmResetAllHotkeys}
+                    >
+                      {t('projects.settings.hotkeys.resetAllConfirmAction')}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </div>
         </div>

--- a/src/i18n/locales/partials/projects.json
+++ b/src/i18n/locales/partials/projects.json
@@ -481,7 +481,9 @@
           "resetAllConfirmTitle": "Reset all shortcuts?",
           "resetAllConfirmDescription": "This will remove all custom shortcut overrides and restore the default keybindings. This cannot be undone.",
           "resetAllConfirmAction": "Reset all",
-          "resetAllToast": "Shortcuts reset to defaults"
+          "resetAllToast": "Shortcuts reset to defaults",
+          "searchResultCount_one": "{{count}} result",
+          "searchResultCount_other": "{{count}} results"
         }
       }
     },
@@ -978,7 +980,9 @@
           "resetAllConfirmTitle": "¿Restablecer todos los atajos?",
           "resetAllConfirmDescription": "Esto eliminará todas las anulaciones de atajos personalizadas y restaurará los atajos predeterminados. Esta acción no se puede deshacer.",
           "resetAllConfirmAction": "Restablecer todo",
-          "resetAllToast": "Atajos restablecidos a los valores predeterminados"
+          "resetAllToast": "Atajos restablecidos a los valores predeterminados",
+          "searchResultCount_one": "{{count}} resultado",
+          "searchResultCount_other": "{{count}} resultados"
         }
       }
     },
@@ -1475,7 +1479,9 @@
           "resetAllConfirmTitle": "Réinitialiser tous les raccourcis ?",
           "resetAllConfirmDescription": "Cela supprimera toutes les personnalisations de raccourcis et restaurera les raccourcis par défaut. Cette action est irréversible.",
           "resetAllConfirmAction": "Tout réinitialiser",
-          "resetAllToast": "Raccourcis réinitialisés aux valeurs par défaut"
+          "resetAllToast": "Raccourcis réinitialisés aux valeurs par défaut",
+          "searchResultCount_one": "{{count}} résultat",
+          "searchResultCount_other": "{{count}} résultats"
         }
       }
     },
@@ -1972,7 +1978,9 @@
           "resetAllConfirmTitle": "Alle Tastenkürzel zurücksetzen?",
           "resetAllConfirmDescription": "Dadurch werden alle benutzerdefinierten Tastenkürzel-Überschreibungen entfernt und die Standardtastenkürzel wiederhergestellt. Dies kann nicht rückgängig gemacht werden.",
           "resetAllConfirmAction": "Alle zurücksetzen",
-          "resetAllToast": "Tastenkürzel auf Standardwerte zurückgesetzt"
+          "resetAllToast": "Tastenkürzel auf Standardwerte zurückgesetzt",
+          "searchResultCount_one": "{{count}} Ergebnis",
+          "searchResultCount_other": "{{count}} Ergebnisse"
         }
       }
     },
@@ -2469,7 +2477,9 @@
           "resetAllConfirmTitle": "Redefinir todos os atalhos?",
           "resetAllConfirmDescription": "Isso removerá todas as substituições de atalhos personalizadas e restaurará os atalhos padrão. Esta ação não pode ser desfeita.",
           "resetAllConfirmAction": "Redefinir tudo",
-          "resetAllToast": "Atalhos redefinidos para os padrões"
+          "resetAllToast": "Atalhos redefinidos para os padrões",
+          "searchResultCount_one": "{{count}} resultado",
+          "searchResultCount_other": "{{count}} resultados"
         }
       }
     },
@@ -2966,7 +2976,9 @@
           "resetAllConfirmTitle": "すべてのショートカットをリセットしますか？",
           "resetAllConfirmDescription": "すべてのカスタムショートカット設定を削除し、既定のキー割り当てに戻します。この操作は元に戻せません。",
           "resetAllConfirmAction": "すべてリセット",
-          "resetAllToast": "ショートカットを既定値にリセットしました"
+          "resetAllToast": "ショートカットを既定値にリセットしました",
+          "searchResultCount_one": "{{count}} 件の結果",
+          "searchResultCount_other": "{{count}} 件の結果"
         }
       }
     },
@@ -3463,7 +3475,9 @@
           "resetAllConfirmTitle": "모든 단축키를 초기화할까요?",
           "resetAllConfirmDescription": "모든 사용자 지정 단축키 재정의를 제거하고 기본 키 바인딩으로 복원합니다. 이 작업은 되돌릴 수 없습니다.",
           "resetAllConfirmAction": "모두 초기화",
-          "resetAllToast": "단축키가 기본값으로 초기화되었습니다"
+          "resetAllToast": "단축키가 기본값으로 초기화되었습니다",
+          "searchResultCount_one": "결과 {{count}}개",
+          "searchResultCount_other": "결과 {{count}}개"
         }
       }
     },
@@ -3960,7 +3974,9 @@
           "resetAllConfirmTitle": "重置所有快捷键？",
           "resetAllConfirmDescription": "这会移除所有自定义快捷键覆盖并恢复默认按键绑定。此操作无法撤销。",
           "resetAllConfirmAction": "全部重置",
-          "resetAllToast": "快捷键已重置为默认值"
+          "resetAllToast": "快捷键已重置为默认值",
+          "searchResultCount_one": "{{count}} 个结果",
+          "searchResultCount_other": "{{count}} 个结果"
         }
       }
     },
@@ -4457,7 +4473,9 @@
           "resetAllConfirmTitle": "Tüm kısayollar sıfırlansın mı?",
           "resetAllConfirmDescription": "Bu işlem tüm özel kısayol geçersiz kılmalarını kaldırır ve varsayılan kısayolları geri yükler. Bu geri alınamaz.",
           "resetAllConfirmAction": "Tümünü sıfırla",
-          "resetAllToast": "Kısayollar varsayılanlara sıfırlandı"
+          "resetAllToast": "Kısayollar varsayılanlara sıfırlandı",
+          "searchResultCount_one": "{{count}} sonuç",
+          "searchResultCount_other": "{{count}} sonuç"
         }
       }
     },

--- a/src/i18n/locales/partials/projects.json
+++ b/src/i18n/locales/partials/projects.json
@@ -474,7 +474,10 @@
             "saveProject": "Save project",
             "exportVideo": "Export video",
             "openSceneBrowser": "Open Scene Browser (search AI captions)"
-          }
+          },
+          "searchPlaceholder": "Search commands or shortcuts",
+          "searchResults": "Shortcut search results",
+          "noSearchResults": "No matching commands"
         }
       }
     },
@@ -964,7 +967,10 @@
             "saveProject": "Guardar proyecto",
             "exportVideo": "Exportar video",
             "openSceneBrowser": "Abrir el explorador de escenas (buscar subtítulos de IA)"
-          }
+          },
+          "searchPlaceholder": "Buscar comandos o atajos",
+          "searchResults": "Resultados de búsqueda de atajos",
+          "noSearchResults": "No hay comandos coincidentes"
         }
       }
     },
@@ -1454,7 +1460,10 @@
             "saveProject": "Enregistrer le projet",
             "exportVideo": "Exporter la vidéo",
             "openSceneBrowser": "Ouvrir l'explorateur de scènes (rechercher les sous-titres IA)"
-          }
+          },
+          "searchPlaceholder": "Rechercher des commandes ou raccourcis",
+          "searchResults": "Résultats de recherche de raccourcis",
+          "noSearchResults": "Aucune commande correspondante"
         }
       }
     },
@@ -1944,7 +1953,10 @@
             "saveProject": "Projekt speichern",
             "exportVideo": "Video exportieren",
             "openSceneBrowser": "Szenenbrowser öffnen (KI-Untertitel durchsuchen)"
-          }
+          },
+          "searchPlaceholder": "Befehle oder Tastenkürzel suchen",
+          "searchResults": "Suchergebnisse für Tastenkürzel",
+          "noSearchResults": "Keine passenden Befehle"
         }
       }
     },
@@ -2434,7 +2446,10 @@
             "saveProject": "Salvar projeto",
             "exportVideo": "Exportar vídeo",
             "openSceneBrowser": "Abrir o navegador de cenas (pesquisar legendas de IA)"
-          }
+          },
+          "searchPlaceholder": "Pesquisar comandos ou atalhos",
+          "searchResults": "Resultados da pesquisa de atalhos",
+          "noSearchResults": "Nenhum comando correspondente"
         }
       }
     },
@@ -2924,7 +2939,10 @@
             "saveProject": "プロジェクトを保存",
             "exportVideo": "動画をエクスポート",
             "openSceneBrowser": "シーンブラウザを開く（AIキャプションを検索）"
-          }
+          },
+          "searchPlaceholder": "コマンドまたはショートカットを検索",
+          "searchResults": "ショートカット検索結果",
+          "noSearchResults": "一致するコマンドがありません"
         }
       }
     },
@@ -3414,7 +3432,10 @@
             "saveProject": "프로젝트 저장",
             "exportVideo": "동영상 내보내기",
             "openSceneBrowser": "장면 브라우저 열기 (AI 자막 검색)"
-          }
+          },
+          "searchPlaceholder": "명령 또는 단축키 검색",
+          "searchResults": "단축키 검색 결과",
+          "noSearchResults": "일치하는 명령이 없습니다"
         }
       }
     },
@@ -3904,7 +3925,10 @@
             "saveProject": "保存项目",
             "exportVideo": "导出视频",
             "openSceneBrowser": "打开场景浏览器（搜索 AI 字幕）"
-          }
+          },
+          "searchPlaceholder": "搜索命令或快捷键",
+          "searchResults": "快捷键搜索结果",
+          "noSearchResults": "没有匹配的命令"
         }
       }
     },
@@ -4394,7 +4418,10 @@
             "saveProject": "Projeyi kaydet",
             "exportVideo": "Videoyu dışa aktar",
             "openSceneBrowser": "Sahne Tarayıcısını aç (YZ altyazılarında ara)"
-          }
+          },
+          "searchPlaceholder": "Komutları veya kısayolları ara",
+          "searchResults": "Kısayol arama sonuçları",
+          "noSearchResults": "Eşleşen komut yok"
         }
       }
     },

--- a/src/i18n/locales/partials/projects.json
+++ b/src/i18n/locales/partials/projects.json
@@ -477,7 +477,11 @@
           },
           "searchPlaceholder": "Search commands or shortcuts",
           "searchResults": "Shortcut search results",
-          "noSearchResults": "No matching commands"
+          "noSearchResults": "No matching commands",
+          "resetAllConfirmTitle": "Reset all shortcuts?",
+          "resetAllConfirmDescription": "This will remove all custom shortcut overrides and restore the default keybindings. This cannot be undone.",
+          "resetAllConfirmAction": "Reset all",
+          "resetAllToast": "Shortcuts reset to defaults"
         }
       }
     },
@@ -970,7 +974,11 @@
           },
           "searchPlaceholder": "Buscar comandos o atajos",
           "searchResults": "Resultados de búsqueda de atajos",
-          "noSearchResults": "No hay comandos coincidentes"
+          "noSearchResults": "No hay comandos coincidentes",
+          "resetAllConfirmTitle": "¿Restablecer todos los atajos?",
+          "resetAllConfirmDescription": "Esto eliminará todas las anulaciones de atajos personalizadas y restaurará los atajos predeterminados. Esta acción no se puede deshacer.",
+          "resetAllConfirmAction": "Restablecer todo",
+          "resetAllToast": "Atajos restablecidos a los valores predeterminados"
         }
       }
     },
@@ -1463,7 +1471,11 @@
           },
           "searchPlaceholder": "Rechercher des commandes ou raccourcis",
           "searchResults": "Résultats de recherche de raccourcis",
-          "noSearchResults": "Aucune commande correspondante"
+          "noSearchResults": "Aucune commande correspondante",
+          "resetAllConfirmTitle": "Réinitialiser tous les raccourcis ?",
+          "resetAllConfirmDescription": "Cela supprimera toutes les personnalisations de raccourcis et restaurera les raccourcis par défaut. Cette action est irréversible.",
+          "resetAllConfirmAction": "Tout réinitialiser",
+          "resetAllToast": "Raccourcis réinitialisés aux valeurs par défaut"
         }
       }
     },
@@ -1956,7 +1968,11 @@
           },
           "searchPlaceholder": "Befehle oder Tastenkürzel suchen",
           "searchResults": "Suchergebnisse für Tastenkürzel",
-          "noSearchResults": "Keine passenden Befehle"
+          "noSearchResults": "Keine passenden Befehle",
+          "resetAllConfirmTitle": "Alle Tastenkürzel zurücksetzen?",
+          "resetAllConfirmDescription": "Dadurch werden alle benutzerdefinierten Tastenkürzel-Überschreibungen entfernt und die Standardtastenkürzel wiederhergestellt. Dies kann nicht rückgängig gemacht werden.",
+          "resetAllConfirmAction": "Alle zurücksetzen",
+          "resetAllToast": "Tastenkürzel auf Standardwerte zurückgesetzt"
         }
       }
     },
@@ -2449,7 +2465,11 @@
           },
           "searchPlaceholder": "Pesquisar comandos ou atalhos",
           "searchResults": "Resultados da pesquisa de atalhos",
-          "noSearchResults": "Nenhum comando correspondente"
+          "noSearchResults": "Nenhum comando correspondente",
+          "resetAllConfirmTitle": "Redefinir todos os atalhos?",
+          "resetAllConfirmDescription": "Isso removerá todas as substituições de atalhos personalizadas e restaurará os atalhos padrão. Esta ação não pode ser desfeita.",
+          "resetAllConfirmAction": "Redefinir tudo",
+          "resetAllToast": "Atalhos redefinidos para os padrões"
         }
       }
     },
@@ -2942,7 +2962,11 @@
           },
           "searchPlaceholder": "コマンドまたはショートカットを検索",
           "searchResults": "ショートカット検索結果",
-          "noSearchResults": "一致するコマンドがありません"
+          "noSearchResults": "一致するコマンドがありません",
+          "resetAllConfirmTitle": "すべてのショートカットをリセットしますか？",
+          "resetAllConfirmDescription": "すべてのカスタムショートカット設定を削除し、既定のキー割り当てに戻します。この操作は元に戻せません。",
+          "resetAllConfirmAction": "すべてリセット",
+          "resetAllToast": "ショートカットを既定値にリセットしました"
         }
       }
     },
@@ -3435,7 +3459,11 @@
           },
           "searchPlaceholder": "명령 또는 단축키 검색",
           "searchResults": "단축키 검색 결과",
-          "noSearchResults": "일치하는 명령이 없습니다"
+          "noSearchResults": "일치하는 명령이 없습니다",
+          "resetAllConfirmTitle": "모든 단축키를 초기화할까요?",
+          "resetAllConfirmDescription": "모든 사용자 지정 단축키 재정의를 제거하고 기본 키 바인딩으로 복원합니다. 이 작업은 되돌릴 수 없습니다.",
+          "resetAllConfirmAction": "모두 초기화",
+          "resetAllToast": "단축키가 기본값으로 초기화되었습니다"
         }
       }
     },
@@ -3928,7 +3956,11 @@
           },
           "searchPlaceholder": "搜索命令或快捷键",
           "searchResults": "快捷键搜索结果",
-          "noSearchResults": "没有匹配的命令"
+          "noSearchResults": "没有匹配的命令",
+          "resetAllConfirmTitle": "重置所有快捷键？",
+          "resetAllConfirmDescription": "这会移除所有自定义快捷键覆盖并恢复默认按键绑定。此操作无法撤销。",
+          "resetAllConfirmAction": "全部重置",
+          "resetAllToast": "快捷键已重置为默认值"
         }
       }
     },
@@ -4421,7 +4453,11 @@
           },
           "searchPlaceholder": "Komutları veya kısayolları ara",
           "searchResults": "Kısayol arama sonuçları",
-          "noSearchResults": "Eşleşen komut yok"
+          "noSearchResults": "Eşleşen komut yok",
+          "resetAllConfirmTitle": "Tüm kısayollar sıfırlansın mı?",
+          "resetAllConfirmDescription": "Bu işlem tüm özel kısayol geçersiz kılmalarını kaldırır ve varsayılan kısayolları geri yükler. Bu geri alınamaz.",
+          "resetAllConfirmAction": "Tümünü sıfırla",
+          "resetAllToast": "Kısayollar varsayılanlara sıfırlandı"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add shortcut search with explicit unassigned display
- add reset-all confirmation for destructive shortcut reset flow
- add per-conflict overwrite actions, direct unbind polish, search result counts, and explicit-unassigned import/export coverage

## Verification
- npm run test:run -- src/features/settings/components/hotkey-editor-reset-dialog.test.tsx src/features/settings/components/hotkey-editor-search.test.ts src/features/settings/components/hotkey-editor.test.ts src/features/settings/stores/settings-store.test.ts src/config/hotkeys.test.ts
- npm run lint
- npx vp fmt --check src/features/settings/components/hotkey-editor.tsx src/features/settings/components/hotkey-editor-reset-dialog.test.tsx src/config/hotkeys.test.ts src/i18n/locales/partials/projects.json
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable hotkey command sidebar with filtering and result count display
  * Added confirmation dialog before resetting all hotkeys to defaults

* **Improvements**
  * Enhanced hotkey binding display labels to clearly indicate unassigned states
  * Improved hotkey conflict resolution UI with per-conflict actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->