### PR TITLE
fix(timeline): match IO drag readout styling to clip trim readout

### DIFF
--- a/src/shared/timeline/io-range/io-range-readout.tsx
+++ b/src/shared/timeline/io-range/io-range-readout.tsx
@@ -12,20 +12,18 @@ export const IoDragReadout = memo(function IoDragReadout() {
   const readout = useIoRangeReadoutStore((s) => s.readout)
   if (!readout) return null
 
+  // Matches the clip trim readout (TrimInfoOverlay) for a consistent look;
+  // positioned centered above the cursor rather than anchored to a clip edge.
   return createPortal(
     <div
-      className="pointer-events-none"
+      className="pointer-events-none fixed z-[10000] min-w-[58px] rounded-sm bg-neutral-950/90 px-1.5 py-0.5 text-center font-mono text-[11px] font-semibold leading-tight text-white shadow-[0_2px_8px_rgba(0,0,0,0.45)] ring-1 ring-white/15 tabular-nums"
       style={{
-        position: 'fixed',
         left: readout.x,
         top: readout.y - 16,
         transform: 'translate(-50%, -100%)',
-        zIndex: 10000,
       }}
     >
-      <div className="rounded-md border border-slate-200/70 bg-slate-900/92 px-2 py-1 text-[11px] font-medium tabular-nums text-slate-50 shadow-xl backdrop-blur-sm">
-        {readout.label}
-      </div>
+      {readout.label}
     </div>,
     document.body,
   )


### PR DESCRIPTION
The IO drag cursor readout (added with the IO drag fixes) copied the `TransitionDragTooltip` look — slate background, border, `rounded-md`, backdrop-blur — which read inconsistently next to the **clip trim/extend readout**.

Switches `IoDragReadout` to the same box style as `TrimInfoOverlay`: `bg-neutral-950/90`, `ring-1 ring-white/15`, `rounded-sm`, `font-mono font-semibold`, `min-w-[58px]`, tighter padding, matching shadow. Positioning is unchanged (centered above the cursor rather than anchored to a clip edge).

One-line component change; lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the timeline readout’s appearance with a simpler, more consistent floating label.
  * Improved layering and visual styling for better readability and placement on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->