### PR TITLE
ci(preview-sync): rebalance stress test + Discord community links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Nightly soak for the preview-sync stress job (catches ordering flakes
+    # introduced via indirect deps that the PR path-filter would miss).
+    - cron: '0 7 * * *'
 
 jobs:
   quality:
@@ -65,9 +69,6 @@ jobs:
       - name: Unit tests (with coverage floor)
         run: vp test run --coverage
 
-      - name: Preview Sync Stress (10x)
-        run: vp run test:preview-sync:stress -- --runs 10
-
       - name: Build
         run: vp build
 
@@ -86,3 +87,53 @@ jobs:
         run: |
           npm install -g fallow
           fallow audit --base "origin/${{ github.base_ref }}" --gate new-only --ci
+
+  # Repeatedly re-runs the preview-sync suite from cold to surface ordering /
+  # stale-render flakes in the fast-scrub state machine. Kept OFF the common PR
+  # critical path: it only runs nightly (full soak) or on PRs that actually
+  # touch preview code. See scripts/preview-sync-stress.mjs.
+  preview-sync-stress:
+    name: Preview Sync Stress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the PR path-filter can diff against the base branch.
+          fetch-depth: 0
+
+      - name: Decide whether to run
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Nightly schedule and pushes to main soak the whole thing.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "runs=10" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event (${{ github.event_name }}) — full soak (10x)."
+            exit 0
+          fi
+          base="origin/${{ github.base_ref }}"
+          if git diff --name-only "$base"...HEAD \
+            | grep -qE '^(src/features/preview/|scripts/preview-sync-stress\.mjs$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "runs=5" >> "$GITHUB_OUTPUT"
+            echo "Preview code changed — running stress (5x)."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No preview changes — skipping stress (nightly soak still covers it)."
+          fi
+
+      - name: Setup Vite+
+        if: steps.gate.outputs.run == 'true'
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22'
+          cache: true
+
+      - name: Install dependencies
+        if: steps.gate.outputs.run == 'true'
+        run: vp install
+
+      - name: Preview Sync Stress
+        if: steps.gate.outputs.run == 'true'
+        run: vp run test:preview-sync:stress -- --runs ${{ steps.gate.outputs.runs }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **Edit videos. In your browser.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/aQtQ7NyUBd)
 
 ![FreeCut editor workspace](./public/assets/landing/main.png)
 
@@ -20,6 +21,11 @@ folder you choose on disk.
 ## User Guide
 
 New to FreeCut? Start with the [user guide](https://freecut.net/docs).
+
+## Community
+
+Join the [FreeCut Discord](https://discord.gg/aQtQ7NyUBd) to share edits,
+request features, report bugs, and give feedback on browser-based editing workflows.
 
 ## Screenshots
 

--- a/scripts/preview-sync-stress.mjs
+++ b/scripts/preview-sync-stress.mjs
@@ -4,22 +4,26 @@ import process from 'node:process';
 const DEFAULT_RUNS = 20;
 
 function parseRuns(argv) {
+  // Scan the whole argv and let the LAST valid --runs win. `vp run <script> --
+  // --runs N` appends the override after the script's own baked-in `--runs 20`,
+  // so returning the first match would silently ignore the CI/CLI override.
+  let runs = DEFAULT_RUNS;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--runs') {
       const value = Number(argv[i + 1]);
       if (Number.isFinite(value) && value > 0) {
-        return Math.floor(value);
+        runs = Math.floor(value);
       }
     }
     if (arg.startsWith('--runs=')) {
       const value = Number(arg.slice('--runs='.length));
       if (Number.isFinite(value) && value > 0) {
-        return Math.floor(value);
+        runs = Math.floor(value);
       }
     }
   }
-  return DEFAULT_RUNS;
+  return runs;
 }
 
 const runs = parseRuns(process.argv.slice(2));

--- a/src/config/community.ts
+++ b/src/config/community.ts
@@ -1,0 +1,1 @@
+export const DISCORD_INVITE_URL = 'https://discord.gg/aQtQ7NyUBd'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,9 +9,11 @@ import {
   Star,
   ExternalLink,
   BookOpen,
+  MessageCircle,
 } from 'lucide-react'
 import { FreeCutLogo } from '@/components/brand/freecut-logo'
 import { Button } from '@/components/ui/button'
+import { DISCORD_INVITE_URL } from '@/config/community'
 import {
   Accordion,
   AccordionContent,
@@ -183,6 +185,13 @@ function LandingPage() {
             </Button>
 
             <Button asChild variant="outline" size="lg" className="gap-2">
+              <a href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+                <MessageCircle className="h-4 w-4" />
+                Join Discord
+              </a>
+            </Button>
+
+            <Button asChild variant="outline" size="lg" className="gap-2">
               <a
                 href="https://github.com/walterlow/freecut"
                 target="_blank"
@@ -342,6 +351,13 @@ function LandingPage() {
                 <BookOpen className="h-4 w-4" />
                 Docs
               </Link>
+            </Button>
+
+            <Button asChild variant="outline" size="lg" className="gap-2">
+              <a href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+                <MessageCircle className="h-4 w-4" />
+                Join Discord
+              </a>
             </Button>
 
             <Button asChild variant="outline" size="lg" className="gap-2">

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -6,8 +6,9 @@ import { createLogger } from '@/shared/logging/logger'
 
 const logger = createLogger('ProjectsIndex')
 import { Button } from '@/components/ui/button'
-import { Plus, Upload, FolderOpen, File, Github, BookOpen } from 'lucide-react'
+import { Plus, Upload, FolderOpen, File, Github, BookOpen, MessageCircle } from 'lucide-react'
 import { FreeCutLogo } from '@/components/brand/freecut-logo'
+import { DISCORD_INVITE_URL } from '@/config/community'
 import { ProjectList } from '@/features/projects/components/project-list'
 import { EditProjectForm } from '@/features/projects/components/project-form'
 import {
@@ -276,6 +277,12 @@ function ProjectsIndex() {
                   <BookOpen className="w-4 h-4" />
                   Docs
                 </Link>
+              </Button>
+              <Button variant="outline" size="lg" className="gap-2" asChild>
+                <a href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+                  <MessageCircle className="w-4 h-4" />
+                  Discord
+                </a>
               </Button>
               <Button variant="outline" size="icon" className="h-10 w-10" asChild>
                 <a

--- a/src/routes/projects/new.tsx
+++ b/src/routes/projects/new.tsx
@@ -8,7 +8,8 @@ import { useCreateProject } from '@/features/projects/hooks/use-project-actions'
 import { useProjectStore } from '@/features/projects/stores/project-store'
 import { FreeCutLogo } from '@/components/brand/freecut-logo'
 import { Button } from '@/components/ui/button'
-import { Github } from 'lucide-react'
+import { Github, MessageCircle } from 'lucide-react'
+import { DISCORD_INVITE_URL } from '@/config/community'
 import type { ProjectFormData } from '@/features/projects/utils/validation'
 
 const logger = createLogger('NewProject')
@@ -62,17 +63,25 @@ function NewProject() {
           <Link to="/">
             <FreeCutLogo variant="full" size="md" className="hover:opacity-80 transition-opacity" />
           </Link>
-          <Button variant="outline" size="icon" className="h-10 w-10" asChild>
-            <a
-              href="https://github.com/walterlow/freecut"
-              target="_blank"
-              rel="noopener noreferrer"
-              data-tooltip={t('projects.viewOnGitHub')}
-              data-tooltip-side="left"
-            >
-              <Github className="w-5 h-5" />
-            </a>
-          </Button>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" size="lg" className="gap-2" asChild>
+              <a href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+                <MessageCircle className="w-4 h-4" />
+                Discord
+              </a>
+            </Button>
+            <Button variant="outline" size="icon" className="h-10 w-10" asChild>
+              <a
+                href="https://github.com/walterlow/freecut"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-tooltip={t('projects.viewOnGitHub')}
+                data-tooltip-side="left"
+              >
+                <Github className="w-5 h-5" />
+              </a>
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Two independent changes bundled from `develop`:

### 1. Rebalance the preview-sync stress test (`44a780fc`)
- Moved the preview-sync stress test **off every PR's critical path** into its own `preview-sync-stress` job.
  - **Nightly** (cron) + pushes to `main`: full 10x soak.
  - **PRs**: 5x, but only when the diff touches `src/features/preview/` or the stress script — otherwise skipped (nightly is the catch-all).
- Fixed `parseRuns` in `scripts/preview-sync-stress.mjs` to let the **last** `--runs` win. `vp run <script> -- --runs N` appends after the script's baked-in `--runs 20`, so the first match won — the override was silently ignored and the "10x" step was actually running **20x**.

**Why:** the stress step was ~4.5 min on every PR's critical path (including PRs unrelated to preview), mostly redundant cold-start. This keeps the ordering/stale-render flake guard but stops charging every PR for it.

### 2. Discord community links (`4c425036`)
- Discord invite surfaced on the landing page, projects list, and new-project header.
- README badge + Community section.
- Invite URL centralized in `src/config/community.ts`.

## Test plan
- [x] `parseRuns` override verified locally (`--runs 20 --runs 1` → 1 run, passes green).
- [x] `ci.yml` YAML validated.
- [ ] Confirm the `preview-sync-stress` job gate behaves as expected on this PR (this PR touches the stress script, so it should run 5x).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord community links across the site, including the homepage, projects page, and new project page.
  * Added a Community section in the README inviting users to join the Discord for feedback and support.
* **Chores**
  * Improved CI coverage by adding a scheduled nightly run and making preview stress checks run more selectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->