### PR TITLE
refactor: apply composition patterns across feature components

### DIFF
--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-graph-pane.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-graph-pane.tsx
@@ -54,7 +54,7 @@ interface DopesheetGraphPaneProps {
   onNavigateToKeyframe?: (frame: number) => void
   transitionBlockedRanges?: BlockedFrameRange[]
   snapEnabled: boolean
-  showAllGraphHandles: boolean
+  graphHandleVisibility: 'selected' | 'all'
   graphRulerUnit: 'frames' | 'seconds'
   autoZoomGraphHeight: boolean
   graphVerticalZoomValue: number
@@ -99,7 +99,7 @@ export function DopesheetGraphPane({
   onNavigateToKeyframe,
   transitionBlockedRanges,
   snapEnabled,
-  showAllGraphHandles,
+  graphHandleVisibility,
   graphRulerUnit,
   autoZoomGraphHeight,
   graphVerticalZoomValue,
@@ -155,7 +155,7 @@ export function DopesheetGraphPane({
             onNavigateToKeyframe={onNavigateToKeyframe}
             transitionBlockedRanges={transitionBlockedRanges}
             snapEnabled={snapEnabled}
-            showAllHandles={showAllGraphHandles}
+            handleVisibility={graphHandleVisibility}
             rulerUnit={graphRulerUnit}
             autoZoomGraphHeight={autoZoomGraphHeight}
             externalValueZoomLevel={graphVerticalZoomValue}

--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-parameter-menu.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-parameter-menu.tsx
@@ -15,7 +15,7 @@ import type { PropertyAccordionGroup } from './property-groups'
 interface DopesheetParameterMenuProps {
   disabled: boolean
   hasAvailableProperties: boolean
-  showKeyframedOnly: boolean
+  parameterFilter: 'all' | 'keyframed'
   onToggleKeyframedOnly: () => void
   allPropertyGroups: PropertyAccordionGroup[]
   visibleGroups: Record<string, boolean>
@@ -28,7 +28,7 @@ interface DopesheetParameterMenuProps {
 export function DopesheetParameterMenu({
   disabled,
   hasAvailableProperties,
-  showKeyframedOnly,
+  parameterFilter,
   onToggleKeyframedOnly,
   allPropertyGroups,
   visibleGroups,
@@ -59,7 +59,7 @@ export function DopesheetParameterMenu({
             onToggleKeyframedOnly()
           }}
         >
-          <Check className={cn('h-3.5 w-3.5', !showKeyframedOnly && 'opacity-0')} />
+          <Check className={cn('h-3.5 w-3.5', parameterFilter !== 'keyframed' && 'opacity-0')} />
           {t('timeline.keyframeEditor.displayKeyframedParameters')}
         </DropdownMenuItem>
         {allPropertyGroups.length > 0 && <DropdownMenuSeparator />}

--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-view-options-menu.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-view-options-menu.tsx
@@ -15,8 +15,8 @@ interface DopesheetViewOptionsMenuProps {
   visualizationMode: 'dopesheet' | 'graph'
   graphRulerUnit: 'frames' | 'seconds'
   onChangeRulerUnit: (unit: 'frames' | 'seconds') => void
-  showAllGraphHandles: boolean
-  onToggleShowAllGraphHandles: () => void
+  graphHandleVisibility: 'selected' | 'all'
+  onToggleGraphHandleVisibility: () => void
   autoZoomGraphHeight: boolean
   onToggleAutoZoomGraphHeight: () => void
 }
@@ -26,8 +26,8 @@ export function DopesheetViewOptionsMenu({
   visualizationMode,
   graphRulerUnit,
   onChangeRulerUnit,
-  showAllGraphHandles,
-  onToggleShowAllGraphHandles,
+  graphHandleVisibility,
+  onToggleGraphHandleVisibility,
   autoZoomGraphHeight,
   onToggleAutoZoomGraphHeight,
 }: DopesheetViewOptionsMenuProps) {
@@ -76,10 +76,12 @@ export function DopesheetViewOptionsMenu({
             <DropdownMenuItem
               onSelect={(event) => {
                 event.preventDefault()
-                onToggleShowAllGraphHandles()
+                onToggleGraphHandleVisibility()
               }}
             >
-              <Check className={cn('h-3.5 w-3.5', !showAllGraphHandles && 'opacity-0')} />
+              <Check
+                className={cn('h-3.5 w-3.5', graphHandleVisibility !== 'all' && 'opacity-0')}
+              />
               {t('timeline.keyframeEditor.showAllHandles')}
             </DropdownMenuItem>
             <DropdownMenuItem

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -2728,7 +2728,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
             <DopesheetParameterMenu
               disabled={disabled}
               hasAvailableProperties={availableProperties.length > 0}
-              showKeyframedOnly={showKeyframedOnly}
+              parameterFilter={showKeyframedOnly ? 'keyframed' : 'all'}
               onToggleKeyframedOnly={() => setShowKeyframedOnly((prev) => !prev)}
               allPropertyGroups={allPropertyGroups}
               visibleGroups={visibleGroups}
@@ -2814,8 +2814,8 @@ export const DopesheetEditor = memo(function DopesheetEditor({
             visualizationMode={visualizationMode}
             graphRulerUnit={graphRulerUnit}
             onChangeRulerUnit={setGraphRulerUnit}
-            showAllGraphHandles={showAllGraphHandles}
-            onToggleShowAllGraphHandles={() => setShowAllGraphHandles((prev) => !prev)}
+            graphHandleVisibility={showAllGraphHandles ? 'all' : 'selected'}
+            onToggleGraphHandleVisibility={() => setShowAllGraphHandles((prev) => !prev)}
             autoZoomGraphHeight={autoZoomGraphHeight}
             onToggleAutoZoomGraphHeight={() => setAutoZoomGraphHeight((prev) => !prev)}
           />
@@ -2887,7 +2887,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
               onNavigateToKeyframe={onNavigateToKeyframe}
               transitionBlockedRanges={transitionBlockedRanges}
               snapEnabled={snapEnabled}
-              showAllGraphHandles={showAllGraphHandles}
+              graphHandleVisibility={showAllGraphHandles ? 'all' : 'selected'}
               graphRulerUnit={graphRulerUnit}
               autoZoomGraphHeight={autoZoomGraphHeight}
               graphVerticalZoomValue={graphVerticalZoomValue}

--- a/src/features/keyframes/components/value-graph-editor/graph-curve.tsx
+++ b/src/features/keyframes/components/value-graph-editor/graph-curve.tsx
@@ -210,7 +210,7 @@ interface GraphPlayheadProps {
   /** Whether scrubbing is disabled */
   disabled?: boolean
   /** Whether to render the visible playhead line/marker */
-  showVisuals?: boolean
+  visuals?: 'visible' | 'hidden'
 }
 
 /**
@@ -227,7 +227,7 @@ export const GraphPlayhead = memo(function GraphPlayhead({
   onScrubStart,
   onScrubEnd,
   disabled = false,
-  showVisuals = true,
+  visuals = 'visible',
 }: GraphPlayheadProps) {
   const { startFrame, endFrame, width, height } = viewport
 
@@ -319,7 +319,7 @@ export const GraphPlayhead = memo(function GraphPlayhead({
           style={{ cursor: 'ew-resize' }}
         />
       )}
-      {showVisuals && (
+      {visuals === 'visible' && (
         <>
           <line
             x1={x}

--- a/src/features/keyframes/components/value-graph-editor/graph-grid.tsx
+++ b/src/features/keyframes/components/value-graph-editor/graph-grid.tsx
@@ -12,7 +12,7 @@ interface GraphGridProps {
   /** Padding inside the graph area */
   padding: { top: number; right: number; bottom: number; left: number }
   /** Show axis labels */
-  labelVisibility?: 'both' | 'y-only' | 'none'
+  labelVisibility?: 'both' | 'y-only'
   /** Show X-axis (time) labels — set false when an external ruler provides them */
   /** Major grid line interval for X (frames) */
   xMajorInterval?: number

--- a/src/features/keyframes/components/value-graph-editor/graph-grid.tsx
+++ b/src/features/keyframes/components/value-graph-editor/graph-grid.tsx
@@ -12,9 +12,8 @@ interface GraphGridProps {
   /** Padding inside the graph area */
   padding: { top: number; right: number; bottom: number; left: number }
   /** Show axis labels */
-  showLabels?: boolean
+  labelVisibility?: 'both' | 'y-only' | 'none'
   /** Show X-axis (time) labels — set false when an external ruler provides them */
-  showXLabels?: boolean
   /** Major grid line interval for X (frames) */
   xMajorInterval?: number
   /** Major grid line interval for Y (value) */
@@ -32,13 +31,14 @@ interface GraphGridProps {
 export const GraphGrid = memo(function GraphGrid({
   viewport,
   padding,
-  showLabels = true,
-  showXLabels = true,
+  labelVisibility = 'both',
   xMajorInterval: xMajorProp,
   yMajorInterval: yMajorProp,
   rulerUnit = 'frames',
   fps = 30,
 }: GraphGridProps) {
+  const showXLabels = labelVisibility === 'both'
+  const showYLabels = labelVisibility === 'both' || labelVisibility === 'y-only'
   const { width, height, startFrame, endFrame, minValue, maxValue } = viewport
 
   // Calculate usable area
@@ -180,8 +180,7 @@ export const GraphGrid = memo(function GraphGrid({
       )}
 
       {/* X axis labels (hidden when external ruler provides them) */}
-      {showLabels &&
-        showXLabels &&
+      {showXLabels &&
         xLines
           .filter((l) => l.isMajor)
           .map(({ x, frame }) => (
@@ -200,7 +199,7 @@ export const GraphGrid = memo(function GraphGrid({
           ))}
 
       {/* Y axis labels (values) — rendered inside the graph area */}
-      {showLabels &&
+      {showYLabels &&
         yLines
           .filter((l) => l.isMajor)
           .map(({ y, value }) => (

--- a/src/features/keyframes/components/value-graph-editor/graph-handles.tsx
+++ b/src/features/keyframes/components/value-graph-editor/graph-handles.tsx
@@ -22,8 +22,8 @@ interface GraphHandlesProps {
   draggingHandle?: { keyframeId: string; type: 'in' | 'out' } | null
   /** Preview bezier configs during drag (overrides keyframe data for lag-free rendering) */
   previewBezierConfigs?: Record<string, BezierControlPoints> | null
-  /** Whether handles for all visible segments should be shown */
-  showAllHandles?: boolean
+  /** Which bezier handles should be visible */
+  handleVisibility?: 'selected' | 'all'
   /** Whether the graph is disabled */
   disabled?: boolean
 }
@@ -37,9 +37,11 @@ export const GraphHandles = memo(function GraphHandles({
   onHandlePointerDown,
   draggingHandle,
   previewBezierConfigs,
-  showAllHandles = false,
+  handleVisibility = 'selected',
   disabled = false,
 }: GraphHandlesProps) {
+  const showAllHandles = handleVisibility === 'all'
+
   // Sort points by frame (toSorted for immutability)
   const sortedPoints = useMemo(
     () => points.toSorted((a, b) => a.keyframe.frame - b.keyframe.frame),

--- a/src/features/keyframes/components/value-graph-editor/index.test.tsx
+++ b/src/features/keyframes/components/value-graph-editor/index.test.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { ValueGraphEditor } from './index'
+import { EmbeddedValueGraphEditor, ValueGraphEditor } from './index'
 import { DEFAULT_GRAPH_PADDING } from './types'
 
 function SelectionHarness() {
@@ -10,7 +10,7 @@ function SelectionHarness() {
 
   return (
     <TooltipProvider>
-      <ValueGraphEditor
+      <EmbeddedValueGraphEditor
         itemId="item-1"
         keyframesByProperty={{
           opacity: [
@@ -24,7 +24,6 @@ function SelectionHarness() {
         width={480}
         height={260}
         totalFrames={60}
-        showToolbar={false}
       />
       <output data-testid="selection">{[...selection].join(',')}</output>
     </TooltipProvider>
@@ -36,7 +35,7 @@ function PointSelectionHarness() {
 
   return (
     <TooltipProvider>
-      <ValueGraphEditor
+      <EmbeddedValueGraphEditor
         itemId="item-1"
         keyframesByProperty={{
           opacity: [
@@ -50,7 +49,6 @@ function PointSelectionHarness() {
         width={480}
         height={260}
         totalFrames={60}
-        showToolbar={false}
       />
       <output data-testid="point-selection">{[...selection].join(',')}</output>
     </TooltipProvider>
@@ -137,7 +135,6 @@ describe('ValueGraphEditor clipping', () => {
           totalFrames={60}
           fps={30}
           rulerUnit="seconds"
-          showToolbar={false}
         />
       </TooltipProvider>,
     )
@@ -174,12 +171,11 @@ describe('ValueGraphEditor clipping', () => {
       width: 480,
       height: 260,
       totalFrames: 60,
-      showToolbar: false,
     }
 
     const { container, rerender } = render(
       <TooltipProvider>
-        <ValueGraphEditor {...props} />
+        <EmbeddedValueGraphEditor {...props} />
       </TooltipProvider>,
     )
 
@@ -187,7 +183,11 @@ describe('ValueGraphEditor clipping', () => {
 
     rerender(
       <TooltipProvider>
-        <ValueGraphEditor {...props} selectedKeyframeIds={new Set()} showAllHandles />
+        <EmbeddedValueGraphEditor
+          {...props}
+          selectedKeyframeIds={new Set()}
+          handleVisibility="all"
+        />
       </TooltipProvider>,
     )
 
@@ -198,7 +198,7 @@ describe('ValueGraphEditor clipping', () => {
     const onPropertyChange = vi.fn()
     const { container } = render(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             x: [{ id: 'kf-x', frame: 0, value: 100, easing: 'linear' }],
@@ -209,7 +209,6 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
           onPropertyChange={onPropertyChange}
         />
       </TooltipProvider>,
@@ -228,7 +227,7 @@ describe('ValueGraphEditor clipping', () => {
     const onPropertyChange = vi.fn()
     const { container } = render(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             x: [{ id: 'kf-x', frame: 0, value: 100, easing: 'linear' }],
@@ -239,7 +238,6 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
           onPropertyChange={onPropertyChange}
         />
       </TooltipProvider>,
@@ -253,7 +251,7 @@ describe('ValueGraphEditor clipping', () => {
   it('keeps visible curves rendered after the active curve is cleared', () => {
     const { container, rerender } = render(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             x: [{ id: 'kf-x', frame: 0, value: 100, easing: 'linear' }],
@@ -264,14 +262,13 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
         />
       </TooltipProvider>,
     )
 
     rerender(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             x: [{ id: 'kf-x', frame: 0, value: 100, easing: 'linear' }],
@@ -282,7 +279,6 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
         />
       </TooltipProvider>,
     )
@@ -293,7 +289,7 @@ describe('ValueGraphEditor clipping', () => {
   it('renders a single visible handle for one-handle easing presets', () => {
     const { container } = render(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             opacity: [
@@ -306,7 +302,6 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
         />
       </TooltipProvider>,
     )
@@ -317,7 +312,7 @@ describe('ValueGraphEditor clipping', () => {
   it('shows handles only for the selected keyframe that owns them', () => {
     const { container } = render(
       <TooltipProvider>
-        <ValueGraphEditor
+        <EmbeddedValueGraphEditor
           itemId="item-1"
           keyframesByProperty={{
             opacity: [
@@ -339,7 +334,6 @@ describe('ValueGraphEditor clipping', () => {
           width={480}
           height={260}
           totalFrames={60}
-          showToolbar={false}
         />
       </TooltipProvider>,
     )

--- a/src/features/keyframes/components/value-graph-editor/index.tsx
+++ b/src/features/keyframes/components/value-graph-editor/index.tsx
@@ -47,7 +47,7 @@ import { getCombinedGraphValueRange } from './value-range-utils'
 
 const OVERLAY_COLORS = ['#6366f1', '#22d3ee', '#a3e635', '#f472b6', '#fb923c', '#a78bfa', '#34d399']
 
-interface ValueGraphEditorProps {
+interface ValueGraphEditorSharedProps {
   /** Shared time viewport when split mode needs synchronized frame zoom/pan */
   frameViewport?: { startFrame: number; endFrame: number }
   /** Callback when the shared time viewport changes */
@@ -106,50 +106,40 @@ interface ValueGraphEditorProps {
   transitionBlockedRanges?: BlockedFrameRange[]
   /** Controls whether snapping is enabled */
   snapEnabled?: boolean
-  /** Whether to render the internal toolbar */
-  showToolbar?: boolean
-  /** Whether to render the drag hint footer */
-  showKeyboardHints?: boolean
-  /** Whether to remove the default graph border/radius */
-  borderless?: boolean
-  /** Whether handles for all visible segments should be shown */
-  showAllHandles?: boolean
+  /** Which bezier handles should be visible */
+  handleVisibility?: 'selected' | 'all'
   /** How to render the time ruler */
   rulerUnit?: 'frames' | 'seconds'
   /** Automatically fit the Y range to the active curve values */
   autoZoomGraphHeight?: boolean
   /** Optional externally controlled Y zoom level (0-100) */
   externalValueZoomLevel?: number
-  /** Hide X-axis labels when an external ruler provides them */
-  hideXLabels?: boolean
   /** Whether the editor is disabled */
   disabled?: boolean
   /** Additional class name */
   className?: string
 }
 
-type EmbeddedValueGraphEditorProps = Omit<
-  ValueGraphEditorProps,
-  'showToolbar' | 'showKeyboardHints' | 'borderless' | 'hideXLabels'
->
+interface ValueGraphEditorBaseProps extends ValueGraphEditorSharedProps {
+  chrome: 'full' | 'embedded'
+}
+
+type ValueGraphEditorProps = ValueGraphEditorSharedProps
+type EmbeddedValueGraphEditorProps = ValueGraphEditorSharedProps
 
 export function EmbeddedValueGraphEditor(props: EmbeddedValueGraphEditorProps) {
-  return (
-    <ValueGraphEditor
-      {...props}
-      showToolbar={false}
-      showKeyboardHints={false}
-      borderless
-      hideXLabels
-    />
-  )
+  return <ValueGraphEditorBase {...props} chrome="embedded" />
 }
 
 /**
  * Full-featured value graph editor for keyframe animation.
  * Shows keyframes as draggable points with interpolation curves.
  */
-export const ValueGraphEditor = memo(function ValueGraphEditor({
+export const ValueGraphEditor = memo(function ValueGraphEditor(props: ValueGraphEditorProps) {
+  return <ValueGraphEditorBase {...props} chrome="full" />
+})
+
+const ValueGraphEditorBase = memo(function ValueGraphEditorBase({
   frameViewport,
   onFrameViewportChange,
   itemId,
@@ -178,18 +168,20 @@ export const ValueGraphEditor = memo(function ValueGraphEditor({
   onNavigateToKeyframe,
   transitionBlockedRanges = [],
   snapEnabled: controlledSnapEnabled,
-  showToolbar = true,
-  showKeyboardHints = true,
-  borderless = false,
-  showAllHandles = false,
+  handleVisibility = 'selected',
   rulerUnit = 'frames',
   autoZoomGraphHeight = false,
   externalValueZoomLevel,
-  hideXLabels = false,
   disabled = false,
   className,
-}: ValueGraphEditorProps) {
+  chrome,
+}: ValueGraphEditorBaseProps) {
   const { t } = useTranslation()
+  const isEmbedded = chrome === 'embedded'
+  const showToolbar = !isEmbedded
+  const showKeyboardHints = !isEmbedded
+  const borderless = isEmbedded
+  const hideXLabels = isEmbedded
   const padding = useMemo(
     () => (hideXLabels ? { ...DEFAULT_GRAPH_PADDING, bottom: 8 } : DEFAULT_GRAPH_PADDING),
     [hideXLabels],
@@ -1191,7 +1183,7 @@ export const ValueGraphEditor = memo(function ValueGraphEditor({
           padding={padding}
           rulerUnit={rulerUnit}
           fps={fps}
-          showXLabels={!hideXLabels}
+          labelVisibility={hideXLabels ? 'y-only' : 'both'}
         />
 
         {/* Dedicated hit target for empty graph-space interactions */}
@@ -1246,7 +1238,7 @@ export const ValueGraphEditor = memo(function ValueGraphEditor({
             onScrubStart={handlePlayheadScrubStart}
             onScrubEnd={handlePlayheadScrubEnd}
             disabled={disabled}
-            showVisuals={false}
+            visuals="hidden"
           />
 
           {/* Bezier handles (for selected keyframes with cubic-bezier easing) */}
@@ -1256,7 +1248,7 @@ export const ValueGraphEditor = memo(function ValueGraphEditor({
             onHandlePointerDown={handleBezierPointerDown}
             draggingHandle={draggingHandle}
             previewBezierConfigs={previewBezierConfigs}
-            showAllHandles={showAllHandles}
+            handleVisibility={handleVisibility}
             disabled={disabled}
           />
 

--- a/src/features/media-library/components/compositions-section.tsx
+++ b/src/features/media-library/components/compositions-section.tsx
@@ -308,20 +308,20 @@ interface CompositionCardProps {
 }
 
 interface CompositionCardInternalProps extends CompositionCardProps {
-  viewMode: 'grid' | 'list'
+  layout: 'grid' | 'list'
 }
 
 const GridCompositionCard = memo(function GridCompositionCard(props: CompositionCardProps) {
-  return <CompositionCardInternal {...props} viewMode="grid" />
+  return <CompositionCardInternal {...props} layout="grid" />
 })
 
 const ListCompositionCard = memo(function ListCompositionCard(props: CompositionCardProps) {
-  return <CompositionCardInternal {...props} viewMode="list" />
+  return <CompositionCardInternal {...props} layout="list" />
 })
 
 const CompositionCardInternal = memo(function CompositionCardInternal({
   composition,
-  viewMode,
+  layout,
   selected,
   isTranscriptionDialogOpen,
   dragDisabled,
@@ -473,7 +473,7 @@ const CompositionCardInternal = memo(function CompositionCardInternal({
       ? `${durationSecs.toFixed(1)}s`
       : `${Math.floor(durationSecs / 60)}:${String(Math.floor(durationSecs % 60)).padStart(2, '0')}`
 
-  if (viewMode === 'grid') {
+  if (layout === 'grid') {
     return (
       <ContextMenu>
         <ContextMenuTrigger asChild>

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -74,7 +74,7 @@ interface MediaCardProps {
 }
 
 interface MediaCardInternalProps extends MediaCardProps {
-  viewMode: 'grid' | 'list'
+  layout: 'grid' | 'list'
 }
 
 interface MediaCardActionMenuProps {
@@ -455,11 +455,11 @@ function DeleteMediaAction({ t, onDelete }: DeleteMediaActionProps) {
 }
 
 export const GridMediaCard = memo(function GridMediaCard(props: MediaCardProps) {
-  return <MediaCardInternal {...props} viewMode="grid" />
+  return <MediaCardInternal {...props} layout="grid" />
 })
 
 export const ListMediaCard = memo(function ListMediaCard(props: MediaCardProps) {
-  return <MediaCardInternal {...props} viewMode="list" />
+  return <MediaCardInternal {...props} layout="list" />
 })
 
 const MediaCardInternal = memo(function MediaCardInternal({
@@ -470,7 +470,7 @@ const MediaCardInternal = memo(function MediaCardInternal({
   onDoubleClick,
   onDelete,
   onRelink,
-  viewMode,
+  layout,
 }: MediaCardInternalProps) {
   const { t } = useTranslation()
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
@@ -1351,7 +1351,7 @@ const MediaCardInternal = memo(function MediaCardInternal({
   }
 
   // List view
-  if (viewMode === 'list') {
+  if (layout === 'list') {
     return (
       <>
         {transcribeDialog}

--- a/src/features/media-library/components/media-grid.tsx
+++ b/src/features/media-library/components/media-grid.tsx
@@ -32,19 +32,30 @@ import {
 
 interface MediaGridProps {
   onMediaSelect?: (mediaId: string) => void
-  viewMode?: 'grid' | 'list'
   /** Grid item size (1 = largest, 5 = smallest) */
   itemSize?: number
   /** When provided, renders these items instead of pulling from the store */
   items?: MediaMetadata[]
 }
 
-export const MediaGrid = memo(function MediaGrid({
+interface MediaGridBaseProps extends MediaGridProps {
+  layout: 'grid' | 'list'
+}
+
+export const GridMediaGrid = memo(function GridMediaGrid(props: MediaGridProps) {
+  return <MediaGridBase {...props} layout="grid" />
+})
+
+export const ListMediaGrid = memo(function ListMediaGrid(props: MediaGridProps) {
+  return <MediaGridBase {...props} layout="list" />
+})
+
+const MediaGridBase = memo(function MediaGridBase({
   onMediaSelect,
-  viewMode = 'grid',
+  layout,
   itemSize = 3,
   items,
-}: MediaGridProps) {
+}: MediaGridBaseProps) {
   const { t } = useTranslation()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [mediaIdsToDelete, setMediaIdsToDelete] = useState<string[]>([])
@@ -264,12 +275,12 @@ export const MediaGrid = memo(function MediaGrid({
       ) : (
         <div
           className={
-            viewMode === 'grid'
+            layout === 'grid'
               ? `grid ${GRID_GAP_BY_SIZE[itemSize] ?? GRID_GAP_BY_SIZE[3]}`
               : 'space-y-1'
           }
           style={
-            viewMode === 'grid'
+            layout === 'grid'
               ? {
                   gridTemplateColumns: `repeat(auto-fill, minmax(min(${GRID_MIN_SIZE_PX[itemSize] ?? GRID_MIN_SIZE_PX[3]}px, 100%), 1fr))`,
                 }
@@ -278,7 +289,7 @@ export const MediaGrid = memo(function MediaGrid({
         >
           {filteredItems.map((media) => {
             const handlers = cardHandlersById.get(media.id)
-            const Card = viewMode === 'grid' ? GridMediaCard : ListMediaCard
+            const Card = layout === 'grid' ? GridMediaCard : ListMediaCard
 
             return (
               <div key={media.id} data-media-id={media.id}>

--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -77,7 +77,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { MarqueeOverlay } from '@/shared/marquee/marquee-overlay'
 import { cn } from '@/shared/ui/cn'
-import { MediaGrid } from './media-grid'
+import { GridMediaGrid, ListMediaGrid } from './media-grid'
 import { CompositionsSection } from './compositions-section'
 import { BackgroundTaskProgress } from './background-task-progress'
 import { MissingMediaDialog } from './missing-media-dialog'
@@ -165,11 +165,22 @@ interface MediaTypeGroupProps {
   isOpen: boolean
   onToggle: (key: string, open: boolean) => void
   onMediaSelect?: (mediaId: string) => void
-  viewMode: 'grid' | 'list'
   itemSize: number
 }
 
-const MediaTypeGroup = memo(function MediaTypeGroup({
+interface MediaTypeGroupBaseProps extends MediaTypeGroupProps {
+  Grid: typeof GridMediaGrid | typeof ListMediaGrid
+}
+
+const GridMediaTypeGroup = memo(function GridMediaTypeGroup(props: MediaTypeGroupProps) {
+  return <MediaTypeGroupBase {...props} Grid={GridMediaGrid} />
+})
+
+const ListMediaTypeGroup = memo(function ListMediaTypeGroup(props: MediaTypeGroupProps) {
+  return <MediaTypeGroupBase {...props} Grid={ListMediaGrid} />
+})
+
+const MediaTypeGroupBase = memo(function MediaTypeGroupBase({
   groupKey,
   label,
   icon,
@@ -177,9 +188,9 @@ const MediaTypeGroup = memo(function MediaTypeGroup({
   isOpen,
   onToggle,
   onMediaSelect,
-  viewMode,
   itemSize,
-}: MediaTypeGroupProps) {
+  Grid,
+}: MediaTypeGroupBaseProps) {
   const Icon = GROUP_ICONS[icon]
   return (
     <Collapsible open={isOpen} onOpenChange={(open) => onToggle(groupKey, open)}>
@@ -197,12 +208,7 @@ const MediaTypeGroup = memo(function MediaTypeGroup({
         <span className="text-[10px] tabular-nums text-muted-foreground/60">{items.length}</span>
       </CollapsibleTrigger>
       <CollapsibleContent className="pt-1 pb-2">
-        <MediaGrid
-          items={items}
-          onMediaSelect={onMediaSelect}
-          viewMode={viewMode}
-          itemSize={itemSize}
-        />
+        <Grid items={items} onMediaSelect={onMediaSelect} itemSize={itemSize} />
       </CollapsibleContent>
     </Collapsible>
   )
@@ -329,6 +335,8 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
     return groups
   }, [filteredMediaItems, t])
   const compositions = useCompositionsStore((s) => s.compositions)
+  const MediaTypeGroupView = viewMode === 'grid' ? GridMediaTypeGroup : ListMediaTypeGroup
+  const EmptyMediaGrid = viewMode === 'grid' ? GridMediaGrid : ListMediaGrid
 
   // Composition navigation — show banner when inside a sub-comp
   const activeCompositionId = useCompositionNavigationStore((s) => s.activeCompositionId)
@@ -1546,7 +1554,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
 
           {/* Media sections — grouped by type */}
           {mediaGroups.map((group) => (
-            <MediaTypeGroup
+            <MediaTypeGroupView
               key={group.key}
               groupKey={group.key}
               label={group.label}
@@ -1562,14 +1570,13 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
                 })
               }
               onMediaSelect={onMediaSelect}
-              viewMode={viewMode}
               itemSize={mediaItemSize}
             />
           ))}
 
           {/* Loading / empty state when no groups to show */}
           {mediaGroups.length === 0 && (
-            <MediaGrid onMediaSelect={onMediaSelect} viewMode={viewMode} itemSize={mediaItemSize} />
+            <EmptyMediaGrid onMediaSelect={onMediaSelect} itemSize={mediaItemSize} />
           )}
         </div>
 

--- a/src/features/projects/components/project-form.tsx
+++ b/src/features/projects/components/project-form.tsx
@@ -22,24 +22,40 @@ import {
 import { getProjectFpsOptions } from '../utils/project-fps'
 import { ProjectTemplatePicker } from './project-template-picker'
 
-interface ProjectFormProps {
+interface ProjectFormBaseProps {
   onSubmit: (data: ProjectFormData) => Promise<void> | void
   onCancel?: () => void
   defaultValues?: Partial<ProjectFormData>
-  isEditing?: boolean
   isSubmitting?: boolean
-  hideHeader?: boolean
+  mode: 'create' | 'edit'
+  surface: 'page' | 'inline'
 }
 
-export function ProjectForm({
+type ProjectFormProps = Omit<ProjectFormBaseProps, 'mode' | 'surface'>
+
+export function CreateProjectForm(props: ProjectFormProps) {
+  return <ProjectFormBase {...props} mode="create" surface="page" />
+}
+
+export function InlineCreateProjectForm(props: ProjectFormProps) {
+  return <ProjectFormBase {...props} mode="create" surface="inline" />
+}
+
+export function EditProjectForm(props: ProjectFormProps) {
+  return <ProjectFormBase {...props} mode="edit" surface="inline" />
+}
+
+function ProjectFormBase({
   onSubmit,
   onCancel,
   defaultValues,
-  isEditing = false,
   isSubmitting = false,
-  hideHeader = false,
-}: ProjectFormProps) {
+  mode,
+  surface,
+}: ProjectFormBaseProps) {
   const { t } = useTranslation()
+  const isEditing = mode === 'edit'
+  const isInlineSurface = surface === 'inline'
   const resolvedDefaultValues = useMemo(
     () => ({
       ...DEFAULT_PROJECT_VALUES,
@@ -96,7 +112,7 @@ export function ProjectForm({
   return (
     <div className="bg-background">
       {/* Header */}
-      {!hideHeader && (
+      {!isInlineSurface && (
         <div className="panel-header border-b border-border">
           <div className="max-w-[1400px] mx-auto px-6 py-5">
             <h1 className="text-2xl font-semibold tracking-tight text-foreground mb-1">
@@ -110,12 +126,12 @@ export function ProjectForm({
       )}
 
       {/* Form */}
-      <div className={hideHeader ? '' : 'max-w-[1400px] mx-auto px-6 py-8'}>
+      <div className={isInlineSurface ? '' : 'max-w-[1400px] mx-auto px-6 py-8'}>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-[minmax(320px,420px)_1fr] gap-6 items-start">
             {/* Project Details */}
             <div
-              className={`panel-bg border border-border rounded-lg p-6 ${hideHeader ? '' : 'lg:sticky lg:top-6'}`}
+              className={`panel-bg border border-border rounded-lg p-6 ${isInlineSurface ? '' : 'lg:sticky lg:top-6'}`}
             >
               <div className="flex items-center gap-3 mb-6">
                 <div className="h-8 w-1 bg-primary rounded-full" />
@@ -201,12 +217,9 @@ export function ProjectForm({
               </div>
 
               <ProjectTemplatePicker
-                selectedTemplateId={
-                  selectedTemplateId === 'custom' ? undefined : selectedTemplateId
-                }
+                selectedTemplateId={selectedTemplateId}
                 onSelectTemplate={handleSelectTemplate}
                 onSelectCustom={handleCustomSelect}
-                isCustomSelected={selectedTemplateId === 'custom'}
               />
               {selectedTemplateId === 'custom' && (
                 <div className="mt-5 flex items-center gap-3">

--- a/src/features/projects/components/project-template-picker.tsx
+++ b/src/features/projects/components/project-template-picker.tsx
@@ -4,18 +4,17 @@ import { PROJECT_TEMPLATES, getAspectRatio, type ProjectTemplate } from '../util
 
 interface ProjectTemplatePickerProps {
   onSelectTemplate: (template: ProjectTemplate) => void
-  selectedTemplateId?: string
+  selectedTemplateId?: string | 'custom'
   onSelectCustom?: () => void
-  isCustomSelected?: boolean
 }
 
 export function ProjectTemplatePicker({
   onSelectTemplate,
   selectedTemplateId,
   onSelectCustom,
-  isCustomSelected,
 }: ProjectTemplatePickerProps) {
   const { t } = useTranslation()
+  const isCustomSelected = selectedTemplateId === 'custom'
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
       {PROJECT_TEMPLATES.map((template) => {

--- a/src/features/scene-browser/components/scene-browser-panel.tsx
+++ b/src/features/scene-browser/components/scene-browser-panel.tsx
@@ -36,18 +36,8 @@ import {
 import { useRankedScenes } from '../hooks/use-ranked-scenes'
 import { useSemanticIndex } from '../hooks/use-semantic-index'
 import { SceneSearchField, SceneSearchModeButtons } from './scene-search-input'
-import {
-  GlobalMatchedSceneRow,
-  GlobalSceneRow,
-  ScopedMatchedSceneRow,
-  ScopedSceneRow,
-} from './scene-row'
-import {
-  GlobalMatchedSceneCard,
-  GlobalSceneCard,
-  ScopedMatchedSceneCard,
-  ScopedSceneCard,
-} from './scene-card'
+import { GlobalSceneRow, ScopedSceneRow } from './scene-row'
+import { GlobalSceneCard, ScopedSceneCard } from './scene-card'
 
 interface SceneBrowserPanelProps {
   className?: string
@@ -147,9 +137,7 @@ export function SceneBrowserPanel({ className }: SceneBrowserPanelProps) {
   const hasResults = scenes.length > 0
   const isFiltered = query.trim().length > 0
   const SceneGridCard = scope === null ? GlobalSceneCard : ScopedSceneCard
-  const MatchedSceneGridCard = scope === null ? GlobalMatchedSceneCard : ScopedMatchedSceneCard
   const SceneListRow = scope === null ? GlobalSceneRow : ScopedSceneRow
-  const MatchedSceneListRow = scope === null ? GlobalMatchedSceneRow : ScopedMatchedSceneRow
 
   const scopeLabel = `${t('sceneBrowser.counts.clip', {
     count: clipsWithCaptions,
@@ -237,30 +225,22 @@ export function SceneBrowserPanel({ className }: SceneBrowserPanelProps) {
           {hasResults ? (
             viewMode === 'grid' ? (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2">
-                {scenes.map((scene, index) =>
-                  isQuerying ? (
-                    <MatchedSceneGridCard
-                      key={scene.id}
-                      scene={scene}
-                      rank={index === 0 ? 'top' : 'default'}
-                    />
-                  ) : (
-                    <SceneGridCard key={scene.id} scene={scene} />
-                  ),
-                )}
-              </div>
-            ) : (
-              scenes.map((scene, index) =>
-                isQuerying ? (
-                  <MatchedSceneListRow
+                {scenes.map((scene, index) => (
+                  <SceneGridCard
                     key={scene.id}
                     scene={scene}
-                    rank={index === 0 ? 'top' : 'default'}
+                    match={isQuerying ? { rank: index === 0 ? 'top' : 'default' } : undefined}
                   />
-                ) : (
-                  <SceneListRow key={scene.id} scene={scene} />
-                ),
-              )
+                ))}
+              </div>
+            ) : (
+              scenes.map((scene, index) => (
+                <SceneListRow
+                  key={scene.id}
+                  scene={scene}
+                  match={isQuerying ? { rank: index === 0 ? 'top' : 'default' } : undefined}
+                />
+              ))
             )
           ) : reanalyzingMedia.length === 0 ? (
             <EmptyState hasAnyCaptions={hasAnyCaptions} isFiltered={isFiltered} />

--- a/src/features/scene-browser/components/scene-browser-panel.tsx
+++ b/src/features/scene-browser/components/scene-browser-panel.tsx
@@ -36,8 +36,18 @@ import {
 import { useRankedScenes } from '../hooks/use-ranked-scenes'
 import { useSemanticIndex } from '../hooks/use-semantic-index'
 import { SceneSearchField, SceneSearchModeButtons } from './scene-search-input'
-import { SceneRow } from './scene-row'
-import { SceneCard } from './scene-card'
+import {
+  GlobalMatchedSceneRow,
+  GlobalSceneRow,
+  ScopedMatchedSceneRow,
+  ScopedSceneRow,
+} from './scene-row'
+import {
+  GlobalMatchedSceneCard,
+  GlobalSceneCard,
+  ScopedMatchedSceneCard,
+  ScopedSceneCard,
+} from './scene-card'
 
 interface SceneBrowserPanelProps {
   className?: string
@@ -133,10 +143,13 @@ export function SceneBrowserPanel({ className }: SceneBrowserPanelProps) {
     [setScope],
   )
 
-  const showMediaName = scope === null
   const hasAnyCaptions = totalScenes > 0
   const hasResults = scenes.length > 0
   const isFiltered = query.trim().length > 0
+  const SceneGridCard = scope === null ? GlobalSceneCard : ScopedSceneCard
+  const MatchedSceneGridCard = scope === null ? GlobalMatchedSceneCard : ScopedMatchedSceneCard
+  const SceneListRow = scope === null ? GlobalSceneRow : ScopedSceneRow
+  const MatchedSceneListRow = scope === null ? GlobalMatchedSceneRow : ScopedMatchedSceneRow
 
   const scopeLabel = `${t('sceneBrowser.counts.clip', {
     count: clipsWithCaptions,
@@ -224,26 +237,30 @@ export function SceneBrowserPanel({ className }: SceneBrowserPanelProps) {
           {hasResults ? (
             viewMode === 'grid' ? (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2">
-                {scenes.map((scene, index) => (
-                  <SceneCard
-                    key={scene.id}
-                    scene={scene}
-                    showMediaName={showMediaName}
-                    showSignals={isQuerying}
-                    isTop={isQuerying && index === 0}
-                  />
-                ))}
+                {scenes.map((scene, index) =>
+                  isQuerying ? (
+                    <MatchedSceneGridCard
+                      key={scene.id}
+                      scene={scene}
+                      rank={index === 0 ? 'top' : 'default'}
+                    />
+                  ) : (
+                    <SceneGridCard key={scene.id} scene={scene} />
+                  ),
+                )}
               </div>
             ) : (
-              scenes.map((scene, index) => (
-                <SceneRow
-                  key={scene.id}
-                  scene={scene}
-                  showMediaName={showMediaName}
-                  showSignals={isQuerying}
-                  isTop={isQuerying && index === 0}
-                />
-              ))
+              scenes.map((scene, index) =>
+                isQuerying ? (
+                  <MatchedSceneListRow
+                    key={scene.id}
+                    scene={scene}
+                    rank={index === 0 ? 'top' : 'default'}
+                  />
+                ) : (
+                  <SceneListRow key={scene.id} scene={scene} />
+                ),
+              )
             )
           ) : reanalyzingMedia.length === 0 ? (
             <EmptyState hasAnyCaptions={hasAnyCaptions} isFiltered={isFiltered} />

--- a/src/features/scene-browser/components/scene-card.tsx
+++ b/src/features/scene-browser/components/scene-card.tsx
@@ -19,10 +19,8 @@ interface SceneCardBaseProps {
 
 interface SceneCardVariantProps {
   scene: ScoredScene
-}
-
-interface MatchedSceneCardVariantProps extends SceneCardVariantProps {
-  rank?: SceneMatchRank
+  /** Present while a search is active; toggling it preserves the fiber instead of remounting. */
+  match?: SceneMatchState
 }
 
 type SceneMatchRank = 'top' | 'default'
@@ -188,24 +186,16 @@ function SceneCardBase({ scene, mediaName, match }: SceneCardBaseProps) {
   )
 }
 
-export const GlobalSceneCard = memo(function GlobalSceneCard({ scene }: SceneCardVariantProps) {
-  return <SceneCardBase scene={scene} mediaName="source" />
-})
-
-export const ScopedSceneCard = memo(function ScopedSceneCard({ scene }: SceneCardVariantProps) {
-  return <SceneCardBase scene={scene} mediaName="hidden" />
-})
-
-export const GlobalMatchedSceneCard = memo(function GlobalMatchedSceneCard({
+export const GlobalSceneCard = memo(function GlobalSceneCard({
   scene,
-  rank = 'default',
-}: MatchedSceneCardVariantProps) {
-  return <SceneCardBase scene={scene} mediaName="source" match={{ rank }} />
+  match,
+}: SceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="source" match={match} />
 })
 
-export const ScopedMatchedSceneCard = memo(function ScopedMatchedSceneCard({
+export const ScopedSceneCard = memo(function ScopedSceneCard({
   scene,
-  rank = 'default',
-}: MatchedSceneCardVariantProps) {
-  return <SceneCardBase scene={scene} mediaName="hidden" match={{ rank }} />
+  match,
+}: SceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="hidden" match={match} />
 })

--- a/src/features/scene-browser/components/scene-card.tsx
+++ b/src/features/scene-browser/components/scene-card.tsx
@@ -11,15 +11,22 @@ import { SceneMatchBadges, SceneMatchStrength } from './scene-match-badges'
 import { ScenePaletteSwatches } from './scene-palette-swatches'
 import type { ScoredScene } from '../utils/rank'
 
-interface SceneCardProps {
+interface SceneCardBaseProps {
   scene: ScoredScene
-  /** When true, render the source filename line — hidden in per-media scope. */
-  showMediaName: boolean
-  /** True when this card is the first result for the active query. */
-  isTop?: boolean
-  /** Only render match signal chrome when a query is active. */
-  showSignals?: boolean
+  mediaName: 'source' | 'hidden'
+  match?: SceneMatchState
 }
+
+interface SceneCardVariantProps {
+  scene: ScoredScene
+}
+
+interface MatchedSceneCardVariantProps extends SceneCardVariantProps {
+  rank?: SceneMatchRank
+}
+
+type SceneMatchRank = 'top' | 'default'
+type SceneMatchState = { rank: SceneMatchRank }
 
 function parseCaptionIndex(sceneId: string): number | null {
   const idx = sceneId.lastIndexOf(':')
@@ -28,12 +35,7 @@ function parseCaptionIndex(sceneId: string): number | null {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
 }
 
-export const SceneCard = memo(function SceneCard({
-  scene,
-  showMediaName,
-  isTop,
-  showSignals,
-}: SceneCardProps) {
+function SceneCardBase({ scene, mediaName, match }: SceneCardBaseProps) {
   const { t } = useTranslation()
   const captionIndex = parseCaptionIndex(scene.id)
   const thumbUrl = useCaptionThumbnail(
@@ -101,6 +103,9 @@ export const SceneCard = memo(function SceneCard({
 
   const timestampLabel = formatDuration(scene.timeSec)
   const hasPalette = !!scene.palette && scene.palette.length > 0
+  const isTopMatch = match?.rank === 'top'
+  const showSourceMediaName = mediaName === 'source'
+  const showMatchSignals = match !== undefined
 
   return (
     <button
@@ -113,7 +118,7 @@ export const SceneCard = memo(function SceneCard({
         'text-left transition-colors',
         'hover:border-border/60 hover:bg-foreground/5 focus-visible:outline-none',
         'focus-visible:border-primary/60 focus-visible:bg-primary/10',
-        showSignals && isTop && 'border-primary/40 bg-primary/5',
+        isTopMatch && 'border-primary/40 bg-primary/5',
       )}
       title={t('sceneBrowser.scene.previewAndDragHint')}
     >
@@ -151,7 +156,7 @@ export const SceneCard = memo(function SceneCard({
         )}
       </div>
       <div className="min-w-0 space-y-1 px-1.5 py-1.5">
-        {showMediaName && (
+        {showSourceMediaName && (
           <div className="truncate text-[10px] text-muted-foreground" title={scene.mediaFileName}>
             {scene.mediaFileName}
           </div>
@@ -159,16 +164,20 @@ export const SceneCard = memo(function SceneCard({
         <div className="whitespace-normal break-words text-[11px] leading-snug text-foreground">
           {scene.text}
         </div>
-        {showSignals && <SceneMatchStrength signals={scene.signals} score={scene.score} />}
-        {(showSignals || (colorMode && hasPalette)) && (
+        {showMatchSignals && <SceneMatchStrength signals={scene.signals} score={scene.score} />}
+        {(showMatchSignals || (colorMode && hasPalette)) && (
           <div className="flex flex-wrap items-center gap-1">
-            {showSignals && (
-              <SceneMatchBadges signals={scene.signals} score={scene.score} isTop={isTop} />
+            {showMatchSignals && (
+              <SceneMatchBadges
+                signals={scene.signals}
+                score={scene.score}
+                rank={isTopMatch ? 'top' : 'default'}
+              />
             )}
-            {hasPalette && (colorMode || showSignals) && (
+            {hasPalette && (colorMode || showMatchSignals) && (
               <ScenePaletteSwatches
                 palette={scene.palette}
-                highlight={showSignals ? (scene.signals.colorMatch ?? null) : null}
+                highlight={showMatchSignals ? (scene.signals.colorMatch ?? null) : null}
                 onSwatchClick={handleSwatchClick}
               />
             )}
@@ -177,4 +186,26 @@ export const SceneCard = memo(function SceneCard({
       </div>
     </button>
   )
+}
+
+export const GlobalSceneCard = memo(function GlobalSceneCard({ scene }: SceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="source" />
+})
+
+export const ScopedSceneCard = memo(function ScopedSceneCard({ scene }: SceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="hidden" />
+})
+
+export const GlobalMatchedSceneCard = memo(function GlobalMatchedSceneCard({
+  scene,
+  rank = 'default',
+}: MatchedSceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="source" match={{ rank }} />
+})
+
+export const ScopedMatchedSceneCard = memo(function ScopedMatchedSceneCard({
+  scene,
+  rank = 'default',
+}: MatchedSceneCardVariantProps) {
+  return <SceneCardBase scene={scene} mediaName="hidden" match={{ rank }} />
 })

--- a/src/features/scene-browser/components/scene-match-badges.tsx
+++ b/src/features/scene-browser/components/scene-match-badges.tsx
@@ -86,19 +86,19 @@ function imageFraction(score: number): number {
 interface SceneMatchBadgesProps {
   signals: SceneMatchSignals
   score: number
-  /** `true` for the first scene in the list — earns a "Top" label. */
-  isTop?: boolean
+  rank?: 'top' | 'default'
   className?: string
 }
 
 export const SceneMatchBadges = memo(function SceneMatchBadges({
   signals,
   score,
-  isTop,
+  rank = 'default',
   className,
 }: SceneMatchBadgesProps) {
   const { t } = useTranslation()
   const chips: React.ReactNode[] = []
+  const isTopRank = rank === 'top'
 
   if (signals.ranker === 'keyword' && signals.keywordMatched) {
     chips.push(
@@ -194,11 +194,11 @@ export const SceneMatchBadges = memo(function SceneMatchBadges({
     }
   }
 
-  if (chips.length === 0 && !isTop) return null
+  if (chips.length === 0 && !isTopRank) return null
 
   return (
     <div className={cn('flex flex-wrap items-center gap-1', className)}>
-      {isTop && (
+      {isTopRank && (
         <Chip
           tone="top"
           icon={<Sparkles className="h-2.5 w-2.5" />}

--- a/src/features/scene-browser/components/scene-row.tsx
+++ b/src/features/scene-browser/components/scene-row.tsx
@@ -20,10 +20,8 @@ interface SceneRowBaseProps {
 
 interface SceneRowVariantProps {
   scene: ScoredScene
-}
-
-interface MatchedSceneRowVariantProps extends SceneRowVariantProps {
-  rank?: SceneMatchRank
+  /** Present while a search is active; toggling it preserves the fiber instead of remounting. */
+  match?: SceneMatchState
 }
 
 type SceneMatchRank = 'top' | 'default'
@@ -222,24 +220,10 @@ function SceneRowBase({ scene, mediaName, match }: SceneRowBaseProps) {
   )
 }
 
-export const GlobalSceneRow = memo(function GlobalSceneRow({ scene }: SceneRowVariantProps) {
-  return <SceneRowBase scene={scene} mediaName="source" />
+export const GlobalSceneRow = memo(function GlobalSceneRow({ scene, match }: SceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="source" match={match} />
 })
 
-export const ScopedSceneRow = memo(function ScopedSceneRow({ scene }: SceneRowVariantProps) {
-  return <SceneRowBase scene={scene} mediaName="hidden" />
-})
-
-export const GlobalMatchedSceneRow = memo(function GlobalMatchedSceneRow({
-  scene,
-  rank = 'default',
-}: MatchedSceneRowVariantProps) {
-  return <SceneRowBase scene={scene} mediaName="source" match={{ rank }} />
-})
-
-export const ScopedMatchedSceneRow = memo(function ScopedMatchedSceneRow({
-  scene,
-  rank = 'default',
-}: MatchedSceneRowVariantProps) {
-  return <SceneRowBase scene={scene} mediaName="hidden" match={{ rank }} />
+export const ScopedSceneRow = memo(function ScopedSceneRow({ scene, match }: SceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="hidden" match={match} />
 })

--- a/src/features/scene-browser/components/scene-row.tsx
+++ b/src/features/scene-browser/components/scene-row.tsx
@@ -12,15 +12,22 @@ import { SceneMatchBadges, SceneMatchStrength } from './scene-match-badges'
 import { ScenePaletteSwatches } from './scene-palette-swatches'
 import type { ScoredScene } from '../utils/rank'
 
-interface SceneRowProps {
+interface SceneRowBaseProps {
   scene: ScoredScene
-  /** When true, render the source filename line — hidden in per-media scope. */
-  showMediaName: boolean
-  /** True when this row is the first result for the active query. */
-  isTop?: boolean
-  /** Only render match signal chrome when a query is active. */
-  showSignals?: boolean
+  mediaName: 'source' | 'hidden'
+  match?: SceneMatchState
 }
+
+interface SceneRowVariantProps {
+  scene: ScoredScene
+}
+
+interface MatchedSceneRowVariantProps extends SceneRowVariantProps {
+  rank?: SceneMatchRank
+}
+
+type SceneMatchRank = 'top' | 'default'
+type SceneMatchState = { rank: SceneMatchRank }
 
 function formatSceneTimestamp(sec: number): string {
   return formatDuration(sec)
@@ -33,12 +40,7 @@ function parseCaptionIndex(sceneId: string): number | null {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
 }
 
-export const SceneRow = memo(function SceneRow({
-  scene,
-  showMediaName,
-  isTop,
-  showSignals,
-}: SceneRowProps) {
+function SceneRowBase({ scene, mediaName, match }: SceneRowBaseProps) {
   const { t } = useTranslation()
   const captionIndex = parseCaptionIndex(scene.id)
   const thumbUrl = useCaptionThumbnail(
@@ -105,6 +107,9 @@ export const SceneRow = memo(function SceneRow({
   )
 
   const timestampLabel = useMemo(() => formatSceneTimestamp(scene.timeSec), [scene.timeSec])
+  const isTopMatch = match?.rank === 'top'
+  const showSourceMediaName = mediaName === 'source'
+  const showMatchSignals = match !== undefined
 
   return (
     <button
@@ -119,7 +124,7 @@ export const SceneRow = memo(function SceneRow({
         'focus-visible:border-primary/60 focus-visible:bg-primary/10',
         // A subtle backdrop on the top match so it stands out without
         // stealing focus from lower-scoring but still-relevant rows.
-        showSignals && isTop && 'bg-primary/5',
+        isTopMatch && 'bg-primary/5',
       )}
       title={t('sceneBrowser.scene.previewAndDragHint')}
     >
@@ -145,7 +150,7 @@ export const SceneRow = memo(function SceneRow({
         </span>
       </div>
       <div className="min-w-0 flex-1 space-y-0.5">
-        {showMediaName && (
+        {showSourceMediaName && (
           <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
             <Clock className="h-2.5 w-2.5 shrink-0" />
             <span className="truncate">{scene.mediaFileName}</span>
@@ -156,11 +161,15 @@ export const SceneRow = memo(function SceneRow({
           spans={scene.matchSpans}
           className="line-clamp-3 text-[12px] leading-snug text-foreground"
         />
-        {showSignals && (
+        {showMatchSignals && (
           <div className="space-y-1 pt-0.5">
             <SceneMatchStrength signals={scene.signals} score={scene.score} />
             <div className="flex flex-wrap items-center gap-2">
-              <SceneMatchBadges signals={scene.signals} score={scene.score} isTop={isTop} />
+              <SceneMatchBadges
+                signals={scene.signals}
+                score={scene.score}
+                rank={isTopMatch ? 'top' : 'default'}
+              />
               <ScenePaletteSwatches
                 palette={scene.palette}
                 highlight={scene.signals.colorMatch ?? null}
@@ -181,7 +190,7 @@ export const SceneRow = memo(function SceneRow({
             </div>
           </div>
         )}
-        {!showSignals && colorMode && (
+        {!showMatchSignals && colorMode && (
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             {scene.palette && scene.palette.length > 0 ? (
               <>
@@ -211,4 +220,26 @@ export const SceneRow = memo(function SceneRow({
       </div>
     </button>
   )
+}
+
+export const GlobalSceneRow = memo(function GlobalSceneRow({ scene }: SceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="source" />
+})
+
+export const ScopedSceneRow = memo(function ScopedSceneRow({ scene }: SceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="hidden" />
+})
+
+export const GlobalMatchedSceneRow = memo(function GlobalMatchedSceneRow({
+  scene,
+  rank = 'default',
+}: MatchedSceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="source" match={{ rank }} />
+})
+
+export const ScopedMatchedSceneRow = memo(function ScopedMatchedSceneRow({
+  scene,
+  rank = 'default',
+}: MatchedSceneRowVariantProps) {
+  return <SceneRowBase scene={scene} mediaName="hidden" match={{ rank }} />
 })

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -68,6 +68,7 @@ vi.mock('./timeline-media-drop-zone', () => ({
 }))
 
 vi.mock('./track-row-frame', () => ({
+  FirstTrackRowFrame: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TrackRowFrame: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TrackSectionDivider: () => null,
 }))

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -40,7 +40,7 @@ import { TimelinePreviewScrubber } from './timeline-preview-scrubber'
 import { TimelineTrack } from './timeline-track'
 import { TimelineGuidelines } from './timeline-guidelines'
 import { TimelineMediaDropZone } from './timeline-media-drop-zone'
-import { TrackRowFrame, TrackSectionDivider } from './track-row-frame'
+import { FirstTrackRowFrame, TrackRowFrame, TrackSectionDivider } from './track-row-frame'
 import { MarqueeOverlay } from '@/shared/marquee/marquee-overlay'
 
 // Group utilities
@@ -563,7 +563,7 @@ const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface(
       height: number
       zoneHeight: number
       anchorTrackId: string | null
-      showTopDividerForFirstTrack: boolean
+      firstTrackFrame: 'with-top-divider' | 'regular'
       scrollRef?: React.RefObject<HTMLDivElement | null>
     },
   ) => (
@@ -585,14 +585,17 @@ const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface(
           <div aria-hidden="true" style={{ height: `${options.zoneHeight}px` }} />
         )}
 
-        {sectionTracks.map((track, index) => (
-          <TrackRowFrame
-            key={track.id}
-            showTopDivider={options.showTopDividerForFirstTrack && index === 0}
-          >
-            <TimelineTrack track={track} />
-          </TrackRowFrame>
-        ))}
+        {sectionTracks.map((track, index) => {
+          const RowFrame =
+            options.firstTrackFrame === 'with-top-divider' && index === 0
+              ? FirstTrackRowFrame
+              : TrackRowFrame
+          return (
+            <RowFrame key={track.id}>
+              <TimelineTrack track={track} />
+            </RowFrame>
+          )
+        })}
 
         {options.section === 'audio' && options.anchorTrackId && (
           <TimelineMediaDropZone
@@ -630,7 +633,7 @@ const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface(
             height: videoPaneHeight,
             zoneHeight: videoZoneHeight,
             anchorTrackId: topZoneAnchorTrackId,
-            showTopDividerForFirstTrack: true,
+            firstTrackFrame: 'with-top-divider',
             scrollRef: videoTracksScrollRef,
           })}
           <TrackSectionDivider onMouseDown={onSectionDividerMouseDown} />
@@ -639,7 +642,7 @@ const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface(
             height: audioPaneHeight,
             zoneHeight: audioZoneHeight,
             anchorTrackId: bottomZoneAnchorTrackId,
-            showTopDividerForFirstTrack: false,
+            firstTrackFrame: 'regular',
             scrollRef: audioTracksScrollRef,
           })}
         </>
@@ -649,7 +652,7 @@ const TimelineTrackSectionsSurface = memo(function TimelineTrackSectionsSurface(
           height: singleSectionHeight,
           zoneHeight: singleSectionZoneHeight,
           anchorTrackId: singleSectionAnchorTrackId,
-          showTopDividerForFirstTrack: true,
+          firstTrackFrame: 'with-top-divider',
           scrollRef: allTracksScrollRef,
         })
       )}

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -6,7 +6,7 @@ import { TimelineContent } from './timeline-content'
 import { TimelineNavigator } from './timeline-navigator'
 import { TrackHeader } from './track-header'
 import { TransitionDragTooltip } from './transition-drag-tooltip'
-import { TrackRowFrame, TrackSectionDivider } from './track-row-frame'
+import { FirstTrackRowFrame, TrackRowFrame, TrackSectionDivider } from './track-row-frame'
 import { useTimelineTracks } from '../hooks/use-timeline-tracks'
 import { useItemsStore } from '../stores/items-store'
 import { useSelectionStore } from '@/shared/state/selection'
@@ -764,7 +764,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
       zoneHeight: number
       scrollRef: React.RefObject<HTMLDivElement | null>
       dropIndicatorLocalIndex: number
-      showTopDividerForFirstTrack: boolean
+      firstTrackFrame: 'with-top-divider' | 'regular'
     },
   ) => (
     <div
@@ -783,10 +783,13 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
           )}
 
           {sectionTracks.map((track, index) => {
+            const RowFrame =
+              options.firstTrackFrame === 'with-top-divider' && index === 0
+                ? FirstTrackRowFrame
+                : TrackRowFrame
             return (
-              <TrackRowFrame
+              <RowFrame
                 key={track.id}
-                showTopDivider={options.showTopDividerForFirstTrack && index === 0}
                 onResizeMouseDown={(event) => handleTrackResizeStart(event, track.id)}
                 onResizeDoubleClick={(event) => handleTrackResizeReset(event, track.id)}
                 resizeHandleLabel={`Resize ${track.name} height`}
@@ -825,7 +828,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
                     }
                   }}
                 />
-              </TrackRowFrame>
+              </RowFrame>
             )
           })}
 
@@ -939,7 +942,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
                     zoneHeight: videoZoneHeight,
                     scrollRef: videoTrackHeadersScrollRef,
                     dropIndicatorLocalIndex: videoDropIndicatorIndex,
-                    showTopDividerForFirstTrack: true,
+                    firstTrackFrame: 'with-top-divider',
                   })}
                   <TrackSectionDivider onMouseDown={handleSectionDividerMouseDown} />
                   {renderTrackHeadersSection(audioTracks, {
@@ -948,7 +951,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
                     zoneHeight: audioZoneHeight,
                     scrollRef: audioTrackHeadersScrollRef,
                     dropIndicatorLocalIndex: audioDropIndicatorIndex,
-                    showTopDividerForFirstTrack: false,
+                    firstTrackFrame: 'regular',
                   })}
                 </>
               ) : (
@@ -958,7 +961,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
                   zoneHeight: singleSectionZoneHeight,
                   scrollRef: allTrackHeadersScrollRef,
                   dropIndicatorLocalIndex: singleDropIndicatorIndex,
-                  showTopDividerForFirstTrack: true,
+                  firstTrackFrame: 'with-top-divider',
                 })
               )}
             </div>

--- a/src/features/timeline/components/track-row-frame.test.tsx
+++ b/src/features/timeline/components/track-row-frame.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vite-plus/test'
 import { TRACK_SECTION_DIVIDER_HEIGHT } from '@/features/timeline/constants'
-import { TrackRowFrame, TrackSectionDivider } from './track-row-frame'
+import { FirstTrackRowFrame, TrackRowFrame, TrackSectionDivider } from './track-row-frame'
 
 describe('TrackRowFrame', () => {
   it('renders a divider for every wrapped row, including the last row', () => {
@@ -21,9 +21,9 @@ describe('TrackRowFrame', () => {
 
   it('anchors the divider to the row and keeps it out of hit testing', () => {
     const { container } = render(
-      <TrackRowFrame showTopDivider>
+      <FirstTrackRowFrame>
         <div>Track</div>
-      </TrackRowFrame>,
+      </FirstTrackRowFrame>,
     )
 
     const row = container.firstElementChild as HTMLDivElement | null

--- a/src/features/timeline/components/track-row-frame.tsx
+++ b/src/features/timeline/components/track-row-frame.tsx
@@ -5,12 +5,14 @@ import { cn } from '@/shared/ui/cn'
 
 interface TrackRowFrameProps extends PropsWithChildren {
   className?: string
-  showTopDivider?: boolean
-  hideBottomDivider?: boolean
   onResizeMouseDown?: (event: MouseEvent<HTMLButtonElement>) => void
   onResizeDoubleClick?: (event: MouseEvent<HTMLButtonElement>) => void
   resizeHandleLabel?: string
   resizeHandlePosition?: 'top' | 'bottom'
+}
+
+interface TrackRowFrameBaseProps extends TrackRowFrameProps {
+  dividers: 'bottom' | 'top-and-bottom'
 }
 
 interface TrackSectionDividerProps {
@@ -21,22 +23,22 @@ interface TrackSectionDividerProps {
 /**
  * Keeps the row separator outside the lane content so clips can fill the row.
  */
-export function TrackRowFrame({
+function TrackRowFrameBase({
   children,
   className,
-  showTopDivider = false,
-  hideBottomDivider = false,
   onResizeMouseDown,
   onResizeDoubleClick,
   resizeHandleLabel,
   resizeHandlePosition = 'bottom',
-}: TrackRowFrameProps) {
+  dividers,
+}: TrackRowFrameBaseProps) {
   const { t } = useTranslation()
   const resizeHandlePositionClass = resizeHandlePosition === 'top' ? 'top-0' : 'bottom-0'
+  const hasTopDivider = dividers === 'top-and-bottom'
 
   return (
     <div className={cn('relative', className)}>
-      {showTopDivider && (
+      {hasTopDivider && (
         <div
           aria-hidden="true"
           data-testid="track-row-top-divider"
@@ -44,13 +46,11 @@ export function TrackRowFrame({
         />
       )}
       {children}
-      {!hideBottomDivider && (
-        <div
-          aria-hidden="true"
-          data-testid="track-row-divider"
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-border"
-        />
-      )}
+      <div
+        aria-hidden="true"
+        data-testid="track-row-divider"
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-border"
+      />
       {onResizeMouseDown && (
         <button
           type="button"
@@ -66,6 +66,14 @@ export function TrackRowFrame({
       )}
     </div>
   )
+}
+
+export function TrackRowFrame(props: TrackRowFrameProps) {
+  return <TrackRowFrameBase {...props} dividers="bottom" />
+}
+
+export function FirstTrackRowFrame(props: TrackRowFrameProps) {
+  return <TrackRowFrameBase {...props} dividers="top-and-bottom" />
 }
 
 export function TrackSectionDivider({ className, onMouseDown }: TrackSectionDividerProps) {

--- a/src/features/timeline/hooks/use-waveform-prefetch.test.ts
+++ b/src/features/timeline/hooks/use-waveform-prefetch.test.ts
@@ -61,6 +61,11 @@ function WaveformPrefetchProbe({ onRender }: { onRender: () => void }) {
 }
 
 async function flushPrefetchTimers() {
+  // Three passes drain the full prefetch chain: each store update reschedules the
+  // schedulePreviewWork debounce timer (advanceTimersByTime), the fired callback awaits
+  // a dynamic import() of the waveform-cache module, and the resolved import then queues
+  // the prefetch calls. The two Promise.resolve() drains flush the import microtask before
+  // the next pass advances timers, so any work it re-scheduled is picked up.
   for (let i = 0; i < 3; i += 1) {
     await act(async () => {
       vi.advanceTimersByTime(120)

--- a/src/features/timeline/hooks/use-waveform-prefetch.test.ts
+++ b/src/features/timeline/hooks/use-waveform-prefetch.test.ts
@@ -61,11 +61,14 @@ function WaveformPrefetchProbe({ onRender }: { onRender: () => void }) {
 }
 
 async function flushPrefetchTimers() {
-  await act(async () => {
-    vi.advanceTimersByTime(120)
-    vi.runOnlyPendingTimers()
-    await Promise.resolve()
-  })
+  for (let i = 0; i < 3; i += 1) {
+    await act(async () => {
+      vi.advanceTimersByTime(120)
+      vi.runOnlyPendingTimers()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+  }
 }
 
 /** Replicate the prefetch range calculation */

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Plus, Upload, FolderOpen, File, Github } from 'lucide-react'
 import { FreeCutLogo } from '@/components/brand/freecut-logo'
 import { ProjectList } from '@/features/projects/components/project-list'
-import { ProjectForm } from '@/features/projects/components/project-form'
+import { EditProjectForm } from '@/features/projects/components/project-form'
 import {
   Dialog,
   DialogContent,
@@ -347,7 +347,7 @@ function ProjectsIndex() {
             <DialogDescription>{t('projects.form.editSubtitle')}</DialogDescription>
           </DialogHeader>
           {editingProject && (
-            <ProjectForm
+            <EditProjectForm
               onSubmit={handleEditSubmit}
               onCancel={() => setEditingProject(null)}
               defaultValues={{
@@ -357,9 +357,7 @@ function ProjectsIndex() {
                 height: editingProject.metadata.height,
                 fps: editingProject.metadata.fps,
               }}
-              isEditing={true}
               isSubmitting={isSubmitting}
-              hideHeader
             />
           )}
         </DialogContent>

--- a/src/routes/projects/new.tsx
+++ b/src/routes/projects/new.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { createLogger } from '@/shared/logging/logger'
-import { ProjectForm } from '@/features/projects/components/project-form'
+import { InlineCreateProjectForm } from '@/features/projects/components/project-form'
 import { useCreateProject } from '@/features/projects/hooks/use-project-actions'
 import { useProjectStore } from '@/features/projects/stores/project-store'
 import { FreeCutLogo } from '@/components/brand/freecut-logo'
@@ -78,7 +78,7 @@ function NewProject() {
 
       {/* Content */}
       <div className="max-w-7xl mx-auto px-6 py-8">
-        <ProjectForm onSubmit={handleSubmit} isSubmitting={isSubmitting} hideHeader={true} />
+        <InlineCreateProjectForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
       </div>
     </div>
   )

--- a/src/runtime/player/composition/Sequence.tsx
+++ b/src/runtime/player/composition/Sequence.tsx
@@ -41,10 +41,6 @@ interface SequenceProps {
    * Used for preloading content like videos.
    */
   premountFor?: number
-  /**
-   * Show loop timestamps for debugging (Composition compat, ignored)
-   */
-  showLoopTimestamps?: boolean
 }
 
 /**
@@ -64,10 +60,7 @@ export const Sequence = memo<SequenceProps>(
     style,
     className,
     premountFor = 0,
-    showLoopTimestamps,
   }) => {
-    void showLoopTimestamps
-
     // Get the global frame from the clock
     const globalFrame = useClockFrame()
 


### PR DESCRIPTION
## Summary

Applies React composition patterns across feature components (keyframes dopesheet/value-graph editors, media-library, projects, scene-browser, timeline, and project routes).

- Renames `showAllGraphHandles` boolean prop to a `graphHandleVisibility: 'selected' | 'all'` union throughout the dopesheet/value-graph editor chain
- Refactors components in media-library, projects, scene-browser, and timeline to follow composition conventions

## Test plan

- [x] `vp check` (lint + types) passes
- [x] Boundary / deps-contract checks pass
- [ ] Manual smoke test of keyframe graph handle visibility toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated view/displays to use explicit modes (handle visibility, label visibility, visuals, layout, rank) for clearer UI behavior across keyframes, graphs, media library, scene browser, timeline, and project forms.
  * Project form split into dedicated create/edit/inline variants.

* **Tests**
  * Adjusted tests to exercise embedded editor and updated track-row/frame variants.

* **Chores**
  * Removed several deprecated/unused props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->