### PR TITLE
fix: prefer waveform meter estimates during audio skimming

### DIFF
--- a/src/features/editor/components/audio-meter-panel.tsx
+++ b/src/features/editor/components/audio-meter-panel.tsx
@@ -425,14 +425,18 @@ export const AudioMeterPanel = memo(function AudioMeterPanel() {
       waveformsByMediaId,
     })
   }, [sources, waveformsByMediaId])
-  const estimate = audioSkimMeterLevel
+  const skimFallbackEstimate = audioSkimMeterLevel
     ? {
         left: audioSkimMeterLevel.left,
         right: audioSkimMeterLevel.right,
         resolvedSourceCount: 1,
         unresolvedSourceCount: 0,
       }
-    : waveformEstimate
+    : null
+  const estimate =
+    isAudioSkimMeterActive && waveformEstimate.resolvedSourceCount === 0 && skimFallbackEstimate
+      ? skimFallbackEstimate
+      : waveformEstimate
   const maxLevel = Math.max(estimate.left, estimate.right)
   const statusLabel = !isMeterActive
     ? 'Idle'


### PR DESCRIPTION
## Summary
- Prefer waveform meter estimates during audio skimming in the audio meter panel

## Commits
- `d61317fa` (fix): prefer waveform meter estimates during audio skimming

## Files
- `src/features/editor/components/audio-meter-panel.tsx` (+6/-2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio meter accuracy by refining fallback estimation logic to apply skim-mode estimates more selectively, ensuring waveform-based readings remain the primary source for level measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->