### PR TITLE
fix(preview): plug decoder and video-source memory leaks

### DIFF
--- a/src/features/export/utils/shared-video-extractor.test.ts
+++ b/src/features/export/utils/shared-video-extractor.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { SharedVideoExtractorPool } from './shared-video-extractor'
+
+const extractorState = vi.hoisted(() => ({
+  instances: [] as Array<{
+    init: ReturnType<typeof vi.fn>
+    drawFrame: ReturnType<typeof vi.fn>
+    drawFrameWithCapture: ReturnType<typeof vi.fn>
+    captureFrame: ReturnType<typeof vi.fn>
+    getLastFailureKind: ReturnType<typeof vi.fn>
+    getDimensions: ReturnType<typeof vi.fn>
+    getDuration: ReturnType<typeof vi.fn>
+    prewarmBatch: ReturnType<typeof vi.fn>
+    isBatchPrewarmAvailable: ReturnType<typeof vi.fn>
+    dispose: ReturnType<typeof vi.fn>
+  }>,
+}))
+
+vi.mock('./canvas-video-extractor', () => ({
+  VideoFrameExtractor: vi.fn(function VideoFrameExtractorMock(this: Record<string, unknown>) {
+    const instance = {
+      init: vi.fn(async () => true),
+      drawFrame: vi.fn(async () => true),
+      drawFrameWithCapture: vi.fn(async () => ({
+        success: true,
+        capturedFrame: null,
+        capturedSourceTime: 0,
+      })),
+      captureFrame: vi.fn(async () => ({ success: true, frame: null, sourceTime: 0 })),
+      getLastFailureKind: vi.fn(() => 'none'),
+      getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getDuration: vi.fn(() => 120),
+      prewarmBatch: vi.fn(async () => 1),
+      isBatchPrewarmAvailable: vi.fn(() => true),
+      dispose: vi.fn(),
+    }
+    extractorState.instances.push(instance)
+    Object.assign(this, instance)
+  }),
+}))
+
+describe('SharedVideoExtractorPool', () => {
+  beforeEach(() => {
+    extractorState.instances = []
+  })
+
+  it('disposes source lanes after the last item using that source is released', async () => {
+    const pool = new SharedVideoExtractorPool({ maxLanesPerSource: 2 })
+    const ctx = {} as CanvasRenderingContext2D
+
+    const first = pool.getOrCreateItemExtractor('item-1', 'blob:source')
+    const second = pool.getOrCreateItemExtractor('item-2', 'blob:source')
+
+    await first.drawFrame(ctx, 0, 0, 0, 1, 1)
+    await second.drawFrame(ctx, 1, 0, 0, 1, 1)
+
+    expect(extractorState.instances).toHaveLength(2)
+
+    pool.releaseItem('item-1')
+
+    expect(extractorState.instances[0]!.dispose).not.toHaveBeenCalled()
+    expect(extractorState.instances[1]!.dispose).not.toHaveBeenCalled()
+
+    pool.releaseItem('item-2')
+
+    expect(extractorState.instances[0]!.dispose).toHaveBeenCalledTimes(1)
+    expect(extractorState.instances[1]!.dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/export/utils/shared-video-extractor.ts
+++ b/src/features/export/utils/shared-video-extractor.ts
@@ -202,6 +202,10 @@ export class SharedVideoExtractorPool {
 
     this.itemSources.delete(itemId)
     this.itemWrappers.delete(itemId)
+
+    if (src) {
+      this.pruneIdleSource(src)
+    }
   }
 
   async drawItemFrame(
@@ -454,5 +458,29 @@ export class SharedVideoExtractorPool {
       const prev = state.laneAssignments[laneIndex] ?? 0
       state.laneAssignments[laneIndex] = Math.max(0, prev - 1)
     }
+  }
+
+  private pruneIdleSource(src: string): void {
+    const state = this.sourceStates.get(src)
+    if (!state) return
+    if (state.itemLaneById.size > 0) return
+    if (this.hasWrapperForSource(src)) return
+
+    for (const lane of state.lanes) {
+      lane.extractor.dispose()
+    }
+    state.lanes = []
+    state.laneAssignments = []
+    state.sourceInitPromise = null
+    state.sourceReady = false
+    state.sourceInitAttempted = false
+    this.sourceStates.delete(src)
+  }
+
+  private hasWrapperForSource(src: string): boolean {
+    for (const wrapperSrc of this.itemSources.values()) {
+      if (wrapperSrc === src) return true
+    }
+    return false
   }
 }

--- a/src/features/preview/utils/decoder-prewarm.test.ts
+++ b/src/features/preview/utils/decoder-prewarm.test.ts
@@ -28,7 +28,7 @@ class MockWorker {
   readonly addEventListener = vi.fn()
   readonly terminate = vi.fn()
   readonly postMessage = vi.fn((message: MockWorkerMessage) => {
-    if (message.type !== 'preseek') {
+    if (message.type !== 'preseek' || !autoRespondPreseek) {
       return
     }
 
@@ -49,11 +49,13 @@ class MockWorker {
 let createdWorkers: MockWorker[] = []
 let fetchMock: ReturnType<typeof vi.fn>
 let mockBitmap: ImageBitmap
+let autoRespondPreseek = true
 
 beforeEach(() => {
   createdWorkers = []
   mockBitmap = { close: vi.fn() } as unknown as ImageBitmap
   fetchMock = vi.fn()
+  autoRespondPreseek = true
 
   vi.stubGlobal('fetch', fetchMock)
   class WorkerStub extends MockWorker {
@@ -157,5 +159,46 @@ describe('decoder prewarm', () => {
     const spawnedCount = createdWorkers.length
     warmDecoderPrewarmWorkerPool()
     expect(createdWorkers.length).toBe(spawnedCount)
+  })
+
+  it('drops speculative preseek work when every worker is already busy', async () => {
+    autoRespondPreseek = false
+    warmDecoderPrewarmWorkerPool()
+
+    const poolSize = createdWorkers.length
+    expect(poolSize).toBeGreaterThan(0)
+
+    for (let index = 0; index < poolSize; index += 1) {
+      const src = `blob:busy-${index}`
+      registerObjectUrl(src, new Blob([`video-${index}`]))
+      void backgroundPreseek(src, index)
+    }
+
+    registerObjectUrl('blob:overflow', new Blob(['overflow']))
+    const overflowResult = await backgroundPreseek('blob:overflow', 999)
+
+    const preseekPosts = createdWorkers
+      .flatMap((worker) => worker.postMessage.mock.calls)
+      .map(([message]) => message as MockWorkerMessage)
+      .filter((message) => message.type === 'preseek')
+
+    expect(overflowResult).toBeNull()
+    expect(preseekPosts).toHaveLength(poolSize)
+  })
+
+  it('closes bitmaps from late worker replies after a request is no longer pending', () => {
+    warmDecoderPrewarmWorkerPool()
+
+    const worker = createdWorkers[0]!
+    worker.onmessage?.({
+      data: {
+        type: 'preseek_done',
+        id: 'missing-request',
+        success: true,
+        bitmap: mockBitmap,
+      },
+    } as MessageEvent)
+
+    expect(mockBitmap.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/preview/utils/decoder-prewarm.test.ts
+++ b/src/features/preview/utils/decoder-prewarm.test.ts
@@ -168,11 +168,18 @@ describe('decoder prewarm', () => {
     const poolSize = createdWorkers.length
     expect(poolSize).toBeGreaterThan(0)
 
+    const inflightPromises: ReturnType<typeof backgroundPreseek>[] = []
     for (let index = 0; index < poolSize; index += 1) {
       const src = `blob:busy-${index}`
       registerObjectUrl(src, new Blob([`video-${index}`]))
-      void backgroundPreseek(src, index)
+      inflightPromises.push(backgroundPreseek(src, index))
     }
+
+    // A duplicate request for an already-inflight src/timestamp needs no extra
+    // worker capacity — even with the pool saturated it must reuse the pending
+    // promise rather than be dropped to null like genuinely new decode work.
+    const duplicateResult = backgroundPreseek('blob:busy-0', 0)
+    expect(duplicateResult).toBe(inflightPromises[0])
 
     registerObjectUrl('blob:overflow', new Blob(['overflow']))
     const overflowResult = await backgroundPreseek('blob:overflow', 999)

--- a/src/features/preview/utils/decoder-prewarm.ts
+++ b/src/features/preview/utils/decoder-prewarm.ts
@@ -29,6 +29,7 @@ import {
 
 const log = createLogger('DecoderPrewarm')
 const MAX_CACHED_BITMAPS_PER_SOURCE = 6
+const MAX_INFLIGHT_PER_WORKER = 1
 const PRESEEK_REQUEST_REUSE_TOLERANCE_SECONDS = 1 / 240
 /** Min 3 (transition pair + spare), max 6 (memory cap ~12MB WASM) */
 const WORKER_POOL_SIZE = Math.max(
@@ -130,6 +131,8 @@ function handleWorkerMessage(event: MessageEvent): void {
     if (pending) {
       pendingRequests.delete(msg.id)
       pending.resolve(msg.bitmap ?? null)
+    } else {
+      closeUnclaimedBitmap(msg.bitmap)
     }
   } else if (msg.type === 'batch_preseek_done') {
     const pending = pendingBatchRequests.get(msg.id)
@@ -142,7 +145,23 @@ function handleWorkerMessage(event: MessageEvent): void {
         }
       }
       pending.resolve(results)
+    } else if (Array.isArray(msg.entries)) {
+      for (const entry of msg.entries) {
+        closeUnclaimedBitmap(entry?.bitmap)
+      }
     }
+  }
+}
+
+function closeUnclaimedBitmap(bitmap: unknown): void {
+  if (!bitmap || typeof (bitmap as ImageBitmap).close !== 'function') {
+    return
+  }
+
+  try {
+    ;(bitmap as ImageBitmap).close()
+  } catch {
+    // Ignore close errors.
   }
 }
 
@@ -204,6 +223,9 @@ function acquireWorker(): PoolWorker | null {
     if (pw.inflightCount < best.inflightCount) {
       best = pw
     }
+  }
+  if (best.inflightCount >= MAX_INFLIGHT_PER_WORKER) {
+    return null
   }
   best.inflightCount++
   return best

--- a/src/features/preview/utils/decoder-prewarm.ts
+++ b/src/features/preview/utils/decoder-prewarm.ts
@@ -374,10 +374,10 @@ async function resolveBlobForUrl(src: string): Promise<Blob | null> {
 }
 
 export function backgroundPreseek(src: string, timestamp: number): Promise<ImageBitmap | null> {
-  const pw = acquireWorker()
-  if (!pw) return Promise.resolve(null)
   decoderPrewarmMetrics.requests += 1
 
+  // Cache and inflight-reuse hits need zero worker capacity — check them before
+  // the saturation guard so a saturated pool still serves already-decoded frames.
   const cachedBitmap = getCachedPredecodedBitmap(
     src,
     timestamp,
@@ -385,7 +385,6 @@ export function backgroundPreseek(src: string, timestamp: number): Promise<Image
   )
   if (cachedBitmap) {
     decoderPrewarmMetrics.cacheHits += 1
-    releaseWorker(pw)
     return Promise.resolve(cachedBitmap)
   }
 
@@ -396,9 +395,12 @@ export function backgroundPreseek(src: string, timestamp: number): Promise<Image
   )
   if (inflightMatch) {
     decoderPrewarmMetrics.inflightReuses += 1
-    releaseWorker(pw)
     return inflightMatch.promise
   }
+
+  // Genuinely new decode work — drop it if every worker is saturated.
+  const pw = acquireWorker()
+  if (!pw) return Promise.resolve(null)
 
   const id = `preseek-${++requestId}`
   const promise = new Promise<ImageBitmap | null>((resolve) => {

--- a/src/features/preview/workers/decoder-prewarm-worker.ts
+++ b/src/features/preview/workers/decoder-prewarm-worker.ts
@@ -13,6 +13,7 @@ const TIMESTAMP_EPSILON = 1e-4
 const LOOKAHEAD_TOLERANCE_SECONDS = 0.05
 const STREAM_BACKTRACK_SECONDS = 1.0
 const FORWARD_JUMP_RESTART_SECONDS = 3.0
+const MAX_EXTRACTORS_PER_WORKER = 8
 
 /** Per-source keyframe index received from main thread */
 const keyframeIndexBySrc = new Map<string, number[]>()
@@ -85,7 +86,10 @@ async function getExtractor(
   options?: WorkerSourceOptions,
 ): Promise<ExtractorState | null> {
   const existing = extractors.get(src)
-  if (existing) return existing
+  if (existing) {
+    touchExtractor(src, existing)
+    return existing
+  }
 
   const inflight = initPromises.get(src)
   if (inflight) return inflight
@@ -167,6 +171,7 @@ async function getExtractor(
         drawLock: null,
       }
       extractors.set(src, state)
+      pruneOldExtractors(src)
       return state
     } catch (error) {
       input.dispose?.()
@@ -179,6 +184,40 @@ async function getExtractor(
     return await promise
   } finally {
     initPromises.delete(src)
+  }
+}
+
+function touchExtractor(src: string, state: ExtractorState): void {
+  extractors.delete(src)
+  extractors.set(src, state)
+}
+
+function disposeExtractorState(state: ExtractorState): void {
+  closeStreamState(state)
+  try {
+    state.input.dispose?.()
+  } catch {
+    // Ignore dispose errors.
+  }
+}
+
+function pruneOldExtractors(activeSrc: string): void {
+  while (extractors.size > MAX_EXTRACTORS_PER_WORKER) {
+    const oldestSrc = extractors.keys().next().value as string | undefined
+    if (!oldestSrc) return
+    if (oldestSrc === activeSrc) {
+      const activeState = extractors.get(oldestSrc)
+      if (!activeState) return
+      touchExtractor(oldestSrc, activeState)
+      continue
+    }
+
+    const oldest = extractors.get(oldestSrc)
+    extractors.delete(oldestSrc)
+    keyframeIndexBySrc.delete(oldestSrc)
+    if (oldest) {
+      disposeExtractorState(oldest)
+    }
   }
 }
 
@@ -450,21 +489,25 @@ async function batchPreseek(
       // state across the batch — each packet decoded at most once.
       const iterator = state.sink.samplesAtTimestamps(timestamps)
       let i = 0
-      for await (const sample of iterator) {
-        if (!sample || i >= timestamps.length) {
+      try {
+        for await (const sample of iterator) {
+          if (!sample || i >= timestamps.length) {
+            i++
+            continue
+          }
+
+          const ts = timestamps[i]!
           i++
-          continue
-        }
 
-        const ts = timestamps[i]!
-        i++
-
-        try {
-          const bitmap = renderSampleToBitmap(state, sample)
-          if (bitmap) results.set(ts, bitmap)
-        } finally {
-          sample.close?.()
+          try {
+            const bitmap = renderSampleToBitmap(state, sample)
+            if (bitmap) results.set(ts, bitmap)
+          } finally {
+            sample.close?.()
+          }
         }
+      } finally {
+        await iterator.return?.()
       }
     } catch {
       // Batch decode failed — return whatever we got

--- a/src/features/timeline/components/clip-filmstrip/image-filmstrip.tsx
+++ b/src/features/timeline/components/clip-filmstrip/image-filmstrip.tsx
@@ -81,6 +81,18 @@ const AnimatedTile = memo(function AnimatedTile({
 const VIEWPORT_PAD_TILES = 2
 const VIEWPORT_PAD_PX = 600
 
+function canUseItemSrcFallback(src: string): boolean {
+  if (!src.startsWith('blob:')) {
+    return true
+  }
+
+  try {
+    return new URL(src).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
 /**
  * Image Filmstrip Component
  *
@@ -151,8 +163,9 @@ export const ImageFilmstrip = memo(function ImageFilmstrip({
   const tileWidth = Math.round(height * (16 / 9)) || 80
   const renderClipWidth = Math.max(clipWidth, renderWidth ?? clipWidth)
 
-  // Resolve the URL to use: prefer freshly resolved blobUrl, fall back to item.src
-  const resolvedSrc = blobUrl || src
+  // Resolve the URL to use: prefer freshly resolved blobUrl. Only use the
+  // saved item src if it is not a stale blob URL from another origin.
+  const resolvedSrc = blobUrl || (canUseItemSrcFallback(src) ? src : '')
 
   const effectiveStart = Math.max(0, sourceStart + trimStart)
 

--- a/src/features/timeline/components/clip-filmstrip/image-filmstrip.tsx
+++ b/src/features/timeline/components/clip-filmstrip/image-filmstrip.tsx
@@ -82,10 +82,6 @@ const VIEWPORT_PAD_TILES = 2
 const VIEWPORT_PAD_PX = 600
 
 function canUseItemSrcFallback(src: string): boolean {
-  if (!src.startsWith('blob:')) {
-    return true
-  }
-
   try {
     return new URL(src).origin === window.location.origin
   } catch {

--- a/src/runtime/composition-runtime/components/video-content.tsx
+++ b/src/runtime/composition-runtime/components/video-content.tsx
@@ -44,6 +44,12 @@ const supportsRVFC =
   typeof HTMLVideoElement !== 'undefined' &&
   'requestVideoFrameCallback' in HTMLVideoElement.prototype
 
+function isRecoverableVideoLoadError(message: string): boolean {
+  return /format error|unknown|empty src|not allowed to load local resource|ERR_UPLOAD_FILE_CHANGED|ERR_FILE_NOT_FOUND|PIPELINE_ERROR_DISCONNECTED|decode error|network/i.test(
+    message,
+  )
+}
+
 /**
  * Native HTML5 video component for preview mode using VideoSourcePool.
  * Uses pooled video elements instead of creating new ones per clip.
@@ -1011,8 +1017,7 @@ export const VideoContent: React.FC<{
     (error: Error) => {
       contentLog.warn(`Media error for item ${item.id}:`, error.message)
 
-      const looksLikeStaleBlob = /format error|unknown|empty src/i.test(error.message)
-      if (looksLikeStaleBlob && !retriedRef.current && item.mediaId) {
+      if (isRecoverableVideoLoadError(error.message) && !retriedRef.current && item.mediaId) {
         retriedRef.current = true
         contentLog.info(`Retrying item ${item.id} with fresh blob URL for media ${item.mediaId}`)
         blobUrlManager.invalidate(item.mediaId)

--- a/src/runtime/player/video/VideoSourcePool.test.ts
+++ b/src/runtime/player/video/VideoSourcePool.test.ts
@@ -137,4 +137,29 @@ describe('VideoSourcePool', () => {
     pool.releaseClip('clip-1')
     expect(pool.getClipElement('clip-1')).toBeNull()
   })
+
+  it('disposes idle overflow elements created beyond the fixed lane pool', () => {
+    const pool = new VideoSourcePool()
+
+    const acquired = Array.from({ length: 5 }, (_, index) =>
+      pool.acquireForClip(`clip-${index}`, 'blob:test-video'),
+    )
+
+    expect(acquired.every(Boolean)).toBe(true)
+    expect(pool.getStats()).toEqual({
+      sourceCount: 1,
+      totalElements: 5,
+      activeClips: 5,
+    })
+
+    pool.releaseClip('clip-4')
+
+    expect(pool.getStats()).toEqual({
+      sourceCount: 1,
+      totalElements: 4,
+      activeClips: 4,
+    })
+    expect(videoMocks.createdVideos[4]!.pause).toHaveBeenCalledTimes(1)
+    expect(videoMocks.createdVideos[4]!.load).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/runtime/player/video/VideoSourcePool.ts
+++ b/src/runtime/player/video/VideoSourcePool.ts
@@ -157,9 +157,7 @@ class SourceController {
         if (this._pendingPrimary === element) {
           this._pendingPrimary = null
         }
-        element.pause()
-        element.src = ''
-        element.load()
+        this.disposeElement(element)
         // Allow retries by clearing the rejected promise
         this.loadPromise = null
         throw err
@@ -257,6 +255,7 @@ class SourceController {
    */
   release(clipId: string): void {
     this.assignments.delete(clipId)
+    this.pruneIdleOverflowElements()
   }
 
   /**
@@ -325,22 +324,16 @@ class SourceController {
 
     // Pause and clear all elements
     if (this.primary) {
-      this.primary.pause()
-      this.primary.src = ''
-      this.primary.load()
+      this.disposeElement(this.primary)
     }
 
     if (this._pendingPrimary) {
-      this._pendingPrimary.pause()
-      this._pendingPrimary.src = ''
-      this._pendingPrimary.load()
+      this.disposeElement(this._pendingPrimary)
       this._pendingPrimary = null
     }
 
     for (const element of this.overflow) {
-      element.pause()
-      element.src = ''
-      element.load()
+      this.disposeElement(element)
     }
 
     this.primary = null
@@ -350,6 +343,27 @@ class SourceController {
   }
 
   // --- Private methods ---
+
+  private disposeElement(element: HTMLVideoElement): void {
+    element.pause()
+    element.src = ''
+    element.load()
+  }
+
+  private pruneIdleOverflowElements(): void {
+    for (
+      let index = this.overflow.length - 1;
+      index >= SourceController.MAX_OVERFLOW_ELEMENTS;
+      index -= 1
+    ) {
+      const element = this.overflow[index]
+      if (!element || this.isElementInUse(element)) {
+        continue
+      }
+      this.disposeElement(element)
+      this.overflow.splice(index, 1)
+    }
+  }
 
   private isElementInUse(element: HTMLVideoElement): boolean {
     for (const assigned of this.assignments.values()) {


### PR DESCRIPTION
## Summary
Hotfix for resource/memory leaks in the preview decode path and video source pool. Branched from \`main\` and cherry-picked so it carries only the fix (no unreleased \`develop\` work).

- Close unclaimed bitmaps from resolved/unmatched worker messages
- Bound in-flight requests per prewarm worker (\`MAX_INFLIGHT_PER_WORKER\`)
- LRU-prune and dispose stale extractors per worker (cap at 8)
- Ensure batch-preseek sample iterators are returned/closed on exit
- Centralize video element disposal and prune idle overflow elements in \`VideoSourcePool\` on release

## Testing
- \`vp test --run\` for decoder-prewarm, VideoSourcePool, shared-video-extractor — 10 passed
- Pre-push quality gate (boundaries, deps contracts, changed-code health, lint/type check) — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented leaked decoded bitmaps by closing images when prewarm responses arrive late or are unclaimed.
  * Improved video load recovery by broadening which errors can trigger a retry.
  * Added safer filmstrip fallback handling to avoid using invalid or cross-origin URLs.

* **Performance**
  * Reduced decoder and extractor churn with per-worker inflight limits and LRU-style eviction.
  * Improved pooling behavior with idle source pruning and overflow element disposal.

* **Tests**
  * Expanded coverage for shared extractor disposal behavior and worker overflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->