### PR TITLE
fix(timeline): IO markers stick to cursor after drag release

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -66,6 +66,7 @@ import {
   useEmbeddedSubtitlePickerStore,
   useSubtitleScanProgressStore,
 } from '@/features/editor/deps/media-library'
+import { IoDragReadout } from '@/shared/timeline/io-range'
 const logger = createLogger('Editor')
 const EDITOR_PROJECT_ROUTE_ID = '/editor/$projectId'
 
@@ -821,6 +822,9 @@ export const LoadedEditor = memo(function LoadedEditor({
 
       <EditorDialogHost projectId={projectId} />
       <TimelineDialogHost />
+
+      {/* Single global cursor-readout for IO (in/out) drags across all surfaces. */}
+      <IoDragReadout />
     </div>
   )
 })

--- a/src/features/editor/components/mini-timeline/mini-timeline-io-lane.tsx
+++ b/src/features/editor/components/mini-timeline/mini-timeline-io-lane.tsx
@@ -7,7 +7,12 @@ import {
 } from '@/features/editor/deps/timeline-store'
 import { usePlaybackStore } from '@/shared/state/playback'
 import type { TimelineAnnotationModel } from '@/shared/timeline/timeline-annotations'
-import { IoRangeHandles, IoRangeStrip, useMeasuredWidth } from '@/shared/timeline/io-range'
+import {
+  beginIoPointerDrag,
+  IoRangeHandles,
+  IoRangeStrip,
+  useMeasuredWidth,
+} from '@/shared/timeline/io-range'
 import { MINI_TIMELINE_IO_HANDLE_WIDTH, MINI_TIMELINE_IO_LANE_HEIGHT } from './constants'
 
 /**
@@ -57,49 +62,42 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
   // mark dirty on release).
   const startRangeDrag = useCallback(
     (event: PointerEvent) => {
-      if (event.button !== 0) return
       const { in: startIn, out: startOut } = inOutRef.current
       if (startIn === null || startOut === null) return
-      event.preventDefault()
-      event.stopPropagation()
       const lane = laneRef.current
       if (!lane) return
 
       const startClientX = event.clientX
       const span = Math.max(1, startOut - startIn)
       const prevCursor = document.body.style.cursor
+      let lastIn = startIn
+
+      const cleanup = beginIoPointerDrag(
+        event,
+        (clientX) => {
+          const rect = lane.getBoundingClientRect()
+          if (rect.width <= 0) return
+          const frameDelta = Math.round(((clientX - startClientX) / rect.width) * maxFrameRef.current)
+          const maxIn = Math.max(0, maxFrameRef.current - span)
+          const nextIn = Math.max(0, Math.min(startIn + frameDelta, maxIn))
+          if (nextIn === lastIn) return
+          lastIn = nextIn
+          setInOutPointsWithoutHistory(nextIn, nextIn + span)
+          // Preview follows the leading edge; the playhead stays put (suppressed).
+          usePlaybackStore.getState().setPreviewFrame(nextIn)
+        },
+        () => {
+          document.body.style.cursor = prevCursor
+          usePlaybackStore.getState().setPreviewFrame(null)
+          suppressPlayheadPreviewRef.current = false
+          useTimelineSettingsStore.getState().markDirty()
+          dragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
       document.body.style.cursor = 'grabbing'
       // Keep the preview live but pin the host playhead while dragging.
       suppressPlayheadPreviewRef.current = true
-      let lastIn = startIn
-
-      const onMove = (ev: globalThis.PointerEvent) => {
-        const rect = lane.getBoundingClientRect()
-        if (rect.width <= 0) return
-        const frameDelta = Math.round(
-          ((ev.clientX - startClientX) / rect.width) * maxFrameRef.current,
-        )
-        const maxIn = Math.max(0, maxFrameRef.current - span)
-        const nextIn = Math.max(0, Math.min(startIn + frameDelta, maxIn))
-        if (nextIn === lastIn) return
-        lastIn = nextIn
-        setInOutPointsWithoutHistory(nextIn, nextIn + span)
-        // Preview follows the leading edge; the playhead stays put (suppressed).
-        usePlaybackStore.getState().setPreviewFrame(nextIn)
-      }
-      const cleanup = () => {
-        document.removeEventListener('pointermove', onMove)
-        document.removeEventListener('pointerup', cleanup)
-        document.removeEventListener('pointercancel', cleanup)
-        document.body.style.cursor = prevCursor
-        usePlaybackStore.getState().setPreviewFrame(null)
-        suppressPlayheadPreviewRef.current = false
-        useTimelineSettingsStore.getState().markDirty()
-        dragCleanupRef.current = null
-      }
-      document.addEventListener('pointermove', onMove)
-      document.addEventListener('pointerup', cleanup)
-      document.addEventListener('pointercancel', cleanup)
       dragCleanupRef.current = cleanup
     },
     [suppressPlayheadPreviewRef],
@@ -107,41 +105,35 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
 
   const startDrag = useCallback(
     (side: 'in' | 'out') => (event: PointerEvent) => {
-      if (event.button !== 0) return
-      // Claim the gesture so the scrub surface underneath doesn't also seek.
-      event.preventDefault()
-      event.stopPropagation()
       const lane = laneRef.current
       if (!lane) return
 
       const setFrame = settersRef.current[side]
       const prevCursor = document.body.style.cursor
+
+      const cleanup = beginIoPointerDrag(
+        event,
+        (clientX) => {
+          const rect = lane.getBoundingClientRect()
+          if (rect.width <= 0) return
+          const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+          const frame = Math.round(ratio * maxFrameRef.current)
+          setFrame(frame)
+          // Skim the preview to the boundary; out is exclusive, so show out - 1.
+          const previewFrame = side === 'out' ? Math.max(0, frame - 1) : frame
+          usePlaybackStore.getState().setPreviewFrame(previewFrame)
+        },
+        () => {
+          document.body.style.cursor = prevCursor
+          usePlaybackStore.getState().setPreviewFrame(null)
+          suppressPlayheadPreviewRef.current = false
+          dragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
       document.body.style.cursor = 'col-resize'
       // Keep the preview live but pin the host playhead while dragging.
       suppressPlayheadPreviewRef.current = true
-
-      const onMove = (ev: globalThis.PointerEvent) => {
-        const rect = lane.getBoundingClientRect()
-        if (rect.width <= 0) return
-        const ratio = Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width))
-        const frame = Math.round(ratio * maxFrameRef.current)
-        setFrame(frame)
-        // Skim the preview to the boundary; out is exclusive, so show out - 1.
-        const previewFrame = side === 'out' ? Math.max(0, frame - 1) : frame
-        usePlaybackStore.getState().setPreviewFrame(previewFrame)
-      }
-      const cleanup = () => {
-        document.removeEventListener('pointermove', onMove)
-        document.removeEventListener('pointerup', cleanup)
-        document.removeEventListener('pointercancel', cleanup)
-        document.body.style.cursor = prevCursor
-        usePlaybackStore.getState().setPreviewFrame(null)
-        suppressPlayheadPreviewRef.current = false
-        dragCleanupRef.current = null
-      }
-      document.addEventListener('pointermove', onMove)
-      document.addEventListener('pointerup', cleanup)
-      document.addEventListener('pointercancel', cleanup)
       dragCleanupRef.current = cleanup
     },
     [suppressPlayheadPreviewRef],

--- a/src/features/editor/components/mini-timeline/mini-timeline-io-lane.tsx
+++ b/src/features/editor/components/mini-timeline/mini-timeline-io-lane.tsx
@@ -14,6 +14,7 @@ import {
   useMeasuredWidth,
 } from '@/shared/timeline/io-range'
 import { MINI_TIMELINE_IO_HANDLE_WIDTH, MINI_TIMELINE_IO_LANE_HEIGHT } from './constants'
+import { formatTimecodeCompact } from '@/shared/utils/time-utils'
 
 /**
  * The IO bar's own lane (DaVinci-style). Renders the in/out range strip (drag
@@ -41,6 +42,7 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
   const setOutPoint = useTimelineStore((s) => s.setOutPoint)
   const inPoint = useTimelineStore((s) => s.inPoint)
   const outPoint = useTimelineStore((s) => s.outPoint)
+  const fps = useTimelineStore((s) => s.fps)
 
   const laneRef = useRef<HTMLDivElement>(null)
   // Lane pixel width — the ratios above render fluidly, but the handles need the
@@ -53,6 +55,8 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
   settersRef.current = { in: setInPoint, out: setOutPoint }
   const inOutRef = useRef({ in: inPoint, out: outPoint })
   inOutRef.current = { in: inPoint, out: outPoint }
+  const fpsRef = useRef(fps)
+  fpsRef.current = fps
 
   // Tear down any in-flight drag if the lane unmounts mid-gesture.
   useEffect(() => () => dragCleanupRef.current?.(), [])
@@ -80,11 +84,13 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
           const frameDelta = Math.round(((clientX - startClientX) / rect.width) * maxFrameRef.current)
           const maxIn = Math.max(0, maxFrameRef.current - span)
           const nextIn = Math.max(0, Math.min(startIn + frameDelta, maxIn))
-          if (nextIn === lastIn) return
+          const label = `${formatTimecodeCompact(nextIn, fpsRef.current)} → ${formatTimecodeCompact(nextIn + span, fpsRef.current)}`
+          if (nextIn === lastIn) return label
           lastIn = nextIn
           setInOutPointsWithoutHistory(nextIn, nextIn + span)
           // Preview follows the leading edge; the playhead stays put (suppressed).
           usePlaybackStore.getState().setPreviewFrame(nextIn)
+          return label
         },
         () => {
           document.body.style.cursor = prevCursor
@@ -122,6 +128,7 @@ export const MiniTimelineIoLane = memo(function MiniTimelineIoLane({
           // Skim the preview to the boundary; out is exclusive, so show out - 1.
           const previewFrame = side === 'out' ? Math.max(0, frame - 1) : frame
           usePlaybackStore.getState().setPreviewFrame(previewFrame)
+          return formatTimecodeCompact(frame, fpsRef.current)
         },
         () => {
           document.body.style.cursor = prevCursor

--- a/src/features/preview/components/source-monitor.tsx
+++ b/src/features/preview/components/source-monitor.tsx
@@ -923,12 +923,13 @@ function SourcePlaybackControls({
             const nextIn = clampDraggedSourceInPoint(point, store().outPoint, lastFrame)
             store().setInPoint(nextIn)
             store().setPreviewSourceFrame(nextIn)
-          } else {
-            const nextOut = clampDraggedSourceOutPoint(point, store().inPoint, durationInFrames)
-            store().setOutPoint(nextOut)
-            // Out is exclusive — skim to the last included frame (out - 1).
-            store().setPreviewSourceFrame(Math.max(0, nextOut - 1))
+            return formatTime(nextIn)
           }
+          const nextOut = clampDraggedSourceOutPoint(point, store().inPoint, durationInFrames)
+          store().setOutPoint(nextOut)
+          // Out is exclusive — skim to the last included frame (out - 1).
+          store().setPreviewSourceFrame(Math.max(0, nextOut - 1))
+          return formatTime(nextOut)
         },
         () => {
           document.body.style.cursor = originalCursor
@@ -940,7 +941,7 @@ function SourcePlaybackControls({
       document.body.style.cursor = 'col-resize'
       ioDragCleanupRef.current = cleanup
     },
-    [durationInFrames, lastFrame, pointFromStripX],
+    [durationInFrames, lastFrame, pointFromStripX, formatTime],
   )
 
   const handleIORangeDragStart = useCallback(
@@ -960,6 +961,7 @@ function SourcePlaybackControls({
           store().setOutPoint(nextRange.outPoint)
           // Skim the preview to the range's leading (in) edge as it slides.
           store().setPreviewSourceFrame(nextRange.inPoint)
+          return `${formatTime(nextRange.inPoint)} → ${formatTime(nextRange.outPoint)}`
         },
         () => {
           document.body.style.cursor = originalCursor
@@ -971,7 +973,7 @@ function SourcePlaybackControls({
       document.body.style.cursor = 'grabbing'
       ioDragCleanupRef.current = cleanup
     },
-    [durationInFrames, pointFromStripX],
+    [durationInFrames, pointFromStripX, formatTime],
   )
 
   useEffect(() => {

--- a/src/features/preview/components/source-monitor.tsx
+++ b/src/features/preview/components/source-monitor.tsx
@@ -58,7 +58,12 @@ import { useSelectionStore } from '@/shared/state/selection'
 import { EDITOR_LAYOUT_CSS_VALUES, getEditorLayout } from '@/config/editor-layout'
 import { createScrubThrottleState, shouldCommitScrubFrame } from '../deps/timeline-utils'
 import { cn } from '@/shared/ui/cn'
-import { IoRangeHandles, IoRangeStrip, useMeasuredWidth } from '@/shared/timeline/io-range'
+import {
+  beginIoPointerDrag,
+  IoRangeHandles,
+  IoRangeStrip,
+  useMeasuredWidth,
+} from '@/shared/timeline/io-range'
 import { formatTimecodeCompact } from '@/shared/utils/time-utils'
 import { getPreviewPixelSnapSize } from '../utils/preview-pixel-snap'
 import type { TimelineTrack } from '@/types/timeline'
@@ -908,83 +913,63 @@ function SourcePlaybackControls({
 
   const handleIODragStart = useCallback(
     (e: React.PointerEvent, type: 'in' | 'out') => {
-      if (e.button !== 0) return
-      e.preventDefault()
-      e.stopPropagation()
-      const originalCursor = document.body.style.cursor
-      document.body.style.cursor = 'col-resize'
-
       const store = useSourcePlayerStore.getState
-      // Pointer events, not mouse: preventDefault() on the pointerdown above
-      // suppresses the compatibility `mouseup`, so a mouse listener would leave
-      // the drag running (marker stuck to the cursor). `pointerup` is unaffected.
-      const onMove = (ev: PointerEvent) => {
-        const point = pointFromStripX(ev.clientX)
-        if (type === 'in') {
-          const out = store().outPoint
-          const nextIn = clampDraggedSourceInPoint(point, out, lastFrame)
-          store().setInPoint(nextIn)
-          store().setPreviewSourceFrame(nextIn)
-        } else {
-          const inp = store().inPoint
-          const nextOut = clampDraggedSourceOutPoint(point, inp, durationInFrames)
-          store().setOutPoint(nextOut)
-          // Out is exclusive — skim to the last included frame (out - 1).
-          store().setPreviewSourceFrame(Math.max(0, nextOut - 1))
-        }
-      }
-      const onUp = () => {
-        document.body.style.cursor = originalCursor
-        document.removeEventListener('pointermove', onMove)
-        document.removeEventListener('pointerup', onUp)
-        document.removeEventListener('pointercancel', onUp)
-        store().setPreviewSourceFrame(null)
-        ioDragCleanupRef.current = null
-      }
-      ioDragCleanupRef.current = onUp
-      document.addEventListener('pointermove', onMove)
-      document.addEventListener('pointerup', onUp)
-      document.addEventListener('pointercancel', onUp)
+      const originalCursor = document.body.style.cursor
+      const cleanup = beginIoPointerDrag(
+        e,
+        (clientX) => {
+          const point = pointFromStripX(clientX)
+          if (type === 'in') {
+            const nextIn = clampDraggedSourceInPoint(point, store().outPoint, lastFrame)
+            store().setInPoint(nextIn)
+            store().setPreviewSourceFrame(nextIn)
+          } else {
+            const nextOut = clampDraggedSourceOutPoint(point, store().inPoint, durationInFrames)
+            store().setOutPoint(nextOut)
+            // Out is exclusive — skim to the last included frame (out - 1).
+            store().setPreviewSourceFrame(Math.max(0, nextOut - 1))
+          }
+        },
+        () => {
+          document.body.style.cursor = originalCursor
+          store().setPreviewSourceFrame(null)
+          ioDragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
+      document.body.style.cursor = 'col-resize'
+      ioDragCleanupRef.current = cleanup
     },
     [durationInFrames, lastFrame, pointFromStripX],
   )
 
   const handleIORangeDragStart = useCallback(
     (e: React.PointerEvent) => {
-      if (e.button !== 0) return
-      e.preventDefault()
-      e.stopPropagation()
       const store = useSourcePlayerStore.getState
       const startIn = store().inPoint
       const startOut = store().outPoint
       if (startIn === null || startOut === null) return
       const startPoint = pointFromStripX(e.clientX)
       const originalCursor = document.body.style.cursor
+      const cleanup = beginIoPointerDrag(
+        e,
+        (clientX) => {
+          const delta = pointFromStripX(clientX) - startPoint
+          const nextRange = shiftSourceIoRange(startIn, startOut, delta, durationInFrames)
+          store().setInPoint(nextRange.inPoint)
+          store().setOutPoint(nextRange.outPoint)
+          // Skim the preview to the range's leading (in) edge as it slides.
+          store().setPreviewSourceFrame(nextRange.inPoint)
+        },
+        () => {
+          document.body.style.cursor = originalCursor
+          store().setPreviewSourceFrame(null)
+          ioDragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
       document.body.style.cursor = 'grabbing'
-
-      // Pointer events, not mouse — see handleIODragStart (preventDefault on the
-      // pointerdown suppresses the compat `mouseup`, which would strand the drag).
-      const onMove = (ev: PointerEvent) => {
-        const nowPoint = pointFromStripX(ev.clientX)
-        const delta = nowPoint - startPoint
-        const nextRange = shiftSourceIoRange(startIn, startOut, delta, durationInFrames)
-        store().setInPoint(nextRange.inPoint)
-        store().setOutPoint(nextRange.outPoint)
-        // Skim the preview to the range's leading (in) edge as it slides.
-        store().setPreviewSourceFrame(nextRange.inPoint)
-      }
-      const onUp = () => {
-        document.body.style.cursor = originalCursor
-        document.removeEventListener('pointermove', onMove)
-        document.removeEventListener('pointerup', onUp)
-        document.removeEventListener('pointercancel', onUp)
-        store().setPreviewSourceFrame(null)
-        ioDragCleanupRef.current = null
-      }
-      ioDragCleanupRef.current = onUp
-      document.addEventListener('pointermove', onMove)
-      document.addEventListener('pointerup', onUp)
-      document.addEventListener('pointercancel', onUp)
+      ioDragCleanupRef.current = cleanup
     },
     [durationInFrames, pointFromStripX],
   )

--- a/src/features/preview/components/source-monitor.tsx
+++ b/src/features/preview/components/source-monitor.tsx
@@ -907,14 +907,18 @@ function SourcePlaybackControls({
   )
 
   const handleIODragStart = useCallback(
-    (e: React.MouseEvent, type: 'in' | 'out') => {
+    (e: React.PointerEvent, type: 'in' | 'out') => {
+      if (e.button !== 0) return
       e.preventDefault()
       e.stopPropagation()
       const originalCursor = document.body.style.cursor
       document.body.style.cursor = 'col-resize'
 
       const store = useSourcePlayerStore.getState
-      const onMove = (ev: MouseEvent) => {
+      // Pointer events, not mouse: preventDefault() on the pointerdown above
+      // suppresses the compatibility `mouseup`, so a mouse listener would leave
+      // the drag running (marker stuck to the cursor). `pointerup` is unaffected.
+      const onMove = (ev: PointerEvent) => {
         const point = pointFromStripX(ev.clientX)
         if (type === 'in') {
           const out = store().outPoint
@@ -931,20 +935,23 @@ function SourcePlaybackControls({
       }
       const onUp = () => {
         document.body.style.cursor = originalCursor
-        document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', onUp)
+        document.removeEventListener('pointermove', onMove)
+        document.removeEventListener('pointerup', onUp)
+        document.removeEventListener('pointercancel', onUp)
         store().setPreviewSourceFrame(null)
         ioDragCleanupRef.current = null
       }
       ioDragCleanupRef.current = onUp
-      document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', onUp)
+      document.addEventListener('pointermove', onMove)
+      document.addEventListener('pointerup', onUp)
+      document.addEventListener('pointercancel', onUp)
     },
     [durationInFrames, lastFrame, pointFromStripX],
   )
 
   const handleIORangeDragStart = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
       e.preventDefault()
       e.stopPropagation()
       const store = useSourcePlayerStore.getState
@@ -955,7 +962,9 @@ function SourcePlaybackControls({
       const originalCursor = document.body.style.cursor
       document.body.style.cursor = 'grabbing'
 
-      const onMove = (ev: MouseEvent) => {
+      // Pointer events, not mouse — see handleIODragStart (preventDefault on the
+      // pointerdown suppresses the compat `mouseup`, which would strand the drag).
+      const onMove = (ev: PointerEvent) => {
         const nowPoint = pointFromStripX(ev.clientX)
         const delta = nowPoint - startPoint
         const nextRange = shiftSourceIoRange(startIn, startOut, delta, durationInFrames)
@@ -966,14 +975,16 @@ function SourcePlaybackControls({
       }
       const onUp = () => {
         document.body.style.cursor = originalCursor
-        document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', onUp)
+        document.removeEventListener('pointermove', onMove)
+        document.removeEventListener('pointerup', onUp)
+        document.removeEventListener('pointercancel', onUp)
         store().setPreviewSourceFrame(null)
         ioDragCleanupRef.current = null
       }
       ioDragCleanupRef.current = onUp
-      document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', onUp)
+      document.addEventListener('pointermove', onMove)
+      document.addEventListener('pointerup', onUp)
+      document.addEventListener('pointercancel', onUp)
     },
     [durationInFrames, pointFromStripX],
   )

--- a/src/features/timeline/components/timeline-in-out-markers.tsx
+++ b/src/features/timeline/components/timeline-in-out-markers.tsx
@@ -35,6 +35,7 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
 
   const startDrag = useCallback(
     (handle: 'in' | 'out') => (e: React.PointerEvent) => {
+      if (e.button !== 0) return
       e.preventDefault()
       e.stopPropagation()
 
@@ -48,7 +49,11 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
       // doesn't chase the marker (matches the Color workspace IO drag).
       previewScrubberSuppressRef.current = true
 
-      const onMove = (ev: MouseEvent) => {
+      // Drive the drag with pointer events: calling preventDefault() on the
+      // pointerdown above suppresses the compatibility `mouseup`, so a
+      // mouse-based listener would never tear the drag down (marker sticks to
+      // the cursor). `pointerup`/`pointercancel` are unaffected.
+      const onMove = (ev: PointerEvent) => {
         const rect = container.getBoundingClientRect()
         const x = ev.clientX - rect.left
         const frame = Math.max(0, pixelsToFrameRef.current(x))
@@ -60,15 +65,17 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
         usePlaybackStore.getState().setPreviewFrame(previewFrame)
       }
       const cleanup = () => {
-        document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', cleanup)
+        document.removeEventListener('pointermove', onMove)
+        document.removeEventListener('pointerup', cleanup)
+        document.removeEventListener('pointercancel', cleanup)
         document.body.style.cursor = prevCursor
         previewScrubberSuppressRef.current = false
         usePlaybackStore.getState().setPreviewFrame(null)
         dragCleanupRef.current = null
       }
-      document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', cleanup)
+      document.addEventListener('pointermove', onMove)
+      document.addEventListener('pointerup', cleanup)
+      document.addEventListener('pointercancel', cleanup)
       dragCleanupRef.current = cleanup
     },
     [],

--- a/src/features/timeline/components/timeline-in-out-markers.tsx
+++ b/src/features/timeline/components/timeline-in-out-markers.tsx
@@ -5,6 +5,7 @@ import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
 import { beginIoPointerDrag, IoRangeHandles } from '@/shared/timeline/io-range'
+import { formatTimecodeCompact } from '@/shared/utils/time-utils'
 
 // Matches the ruler's top IO lane height in timeline-markers.tsx.
 const IO_LANE_HEIGHT = 12
@@ -21,14 +22,17 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
   const outPoint = useTimelineStore((s) => s.outPoint)
   const setInPoint = useTimelineStore((s) => s.setInPoint)
   const setOutPoint = useTimelineStore((s) => s.setOutPoint)
+  const fps = useTimelineStore((s) => s.fps)
   const { frameToPixels, pixelsToFrame } = useTimelineZoomContext()
 
   const pixelsToFrameRef = useRef(pixelsToFrame)
   const setInPointRef = useRef(setInPoint)
   const setOutPointRef = useRef(setOutPoint)
+  const fpsRef = useRef(fps)
   pixelsToFrameRef.current = pixelsToFrame
   setInPointRef.current = setInPoint
   setOutPointRef.current = setOutPoint
+  fpsRef.current = fps
 
   // Store active drag cleanup so we can tear down on unmount
   const dragCleanupRef = useRef<(() => void) | null>(null)
@@ -52,6 +56,7 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
           const previewFrame =
             handle === 'out' ? Math.max(0, Math.round(frame) - 1) : Math.round(frame)
           usePlaybackStore.getState().setPreviewFrame(previewFrame)
+          return formatTimecodeCompact(Math.round(frame), fpsRef.current)
         },
         () => {
           document.body.style.cursor = prevCursor

--- a/src/features/timeline/components/timeline-in-out-markers.tsx
+++ b/src/features/timeline/components/timeline-in-out-markers.tsx
@@ -4,7 +4,7 @@ import { useTimelineStore } from '../stores/timeline-store'
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
-import { IoRangeHandles } from '@/shared/timeline/io-range'
+import { beginIoPointerDrag, IoRangeHandles } from '@/shared/timeline/io-range'
 
 // Matches the ruler's top IO lane height in timeline-markers.tsx.
 const IO_LANE_HEIGHT = 12
@@ -35,47 +35,36 @@ export const TimelineInOutMarkers = memo(function TimelineInOutMarkers() {
 
   const startDrag = useCallback(
     (handle: 'in' | 'out') => (e: React.PointerEvent) => {
-      if (e.button !== 0) return
-      e.preventDefault()
-      e.stopPropagation()
-
       const container = (e.currentTarget as HTMLElement).closest('.timeline-ruler')
       if (!container) return
 
       const setter = handle === 'in' ? setInPointRef : setOutPointRef
       const prevCursor = document.body.style.cursor
+      const cleanup = beginIoPointerDrag(
+        e,
+        (clientX) => {
+          const rect = container.getBoundingClientRect()
+          const x = clientX - rect.left
+          const frame = Math.max(0, pixelsToFrameRef.current(x))
+          setter.current(frame)
+          // Skim the preview to the boundary frame. Out is exclusive, so show the
+          // last included frame (out - 1) rather than the frame just past it.
+          const previewFrame =
+            handle === 'out' ? Math.max(0, Math.round(frame) - 1) : Math.round(frame)
+          usePlaybackStore.getState().setPreviewFrame(previewFrame)
+        },
+        () => {
+          document.body.style.cursor = prevCursor
+          previewScrubberSuppressRef.current = false
+          usePlaybackStore.getState().setPreviewFrame(null)
+          dragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
       document.body.style.cursor = 'col-resize'
       // Keep the preview canvas refreshing but pin the ghost skimmer so it
       // doesn't chase the marker (matches the Color workspace IO drag).
       previewScrubberSuppressRef.current = true
-
-      // Drive the drag with pointer events: calling preventDefault() on the
-      // pointerdown above suppresses the compatibility `mouseup`, so a
-      // mouse-based listener would never tear the drag down (marker sticks to
-      // the cursor). `pointerup`/`pointercancel` are unaffected.
-      const onMove = (ev: PointerEvent) => {
-        const rect = container.getBoundingClientRect()
-        const x = ev.clientX - rect.left
-        const frame = Math.max(0, pixelsToFrameRef.current(x))
-        setter.current(frame)
-        // Skim the preview to the boundary frame. Out is exclusive, so show the
-        // last included frame (out - 1) rather than the frame just past it.
-        const previewFrame =
-          handle === 'out' ? Math.max(0, Math.round(frame) - 1) : Math.round(frame)
-        usePlaybackStore.getState().setPreviewFrame(previewFrame)
-      }
-      const cleanup = () => {
-        document.removeEventListener('pointermove', onMove)
-        document.removeEventListener('pointerup', cleanup)
-        document.removeEventListener('pointercancel', cleanup)
-        document.body.style.cursor = prevCursor
-        previewScrubberSuppressRef.current = false
-        usePlaybackStore.getState().setPreviewFrame(null)
-        dragCleanupRef.current = null
-      }
-      document.addEventListener('pointermove', onMove)
-      document.addEventListener('pointerup', cleanup)
-      document.addEventListener('pointercancel', cleanup)
       dragCleanupRef.current = cleanup
     },
     [],

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -17,7 +17,7 @@ import { useSettingsStore } from '@/features/timeline/deps/settings'
 
 // Utilities and hooks
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
-import { formatTimecode, secondsToFrames } from '@/shared/utils/time-utils'
+import { formatTimecode, formatTimecodeCompact, secondsToFrames } from '@/shared/utils/time-utils'
 import { createScrubThrottleState, shouldCommitScrubFrame } from '../utils/scrub-throttle'
 import { EDITOR_LAYOUT_CSS_VALUES, getEditorLayout } from '@/config/editor-layout'
 import { sanitizeInOutPoints } from '../utils/in-out-points'
@@ -818,13 +818,15 @@ export const TimelineMarkers = memo(function TimelineMarkers({
           const maxIn = Math.max(0, Math.floor(durationRef.current * fpsRef.current) - span)
           const nextIn = Math.max(0, Math.min(startIn + deltaFrames, maxIn))
           const nextOut = nextIn + span
-          // Skip redundant writes while dragging.
-          if (nextIn === lastIn && nextOut === lastOut) return
+          const label = `${formatTimecodeCompact(nextIn, fpsRef.current)} → ${formatTimecodeCompact(nextOut, fpsRef.current)}`
+          // Skip redundant writes while dragging (still update the readout).
+          if (nextIn === lastIn && nextOut === lastOut) return label
           setInOutPointsWithoutHistory(nextIn, nextOut)
           // Skim the preview to the range's leading (in) edge as it slides.
           setPreviewFrameRef.current(nextIn)
           lastIn = nextIn
           lastOut = nextOut
+          return label
         },
         () => {
           document.body.style.cursor = originalCursor

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -12,7 +12,7 @@ import { perfMarkRender } from '@/shared/logging/perf-marks'
 import { TimelineInOutMarkers } from './timeline-in-out-markers'
 import { TimelineProjectMarkers } from './timeline-project-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
-import { IoRangeStrip } from '@/shared/timeline/io-range'
+import { beginIoPointerDrag, IoRangeStrip } from '@/shared/timeline/io-range'
 import { useSettingsStore } from '@/features/timeline/deps/settings'
 
 // Utilities and hooks
@@ -359,11 +359,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
   const durationRef = useRef(duration)
   const inPointRef = useRef(inPoint)
   const outPointRef = useRef(outPoint)
-  const rangeDragStartTimelineXRef = useRef(0)
-  const rangeDragStartInRef = useRef(0)
-  const rangeDragStartOutRef = useRef(0)
-  const rangeDragLastInRef = useRef(0)
-  const rangeDragLastOutRef = useRef(0)
+  const rangeDragCleanupRef = useRef<(() => void) | null>(null)
   const maxFrame = Math.max(1, Math.floor(duration * fps))
   const sanitizedInOutPoints = useMemo(
     () => sanitizeInOutPoints({ inPoint, outPoint, maxFrame }),
@@ -801,19 +797,51 @@ export const TimelineMarkers = memo(function TimelineMarkers({
   }, [isDragging, isRangeDragging])
 
   const handleRangeMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (inPointRef.current === null || outPointRef.current === null) return
+    (e: React.PointerEvent) => {
+      const startIn = inPointRef.current
+      const startOut = outPointRef.current
+      if (startIn === null || startOut === null) return
 
-      e.preventDefault()
-      e.stopPropagation()
+      const startTimelineX = getTimelineXFromClientX(e.clientX)
+      const originalCursor = document.body.style.cursor
+      let lastIn = startIn
+      let lastOut = startOut
 
-      rangeDragStartTimelineXRef.current = getTimelineXFromClientX(e.clientX)
-      rangeDragStartInRef.current = inPointRef.current
-      rangeDragStartOutRef.current = outPointRef.current
-      rangeDragLastInRef.current = inPointRef.current
-      rangeDragLastOutRef.current = outPointRef.current
-
+      const cleanup = beginIoPointerDrag(
+        e,
+        (clientX) => {
+          const deltaFrames = Math.round(
+            pixelsToFrameRef.current(getTimelineXFromClientX(clientX)) -
+              pixelsToFrameRef.current(startTimelineX),
+          )
+          const span = Math.max(1, startOut - startIn)
+          const maxIn = Math.max(0, Math.floor(durationRef.current * fpsRef.current) - span)
+          const nextIn = Math.max(0, Math.min(startIn + deltaFrames, maxIn))
+          const nextOut = nextIn + span
+          // Skip redundant writes while dragging.
+          if (nextIn === lastIn && nextOut === lastOut) return
+          setInOutPointsWithoutHistory(nextIn, nextOut)
+          // Skim the preview to the range's leading (in) edge as it slides.
+          setPreviewFrameRef.current(nextIn)
+          lastIn = nextIn
+          lastOut = nextOut
+        },
+        () => {
+          document.body.style.cursor = originalCursor
+          previewScrubberSuppressRef.current = false
+          setPreviewFrameRef.current(null)
+          markDirtyRef.current()
+          setIsRangeDragging(false)
+          rangeDragCleanupRef.current = null
+        },
+      )
+      if (!cleanup) return
+      document.body.style.cursor = 'move'
+      // Keep the preview canvas refreshing but pin the ghost skimmer so it
+      // doesn't chase the range as it slides (matches the Color workspace).
+      previewScrubberSuppressRef.current = true
       setIsRangeDragging(true)
+      rangeDragCleanupRef.current = cleanup
     },
     [getTimelineXFromClientX],
   )
@@ -909,59 +937,8 @@ export const TimelineMarkers = memo(function TimelineMarkers({
     }
   }, [isDragging])
 
-  // Drag entire in/out range together (preserves selected span length)
-  useEffect(() => {
-    if (!isRangeDragging) return
-
-    const originalCursor = document.body.style.cursor
-    document.body.style.cursor = 'move'
-    // Keep the preview canvas refreshing but pin the ghost skimmer so it doesn't
-    // chase the range as it slides (matches the Color workspace IO drag).
-    previewScrubberSuppressRef.current = true
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const currentTimelineX = getTimelineXFromClientX(e.clientX)
-      const deltaFrames = Math.round(
-        pixelsToFrameRef.current(currentTimelineX) -
-          pixelsToFrameRef.current(rangeDragStartTimelineXRef.current),
-      )
-
-      const startIn = rangeDragStartInRef.current
-      const startOut = rangeDragStartOutRef.current
-      const span = Math.max(1, startOut - startIn)
-      const maxFrame = Math.floor(durationRef.current * fpsRef.current)
-      const maxIn = Math.max(0, maxFrame - span)
-      const nextIn = Math.max(0, Math.min(startIn + deltaFrames, maxIn))
-      const nextOut = nextIn + span
-
-      // Skip redundant writes while dragging
-      if (nextIn === rangeDragLastInRef.current && nextOut === rangeDragLastOutRef.current) {
-        return
-      }
-
-      setInOutPointsWithoutHistory(nextIn, nextOut)
-      // Skim the preview to the range's leading (in) edge as it slides.
-      setPreviewFrameRef.current(nextIn)
-      rangeDragLastInRef.current = nextIn
-      rangeDragLastOutRef.current = nextOut
-    }
-
-    const handleMouseUp = () => {
-      setIsRangeDragging(false)
-      setPreviewFrameRef.current(null)
-      markDirtyRef.current()
-    }
-
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-      document.body.style.cursor = originalCursor
-      previewScrubberSuppressRef.current = false
-    }
-  }, [isRangeDragging, getTimelineXFromClientX])
+  // Tear down an in-flight range drag if the component unmounts mid-gesture.
+  useEffect(() => () => rangeDragCleanupRef.current?.(), [])
 
   return (
     <div

--- a/src/shared/timeline/io-range/index.ts
+++ b/src/shared/timeline/io-range/index.ts
@@ -5,3 +5,4 @@ export {
   useMeasuredWidth,
 } from './io-range-geometry'
 export { IoRangeStrip, IoRangeHandles } from './io-range-markers'
+export { beginIoPointerDrag } from './io-range-drag'

--- a/src/shared/timeline/io-range/index.ts
+++ b/src/shared/timeline/io-range/index.ts
@@ -6,3 +6,4 @@ export {
 } from './io-range-geometry'
 export { IoRangeStrip, IoRangeHandles } from './io-range-markers'
 export { beginIoPointerDrag } from './io-range-drag'
+export { IoDragReadout } from './io-range-readout'

--- a/src/shared/timeline/io-range/io-range-drag.ts
+++ b/src/shared/timeline/io-range/io-range-drag.ts
@@ -1,0 +1,58 @@
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+/**
+ * Start a pointer drag for an IO marker / range strip.
+ *
+ * - Captures the pointer (`setPointerCapture`) so the drag keeps receiving
+ *   events even if the pointer is released outside the browser window — without
+ *   it, `pointerup` can be missed and the drag orphans until a `pointercancel`
+ *   that may never come on desktop.
+ * - Routes move/end through document listeners filtered by `pointerId`, so a
+ *   second touch can't hijack the active drag.
+ *
+ * `onMove` receives the pointer's `clientX` (all IO surfaces resolve position
+ * from X only). Returns a cleanup fn (store it to tear the drag down on
+ * unmount), or `null` for a non-primary button.
+ */
+export function beginIoPointerDrag(
+  e: ReactPointerEvent,
+  onMove: (clientX: number) => void,
+  onEnd?: () => void,
+): (() => void) | null {
+  if (e.button !== 0) return null
+  e.preventDefault()
+  e.stopPropagation()
+
+  const target = e.currentTarget
+  const { pointerId } = e
+  try {
+    target.setPointerCapture(pointerId)
+  } catch {
+    // Pointer capture unsupported (e.g. jsdom) — the document listeners below
+    // still drive the drag; capture is only a robustness upgrade.
+  }
+
+  // Function declarations (hoisted) so move/end/cleanup can reference each other.
+  function move(ev: PointerEvent) {
+    if (ev.pointerId === pointerId) onMove(ev.clientX)
+  }
+  function end(ev: PointerEvent) {
+    if (ev.pointerId === pointerId) cleanup()
+  }
+  function cleanup() {
+    document.removeEventListener('pointermove', move)
+    document.removeEventListener('pointerup', end)
+    document.removeEventListener('pointercancel', end)
+    try {
+      target.releasePointerCapture(pointerId)
+    } catch {
+      // Already released (the normal case on pointerup) — ignore.
+    }
+    onEnd?.()
+  }
+
+  document.addEventListener('pointermove', move)
+  document.addEventListener('pointerup', end)
+  document.addEventListener('pointercancel', end)
+  return cleanup
+}

--- a/src/shared/timeline/io-range/io-range-drag.ts
+++ b/src/shared/timeline/io-range/io-range-drag.ts
@@ -1,4 +1,5 @@
 import type { PointerEvent as ReactPointerEvent } from 'react'
+import { useIoRangeReadoutStore } from './io-range-readout-store'
 
 /**
  * Start a pointer drag for an IO marker / range strip.
@@ -11,12 +12,14 @@ import type { PointerEvent as ReactPointerEvent } from 'react'
  *   second touch can't hijack the active drag.
  *
  * `onMove` receives the pointer's `clientX` (all IO surfaces resolve position
- * from X only). Returns a cleanup fn (store it to tear the drag down on
- * unmount), or `null` for a non-primary button.
+ * from X only). If it returns a string, that label is shown as a cursor-following
+ * readout via {@link IoDragReadout}; return nothing to skip the readout. Returns
+ * a cleanup fn (store it to tear the drag down on unmount), or `null` for a
+ * non-primary button.
  */
 export function beginIoPointerDrag(
   e: ReactPointerEvent,
-  onMove: (clientX: number) => void,
+  onMove: (clientX: number) => string | void,
   onEnd?: () => void,
 ): (() => void) | null {
   if (e.button !== 0) return null
@@ -32,9 +35,16 @@ export function beginIoPointerDrag(
     // still drive the drag; capture is only a robustness upgrade.
   }
 
+  const publish = (clientX: number, clientY: number) => {
+    const label = onMove(clientX)
+    useIoRangeReadoutStore
+      .getState()
+      .setReadout(typeof label === 'string' ? { label, x: clientX, y: clientY } : null)
+  }
+
   // Function declarations (hoisted) so move/end/cleanup can reference each other.
   function move(ev: PointerEvent) {
-    if (ev.pointerId === pointerId) onMove(ev.clientX)
+    if (ev.pointerId === pointerId) publish(ev.clientX, ev.clientY)
   }
   function end(ev: PointerEvent) {
     if (ev.pointerId === pointerId) cleanup()
@@ -48,11 +58,14 @@ export function beginIoPointerDrag(
     } catch {
       // Already released (the normal case on pointerup) — ignore.
     }
+    useIoRangeReadoutStore.getState().setReadout(null)
     onEnd?.()
   }
 
   document.addEventListener('pointermove', move)
   document.addEventListener('pointerup', end)
   document.addEventListener('pointercancel', end)
+  // Show the readout immediately on grab (before the first move).
+  publish(e.clientX, e.clientY)
   return cleanup
 }

--- a/src/shared/timeline/io-range/io-range-readout-store.ts
+++ b/src/shared/timeline/io-range/io-range-readout-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+/** A floating readout shown at the cursor during an IO drag (viewport coords). */
+export interface IoDragReadout {
+  label: string
+  x: number
+  y: number
+}
+
+interface IoRangeReadoutState {
+  readout: IoDragReadout | null
+  setReadout: (readout: IoDragReadout | null) => void
+}
+
+/**
+ * Cursor-following readout for IO (in/out) drag operations — the analogue of the
+ * clip trim readout. Written by {@link beginIoPointerDrag} (when the drag's
+ * `onMove` returns a label) and read by a single mounted {@link IoDragReadout}.
+ */
+export const useIoRangeReadoutStore = create<IoRangeReadoutState>((set) => ({
+  readout: null,
+  setReadout: (readout) => set({ readout }),
+}))

--- a/src/shared/timeline/io-range/io-range-readout.tsx
+++ b/src/shared/timeline/io-range/io-range-readout.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react'
+import { createPortal } from 'react-dom'
+import { useIoRangeReadoutStore } from './io-range-readout-store'
+
+/**
+ * Floating readout shown at the cursor during an IO drag (mirrors the clip trim
+ * readout / TransitionDragTooltip). Mount once, high in the tree — it portals to
+ * `document.body` and positions in viewport coords, so a single instance covers
+ * every IO surface (Edit ruler, mini-timeline, source monitor).
+ */
+export const IoDragReadout = memo(function IoDragReadout() {
+  const readout = useIoRangeReadoutStore((s) => s.readout)
+  if (!readout) return null
+
+  return createPortal(
+    <div
+      className="pointer-events-none"
+      style={{
+        position: 'fixed',
+        left: readout.x,
+        top: readout.y - 16,
+        transform: 'translate(-50%, -100%)',
+        zIndex: 10000,
+      }}
+    >
+      <div className="rounded-md border border-slate-200/70 bg-slate-900/92 px-2 py-1 text-[11px] font-medium tabular-nums text-slate-50 shadow-xl backdrop-blur-sm">
+        {readout.label}
+      </div>
+    </div>,
+    document.body,
+  )
+})


### PR DESCRIPTION
## Problem
Dragging an in/out (IO) marker on the Edit-ruler or source monitor leaves the marker **glued to the cursor after you release** the mouse.

## Cause
Those IO drag handlers start on `pointerdown` and call `preventDefault()` to claim the gesture, but then drive move/release with **mouse events** (`mousemove`/`mouseup`). Chrome suppresses the compatibility `mousedown`/`mouseup`/`click` after a `pointerdown` `preventDefault()` — but **not** `mousemove`. So the marker keeps tracking the cursor (mousemove fires) while the teardown never runs (mouseup is suppressed).

## Fix
Drive the drag entirely with **pointer events** (`pointermove` / `pointerup` / `pointercancel`) — `pointerup` isn't suppressed — matching the mini-timeline IO lane which already works. Also ignore non-primary mouse buttons. Covers all three affected handlers: the Edit-ruler in/out handles, and the source monitor's in/out handles + range-strip drag.

No behavior change beyond the release fix; lint + type checks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-screen cursor readout tooltip during IO in/out range dragging to show live drag position/label across editor surfaces.
* **Bug Fixes**
  * Improved timeline in/out and range strip drag gestures with pointer-based handling for more consistent move/end/cancel behavior.
  * Enhanced live updates of in/out endpoints and playback preview while dragging.
  * Added safer teardown on interruption (including component unmount) to prevent stuck states and restore cursors/preview cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->