### PR TITLE
Promote develop → staging

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -484,6 +484,11 @@ export const LoadedEditor = memo(function LoadedEditor({
     if (previousWorkspace === workspace) return
     previousWorkspaceRef.current = workspace
 
+    // Workspace switches should not carry transient scrub/hover preview
+    // frames across surfaces. Color scopes intentionally skip previewFrame
+    // samples, so a stale Edit preview frame can make them appear frozen.
+    usePlaybackStore.getState().setPreviewFrame(null)
+
     const timelinePanel = timelinePanelRef.current
     if (!timelinePanel) return
 

--- a/src/features/preview/components/color-scopes-view.tsx
+++ b/src/features/preview/components/color-scopes-view.tsx
@@ -19,6 +19,10 @@ const SAMPLE_WIDTH_PLAYING = 256
 const SAMPLE_HEIGHT_PLAYING = 144
 const GPU_INTERVAL = 66 // ~15fps
 const CPU_INTERVAL = 220
+// Watchdog: if a render stays "in flight" past this, assume its capture await
+// wedged (e.g. cold-start scrub-lock contention whose `finally` never ran) and
+// force-clear the gate so the render loop recovers instead of freezing forever.
+const GPU_RENDER_STUCK_TIMEOUT_MS = 1000
 const STACK_LAYOUT_STORAGE_KEY = 'timeline:scopes:stackLayout'
 // Resolve-style RGB parade: three roughly square waveform lanes side by side.
 const PARADE_SCOPE_ASPECT_RATIO = 10 / 3
@@ -578,11 +582,24 @@ export const ColorScopesView = memo(function ColorScopesView({
 
     let cancelled = false
     let lastTime = 0
+    let inFlightSince = 0
+    // Clear any flag left wedged true by a render whose `finally` never ran on a
+    // prior mount — otherwise the loop would start gated and never capture.
+    gpuRenderInFlightRef.current = false
 
     const tick = (time: number) => {
       if (cancelled) return
+      // Self-heal a stuck in-flight render so a single hung capture can't
+      // freeze the scopes for the rest of the session.
+      if (
+        gpuRenderInFlightRef.current &&
+        time - inFlightSince >= GPU_RENDER_STUCK_TIMEOUT_MS
+      ) {
+        gpuRenderInFlightRef.current = false
+      }
       if (time - lastTime >= GPU_INTERVAL && !gpuRenderInFlightRef.current) {
         lastTime = time
+        inFlightSince = time
         void renderGpuFrame()
       }
       requestAnimationFrame(tick)


### PR DESCRIPTION
Promotes the current `develop` line into `staging`.

## Highlights
- **fix(preview): self-heal frozen color scopes render loop** (`1bb0e134`) — the GPU scope render loop could wedge permanently when `gpuRenderInFlightRef` got stuck `true` (a cold-start race where a `renderGpuFrame` await never settled, so its `finally` reset never ran). The rAF tick then skipped capture forever, freezing the scopes in Color mode. Fixed by resetting the flag on loop (re)start and adding a 1s watchdog that force-clears a wedged flag. Verified live: loop runs at ~15fps and the waveform tracks color-grade changes in real time.
- Plus prior `develop` work already merged there (adjustment-layer undo, audio EQ clamp, export/curve-editor fixes, color-scope GPU init stabilization, etc.).

See the commit list for the full range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU rendering watchdog added to detect and recover from stuck render operations, preventing indefinite freezes and keeping the render loop responsive.
  * Cleared transient preview frames when switching workspaces to prevent stale or frozen preview displays carrying across contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->