### PR TITLE
feat(lottie): editing suite (colors, slots, themes, animations, markers, live preview) + preview/GPU fixes

### DIFF
--- a/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
@@ -24,6 +24,7 @@ import { LayoutSection } from './layout-section'
 import { FillSection } from './fill-section'
 import { VideoSection } from './video-section'
 import { GifSection } from './gif-section'
+import { LottieSection } from './lottie-section'
 import { ShapeSection } from './shape-section'
 import { CornerPinSection } from './corner-pin-section'
 
@@ -74,8 +75,10 @@ function computeItemTypeInfo(items: TimelineItem[]) {
       types.has('shape') ||
       types.has('adjustment') ||
       types.has('composition') ||
-      types.has('subtitle'),
+      types.has('subtitle') ||
+      types.has('lottie'),
     hasVideoItems: types.has('video'),
+    hasLottieItems: types.has('lottie'),
     hasGifItems,
     hasAudioItems: types.has('video') || types.has('audio'),
     hasTextItems: types.has('text'),
@@ -160,6 +163,7 @@ export const ClipPanel = memo(function ClipPanel() {
   const {
     hasVisualItems,
     hasVideoItems,
+    hasLottieItems,
     hasGifItems,
     hasAudioItems,
     hasTextItems,
@@ -276,7 +280,11 @@ export const ClipPanel = memo(function ClipPanel() {
     return { label: t('editor.clipPanel.tabEffects'), icon: Sparkles }
   }
   const tabGridColsClass =
-    availableTabs.length <= 1 ? 'grid-cols-1' : availableTabs.length === 2 ? 'grid-cols-2' : 'grid-cols-3'
+    availableTabs.length <= 1
+      ? 'grid-cols-1'
+      : availableTabs.length === 2
+        ? 'grid-cols-2'
+        : 'grid-cols-3'
 
   if (selectedItems.length === 0) {
     return null
@@ -340,6 +348,7 @@ export const ClipPanel = memo(function ClipPanel() {
                 </Suspense>
               )}
               {hasGifItems && <GifSection items={selectedItems} />}
+              {hasLottieItems && <LottieSection items={selectedItems} />}
             </div>
           )}
         </TabsContent>

--- a/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FileJson, Palette, RotateCcw, Sliders, Type } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronRight,
+  FileJson,
+  Palette,
+  RotateCcw,
+  Sliders,
+  Type,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
@@ -306,19 +314,53 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
   // Group the extracted colors by their original value so a color shared across
   // multiple shapes is a single editable swatch (a palette): recoloring it
   // updates every shape that used it. Overrides are still stored per instance.
+  // A group is "named" when any member carries an author name (a slot or a named
+  // shape) — those are the template's intended customization points and are
+  // shown first; the anonymous rest (Fill/N shapes) tuck under a disclosure.
   const colorGroups = useMemo(() => {
-    const byOriginal = new Map<string, { keys: string[]; label: string }>()
+    const byOriginal = new Map<
+      string,
+      { keys: string[]; label: string; namedLabel: string | undefined }
+    >()
     for (const layer of colorLayers) {
       const group = byOriginal.get(layer.color)
-      if (group) group.keys.push(layer.key)
-      else byOriginal.set(layer.color, { keys: [layer.key], label: layer.label })
+      if (group) {
+        group.keys.push(layer.key)
+        if (!group.namedLabel && layer.named) group.namedLabel = layer.label
+      } else {
+        byOriginal.set(layer.color, {
+          keys: [layer.key],
+          label: layer.label,
+          namedLabel: layer.named ? layer.label : undefined,
+        })
+      }
     }
-    return Array.from(byOriginal, ([original, { keys, label }]) => ({
+    return Array.from(byOriginal, ([original, { keys, label, namedLabel }]) => ({
       original,
       keys,
-      label: keys.length > 1 ? t('editor.lottieSection.colorGroup', { count: keys.length }) : label,
+      named: namedLabel !== undefined,
+      // Prefer an author name; fall back to a count ("N shapes") or the fill label.
+      label:
+        namedLabel ??
+        (keys.length > 1 ? t('editor.lottieSection.colorGroup', { count: keys.length }) : label),
     }))
   }, [colorLayers, t])
+
+  const namedColorGroups = useMemo(() => colorGroups.filter((g) => g.named), [colorGroups])
+  const otherColorGroups = useMemo(() => colorGroups.filter((g) => !g.named), [colorGroups])
+  const [showOtherColors, setShowOtherColors] = useState(false)
+
+  const renderColorGroup = (group: { original: string; keys: string[]; label: string }) => (
+    <ColorPicker
+      key={group.original}
+      label={group.label}
+      color={single?.colorOverrides?.[group.keys[0]!] ?? group.original}
+      defaultColor={group.original}
+      onLiveChange={(c) => previewColorGroup(group.keys, group.original, c)}
+      onChange={(c) => commitColorGroup(group.keys, group.original, c)}
+      onReset={() => commitColorGroup(group.keys, group.original, group.original)}
+    />
+  )
 
   const nextColorMap = useCallback(
     (keys: string[], original: string, value: string): Record<string, string> | undefined => {
@@ -557,17 +599,30 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
               </Button>
             )}
           </div>
-          {colorGroups.map((group) => (
-            <ColorPicker
-              key={group.original}
-              label={group.label}
-              color={single.colorOverrides?.[group.keys[0]!] ?? group.original}
-              defaultColor={group.original}
-              onLiveChange={(c) => previewColorGroup(group.keys, group.original, c)}
-              onChange={(c) => commitColorGroup(group.keys, group.original, c)}
-              onReset={() => commitColorGroup(group.keys, group.original, group.original)}
-            />
-          ))}
+          {/* Author-named colors first (or everything, if nothing is named). */}
+          {(namedColorGroups.length > 0 ? namedColorGroups : otherColorGroups).map(
+            renderColorGroup,
+          )}
+
+          {/* The anonymous rest (Fill / N shapes) tuck under a disclosure. */}
+          {namedColorGroups.length > 0 && otherColorGroups.length > 0 && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-full justify-start gap-1 px-1 text-[11px] text-muted-foreground"
+                onClick={() => setShowOtherColors((v) => !v)}
+              >
+                {showOtherColors ? (
+                  <ChevronDown className="w-3 h-3" />
+                ) : (
+                  <ChevronRight className="w-3 h-3" />
+                )}
+                {t('editor.lottieSection.otherColors', { count: otherColorGroups.length })}
+              </Button>
+              {showOtherColors && otherColorGroups.map(renderColorGroup)}
+            </>
+          )}
         </div>
       )}
 

--- a/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FileJson, Palette, RotateCcw, Type } from 'lucide-react'
+import { FileJson, Palette, RotateCcw, Sliders, Type } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
@@ -18,6 +18,7 @@ import {
   extractLottieColorLayers,
   type LottieColorLayer,
 } from '@/infrastructure/lottie/lottie-color'
+import { extractLottieValueSlots, type LottieValueSlot } from '@/infrastructure/lottie/lottie-slots'
 import {
   fetchLottieAnimation,
   fetchLottieManifest,
@@ -110,6 +111,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
   // (for `.lottie` archives) its bundled animations + themes.
   const [textLayers, setTextLayers] = useState<LottieTextLayer[]>([])
   const [colorLayers, setColorLayers] = useState<LottieColorLayer[]>([])
+  const [valueSlots, setValueSlots] = useState<LottieValueSlot[]>([])
   const [markers, setMarkers] = useState<LottieMarker[]>([])
   const [animations, setAnimations] = useState<LottieAnimationEntry[]>([])
   const [themes, setThemes] = useState<string[]>([])
@@ -134,6 +136,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
     const clear = () => {
       setTextLayers([])
       setColorLayers([])
+      setValueSlots([])
       setMarkers([])
       setAnimations([])
       setThemes([])
@@ -159,6 +162,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
       if (cancelled) return
       setTextLayers(animation ? extractLottieTextLayers(animation) : [])
       setColorLayers(animation ? extractLottieColorLayers(animation) : [])
+      setValueSlots(animation ? extractLottieValueSlots(animation) : [])
       setMarkers(animation ? readLottieMarkers(animation) : [])
       setAnimations(manifest?.animations ?? [])
       setThemes(manifest?.themes ?? [])
@@ -306,6 +310,30 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
 
   const hasColorOverrides =
     !!single?.colorOverrides && Object.keys(single.colorOverrides).length > 0
+
+  // Value slots (scalar/vector) applied natively. Reverting to the slot's
+  // authored default drops the override.
+  const commitSlot = useCallback(
+    (id: string, next: number | [number, number], original: number | [number, number]) => {
+      if (!single) return
+      const revert = Array.isArray(next)
+        ? Array.isArray(original) && next[0] === original[0] && next[1] === original[1]
+        : next === original
+      const overrides = { ...(single.slotOverrides ?? {}) }
+      if (revert) delete overrides[id]
+      else overrides[id] = next
+      updateItem(single.id, {
+        slotOverrides: Object.keys(overrides).length > 0 ? overrides : undefined,
+      })
+    },
+    [single, updateItem],
+  )
+
+  const resetAllSlots = useCallback(() => {
+    if (single) updateItem(single.id, { slotOverrides: undefined })
+  }, [single, updateItem])
+
+  const hasSlotOverrides = !!single?.slotOverrides && Object.keys(single.slotOverrides).length > 0
 
   if (lottieItems.length === 0) return null
 
@@ -474,6 +502,60 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
               onReset={() => commitColorGroup(group.keys, group.original, group.original)}
             />
           ))}
+        </div>
+      )}
+
+      {single && valueSlots.length > 0 && (
+        <div className="space-y-1.5 pt-1">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+              <Sliders className="w-3 h-3" />
+              {t('editor.lottieSection.properties')}
+            </div>
+            {hasSlotOverrides && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-[11px] text-muted-foreground"
+                onClick={resetAllSlots}
+              >
+                {t('editor.lottieSection.resetProperties')}
+              </Button>
+            )}
+          </div>
+          {valueSlots.map((slot) => {
+            const current = single.slotOverrides?.[slot.id]
+            if (slot.type === 'scalar') {
+              const value = typeof current === 'number' ? current : slot.value
+              return (
+                <PropertyRow key={slot.id} label={slot.label}>
+                  <NumberInput
+                    value={value}
+                    onChange={(v) => commitSlot(slot.id, v, slot.value)}
+                    step={0.1}
+                    className="w-full"
+                  />
+                </PropertyRow>
+              )
+            }
+            const vec = Array.isArray(current) ? current : slot.value
+            return (
+              <PropertyRow key={slot.id} label={slot.label}>
+                <div className="flex items-center gap-1 w-full">
+                  <NumberInput
+                    value={vec[0]}
+                    onChange={(v) => commitSlot(slot.id, [v, vec[1]], slot.value)}
+                    className="flex-1 min-w-0"
+                  />
+                  <NumberInput
+                    value={vec[1]}
+                    onChange={(v) => commitSlot(slot.id, [vec[0], v], slot.value)}
+                    className="flex-1 min-w-0"
+                  />
+                </div>
+              </PropertyRow>
+            )
+          })}
         </div>
       )}
     </PropertySection>

--- a/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
@@ -1,17 +1,38 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FileJson, RotateCcw, Type } from 'lucide-react'
+import { FileJson, Palette, RotateCcw, Type } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type { LottieItem, TimelineItem } from '@/types/timeline'
 import { useTimelineStore } from '@/features/editor/deps/timeline-store'
 import { extractLottieTextLayers, type LottieTextLayer } from '@/infrastructure/lottie/lottie-text'
-import { createLogger } from '@/shared/logging/logger'
-import { PropertySection, PropertyRow, NumberInput } from '../components'
+import {
+  extractLottieColorLayers,
+  type LottieColorLayer,
+} from '@/infrastructure/lottie/lottie-color'
+import {
+  fetchLottieAnimation,
+  fetchLottieManifest,
+  parseLottieMetadata,
+  readLottieMarkers,
+  type LottieAnimationEntry,
+  type LottieMarker,
+} from '@/infrastructure/lottie/lottie-metadata'
+import { resolveMediaUrl } from '@/features/editor/deps/media-library'
+import { PropertySection, PropertyRow, NumberInput, ColorPicker } from '../components'
 import { getMixedValue } from '../utils'
 
-const log = createLogger('lottie-section')
+/** Sentinel Select value for "no theme" (Radix Select forbids an empty value). */
+const NO_THEME = '__none__'
+
 const MIN_SPEED = 0.1
 const MAX_SPEED = 10
 
@@ -85,29 +106,67 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
   const pingpong = getMixedValue(lottieItems, (i) => (i.loopMode ?? 'loop') === 'pingpong', false)
   const loopOn = loop === true
 
-  // Discover editable text layers for a single raw-JSON Lottie (async read).
+  // Discover the selected clip's editable text/color layers, named markers, and
+  // (for `.lottie` archives) its bundled animations + themes.
   const [textLayers, setTextLayers] = useState<LottieTextLayer[]>([])
+  const [colorLayers, setColorLayers] = useState<LottieColorLayer[]>([])
+  const [markers, setMarkers] = useState<LottieMarker[]>([])
+  const [animations, setAnimations] = useState<LottieAnimationEntry[]>([])
+  const [themes, setThemes] = useState<string[]>([])
   const singleId = single?.id
   const singleSrc = single?.src
+  const singleMediaId = single?.mediaId
+  const singleAnimationId = single?.animationId
+
+  // `item.src` can be a dead blob URL after a page reload; resolve a fresh URL
+  // by mediaId first (fall back to the item's own src, e.g. items with no
+  // mediaId). Shared by discovery and the animation-switch handler.
+  const resolveSingleUrl = useCallback(async (): Promise<string> => {
+    let url = singleSrc ?? ''
+    if (singleMediaId) {
+      const resolved = await resolveMediaUrl(singleMediaId).catch(() => '')
+      if (resolved) url = resolved
+    }
+    return url
+  }, [singleSrc, singleMediaId])
+
   useEffect(() => {
-    if (!singleSrc) {
+    const clear = () => {
       setTextLayers([])
+      setColorLayers([])
+      setMarkers([])
+      setAnimations([])
+      setThemes([])
+    }
+    if (!singleSrc && !singleMediaId) {
+      clear()
       return
     }
     let cancelled = false
     void (async () => {
-      try {
-        const text = await (await fetch(singleSrc)).text()
-        if (!cancelled) setTextLayers(extractLottieTextLayers(text))
-      } catch (err) {
-        log.warn('failed to read Lottie text layers', { error: err })
-        if (!cancelled) setTextLayers([])
+      const url = await resolveSingleUrl()
+      if (cancelled) return
+      if (!url) {
+        clear()
+        return
       }
+      // Archive-aware: layers/markers come from the selected animation; the
+      // manifest lists all bundled animations/themes (null for raw `.json`).
+      const [animation, manifest] = await Promise.all([
+        fetchLottieAnimation(url, false, singleAnimationId),
+        fetchLottieManifest(url),
+      ])
+      if (cancelled) return
+      setTextLayers(animation ? extractLottieTextLayers(animation) : [])
+      setColorLayers(animation ? extractLottieColorLayers(animation) : [])
+      setMarkers(animation ? readLottieMarkers(animation) : [])
+      setAnimations(manifest?.animations ?? [])
+      setThemes(manifest?.themes ?? [])
     })()
     return () => {
       cancelled = true
     }
-  }, [singleId, singleSrc])
+  }, [singleId, singleSrc, singleMediaId, singleAnimationId, resolveSingleUrl])
 
   const handleSpeedChange = useCallback(
     (value: number) => patchAll({ speed: Math.max(MIN_SPEED, Math.min(MAX_SPEED, value)) }),
@@ -134,6 +193,64 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
     [single, updateItem],
   )
 
+  // The animation that plays by default is the manifest's first; a stored
+  // `animationId` overrides it.
+  const effectiveAnimationId = single?.animationId ?? animations[0]?.id
+
+  const handleAnimationChange = useCallback(
+    (animationId: string) => {
+      if (!single || animationId === effectiveAnimationId) return
+      void (async () => {
+        const url = await resolveSingleUrl()
+        const animation = url ? await fetchLottieAnimation(url, false, animationId) : null
+        const meta = animation ? parseLottieMetadata(animation) : null
+        updateItem(single.id, {
+          animationId,
+          // A different animation has its own frames/slots — drop frame-indexed
+          // edits and re-derive timing/size from the chosen animation.
+          segmentStart: undefined,
+          segmentEnd: undefined,
+          textOverrides: undefined,
+          colorOverrides: undefined,
+          ...(meta
+            ? {
+                frameRate: meta.frameRate,
+                totalFrames: meta.totalFrames,
+                sourceWidth: meta.width,
+                sourceHeight: meta.height,
+              }
+            : {}),
+        })
+      })()
+    },
+    [single, effectiveAnimationId, resolveSingleUrl, updateItem],
+  )
+
+  const handleThemeChange = useCallback(
+    (value: string) => {
+      if (single) updateItem(single.id, { themeId: value === NO_THEME ? undefined : value })
+    },
+    [single, updateItem],
+  )
+
+  // Apply a named marker as the active segment. A zero-duration marker (a cue
+  // point) plays from the marker to the end.
+  const handleMarkerSelect = useCallback(
+    (name: string) => {
+      if (!single) return
+      const marker = markers.find((m) => m.name === name)
+      if (!marker) return
+      const maxFrame = single.totalFrames - 1
+      const start = Math.max(0, Math.min(Math.round(marker.start), maxFrame))
+      const end =
+        marker.duration > 0
+          ? Math.max(start, Math.min(Math.round(marker.start + marker.duration), maxFrame))
+          : maxFrame
+      updateItem(single.id, { segmentStart: start, segmentEnd: end })
+    },
+    [single, markers, updateItem],
+  )
+
   const handleTextCommit = useCallback(
     (key: string, value: string) => {
       if (!single) return
@@ -148,6 +265,47 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
     },
     [single, textLayers, updateItem],
   )
+
+  // Group the extracted colors by their original value so a color shared across
+  // multiple shapes is a single editable swatch (a palette): recoloring it
+  // updates every shape that used it. Overrides are still stored per instance.
+  const colorGroups = useMemo(() => {
+    const byOriginal = new Map<string, { keys: string[]; label: string }>()
+    for (const layer of colorLayers) {
+      const group = byOriginal.get(layer.color)
+      if (group) group.keys.push(layer.key)
+      else byOriginal.set(layer.color, { keys: [layer.key], label: layer.label })
+    }
+    return Array.from(byOriginal, ([original, { keys, label }]) => ({
+      original,
+      keys,
+      label: keys.length > 1 ? t('editor.lottieSection.colorGroup', { count: keys.length }) : label,
+    }))
+  }, [colorLayers, t])
+
+  const commitColorGroup = useCallback(
+    (keys: string[], original: string, value: string) => {
+      if (!single) return
+      const next = { ...(single.colorOverrides ?? {}) }
+      // Reverting to the original color drops the override for every shape.
+      const revert = value.toLowerCase() === original.toLowerCase()
+      for (const key of keys) {
+        if (revert) delete next[key]
+        else next[key] = value
+      }
+      updateItem(single.id, {
+        colorOverrides: Object.keys(next).length > 0 ? next : undefined,
+      })
+    },
+    [single, updateItem],
+  )
+
+  const resetAllColors = useCallback(() => {
+    if (single) updateItem(single.id, { colorOverrides: undefined })
+  }, [single, updateItem])
+
+  const hasColorOverrides =
+    !!single?.colorOverrides && Object.keys(single.colorOverrides).length > 0
 
   if (lottieItems.length === 0) return null
 
@@ -193,8 +351,61 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
         </PropertyRow>
       )}
 
+      {single && animations.length > 1 && (
+        <PropertyRow label={t('editor.lottieSection.animation')}>
+          <Select value={effectiveAnimationId} onValueChange={handleAnimationChange}>
+            <SelectTrigger className="h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {animations.map((a, i) => (
+                <SelectItem key={a.id} value={a.id} className="text-xs">
+                  {a.id || t('editor.lottieSection.animationN', { index: i + 1 })}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PropertyRow>
+      )}
+
+      {single && themes.length > 0 && (
+        <PropertyRow label={t('editor.lottieSection.theme')}>
+          <Select value={single.themeId ?? NO_THEME} onValueChange={handleThemeChange}>
+            <SelectTrigger className="h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_THEME} className="text-xs">
+                {t('editor.lottieSection.themeNone')}
+              </SelectItem>
+              {themes.map((id) => (
+                <SelectItem key={id} value={id} className="text-xs">
+                  {id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </PropertyRow>
+      )}
+
       {single && single.totalFrames > 1 && (
         <>
+          {markers.length > 0 && (
+            <PropertyRow label={t('editor.lottieSection.marker')}>
+              <Select onValueChange={handleMarkerSelect}>
+                <SelectTrigger className="h-7 text-xs">
+                  <SelectValue placeholder={t('editor.lottieSection.markerPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {markers.map((m) => (
+                    <SelectItem key={m.name} value={m.name} className="text-xs">
+                      {m.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </PropertyRow>
+          )}
           <PropertyRow label={t('editor.lottieSection.trimIn')}>
             <NumberInput
               value={single.segmentStart ?? 0}
@@ -230,6 +441,37 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
               layer={layer}
               override={single.textOverrides?.[layer.key]}
               onCommit={handleTextCommit}
+            />
+          ))}
+        </div>
+      )}
+
+      {single && colorGroups.length > 0 && (
+        <div className="space-y-1.5 pt-1">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+              <Palette className="w-3 h-3" />
+              {t('editor.lottieSection.colors')}
+            </div>
+            {hasColorOverrides && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-[11px] text-muted-foreground"
+                onClick={resetAllColors}
+              >
+                {t('editor.lottieSection.resetColors')}
+              </Button>
+            )}
+          </div>
+          {colorGroups.map((group) => (
+            <ColorPicker
+              key={group.original}
+              label={group.label}
+              color={single.colorOverrides?.[group.keys[0]!] ?? group.original}
+              defaultColor={group.original}
+              onChange={(c) => commitColorGroup(group.keys, group.original, c)}
+              onReset={() => commitColorGroup(group.keys, group.original, group.original)}
             />
           ))}
         </div>

--- a/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { FileJson, RotateCcw, Type } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import type { LottieItem, TimelineItem } from '@/types/timeline'
+import { useTimelineStore } from '@/features/editor/deps/timeline-store'
+import { extractLottieTextLayers, type LottieTextLayer } from '@/infrastructure/lottie/lottie-text'
+import { createLogger } from '@/shared/logging/logger'
+import { PropertySection, PropertyRow, NumberInput } from '../components'
+import { getMixedValue } from '../utils'
+
+const log = createLogger('lottie-section')
+const MIN_SPEED = 0.1
+const MAX_SPEED = 10
+
+function isLottieItem(item: TimelineItem): item is LottieItem {
+  return item.type === 'lottie'
+}
+
+/**
+ * A single template-text field. Keeps a local draft while editing and commits
+ * on blur/Enter so we don't rebuild the Lottie renderer on every keystroke.
+ */
+function TextLayerInput({
+  layer,
+  override,
+  onCommit,
+}: {
+  layer: LottieTextLayer
+  override: string | undefined
+  onCommit: (key: string, value: string) => void
+}) {
+  const committed = override ?? layer.text
+  const [draft, setDraft] = useState(committed)
+
+  // Resync when the committed value changes from outside (e.g. undo).
+  useEffect(() => setDraft(committed), [committed])
+
+  const commit = () => {
+    if (draft !== committed) onCommit(layer.key, draft)
+  }
+
+  return (
+    <Input
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+      }}
+      className="h-7 text-xs"
+      placeholder={layer.label}
+      aria-label={layer.label}
+    />
+  )
+}
+
+/**
+ * Lottie playback + template controls: speed, reverse, loop style, an in/out
+ * segment, and per-layer text overrides for template animations. All fields are
+ * read at render time by `mapTimelineFrameToLottieFrame` / the text patcher, so
+ * edits apply identically in preview and export. Segment and text editing are
+ * single-selection only (they depend on a specific animation's frames/layers).
+ */
+export function LottieSection({ items }: { items: TimelineItem[] }) {
+  const { t } = useTranslation()
+  const updateItem = useTimelineStore((s) => s.updateItem)
+
+  const lottieItems = useMemo(() => items.filter(isLottieItem), [items])
+  const ids = useMemo(() => lottieItems.map((i) => i.id), [lottieItems])
+  const single = lottieItems.length === 1 ? lottieItems[0]! : null
+
+  const patchAll = useCallback(
+    (updates: Partial<LottieItem>) => {
+      for (const id of ids) updateItem(id, updates)
+    },
+    [ids, updateItem],
+  )
+
+  const speed = getMixedValue(lottieItems, (i) => i.speed, 1)
+  const reversed = getMixedValue(lottieItems, (i) => i.reversed ?? false, false)
+  const loop = getMixedValue(lottieItems, (i) => i.loop ?? true, true)
+  const pingpong = getMixedValue(lottieItems, (i) => (i.loopMode ?? 'loop') === 'pingpong', false)
+  const loopOn = loop === true
+
+  // Discover editable text layers for a single raw-JSON Lottie (async read).
+  const [textLayers, setTextLayers] = useState<LottieTextLayer[]>([])
+  const singleId = single?.id
+  const singleSrc = single?.src
+  useEffect(() => {
+    if (!singleSrc) {
+      setTextLayers([])
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const text = await (await fetch(singleSrc)).text()
+        if (!cancelled) setTextLayers(extractLottieTextLayers(text))
+      } catch (err) {
+        log.warn('failed to read Lottie text layers', { error: err })
+        if (!cancelled) setTextLayers([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [singleId, singleSrc])
+
+  const handleSpeedChange = useCallback(
+    (value: number) => patchAll({ speed: Math.max(MIN_SPEED, Math.min(MAX_SPEED, value)) }),
+    [patchAll],
+  )
+
+  const handleSegmentStart = useCallback(
+    (value: number) => {
+      if (!single) return
+      const maxFrame = single.totalFrames - 1
+      const end = single.segmentEnd ?? maxFrame
+      updateItem(single.id, { segmentStart: Math.max(0, Math.min(Math.round(value), end)) })
+    },
+    [single, updateItem],
+  )
+
+  const handleSegmentEnd = useCallback(
+    (value: number) => {
+      if (!single) return
+      const maxFrame = single.totalFrames - 1
+      const start = single.segmentStart ?? 0
+      updateItem(single.id, { segmentEnd: Math.max(start, Math.min(Math.round(value), maxFrame)) })
+    },
+    [single, updateItem],
+  )
+
+  const handleTextCommit = useCallback(
+    (key: string, value: string) => {
+      if (!single) return
+      const next = { ...(single.textOverrides ?? {}) }
+      const layer = textLayers.find((l) => l.key === key)
+      // Drop the override when the text is reverted to the animation's original.
+      if (layer && value === layer.text) delete next[key]
+      else next[key] = value
+      updateItem(single.id, {
+        textOverrides: Object.keys(next).length > 0 ? next : undefined,
+      })
+    },
+    [single, textLayers, updateItem],
+  )
+
+  if (lottieItems.length === 0) return null
+
+  return (
+    <PropertySection title={t('editor.lottieSection.title')} icon={FileJson} defaultOpen={true}>
+      <PropertyRow label={t('editor.lottieSection.speed')}>
+        <div className="flex items-center gap-1 w-full">
+          <NumberInput
+            value={speed}
+            onChange={handleSpeedChange}
+            min={MIN_SPEED}
+            max={MAX_SPEED}
+            step={0.1}
+            unit="x"
+            className="flex-1 min-w-0"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 flex-shrink-0"
+            onClick={() => patchAll({ speed: 1 })}
+            title={t('editor.lottieSection.resetSpeed')}
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+          </Button>
+        </div>
+      </PropertyRow>
+
+      <PropertyRow label={t('editor.lottieSection.reverse')}>
+        <Switch checked={reversed === true} onCheckedChange={(c) => patchAll({ reversed: c })} />
+      </PropertyRow>
+
+      <PropertyRow label={t('editor.lottieSection.loop')}>
+        <Switch checked={loopOn} onCheckedChange={(c) => patchAll({ loop: c })} />
+      </PropertyRow>
+
+      {loopOn && (
+        <PropertyRow label={t('editor.lottieSection.pingpong')}>
+          <Switch
+            checked={pingpong === true}
+            onCheckedChange={(c) => patchAll({ loopMode: c ? 'pingpong' : 'loop' })}
+          />
+        </PropertyRow>
+      )}
+
+      {single && single.totalFrames > 1 && (
+        <>
+          <PropertyRow label={t('editor.lottieSection.trimIn')}>
+            <NumberInput
+              value={single.segmentStart ?? 0}
+              onChange={handleSegmentStart}
+              min={0}
+              max={single.totalFrames - 1}
+              step={1}
+              className="w-full"
+            />
+          </PropertyRow>
+          <PropertyRow label={t('editor.lottieSection.trimOut')}>
+            <NumberInput
+              value={single.segmentEnd ?? single.totalFrames - 1}
+              onChange={handleSegmentEnd}
+              min={0}
+              max={single.totalFrames - 1}
+              step={1}
+              className="w-full"
+            />
+          </PropertyRow>
+        </>
+      )}
+
+      {single && textLayers.length > 0 && (
+        <div className="space-y-1.5 pt-1">
+          <div className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+            <Type className="w-3 h-3" />
+            {t('editor.lottieSection.text')}
+          </div>
+          {textLayers.map((layer) => (
+            <TextLayerInput
+              key={layer.key}
+              layer={layer}
+              override={single.textOverrides?.[layer.key]}
+              onCommit={handleTextCommit}
+            />
+          ))}
+        </div>
+      )}
+    </PropertySection>
+  )
+}

--- a/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/lottie-section.tsx
@@ -28,6 +28,7 @@ import {
   type LottieMarker,
 } from '@/infrastructure/lottie/lottie-metadata'
 import { resolveMediaUrl } from '@/features/editor/deps/media-library'
+import { useGizmoStore } from '@/features/editor/deps/preview'
 import { PropertySection, PropertyRow, NumberInput, ColorPicker } from '../components'
 import { getMixedValue } from '../utils'
 
@@ -48,10 +49,14 @@ function isLottieItem(item: TimelineItem): item is LottieItem {
 function TextLayerInput({
   layer,
   override,
+  onLive,
   onCommit,
 }: {
   layer: LottieTextLayer
   override: string | undefined
+  /** Live preview on each keystroke (no undo entry). */
+  onLive: (key: string, value: string) => void
+  /** Final commit on blur/Enter. */
   onCommit: (key: string, value: string) => void
 }) {
   const committed = override ?? layer.text
@@ -67,7 +72,11 @@ function TextLayerInput({
   return (
     <Input
       value={draft}
-      onChange={(e) => setDraft(e.target.value)}
+      onChange={(e) => {
+        const value = e.target.value
+        setDraft(value)
+        onLive(layer.key, value)
+      }}
       onBlur={commit}
       onKeyDown={(e) => {
         if (e.key === 'Enter') e.currentTarget.blur()
@@ -89,6 +98,10 @@ function TextLayerInput({
 export function LottieSection({ items }: { items: TimelineItem[] }) {
   const { t } = useTranslation()
   const updateItem = useTimelineStore((s) => s.updateItem)
+  // Live edit preview: drags/keystrokes update the canvas through this channel
+  // (read by the render engine's getLiveItemSnapshot) without a timeline-store
+  // commit, so a single color/slot/text edit is one undo entry, not dozens.
+  const setLottiePreview = useGizmoStore((s) => s.setLottiePreviewNew)
 
   const lottieItems = useMemo(() => items.filter(isLottieItem), [items])
   const ids = useMemo(() => lottieItems.map((i) => i.id), [lottieItems])
@@ -255,19 +268,39 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
     [single, markers, updateItem],
   )
 
-  const handleTextCommit = useCallback(
-    (key: string, value: string) => {
-      if (!single) return
-      const next = { ...(single.textOverrides ?? {}) }
+  // Clear this clip's live preview when the clip changes or the panel unmounts,
+  // so a preview left mid-drag never lingers on the canvas.
+  useEffect(() => {
+    if (!singleId) return
+    return () => setLottiePreview(singleId, null)
+  }, [singleId, setLottiePreview])
+
+  const nextTextMap = useCallback(
+    (key: string, value: string): Record<string, string> | undefined => {
+      const next = { ...(single?.textOverrides ?? {}) }
       const layer = textLayers.find((l) => l.key === key)
       // Drop the override when the text is reverted to the animation's original.
       if (layer && value === layer.text) delete next[key]
       else next[key] = value
-      updateItem(single.id, {
-        textOverrides: Object.keys(next).length > 0 ? next : undefined,
-      })
+      return Object.keys(next).length > 0 ? next : undefined
     },
-    [single, textLayers, updateItem],
+    [single, textLayers],
+  )
+
+  const previewText = useCallback(
+    (key: string, value: string) => {
+      if (single) setLottiePreview(single.id, { textOverrides: nextTextMap(key, value) })
+    },
+    [single, nextTextMap, setLottiePreview],
+  )
+
+  const handleTextCommit = useCallback(
+    (key: string, value: string) => {
+      if (!single) return
+      updateItem(single.id, { textOverrides: nextTextMap(key, value) })
+      setLottiePreview(single.id, null)
+    },
+    [single, nextTextMap, updateItem, setLottiePreview],
   )
 
   // Group the extracted colors by their original value so a color shared across
@@ -287,21 +320,35 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
     }))
   }, [colorLayers, t])
 
-  const commitColorGroup = useCallback(
-    (keys: string[], original: string, value: string) => {
-      if (!single) return
-      const next = { ...(single.colorOverrides ?? {}) }
+  const nextColorMap = useCallback(
+    (keys: string[], original: string, value: string): Record<string, string> | undefined => {
+      const next = { ...(single?.colorOverrides ?? {}) }
       // Reverting to the original color drops the override for every shape.
       const revert = value.toLowerCase() === original.toLowerCase()
       for (const key of keys) {
         if (revert) delete next[key]
         else next[key] = value
       }
-      updateItem(single.id, {
-        colorOverrides: Object.keys(next).length > 0 ? next : undefined,
-      })
+      return Object.keys(next).length > 0 ? next : undefined
     },
-    [single, updateItem],
+    [single],
+  )
+
+  const previewColorGroup = useCallback(
+    (keys: string[], original: string, value: string) => {
+      if (single)
+        setLottiePreview(single.id, { colorOverrides: nextColorMap(keys, original, value) })
+    },
+    [single, nextColorMap, setLottiePreview],
+  )
+
+  const commitColorGroup = useCallback(
+    (keys: string[], original: string, value: string) => {
+      if (!single) return
+      updateItem(single.id, { colorOverrides: nextColorMap(keys, original, value) })
+      setLottiePreview(single.id, null)
+    },
+    [single, nextColorMap, updateItem, setLottiePreview],
   )
 
   const resetAllColors = useCallback(() => {
@@ -313,20 +360,37 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
 
   // Value slots (scalar/vector) applied natively. Reverting to the slot's
   // authored default drops the override.
-  const commitSlot = useCallback(
-    (id: string, next: number | [number, number], original: number | [number, number]) => {
-      if (!single) return
+  const nextSlotMap = useCallback(
+    (
+      id: string,
+      next: number | [number, number],
+      original: number | [number, number],
+    ): Record<string, number | [number, number]> | undefined => {
       const revert = Array.isArray(next)
         ? Array.isArray(original) && next[0] === original[0] && next[1] === original[1]
         : next === original
-      const overrides = { ...(single.slotOverrides ?? {}) }
+      const overrides = { ...(single?.slotOverrides ?? {}) }
       if (revert) delete overrides[id]
       else overrides[id] = next
-      updateItem(single.id, {
-        slotOverrides: Object.keys(overrides).length > 0 ? overrides : undefined,
-      })
+      return Object.keys(overrides).length > 0 ? overrides : undefined
     },
-    [single, updateItem],
+    [single],
+  )
+
+  const previewSlot = useCallback(
+    (id: string, next: number | [number, number], original: number | [number, number]) => {
+      if (single) setLottiePreview(single.id, { slotOverrides: nextSlotMap(id, next, original) })
+    },
+    [single, nextSlotMap, setLottiePreview],
+  )
+
+  const commitSlot = useCallback(
+    (id: string, next: number | [number, number], original: number | [number, number]) => {
+      if (!single) return
+      updateItem(single.id, { slotOverrides: nextSlotMap(id, next, original) })
+      setLottiePreview(single.id, null)
+    },
+    [single, nextSlotMap, updateItem, setLottiePreview],
   )
 
   const resetAllSlots = useCallback(() => {
@@ -468,6 +532,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
               key={layer.key}
               layer={layer}
               override={single.textOverrides?.[layer.key]}
+              onLive={previewText}
               onCommit={handleTextCommit}
             />
           ))}
@@ -498,6 +563,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
               label={group.label}
               color={single.colorOverrides?.[group.keys[0]!] ?? group.original}
               defaultColor={group.original}
+              onLiveChange={(c) => previewColorGroup(group.keys, group.original, c)}
               onChange={(c) => commitColorGroup(group.keys, group.original, c)}
               onReset={() => commitColorGroup(group.keys, group.original, group.original)}
             />
@@ -532,6 +598,7 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
                   <NumberInput
                     value={value}
                     onChange={(v) => commitSlot(slot.id, v, slot.value)}
+                    onLiveChange={(v) => previewSlot(slot.id, v, slot.value)}
                     step={0.1}
                     className="w-full"
                   />
@@ -545,11 +612,13 @@ export function LottieSection({ items }: { items: TimelineItem[] }) {
                   <NumberInput
                     value={vec[0]}
                     onChange={(v) => commitSlot(slot.id, [v, vec[1]], slot.value)}
+                    onLiveChange={(v) => previewSlot(slot.id, [v, vec[1]], slot.value)}
                     className="flex-1 min-w-0"
                   />
                   <NumberInput
                     value={vec[1]}
                     onChange={(v) => commitSlot(slot.id, [vec[0], v], slot.value)}
+                    onLiveChange={(v) => previewSlot(slot.id, [vec[0], v], slot.value)}
                     className="flex-1 min-w-0"
                   />
                 </div>

--- a/src/features/export/utils/canvas-item-renderer/lottie.ts
+++ b/src/features/export/utils/canvas-item-renderer/lottie.ts
@@ -27,6 +27,10 @@ export function renderLottieItem(
     totalFrames: item.totalFrames,
     frameRate: item.frameRate,
     loop: item.loop ?? true,
+    reversed: item.reversed,
+    loopMode: item.loopMode,
+    segmentStart: item.segmentStart,
+    segmentEnd: item.segmentEnd,
   })
 
   const source = lottieProvider.renderFrame(item.id, lottieFrame)

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -23,6 +23,7 @@ import type {
   CompositionItem,
 } from '@/types/timeline'
 import { LottieExportProvider } from '@/infrastructure/lottie/lottie-frame-provider'
+import { resolveLottieOverrideData } from '@/infrastructure/lottie/lottie-text'
 import type { ItemKeyframes } from '@/types/keyframe'
 import type { ItemEffect } from '@/types/effects'
 import type { ResolvedTransform } from '@/types/transform'
@@ -939,7 +940,19 @@ export async function createCompositionRenderer(
                 lottieItem.sourceHeight && lottieItem.sourceHeight > 0
                   ? lottieItem.sourceHeight
                   : 512
-              await lottieProvider.preload(lottieItem.id, lottieItem.src, w, h)
+              // Patch template text before warming so exports reflect overrides.
+              const overrideData = await resolveLottieOverrideData(
+                lottieItem.src,
+                lottieItem.textOverrides,
+              )
+              if (isDisposed) return
+              await lottieProvider.preload(
+                lottieItem.id,
+                lottieItem.src,
+                w,
+                h,
+                overrideData ?? undefined,
+              )
               // Bail if the engine was disposed mid-load so we don't register a
               // renderer into a torn-down provider (dispose() → destroy()).
               if (isDisposed) return

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -23,7 +23,7 @@ import type {
   CompositionItem,
 } from '@/types/timeline'
 import { LottieExportProvider } from '@/infrastructure/lottie/lottie-frame-provider'
-import { resolveLottieOverrideData } from '@/infrastructure/lottie/lottie-text'
+import { resolveLottieRenderSpec } from '@/infrastructure/lottie/lottie-text'
 import type { ItemKeyframes } from '@/types/keyframe'
 import type { ItemEffect } from '@/types/effects'
 import type { ResolvedTransform } from '@/types/transform'
@@ -168,6 +168,25 @@ function recordScrubPerf(frame: number, path: ScrubPerfSample['path'], startMs: 
   } catch {
     /* User Timing unavailable — ignore */
   }
+}
+
+/**
+ * Identity of a Lottie item's animation/theme selection + text/color overrides.
+ * When this changes the preloaded dotlottie renderer must be rebuilt with a
+ * fresh render spec (see the preview freshness sync in `renderFrame`).
+ */
+function lottieOverrideSignature(item: {
+  animationId?: string
+  themeId?: string
+  textOverrides?: Record<string, string>
+  colorOverrides?: Record<string, string>
+}): string {
+  return JSON.stringify({
+    a: item.animationId ?? null,
+    m: item.themeId ?? null,
+    t: item.textOverrides ?? null,
+    c: item.colorOverrides ?? null,
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -397,6 +416,44 @@ export async function createCompositionRenderer(
   // Lottie animations: rendered on demand via dotlottie-web (no frame pre-extraction).
   const lottieItems: LottieItem[] = []
   const lottieProvider = new LottieExportProvider()
+
+  // Preview only: a persistent renderer outlives edits, so when a top-level
+  // Lottie's text/color overrides change we must rebuild its dotlottie renderer
+  // with freshly patched data (the frame mapping already reads live timing).
+  // Cheap when nothing changed (a signature compare); export never calls this
+  // (it preloads final overrides once). Sub-comp Lotties are out of scope.
+  const liveLottieItem = (baseItem: LottieItem): LottieItem => {
+    const live = getLiveItemSnapshot?.(baseItem.id)
+    return live && live.type === 'lottie' ? live : baseItem
+  }
+  const lottieOverridesAreStale = (): boolean =>
+    lottieItems.some(
+      (baseItem) =>
+        lottieProvider.getSignature(baseItem.id) !==
+        lottieOverrideSignature(liveLottieItem(baseItem)),
+    )
+  const ensureLottieOverridesFresh = async (): Promise<void> => {
+    await Promise.all(
+      lottieItems.map(async (baseItem) => {
+        const item = liveLottieItem(baseItem)
+        if (!item.src) return
+        const signature = lottieOverrideSignature(item)
+        if (lottieProvider.getSignature(baseItem.id) === signature) return
+        const w = item.sourceWidth && item.sourceWidth > 0 ? item.sourceWidth : 512
+        const h = item.sourceHeight && item.sourceHeight > 0 ? item.sourceHeight : 512
+        const spec = await resolveLottieRenderSpec(item.src, item)
+        await lottieProvider.rebuild(
+          baseItem.id,
+          item.src,
+          w,
+          h,
+          spec.data ?? undefined,
+          signature,
+          spec.themeData ?? undefined,
+        )
+      }),
+    )
+  }
 
   for (const track of tracks) {
     for (const item of track.items ?? []) {
@@ -940,18 +997,18 @@ export async function createCompositionRenderer(
                 lottieItem.sourceHeight && lottieItem.sourceHeight > 0
                   ? lottieItem.sourceHeight
                   : 512
-              // Patch template text before warming so exports reflect overrides.
-              const overrideData = await resolveLottieOverrideData(
-                lottieItem.src,
-                lottieItem.textOverrides,
-              )
+              // Resolve animation/theme + text/color edits before warming so
+              // exports reflect them.
+              const spec = await resolveLottieRenderSpec(lottieItem.src, lottieItem)
               if (isDisposed) return
               await lottieProvider.preload(
                 lottieItem.id,
                 lottieItem.src,
                 w,
                 h,
-                overrideData ?? undefined,
+                spec.data ?? undefined,
+                lottieOverrideSignature(lottieItem),
+                spec.themeData ?? undefined,
               )
               // Bail if the engine was disposed mid-load so we don't register a
               // renderer into a torn-down provider (dispose() → destroy()).
@@ -1178,7 +1235,16 @@ export async function createCompositionRenderer(
         const subImagePromises: Promise<void>[] = []
         const subGifItems: ImageItem[] = []
         const subWebpItems: ImageItem[] = []
-        const subLottieItems: Array<{ id: string; src: string; w: number; h: number }> = []
+        const subLottieItems: Array<{
+          id: string
+          src: string
+          w: number
+          h: number
+          animationId?: string
+          themeId?: string
+          textOverrides?: Record<string, string>
+          colorOverrides?: Record<string, string>
+        }> = []
 
         for (const { subItem, src } of subCompMediaItems) {
           if (subItem.type === 'lottie' && !lottieProvider.get(subItem.id)) {
@@ -1192,6 +1258,10 @@ export async function createCompositionRenderer(
                 lottieItem.sourceHeight && lottieItem.sourceHeight > 0
                   ? lottieItem.sourceHeight
                   : 512,
+              animationId: lottieItem.animationId,
+              themeId: lottieItem.themeId,
+              textOverrides: lottieItem.textOverrides,
+              colorOverrides: lottieItem.colorOverrides,
             })
           }
           if (subItem.type === 'image' && !imageElements.has(subItem.id)) {
@@ -1293,14 +1363,28 @@ export async function createCompositionRenderer(
           await Promise.all(subWebpPromises)
         }
 
-        // Preload sub-comp Lottie renderers
+        // Preload sub-comp Lottie renderers, applying animation/theme + text/
+        // color edits so compound-clip Lotties reflect them on export (parity
+        // with preview).
         if (hasDom && subLottieItems.length > 0) {
           await Promise.all(
-            subLottieItems.map((it) =>
-              lottieProvider.preload(it.id, it.src, it.w, it.h).catch((err) => {
+            subLottieItems.map(async (it) => {
+              try {
+                const spec = await resolveLottieRenderSpec(it.src, it)
+                if (isDisposed) return
+                await lottieProvider.preload(
+                  it.id,
+                  it.src,
+                  it.w,
+                  it.h,
+                  spec.data ?? undefined,
+                  lottieOverrideSignature(it),
+                  spec.themeData ?? undefined,
+                )
+              } catch (err) {
                 getLog().error('Failed to preload sub-comp Lottie', { itemId: it.id, error: err })
-              }),
-            ),
+              }
+            }),
           )
         }
 
@@ -1338,6 +1422,13 @@ export async function createCompositionRenderer(
       // refresh, effects added after renderer creation stay invisible.
       if (renderMode === 'preview') {
         refreshSubCompRenderData(useCompositionsStore.getState().compositionById)
+      }
+
+      // Rebuild any Lottie whose text/color overrides changed since preload, so
+      // live recolor/text edits show up. The sync guard keeps this ~free on the
+      // hot path — the await only runs the frame after an override edit.
+      if (renderMode === 'preview' && lottieItems.length > 0 && lottieOverridesAreStale()) {
+        await ensureLottieOverridesFresh()
       }
 
       // Clear canvas

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -180,12 +180,14 @@ function lottieOverrideSignature(item: {
   themeId?: string
   textOverrides?: Record<string, string>
   colorOverrides?: Record<string, string>
+  slotOverrides?: Record<string, number | [number, number]>
 }): string {
   return JSON.stringify({
     a: item.animationId ?? null,
     m: item.themeId ?? null,
     t: item.textOverrides ?? null,
     c: item.colorOverrides ?? null,
+    s: item.slotOverrides ?? null,
   })
 }
 
@@ -450,6 +452,7 @@ export async function createCompositionRenderer(
           spec.data ?? undefined,
           signature,
           spec.themeData ?? undefined,
+          spec.slots ?? undefined,
         )
       }),
     )
@@ -1009,6 +1012,7 @@ export async function createCompositionRenderer(
                 spec.data ?? undefined,
                 lottieOverrideSignature(lottieItem),
                 spec.themeData ?? undefined,
+                spec.slots ?? undefined,
               )
               // Bail if the engine was disposed mid-load so we don't register a
               // renderer into a torn-down provider (dispose() → destroy()).
@@ -1244,6 +1248,7 @@ export async function createCompositionRenderer(
           themeId?: string
           textOverrides?: Record<string, string>
           colorOverrides?: Record<string, string>
+          slotOverrides?: Record<string, number | [number, number]>
         }> = []
 
         for (const { subItem, src } of subCompMediaItems) {
@@ -1262,6 +1267,7 @@ export async function createCompositionRenderer(
               themeId: lottieItem.themeId,
               textOverrides: lottieItem.textOverrides,
               colorOverrides: lottieItem.colorOverrides,
+              slotOverrides: lottieItem.slotOverrides,
             })
           }
           if (subItem.type === 'image' && !imageElements.has(subItem.id)) {
@@ -1380,6 +1386,7 @@ export async function createCompositionRenderer(
                   spec.data ?? undefined,
                   lottieOverrideSignature(it),
                   spec.themeData ?? undefined,
+                  spec.slots ?? undefined,
                 )
               } catch (err) {
                 getLog().error('Failed to preload sub-comp Lottie', { itemId: it.id, error: err })

--- a/src/features/preview/components/preview-stage.test.tsx
+++ b/src/features/preview/components/preview-stage.test.tsx
@@ -48,7 +48,11 @@ vi.mock('@/features/preview/deps/composition-runtime', () => ({
   ),
 }))
 
-import { getPreviewPixelSnapOffset, getPreviewPixelSnapSize } from '../utils/preview-pixel-snap'
+import {
+  getPreviewPixelSnapOffset,
+  getPreviewPixelSnapSize,
+  getPreviewPlayerSize,
+} from '../utils/preview-pixel-snap'
 import { PreviewStage } from './preview-stage'
 
 function createInputProps(): CompositionInputProps {
@@ -121,6 +125,30 @@ describe('getPreviewPixelSnapSize', () => {
       width: 590.5,
       height: 332,
     })
+  })
+})
+
+describe('getPreviewPlayerSize', () => {
+  it('keeps auto-fit preview dimensions aspect-stable on the device pixel grid', () => {
+    expect(
+      getPreviewPlayerSize({
+        sourceSize: { width: 1920, height: 1080 },
+        containerSize: { width: 1029.328125, height: 579 },
+        zoom: -1,
+        devicePixelRatio: 1,
+      }),
+    ).toEqual({ width: 1024, height: 576 })
+  })
+
+  it('preserves normal fixed zoom sizing', () => {
+    expect(
+      getPreviewPlayerSize({
+        sourceSize: { width: 1920, height: 1080 },
+        containerSize: { width: 1029.328125, height: 579 },
+        zoom: 0.5,
+        devicePixelRatio: 1,
+      }),
+    ).toEqual({ width: 960, height: 540 })
   })
 })
 

--- a/src/features/preview/components/preview-stage.test.tsx
+++ b/src/features/preview/components/preview-stage.test.tsx
@@ -53,6 +53,7 @@ import {
   getPreviewPixelSnapSize,
   getPreviewPlayerSize,
 } from '../utils/preview-pixel-snap'
+import { getPreviewDisplayEdgePadding } from '../utils/preview-display-canvas'
 import { PreviewStage } from './preview-stage'
 
 function createInputProps(): CompositionInputProps {
@@ -152,6 +153,22 @@ describe('getPreviewPlayerSize', () => {
   })
 })
 
+describe('getPreviewDisplayEdgePadding', () => {
+  it('uses source-pixel padding that lands on whole screen pixels at fixed zooms', () => {
+    const renderSize = { width: 1920, height: 1080 }
+
+    expect(getPreviewDisplayEdgePadding({ width: 480, height: 270 }, renderSize, 1)).toBe(4)
+    expect(getPreviewDisplayEdgePadding({ width: 960, height: 540 }, renderSize, 1)).toBe(2)
+    expect(getPreviewDisplayEdgePadding({ width: 1440, height: 810 }, renderSize, 1)).toBe(4)
+  })
+
+  it('falls back to a minimal source-pixel pad for non-terminating auto-fit scales', () => {
+    expect(
+      getPreviewDisplayEdgePadding({ width: 992, height: 558 }, { width: 1920, height: 1080 }, 1),
+    ).toBe(1)
+  })
+})
+
 describe('PreviewStage', () => {
   it('passes proxy playback mode down to nested composition rendering', () => {
     playbackState.useProxy = true
@@ -180,7 +197,7 @@ describe('PreviewStage', () => {
     expect(screen.getByTestId('main-composition')).toHaveAttribute('data-use-proxy-media', 'true')
   })
 
-  it('keeps render surfaces on one exact geometry and passes that geometry to Player layout', () => {
+  it('keeps the player on exact geometry and pads rendered overlay canvases at the clipped edge', () => {
     render(
       <PreviewStage
         backgroundRef={createRef<HTMLDivElement>()}
@@ -212,9 +229,12 @@ describe('PreviewStage', () => {
     expect(player.style.marginTop).toBe('')
 
     canvases.forEach((canvas) => {
-      expect(canvas).toHaveStyle({ width: '100%', height: '100%' })
-      expect(canvas.style.left).toBe('')
-      expect(canvas.style.top).toBe('')
+      expect(canvas).toHaveStyle({
+        width: 'calc(100% + 2px)',
+        height: 'calc(100% + 2px)',
+        left: '-1px',
+        top: '-1px',
+      })
     })
   })
 
@@ -228,7 +248,12 @@ describe('PreviewStage', () => {
     expect(beforeLayer).toHaveStyle({ width: '100%', height: '100%' })
     expect(beforeLayer.style.clipPath).toBe('inset(0 50% 0 0)')
     expect(beforeLayer.style.overflow).toBe('')
-    expect(scrubCanvas).toHaveStyle({ width: '100%', height: '100%' })
+    expect(scrubCanvas).toHaveStyle({
+      width: 'calc(100% + 2px)',
+      height: 'calc(100% + 2px)',
+      left: '-1px',
+      top: '-1px',
+    })
     expect(scrubCanvas.style.clipPath).toBe('')
     expect(screen.getByLabelText('Split grade comparison')).toBeTruthy()
     expect(screen.getByText('Before')).toBeTruthy()
@@ -252,7 +277,12 @@ describe('PreviewStage', () => {
     expect(beforeLayer).toHaveStyle({ width: '100%' })
     expect(beforeLayer.style.clipPath).toBe('inset(0 65% 0 0)')
     expect(beforeLayer.style.overflow).toBe('')
-    expect(scrubCanvas).toHaveStyle({ width: '100%', height: '100%' })
+    expect(scrubCanvas).toHaveStyle({
+      width: 'calc(100% + 2px)',
+      height: 'calc(100% + 2px)',
+      left: '-1px',
+      top: '-1px',
+    })
     expect(scrubCanvas.style.clipPath).toBe('')
     expect(wipeHandle).toHaveAttribute('aria-valuenow', '35')
 

--- a/src/features/preview/components/preview-stage.tsx
+++ b/src/features/preview/components/preview-stage.tsx
@@ -17,6 +17,7 @@ import type { CompositionInputProps } from '@/types/export'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/config/editor-layout'
 import { FAST_SCRUB_RENDERER_ENABLED } from '../utils/preview-constants'
+import { getPreviewDisplayCanvasStyle } from '../utils/preview-display-canvas'
 import { getPreviewPixelSnapOffset, ZERO_PIXEL_SNAP_OFFSET } from '../utils/preview-pixel-snap'
 import type { ColorGradeComparisonMode } from '../stores/gizmo-store'
 
@@ -113,6 +114,9 @@ export const PreviewStage = memo(function PreviewStage({
     const ResizeObserverCtor = typeof ResizeObserver === 'undefined' ? null : ResizeObserver
     const resizeObserver = ResizeObserverCtor ? new ResizeObserverCtor(scheduleUpdate) : null
     resizeObserver?.observe(anchor)
+    if (anchor.parentElement) {
+      resizeObserver?.observe(anchor.parentElement)
+    }
     window.addEventListener('resize', scheduleUpdate)
 
     return () => {
@@ -133,6 +137,7 @@ export const PreviewStage = memo(function PreviewStage({
   const splitPosition = Math.max(0.05, Math.min(0.95, colorGradeSplitPosition))
   const splitPercent = splitPosition * 100
   const splitClipPath = `inset(0 ${100 - splitPercent}% 0 0)`
+  const displayCanvasStyle = getPreviewDisplayCanvasStyle(playerSize, playerRenderSize)
 
   const updateSplitPositionFromPointer = useCallback(
     (event: { clientX: number }) => {
@@ -276,8 +281,7 @@ export const PreviewStage = memo(function PreviewStage({
                     ref={scrubCanvasRef}
                     className="absolute left-0 top-0 pointer-events-none"
                     style={{
-                      width: '100%',
-                      height: '100%',
+                      ...displayCanvasStyle,
                       maxWidth: 'none',
                       maxHeight: 'none',
                       visibility: isRenderedOverlayVisible ? 'visible' : 'hidden',
@@ -291,8 +295,7 @@ export const PreviewStage = memo(function PreviewStage({
                 className="absolute inset-0 pointer-events-none"
                 data-grade-comparison-after-layer={isSplitGradeAfterVisible ? 'true' : undefined}
                 style={{
-                  width: '100%',
-                  height: '100%',
+                  ...displayCanvasStyle,
                   zIndex: isSplitGradeAfterVisible ? 3 : 5,
                   visibility: isSplitGradeAfterVisible ? 'visible' : 'hidden',
                 }}

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -1477,7 +1477,10 @@ describe('VideoPreview sync behavior', () => {
       expect(beforeLayer).toHaveStyle({ width: '100%', height: '100%' })
       expect(beforeLayer?.style.clipPath).toBe('inset(0 50% 0 0)')
       expect(beforeLayer?.style.overflow).toBe('')
-      expect(scrubCanvas).toHaveStyle({ width: '100%', height: '100%' })
+      expect(scrubCanvas.style.width).toMatch(/^calc\(100% \+ /)
+      expect(scrubCanvas.style.height).toMatch(/^calc\(100% \+ /)
+      expect(scrubCanvas.style.left).not.toBe('')
+      expect(scrubCanvas.style.top).not.toBe('')
       expect(container.querySelector('[data-grade-comparison-after-layer="true"]')).not.toBeNull()
     })
 
@@ -2662,8 +2665,8 @@ describe('VideoPreview sync behavior', () => {
 
     expect(source).not.toBeNull()
     expect(source).not.toBe(scrubCanvas)
-    expect(source?.width).toBe(scrubCanvas.width)
-    expect(source?.height).toBe(scrubCanvas.height)
+    expect(source?.width).toBe(1920)
+    expect(source?.height).toBe(1080)
     expect(renderer.renderFrame).not.toHaveBeenCalled()
     expect(scopeRenderer.renderFrame).toHaveBeenCalledWith(30)
   })
@@ -2691,8 +2694,8 @@ describe('VideoPreview sync behavior', () => {
 
     expect(source).not.toBeNull()
     expect(source).not.toBe(scrubCanvas)
-    expect(source?.width).toBe(scrubCanvas.width)
-    expect(source?.height).toBe(scrubCanvas.height)
+    expect(source?.width).toBe(1920)
+    expect(source?.height).toBe(1080)
     expect(renderer.renderFrame).not.toHaveBeenCalled()
     expect(scopeRenderer.renderFrame).toHaveBeenCalledWith(30)
   })

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -2022,8 +2022,11 @@ describe('VideoPreview sync behavior', () => {
       } as unknown as TimelineItem,
     ])
 
+    // The timeline contains a gpu-effect clip, so the overlay stays warm from
+    // the start (project-level always-on) rather than switching on at the clip
+    // boundary — this is what makes the effect appear instantly on landing.
     const { scrubCanvas } = await renderPreviewAfterInitialSeek()
-    expect(scrubCanvas.style.visibility).toBe('hidden')
+    expect(scrubCanvas.style.visibility).toBe('visible')
 
     act(() => {
       usePlaybackStore.getState().setCurrentFrame(24)
@@ -2067,8 +2070,10 @@ describe('VideoPreview sync behavior', () => {
 
     mockedPlayerFrame = 24
 
+    // Corner-pin is overlay-only content, so the overlay is warm from the start
+    // (project-level always-on) even though the Player already sits at the frame.
     const { scrubCanvas } = await renderPreviewAfterInitialSeek()
-    expect(scrubCanvas.style.visibility).toBe('hidden')
+    expect(scrubCanvas.style.visibility).toBe('visible')
 
     act(() => {
       usePlaybackStore.getState().setCurrentFrame(24)

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -454,6 +454,20 @@ function getDisplayedFrame() {
   return usePreviewBridgeStore.getState().displayedFrame
 }
 
+function getCanvasDrawImageCallCount() {
+  const results = canvasGetContextSpy?.mock.results as
+    | Array<{ type: string; value: unknown }>
+    | undefined
+  return (
+    results?.reduce((total: number, result) => {
+      if (result.type !== 'return' || !result.value) return total
+      const drawImage = (result.value as { drawImage?: unknown }).drawImage
+      if (typeof drawImage !== 'function' || !('mock' in drawImage)) return total
+      return total + (drawImage as { mock: { calls: unknown[] } }).mock.calls.length
+    }, 0) ?? 0
+  )
+}
+
 function resetStores() {
   usePlaybackStore.setState({
     currentFrame: 0,
@@ -2344,7 +2358,7 @@ describe('VideoPreview sync behavior', () => {
     })
   })
 
-  it('keeps settled skim presentation across preview effect refreshes', async () => {
+  it('repaints the settled skim overlay immediately after preview resize', async () => {
     const { container, rerender } = render(
       <VideoPreview
         project={{ width: 1920, height: 1080, backgroundColor: '#000000' }}
@@ -2370,10 +2384,15 @@ describe('VideoPreview sync behavior', () => {
       expect(scrubCanvas.style.visibility).toBe('visible')
     })
 
+    const drawImageCallsBeforeResize = getCanvasDrawImageCallCount()
+    const widthBeforeResize = scrubCanvas.width
+    const renderer = rendererMockState.instances[rendererMockState.instances.length - 1]!
+    renderer.renderFrame.mockClear()
+
     rerender(
       <VideoPreview
         project={{ width: 1920, height: 1080, backgroundColor: '#000000' }}
-        containerSize={{ width: 1281, height: 720 }}
+        containerSize={{ width: 960, height: 540 }}
       />,
     )
 
@@ -2381,7 +2400,10 @@ describe('VideoPreview sync behavior', () => {
       expect(usePlaybackStore.getState().previewFrame).toBeNull()
       expect(getDisplayedFrame()).toBe(48)
       expect(scrubCanvas.style.visibility).toBe('visible')
+      expect(scrubCanvas.width).not.toBe(widthBeforeResize)
+      expect(getCanvasDrawImageCallCount()).toBeGreaterThan(drawImageCallsBeforeResize)
     })
+    expect(renderer.renderFrame).not.toHaveBeenCalled()
   })
 
   it('does not enter scrub mode or repaint when clicking the already displayed settled frame', async () => {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -34,6 +34,10 @@ import { usePreviewViewModel } from '../hooks/use-preview-view-model'
 import { usePreviewTransitionSessionController } from '../hooks/use-preview-transition-session-controller'
 import { useGizmoStore } from '../stores/gizmo-store'
 import { FAST_SCRUB_RENDERER_ENABLED } from '../utils/preview-constants'
+import {
+  drawSourceToPreviewDisplayCanvas,
+  getPreviewDisplayCanvasBackingSize,
+} from '../utils/preview-display-canvas'
 import { importCompositionRenderer, type CompositionRendererInstance } from '../deps/export'
 
 interface VideoPreviewProps {
@@ -371,9 +375,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   useLayoutEffect(() => {
     const canvas = gpuEffectsCanvasRef.current
     if (!canvas) return
-    if (canvas.width !== playerRenderSize.width) canvas.width = playerRenderSize.width
-    if (canvas.height !== playerRenderSize.height) canvas.height = playerRenderSize.height
-  }, [gpuEffectsCanvasRef, playerRenderSize.height, playerRenderSize.width])
+    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, playerRenderSize)
+    if (canvas.width !== backingSize.width) canvas.width = backingSize.width
+    if (canvas.height !== backingSize.height) canvas.height = backingSize.height
+  }, [gpuEffectsCanvasRef, playerRenderSize, playerSize])
 
   const ensureSplitAfterRenderer =
     useCallback(async (): Promise<CompositionRendererInstance | null> => {
@@ -523,6 +528,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       isResolving,
       forceFastScrubOverlay,
       items,
+      playerSize,
       playerRenderSize,
       renderSize,
       fastScrubInputProps,
@@ -710,8 +716,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
 
           const displayCtx = displayCanvas.getContext('2d')
           if (!displayCtx) return
-          displayCtx.clearRect(0, 0, displayCanvas.width, displayCanvas.height)
-          displayCtx.drawImage(offscreen, 0, 0, displayCanvas.width, displayCanvas.height)
+          drawSourceToPreviewDisplayCanvas(displayCtx, displayCanvas, offscreen)
           setSplitAfterRenderedFrame(targetFrame)
         }
       } finally {

--- a/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { shouldForceContinuousPreviewOverlay } from './use-gpu-effects-overlay'
+import {
+  shouldForceContinuousPreviewOverlay,
+  timelineHasContinuousOverlayContent,
+} from './use-gpu-effects-overlay'
 import type { TimelineItem } from '@/types/timeline'
 import type { Transition } from '@/types/transition'
 import type { SubComposition } from '@/features/preview/deps/timeline-store'
@@ -474,6 +477,45 @@ describe('shouldForceContinuousPreviewOverlay', () => {
           ],
         ]),
       ),
+    ).toBe(true)
+  })
+})
+
+describe('timelineHasContinuousOverlayContent', () => {
+  const gpuEffect = {
+    id: 'effect-1',
+    enabled: true,
+    effect: { type: 'gpu-effect' as const, gpuEffectType: 'gpu-blur', params: { amount: 0.5 } },
+  }
+
+  it('is false for a timeline with no overlay-only content', () => {
+    expect(timelineHasContinuousOverlayContent([createVideoItem()])).toBe(false)
+  })
+
+  it('is true when any item has an enabled GPU effect, regardless of frame position', () => {
+    // The clip sits far from frame 0, yet the overlay must stay warm the whole
+    // session — this is exactly what the frame-based check misses.
+    const effected = createVideoItem({ from: 500, durationInFrames: 60, effects: [gpuEffect] })
+    expect(timelineHasContinuousOverlayContent([createVideoItem(), effected])).toBe(true)
+  })
+
+  it('ignores disabled effects', () => {
+    const disabled = createVideoItem({ effects: [{ ...gpuEffect, enabled: false }] })
+    expect(timelineHasContinuousOverlayContent([disabled])).toBe(false)
+  })
+
+  it('is true for a non-normal blend mode', () => {
+    expect(timelineHasContinuousOverlayContent([createVideoItem({ blendMode: 'screen' })])).toBe(
+      true,
+    )
+  })
+
+  it('detects overlay-only content nested inside a sub-composition', () => {
+    const subComp = createSubComposition([
+      createVideoItem({ id: 'sub-item', effects: [gpuEffect] }),
+    ])
+    expect(
+      timelineHasContinuousOverlayContent([createCompositionItem()], { 'sub-1': subComp }),
     ).toBe(true)
   })
 })

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -70,6 +70,32 @@ function subCompositionNeedsRenderedOverlayPath(
 }
 
 /**
+ * Frame-independent scan: does the timeline contain ANY content that can only
+ * be shown through the GPU overlay (enabled GPU effects, non-normal blend modes,
+ * corner pin, text motion) — anywhere, on any clip, at any time?
+ *
+ * When true, the caller keeps the overlay active for the whole session instead
+ * of flipping it on per-frame as the playhead enters each such clip. The
+ * per-frame flip is a reactive React-state round-trip, so effects would
+ * otherwise pop in a few frames late on every skim/playback entry. Trading a
+ * ~1-2ms GPU composite over non-effect clips for instant effects is worth it;
+ * projects with no such content keep the fast DOM path (this returns false).
+ */
+export function timelineHasContinuousOverlayContent(
+  items: TimelineItem[],
+  compositionById?: Record<string, SubComposition>,
+): boolean {
+  return items.some((item) => {
+    if (needsRenderedOverlayPath(item)) return true
+    if (item.type === 'composition' && compositionById) {
+      const subComp = compositionById[item.compositionId]
+      if (subComp && subCompositionNeedsRenderedOverlayPath(subComp, compositionById)) return true
+    }
+    return false
+  })
+}
+
+/**
  * Detects whether the composition renderer overlay should stay active
  * outside of scrub-driven updates.
  *
@@ -163,24 +189,30 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
         : undefined
 
       setNeedsOverlay((prev) => {
-        const next = shouldForceContinuousPreviewOverlay(
-          items,
-          transitions,
-          frame,
-          previewEffectsByItemId,
-          compositionById,
-          // Keep the continuous (fast-scrub) overlay forced across an active
-          // transition window during playback as well as scrubbing — not only
-          // when a participant has GPU effects/blend/corner-pin. Otherwise a
-          // plain transition can drop the continuous overlay mid-window (e.g.
-          // when an unrelated effected/composition item that happened to be
-          // keeping it on ends at the cut), switching to the buffered overlay
-          // path which can leave frames un-rendered and collapse the wipe to
-          // one clip for the rest of the transition. Forcing it for the whole
-          // window keeps every transition on the per-frame render path that
-          // already works for the transitions that look correct today.
-          { forceTransitionFrames: playback.previewFrame !== null || playback.isPlaying },
-        )
+        // Option 1: if the timeline contains any overlay-only content anywhere,
+        // keep the overlay warm for the whole session so effects/blend/corner-pin
+        // are instant on skim + playback instead of lagging the reactive per-frame
+        // flag. Otherwise fall back to the frame-based decision (transitions etc.).
+        const next =
+          timelineHasContinuousOverlayContent(items, compositionById) ||
+          shouldForceContinuousPreviewOverlay(
+            items,
+            transitions,
+            frame,
+            previewEffectsByItemId,
+            compositionById,
+            // Keep the continuous (fast-scrub) overlay forced across an active
+            // transition window during playback as well as scrubbing — not only
+            // when a participant has GPU effects/blend/corner-pin. Otherwise a
+            // plain transition can drop the continuous overlay mid-window (e.g.
+            // when an unrelated effected/composition item that happened to be
+            // keeping it on ends at the cut), switching to the buffered overlay
+            // path which can leave frames un-rendered and collapse the wipe to
+            // one clip for the rest of the transition. Forcing it for the whole
+            // window keeps every transition on the per-frame render path that
+            // already works for the transitions that look correct today.
+            { forceTransitionFrames: playback.previewFrame !== null || playback.isPlaying },
+          )
         return prev === next ? prev : next
       })
     }

--- a/src/features/preview/hooks/use-preview-composition-model.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.ts
@@ -246,7 +246,15 @@ export function usePreviewCompositionModel({
   fastScrubKeyframesByItemIdRef.current = fastScrubKeyframesByItemId
 
   const getLiveItemSnapshot = useCallback((itemId: string) => {
-    return fastScrubLiveItemsByIdRef.current.get(itemId)
+    const item = fastScrubLiveItemsByIdRef.current.get(itemId)
+    // Merge any live Lottie edit preview (color/text/slot drag) so the canvas
+    // reflects it without a timeline-store commit. Each present field replaces
+    // the committed map wholesale; absent fields fall through to `item`.
+    if (item?.type === 'lottie') {
+      const lottiePreview = useGizmoStore.getState().preview?.[itemId]?.lottie
+      if (lottiePreview) return { ...item, ...lottiePreview }
+    }
+    return item
   }, [])
 
   const getLiveKeyframes = useCallback((itemId: string) => {

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -62,6 +62,7 @@ import {
   resolveBoundarySourcePrewarmCacheUpdate,
   resolvePrewarmFrameQueueAfterEnqueue,
 } from '../utils/render-pump-prewarm-plan'
+import { drawSourceToPreviewDisplayCanvas } from '../utils/preview-display-canvas'
 import type { TransitionPreviewSessionTrace } from './use-preview-transition-session-controller'
 import { createLogger } from '@/shared/logging/logger'
 import { isPreviewTraceEnabled, recordPumpTrace } from '@/shared/logging/preview-trace'
@@ -281,8 +282,7 @@ export function usePreviewRenderPump({
       if (!displayCanvas) return
       const displayCtx = displayCanvas.getContext('2d')
       if (!displayCtx) return
-      displayCtx.clearRect(0, 0, displayCanvas.width, displayCanvas.height)
-      displayCtx.drawImage(source, 0, 0, displayCanvas.width, displayCanvas.height)
+      drawSourceToPreviewDisplayCanvas(displayCtx, displayCanvas, source)
       setDisplayedFrame(renderedFrame)
     }
 

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -37,6 +37,7 @@ import {
 } from '../utils/preview-constants'
 import {
   copyPreviewDisplayCanvasContent,
+  drawSourceToPreviewDisplayCanvas,
   getPreviewDisplayCanvasBackingSize,
 } from '../utils/preview-display-canvas'
 import { setActivePreviewScrubbingCache } from '../utils/preview-scrubbing-cache-bridge'
@@ -228,7 +229,24 @@ export function usePreviewRendererController({
     const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, playerRenderSize)
     if (canvas.width !== backingSize.width) canvas.width = backingSize.width
     if (canvas.height !== backingSize.height) canvas.height = backingSize.height
-  }, [playerRenderSize, playerSize, scrubCanvasRef])
+    if (!showFastScrubOverlayRef.current && !showPlaybackTransitionOverlayRef.current) return
+    const renderedFrame = scrubOffscreenRenderedFrameRef.current
+    const offscreen = scrubOffscreenCanvasRef.current
+    if (renderedFrame === null || !offscreen) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    drawSourceToPreviewDisplayCanvas(ctx, canvas, offscreen)
+    setDisplayedFrame(renderedFrame)
+  }, [
+    playerRenderSize,
+    playerSize,
+    scrubCanvasRef,
+    scrubOffscreenCanvasRef,
+    scrubOffscreenRenderedFrameRef,
+    setDisplayedFrame,
+    showFastScrubOverlayRef,
+    showPlaybackTransitionOverlayRef,
+  ])
 
   const disposeFastScrubRenderer = useCallback(() => {
     scrubInitPromiseRef.current = null

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -35,6 +35,10 @@ import {
   FAST_SCRUB_RENDERER_ENABLED,
   blobToDataUrl,
 } from '../utils/preview-constants'
+import {
+  copyPreviewDisplayCanvasContent,
+  getPreviewDisplayCanvasBackingSize,
+} from '../utils/preview-display-canvas'
 import { setActivePreviewScrubbingCache } from '../utils/preview-scrubbing-cache-bridge'
 import { warmDecoderPrewarmWorkerPool } from '../utils/decoder-prewarm'
 import { collectVisualInvalidationRanges } from '../utils/preview-frame-invalidation'
@@ -62,6 +66,7 @@ interface UsePreviewRendererControllerParams {
   isResolving: boolean
   forceFastScrubOverlay: boolean
   items: TimelineItem[]
+  playerSize: { width: number; height: number }
   playerRenderSize: { width: number; height: number }
   renderSize: { width: number; height: number }
   fastScrubInputProps: CompositionInputProps
@@ -136,6 +141,7 @@ export function usePreviewRendererController({
   isResolving,
   forceFastScrubOverlay,
   items,
+  playerSize,
   playerRenderSize,
   renderSize,
   fastScrubInputProps,
@@ -219,9 +225,10 @@ export function usePreviewRendererController({
   useLayoutEffect(() => {
     const canvas = scrubCanvasRef.current
     if (!canvas) return
-    if (canvas.width !== playerRenderSize.width) canvas.width = playerRenderSize.width
-    if (canvas.height !== playerRenderSize.height) canvas.height = playerRenderSize.height
-  }, [playerRenderSize.height, playerRenderSize.width, scrubCanvasRef])
+    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, playerRenderSize)
+    if (canvas.width !== backingSize.width) canvas.width = backingSize.width
+    if (canvas.height !== backingSize.height) canvas.height = backingSize.height
+  }, [playerRenderSize, playerSize, scrubCanvasRef])
 
   const disposeFastScrubRenderer = useCallback(() => {
     scrubInitPromiseRef.current = null
@@ -1148,22 +1155,20 @@ export function usePreviewRendererController({
         return null
       }
 
+      const targetWidth = Math.max(1, playerRenderSize.width)
+      const targetHeight = Math.max(1, playerRenderSize.height)
+
       let snapshot = captureDisplaySnapshotCanvasRef.current
-      if (
-        !snapshot ||
-        snapshot.width !== displayCanvas.width ||
-        snapshot.height !== displayCanvas.height
-      ) {
-        snapshot = new OffscreenCanvas(displayCanvas.width, displayCanvas.height)
+      if (!snapshot || snapshot.width !== targetWidth || snapshot.height !== targetHeight) {
+        snapshot = new OffscreenCanvas(targetWidth, targetHeight)
         captureDisplaySnapshotCanvasRef.current = snapshot
       }
       const snapshotCtx = snapshot.getContext('2d')
       if (!snapshotCtx) return null
-      snapshotCtx.clearRect(0, 0, snapshot.width, snapshot.height)
-      snapshotCtx.drawImage(displayCanvas, 0, 0)
+      copyPreviewDisplayCanvasContent(displayCanvas, snapshotCtx)
       return snapshot
     },
-    [scrubCanvasRef],
+    [playerRenderSize.height, playerRenderSize.width, scrubCanvasRef],
   )
 
   const captureLiveScopeRenderedSnapshot = useCallback(

--- a/src/features/preview/stores/gizmo-store.ts
+++ b/src/features/preview/stores/gizmo-store.ts
@@ -20,6 +20,18 @@ function clampColorGradeSplitPosition(position: number): number {
   )
 }
 
+/**
+ * Live Lottie edits previewed without touching the timeline store, so dragging a
+ * color / slot / text updates the canvas without spamming undo history. The
+ * render engine merges these over the item (see `getLiveItemSnapshot`); each
+ * field, when present, replaces the committed map wholesale.
+ */
+export interface LottiePreview {
+  colorOverrides?: Record<string, string>
+  textOverrides?: Record<string, string>
+  slotOverrides?: Record<string, number | [number, number]>
+}
+
 /** Item properties that can be previewed (non-transform) */
 export interface ItemPropertiesPreview {
   fadeIn?: number
@@ -119,6 +131,8 @@ export interface ItemPreview {
   properties?: ItemPropertiesPreview
   /** Effects preview */
   effects?: ItemEffect[]
+  /** Live Lottie color/text/slot edits (see {@link LottiePreview}) */
+  lottie?: LottiePreview
 }
 
 interface GizmoStoreState {
@@ -254,6 +268,9 @@ interface GizmoStoreActions {
    * Convenience method for effects sliders.
    */
   setEffectsPreviewNew: (effects: Record<string, ItemEffect[]>) => void
+
+  /** Set (or clear, with null) the live Lottie edit preview for one item. */
+  setLottiePreviewNew: (itemId: string, lottie: LottiePreview | null) => void
 
   /** Toggle preview-only color grade bypass (before/after comparison) */
   toggleColorGradeBypass: () => void
@@ -509,6 +526,18 @@ export const useGizmoStore = create<GizmoStoreState & GizmoStoreActions>((set, g
       }
     }
     set({ preview: merged })
+  },
+
+  setLottiePreviewNew: (itemId, lottie) => {
+    const current = get().preview ?? {}
+    const existing = current[itemId]
+    if (lottie === null) {
+      if (!existing?.lottie) return // nothing to clear
+      const { lottie: _dropped, ...rest } = existing
+      set({ preview: { ...current, [itemId]: rest } })
+      return
+    }
+    set({ preview: { ...current, [itemId]: { ...existing, lottie } } })
   },
 
   toggleColorGradeBypass: () =>

--- a/src/features/preview/utils/preview-display-canvas.ts
+++ b/src/features/preview/utils/preview-display-canvas.ts
@@ -1,0 +1,171 @@
+const MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX = 1
+const MAX_PREVIEW_DISPLAY_EDGE_PADDING_PX = 16
+const PIXEL_ALIGNMENT_EPSILON = 1e-3
+
+type PreviewCanvasSize = {
+  width: number
+  height: number
+}
+
+export function getPreviewDisplayEdgePadding(
+  playerSize: PreviewCanvasSize,
+  renderSize: PreviewCanvasSize,
+  devicePixelRatio = typeof window === 'undefined' ? 1 : Math.max(1, window.devicePixelRatio || 1),
+): number {
+  const scaleX = renderSize.width > 0 ? playerSize.width / renderSize.width : 1
+  const scaleY = renderSize.height > 0 ? playerSize.height / renderSize.height : 1
+
+  for (
+    let padding = MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX;
+    padding <= MAX_PREVIEW_DISPLAY_EDGE_PADDING_PX;
+    padding++
+  ) {
+    const xDevicePixels = padding * scaleX * devicePixelRatio
+    const yDevicePixels = padding * scaleY * devicePixelRatio
+    if (
+      xDevicePixels >= MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX &&
+      yDevicePixels >= MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX &&
+      Math.abs(xDevicePixels - Math.round(xDevicePixels)) < PIXEL_ALIGNMENT_EPSILON &&
+      Math.abs(yDevicePixels - Math.round(yDevicePixels)) < PIXEL_ALIGNMENT_EPSILON
+    ) {
+      return padding
+    }
+  }
+
+  return MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX
+}
+
+export function getPreviewDisplayCanvasBackingSize(
+  playerSize: PreviewCanvasSize,
+  renderSize: PreviewCanvasSize,
+): PreviewCanvasSize {
+  const padding = getPreviewDisplayEdgePadding(playerSize, renderSize) * 2
+  return {
+    width: Math.max(1, Math.round(renderSize.width + padding)),
+    height: Math.max(1, Math.round(renderSize.height + padding)),
+  }
+}
+
+export function getPreviewDisplayCanvasStyle(
+  playerSize: PreviewCanvasSize,
+  renderSize: PreviewCanvasSize,
+): {
+  left: string
+  top: string
+  width: string
+  height: string
+} {
+  const padding = getPreviewDisplayEdgePadding(playerSize, renderSize)
+  const padX = renderSize.width > 0 ? (playerSize.width / renderSize.width) * padding : padding
+  const padY = renderSize.height > 0 ? (playerSize.height / renderSize.height) * padding : padding
+
+  return {
+    left: `-${padX}px`,
+    top: `-${padY}px`,
+    width: `calc(100% + ${padX * 2}px)`,
+    height: `calc(100% + ${padY * 2}px)`,
+  }
+}
+
+export function drawSourceToPreviewDisplayCanvas(
+  displayCtx: CanvasRenderingContext2D,
+  displayCanvas: HTMLCanvasElement,
+  source: OffscreenCanvas | HTMLCanvasElement,
+): void {
+  const padX = Math.max(0, Math.round((displayCanvas.width - source.width) / 2))
+  const padY = Math.max(0, Math.round((displayCanvas.height - source.height) / 2))
+  const contentWidth = Math.max(1, displayCanvas.width - padX * 2)
+  const contentHeight = Math.max(1, displayCanvas.height - padY * 2)
+
+  displayCtx.clearRect(0, 0, displayCanvas.width, displayCanvas.height)
+  displayCtx.drawImage(source, padX, padY, contentWidth, contentHeight)
+
+  if (padY > 0) {
+    displayCtx.drawImage(displayCanvas, padX, padY, contentWidth, 1, padX, 0, contentWidth, padY)
+    displayCtx.drawImage(
+      displayCanvas,
+      padX,
+      padY + contentHeight - 1,
+      contentWidth,
+      1,
+      padX,
+      padY + contentHeight,
+      contentWidth,
+      padY,
+    )
+  }
+  if (padX > 0) {
+    displayCtx.drawImage(displayCanvas, padX, padY, 1, contentHeight, 0, padY, padX, contentHeight)
+    displayCtx.drawImage(
+      displayCanvas,
+      padX + contentWidth - 1,
+      padY,
+      1,
+      contentHeight,
+      padX + contentWidth,
+      padY,
+      padX,
+      contentHeight,
+    )
+  }
+
+  if (padX > 0 && padY > 0) {
+    displayCtx.drawImage(displayCanvas, padX, padY, 1, 1, 0, 0, padX, padY)
+    displayCtx.drawImage(
+      displayCanvas,
+      padX + contentWidth - 1,
+      padY,
+      1,
+      1,
+      padX + contentWidth,
+      0,
+      padX,
+      padY,
+    )
+    displayCtx.drawImage(
+      displayCanvas,
+      padX,
+      padY + contentHeight - 1,
+      1,
+      1,
+      0,
+      padY + contentHeight,
+      padX,
+      padY,
+    )
+    displayCtx.drawImage(
+      displayCanvas,
+      padX + contentWidth - 1,
+      padY + contentHeight - 1,
+      1,
+      1,
+      padX + contentWidth,
+      padY + contentHeight,
+      padX,
+      padY,
+    )
+  }
+}
+
+export function copyPreviewDisplayCanvasContent(
+  sourceCanvas: HTMLCanvasElement,
+  targetCtx: OffscreenCanvasRenderingContext2D,
+): void {
+  const padX = Math.max(0, Math.round((sourceCanvas.width - targetCtx.canvas.width) / 2))
+  const padY = Math.max(0, Math.round((sourceCanvas.height - targetCtx.canvas.height) / 2))
+  const contentWidth = Math.max(1, sourceCanvas.width - padX * 2)
+  const contentHeight = Math.max(1, sourceCanvas.height - padY * 2)
+
+  targetCtx.clearRect(0, 0, targetCtx.canvas.width, targetCtx.canvas.height)
+  targetCtx.drawImage(
+    sourceCanvas,
+    padX,
+    padY,
+    contentWidth,
+    contentHeight,
+    0,
+    0,
+    targetCtx.canvas.width,
+    targetCtx.canvas.height,
+  )
+}

--- a/src/features/preview/utils/preview-pixel-snap.ts
+++ b/src/features/preview/utils/preview-pixel-snap.ts
@@ -11,6 +11,17 @@ const MIN_PIXEL_SNAP_DELTA = 0.001
 
 export const ZERO_PIXEL_SNAP_OFFSET: PixelSnapOffset = { x: 0, y: 0 }
 
+function greatestCommonDivisor(a: number, b: number): number {
+  let x = Math.abs(Math.round(a))
+  let y = Math.abs(Math.round(b))
+  while (y > 0) {
+    const next = x % y
+    x = y
+    y = next
+  }
+  return x || 1
+}
+
 function normalizeDevicePixelRatio(devicePixelRatio: number): number {
   return Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1
 }
@@ -46,6 +57,51 @@ export function getPreviewPixelSnapSize(
   }
 }
 
+function floorCssPixel(value: number, devicePixelRatio: number): number {
+  if (!Number.isFinite(value)) return 0
+  const dpr = normalizeDevicePixelRatio(devicePixelRatio)
+  return Math.max(0, Math.floor(value * dpr + MIN_PIXEL_SNAP_DELTA) / dpr)
+}
+
+function getAspectStableFitSize({
+  sourceSize,
+  containerSize,
+  devicePixelRatio,
+}: {
+  sourceSize: PixelSnapSize
+  containerSize: PixelSnapSize
+  devicePixelRatio: number
+}): PixelSnapSize {
+  const dpr = normalizeDevicePixelRatio(devicePixelRatio)
+  const aspectRatio = sourceSize.width / sourceSize.height
+  const sourceWidth = Math.max(1, Math.round(sourceSize.width))
+  const sourceHeight = Math.max(1, Math.round(sourceSize.height))
+  const divisor = greatestCommonDivisor(sourceWidth, sourceHeight)
+  const unitWidth = sourceWidth / divisor
+  const unitHeight = sourceHeight / divisor
+  const maxDeviceWidth = Math.max(0, Math.floor(containerSize.width * dpr + MIN_PIXEL_SNAP_DELTA))
+  const maxDeviceHeight = Math.max(0, Math.floor(containerSize.height * dpr + MIN_PIXEL_SNAP_DELTA))
+  const unitCount = Math.floor(
+    Math.min(maxDeviceWidth / unitWidth, maxDeviceHeight / unitHeight),
+  )
+
+  if (unitCount > 0) {
+    return {
+      width: (unitWidth * unitCount) / dpr,
+      height: (unitHeight * unitCount) / dpr,
+    }
+  }
+
+  const containerAspectRatio = containerSize.width / containerSize.height
+  if (containerAspectRatio > aspectRatio) {
+    const height = floorCssPixel(containerSize.height, dpr)
+    return { width: height * aspectRatio, height }
+  }
+
+  const width = floorCssPixel(containerSize.width, dpr)
+  return { width, height: width / aspectRatio }
+}
+
 function getDevicePixelRatio(): number {
   return typeof window === 'undefined' ? 1 : window.devicePixelRatio
 }
@@ -60,21 +116,7 @@ export function getPreviewPlayerSize({
 
   if (zoom === -1) {
     if (containerSize.width > 0 && containerSize.height > 0) {
-      const containerAspectRatio = containerSize.width / containerSize.height
-
-      if (containerAspectRatio > aspectRatio) {
-        const { height } = getPreviewPixelSnapSize(
-          { width: containerSize.height * aspectRatio, height: containerSize.height },
-          devicePixelRatio,
-        )
-        return { width: height * aspectRatio, height }
-      }
-
-      const { width } = getPreviewPixelSnapSize(
-        { width: containerSize.width, height: containerSize.width / aspectRatio },
-        devicePixelRatio,
-      )
-      return { width, height: width / aspectRatio }
+      return getAspectStableFitSize({ sourceSize, containerSize, devicePixelRatio })
     }
 
     return sourceSize

--- a/src/i18n/locales/partials/de/editor.json
+++ b/src/i18n/locales/partials/de/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-Pong",
       "trimIn": "Startbild",
       "trimOut": "Endbild",
-      "text": "Text"
+      "text": "Text",
+      "colors": "Farben",
+      "colorGroup": "{{count}} Formen",
+      "resetColors": "Alle zurücksetzen",
+      "animation": "Animation",
+      "animationN": "Animation {{index}}",
+      "theme": "Thema",
+      "themeNone": "Keine",
+      "marker": "Marker",
+      "markerPlaceholder": "Zu Marker springen…"
     },
     "cornerPinSection": {
       "title": "Eckpunkt-Verzerrung",

--- a/src/i18n/locales/partials/de/editor.json
+++ b/src/i18n/locales/partials/de/editor.json
@@ -285,7 +285,8 @@
       "marker": "Marker",
       "markerPlaceholder": "Zu Marker springen…",
       "properties": "Eigenschaften",
-      "resetProperties": "Alle zurücksetzen"
+      "resetProperties": "Alle zurücksetzen",
+      "otherColors": "Weitere Farben ({{count}})"
     },
     "cornerPinSection": {
       "title": "Eckpunkt-Verzerrung",

--- a/src/i18n/locales/partials/de/editor.json
+++ b/src/i18n/locales/partials/de/editor.json
@@ -265,6 +265,17 @@
       "speed": "Geschwindigkeit",
       "resetSpeed": "Auf 1x zurücksetzen"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Geschwindigkeit",
+      "resetSpeed": "Auf 1x zurücksetzen",
+      "reverse": "Rückwärts",
+      "loop": "Schleife",
+      "pingpong": "Ping-Pong",
+      "trimIn": "Startbild",
+      "trimOut": "Endbild",
+      "text": "Text"
+    },
     "cornerPinSection": {
       "title": "Eckpunkt-Verzerrung",
       "exitEditor": "Eckpunkt-Editor verlassen",

--- a/src/i18n/locales/partials/de/editor.json
+++ b/src/i18n/locales/partials/de/editor.json
@@ -283,7 +283,9 @@
       "theme": "Thema",
       "themeNone": "Keine",
       "marker": "Marker",
-      "markerPlaceholder": "Zu Marker springen…"
+      "markerPlaceholder": "Zu Marker springen…",
+      "properties": "Eigenschaften",
+      "resetProperties": "Alle zurücksetzen"
     },
     "cornerPinSection": {
       "title": "Eckpunkt-Verzerrung",

--- a/src/i18n/locales/partials/en/editor.json
+++ b/src/i18n/locales/partials/en/editor.json
@@ -285,7 +285,8 @@
       "marker": "Marker",
       "markerPlaceholder": "Jump to marker…",
       "properties": "Properties",
-      "resetProperties": "Reset all"
+      "resetProperties": "Reset all",
+      "otherColors": "Other colors ({{count}})"
     },
     "cornerPinSection": {
       "title": "Corner Pin",

--- a/src/i18n/locales/partials/en/editor.json
+++ b/src/i18n/locales/partials/en/editor.json
@@ -283,7 +283,9 @@
       "theme": "Theme",
       "themeNone": "None",
       "marker": "Marker",
-      "markerPlaceholder": "Jump to marker…"
+      "markerPlaceholder": "Jump to marker…",
+      "properties": "Properties",
+      "resetProperties": "Reset all"
     },
     "cornerPinSection": {
       "title": "Corner Pin",

--- a/src/i18n/locales/partials/en/editor.json
+++ b/src/i18n/locales/partials/en/editor.json
@@ -265,6 +265,17 @@
       "speed": "Speed",
       "resetSpeed": "Reset to 1x"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Speed",
+      "resetSpeed": "Reset to 1x",
+      "reverse": "Reverse",
+      "loop": "Loop",
+      "pingpong": "Ping-pong",
+      "trimIn": "Start frame",
+      "trimOut": "End frame",
+      "text": "Text"
+    },
     "cornerPinSection": {
       "title": "Corner Pin",
       "exitEditor": "Exit corner pin editor",

--- a/src/i18n/locales/partials/en/editor.json
+++ b/src/i18n/locales/partials/en/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-pong",
       "trimIn": "Start frame",
       "trimOut": "End frame",
-      "text": "Text"
+      "text": "Text",
+      "colors": "Colors",
+      "colorGroup": "{{count}} shapes",
+      "resetColors": "Reset all",
+      "animation": "Animation",
+      "animationN": "Animation {{index}}",
+      "theme": "Theme",
+      "themeNone": "None",
+      "marker": "Marker",
+      "markerPlaceholder": "Jump to marker…"
     },
     "cornerPinSection": {
       "title": "Corner Pin",

--- a/src/i18n/locales/partials/es/editor.json
+++ b/src/i18n/locales/partials/es/editor.json
@@ -265,6 +265,17 @@
       "speed": "Velocidad",
       "resetSpeed": "Restablecer a 1x"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Velocidad",
+      "resetSpeed": "Restablecer a 1x",
+      "reverse": "Invertir",
+      "loop": "Bucle",
+      "pingpong": "Ping-pong",
+      "trimIn": "Fotograma inicial",
+      "trimOut": "Fotograma final",
+      "text": "Texto"
+    },
     "cornerPinSection": {
       "title": "Corrección de esquinas",
       "exitEditor": "Salir del editor de esquinas",

--- a/src/i18n/locales/partials/es/editor.json
+++ b/src/i18n/locales/partials/es/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-pong",
       "trimIn": "Fotograma inicial",
       "trimOut": "Fotograma final",
-      "text": "Texto"
+      "text": "Texto",
+      "colors": "Colores",
+      "colorGroup": "{{count}} formas",
+      "resetColors": "Restablecer todo",
+      "animation": "Animación",
+      "animationN": "Animación {{index}}",
+      "theme": "Tema",
+      "themeNone": "Ninguno",
+      "marker": "Marcador",
+      "markerPlaceholder": "Ir al marcador…"
     },
     "cornerPinSection": {
       "title": "Corrección de esquinas",

--- a/src/i18n/locales/partials/es/editor.json
+++ b/src/i18n/locales/partials/es/editor.json
@@ -285,7 +285,8 @@
       "marker": "Marcador",
       "markerPlaceholder": "Ir al marcador…",
       "properties": "Propiedades",
-      "resetProperties": "Restablecer todo"
+      "resetProperties": "Restablecer todo",
+      "otherColors": "Otros colores ({{count}})"
     },
     "cornerPinSection": {
       "title": "Corrección de esquinas",

--- a/src/i18n/locales/partials/es/editor.json
+++ b/src/i18n/locales/partials/es/editor.json
@@ -283,7 +283,9 @@
       "theme": "Tema",
       "themeNone": "Ninguno",
       "marker": "Marcador",
-      "markerPlaceholder": "Ir al marcador…"
+      "markerPlaceholder": "Ir al marcador…",
+      "properties": "Propiedades",
+      "resetProperties": "Restablecer todo"
     },
     "cornerPinSection": {
       "title": "Corrección de esquinas",

--- a/src/i18n/locales/partials/fr/editor.json
+++ b/src/i18n/locales/partials/fr/editor.json
@@ -283,7 +283,9 @@
       "theme": "Thème",
       "themeNone": "Aucun",
       "marker": "Repère",
-      "markerPlaceholder": "Aller au repère…"
+      "markerPlaceholder": "Aller au repère…",
+      "properties": "Propriétés",
+      "resetProperties": "Tout réinitialiser"
     },
     "cornerPinSection": {
       "title": "Calage des coins",

--- a/src/i18n/locales/partials/fr/editor.json
+++ b/src/i18n/locales/partials/fr/editor.json
@@ -285,7 +285,8 @@
       "marker": "Repère",
       "markerPlaceholder": "Aller au repère…",
       "properties": "Propriétés",
-      "resetProperties": "Tout réinitialiser"
+      "resetProperties": "Tout réinitialiser",
+      "otherColors": "Autres couleurs ({{count}})"
     },
     "cornerPinSection": {
       "title": "Calage des coins",

--- a/src/i18n/locales/partials/fr/editor.json
+++ b/src/i18n/locales/partials/fr/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-pong",
       "trimIn": "Image de début",
       "trimOut": "Image de fin",
-      "text": "Texte"
+      "text": "Texte",
+      "colors": "Couleurs",
+      "colorGroup": "{{count}} formes",
+      "resetColors": "Tout réinitialiser",
+      "animation": "Animation",
+      "animationN": "Animation {{index}}",
+      "theme": "Thème",
+      "themeNone": "Aucun",
+      "marker": "Repère",
+      "markerPlaceholder": "Aller au repère…"
     },
     "cornerPinSection": {
       "title": "Calage des coins",

--- a/src/i18n/locales/partials/fr/editor.json
+++ b/src/i18n/locales/partials/fr/editor.json
@@ -265,6 +265,17 @@
       "speed": "Vitesse",
       "resetSpeed": "Réinitialiser à 1x"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Vitesse",
+      "resetSpeed": "Réinitialiser à 1x",
+      "reverse": "Inverser",
+      "loop": "Boucle",
+      "pingpong": "Ping-pong",
+      "trimIn": "Image de début",
+      "trimOut": "Image de fin",
+      "text": "Texte"
+    },
     "cornerPinSection": {
       "title": "Calage des coins",
       "exitEditor": "Quitter l'éditeur de coins",

--- a/src/i18n/locales/partials/ja/editor.json
+++ b/src/i18n/locales/partials/ja/editor.json
@@ -283,7 +283,9 @@
       "theme": "テーマ",
       "themeNone": "なし",
       "marker": "マーカー",
-      "markerPlaceholder": "マーカーへ移動…"
+      "markerPlaceholder": "マーカーへ移動…",
+      "properties": "プロパティ",
+      "resetProperties": "すべてリセット"
     },
     "cornerPinSection": {
       "title": "コーナーピン",

--- a/src/i18n/locales/partials/ja/editor.json
+++ b/src/i18n/locales/partials/ja/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "ピンポン",
       "trimIn": "開始フレーム",
       "trimOut": "終了フレーム",
-      "text": "テキスト"
+      "text": "テキスト",
+      "colors": "カラー",
+      "colorGroup": "{{count}} 個のシェイプ",
+      "resetColors": "すべてリセット",
+      "animation": "アニメーション",
+      "animationN": "アニメーション {{index}}",
+      "theme": "テーマ",
+      "themeNone": "なし",
+      "marker": "マーカー",
+      "markerPlaceholder": "マーカーへ移動…"
     },
     "cornerPinSection": {
       "title": "コーナーピン",

--- a/src/i18n/locales/partials/ja/editor.json
+++ b/src/i18n/locales/partials/ja/editor.json
@@ -285,7 +285,8 @@
       "marker": "マーカー",
       "markerPlaceholder": "マーカーへ移動…",
       "properties": "プロパティ",
-      "resetProperties": "すべてリセット"
+      "resetProperties": "すべてリセット",
+      "otherColors": "その他の色 ({{count}})"
     },
     "cornerPinSection": {
       "title": "コーナーピン",

--- a/src/i18n/locales/partials/ja/editor.json
+++ b/src/i18n/locales/partials/ja/editor.json
@@ -265,6 +265,17 @@
       "speed": "速度",
       "resetSpeed": "1xにリセット"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "速度",
+      "resetSpeed": "1xにリセット",
+      "reverse": "逆再生",
+      "loop": "ループ",
+      "pingpong": "ピンポン",
+      "trimIn": "開始フレーム",
+      "trimOut": "終了フレーム",
+      "text": "テキスト"
+    },
     "cornerPinSection": {
       "title": "コーナーピン",
       "exitEditor": "コーナーピンエディターを終了",

--- a/src/i18n/locales/partials/ko/editor.json
+++ b/src/i18n/locales/partials/ko/editor.json
@@ -285,7 +285,8 @@
       "marker": "마커",
       "markerPlaceholder": "마커로 이동…",
       "properties": "속성",
-      "resetProperties": "모두 재설정"
+      "resetProperties": "모두 재설정",
+      "otherColors": "기타 색상 ({{count}})"
     },
     "cornerPinSection": {
       "title": "코너 핀",

--- a/src/i18n/locales/partials/ko/editor.json
+++ b/src/i18n/locales/partials/ko/editor.json
@@ -283,7 +283,9 @@
       "theme": "테마",
       "themeNone": "없음",
       "marker": "마커",
-      "markerPlaceholder": "마커로 이동…"
+      "markerPlaceholder": "마커로 이동…",
+      "properties": "속성",
+      "resetProperties": "모두 재설정"
     },
     "cornerPinSection": {
       "title": "코너 핀",

--- a/src/i18n/locales/partials/ko/editor.json
+++ b/src/i18n/locales/partials/ko/editor.json
@@ -265,6 +265,17 @@
       "speed": "속도",
       "resetSpeed": "1x로 재설정"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "속도",
+      "resetSpeed": "1x로 재설정",
+      "reverse": "역재생",
+      "loop": "반복",
+      "pingpong": "핑퐁",
+      "trimIn": "시작 프레임",
+      "trimOut": "종료 프레임",
+      "text": "텍스트"
+    },
     "cornerPinSection": {
       "title": "코너 핀",
       "exitEditor": "코너 핀 편집기 종료",

--- a/src/i18n/locales/partials/ko/editor.json
+++ b/src/i18n/locales/partials/ko/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "핑퐁",
       "trimIn": "시작 프레임",
       "trimOut": "종료 프레임",
-      "text": "텍스트"
+      "text": "텍스트",
+      "colors": "색상",
+      "colorGroup": "도형 {{count}}개",
+      "resetColors": "모두 재설정",
+      "animation": "애니메이션",
+      "animationN": "애니메이션 {{index}}",
+      "theme": "테마",
+      "themeNone": "없음",
+      "marker": "마커",
+      "markerPlaceholder": "마커로 이동…"
     },
     "cornerPinSection": {
       "title": "코너 핀",

--- a/src/i18n/locales/partials/pt-BR/editor.json
+++ b/src/i18n/locales/partials/pt-BR/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-pong",
       "trimIn": "Quadro inicial",
       "trimOut": "Quadro final",
-      "text": "Texto"
+      "text": "Texto",
+      "colors": "Cores",
+      "colorGroup": "{{count}} formas",
+      "resetColors": "Redefinir tudo",
+      "animation": "Animação",
+      "animationN": "Animação {{index}}",
+      "theme": "Tema",
+      "themeNone": "Nenhum",
+      "marker": "Marcador",
+      "markerPlaceholder": "Ir para o marcador…"
     },
     "cornerPinSection": {
       "title": "Fixação de cantos",

--- a/src/i18n/locales/partials/pt-BR/editor.json
+++ b/src/i18n/locales/partials/pt-BR/editor.json
@@ -285,7 +285,8 @@
       "marker": "Marcador",
       "markerPlaceholder": "Ir para o marcador…",
       "properties": "Propriedades",
-      "resetProperties": "Redefinir tudo"
+      "resetProperties": "Redefinir tudo",
+      "otherColors": "Outras cores ({{count}})"
     },
     "cornerPinSection": {
       "title": "Fixação de cantos",

--- a/src/i18n/locales/partials/pt-BR/editor.json
+++ b/src/i18n/locales/partials/pt-BR/editor.json
@@ -265,6 +265,17 @@
       "speed": "Velocidade",
       "resetSpeed": "Redefinir para 1x"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Velocidade",
+      "resetSpeed": "Redefinir para 1x",
+      "reverse": "Inverter",
+      "loop": "Repetir",
+      "pingpong": "Ping-pong",
+      "trimIn": "Quadro inicial",
+      "trimOut": "Quadro final",
+      "text": "Texto"
+    },
     "cornerPinSection": {
       "title": "Fixação de cantos",
       "exitEditor": "Sair do editor de cantos",

--- a/src/i18n/locales/partials/pt-BR/editor.json
+++ b/src/i18n/locales/partials/pt-BR/editor.json
@@ -283,7 +283,9 @@
       "theme": "Tema",
       "themeNone": "Nenhum",
       "marker": "Marcador",
-      "markerPlaceholder": "Ir para o marcador…"
+      "markerPlaceholder": "Ir para o marcador…",
+      "properties": "Propriedades",
+      "resetProperties": "Redefinir tudo"
     },
     "cornerPinSection": {
       "title": "Fixação de cantos",

--- a/src/i18n/locales/partials/tr/editor.json
+++ b/src/i18n/locales/partials/tr/editor.json
@@ -265,6 +265,17 @@
       "speed": "Hız",
       "resetSpeed": "1x'e sıfırla"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "Hız",
+      "resetSpeed": "1x'e sıfırla",
+      "reverse": "Ters",
+      "loop": "Döngü",
+      "pingpong": "Ping-pong",
+      "trimIn": "Başlangıç karesi",
+      "trimOut": "Bitiş karesi",
+      "text": "Metin"
+    },
     "cornerPinSection": {
       "title": "Köşe Sabitleme",
       "exitEditor": "Köşe sabitleme düzenleyicisinden çık",

--- a/src/i18n/locales/partials/tr/editor.json
+++ b/src/i18n/locales/partials/tr/editor.json
@@ -285,7 +285,8 @@
       "marker": "İşaretçi",
       "markerPlaceholder": "İşaretçiye git…",
       "properties": "Özellikler",
-      "resetProperties": "Tümünü sıfırla"
+      "resetProperties": "Tümünü sıfırla",
+      "otherColors": "Diğer renkler ({{count}})"
     },
     "cornerPinSection": {
       "title": "Köşe Sabitleme",

--- a/src/i18n/locales/partials/tr/editor.json
+++ b/src/i18n/locales/partials/tr/editor.json
@@ -283,7 +283,9 @@
       "theme": "Tema",
       "themeNone": "Yok",
       "marker": "İşaretçi",
-      "markerPlaceholder": "İşaretçiye git…"
+      "markerPlaceholder": "İşaretçiye git…",
+      "properties": "Özellikler",
+      "resetProperties": "Tümünü sıfırla"
     },
     "cornerPinSection": {
       "title": "Köşe Sabitleme",

--- a/src/i18n/locales/partials/tr/editor.json
+++ b/src/i18n/locales/partials/tr/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "Ping-pong",
       "trimIn": "Başlangıç karesi",
       "trimOut": "Bitiş karesi",
-      "text": "Metin"
+      "text": "Metin",
+      "colors": "Renkler",
+      "colorGroup": "{{count}} şekil",
+      "resetColors": "Tümünü sıfırla",
+      "animation": "Animasyon",
+      "animationN": "Animasyon {{index}}",
+      "theme": "Tema",
+      "themeNone": "Yok",
+      "marker": "İşaretçi",
+      "markerPlaceholder": "İşaretçiye git…"
     },
     "cornerPinSection": {
       "title": "Köşe Sabitleme",

--- a/src/i18n/locales/partials/zh/editor.json
+++ b/src/i18n/locales/partials/zh/editor.json
@@ -265,6 +265,17 @@
       "speed": "速度",
       "resetSpeed": "重置为 1x"
     },
+    "lottieSection": {
+      "title": "Lottie",
+      "speed": "速度",
+      "resetSpeed": "重置为 1x",
+      "reverse": "反向",
+      "loop": "循环",
+      "pingpong": "乒乓",
+      "trimIn": "起始帧",
+      "trimOut": "结束帧",
+      "text": "文本"
+    },
     "cornerPinSection": {
       "title": "边角定位",
       "exitEditor": "退出边角定位编辑器",

--- a/src/i18n/locales/partials/zh/editor.json
+++ b/src/i18n/locales/partials/zh/editor.json
@@ -283,7 +283,9 @@
       "theme": "主题",
       "themeNone": "无",
       "marker": "标记",
-      "markerPlaceholder": "跳转到标记…"
+      "markerPlaceholder": "跳转到标记…",
+      "properties": "属性",
+      "resetProperties": "全部重置"
     },
     "cornerPinSection": {
       "title": "边角定位",

--- a/src/i18n/locales/partials/zh/editor.json
+++ b/src/i18n/locales/partials/zh/editor.json
@@ -274,7 +274,16 @@
       "pingpong": "乒乓",
       "trimIn": "起始帧",
       "trimOut": "结束帧",
-      "text": "文本"
+      "text": "文本",
+      "colors": "颜色",
+      "colorGroup": "{{count}} 个形状",
+      "resetColors": "全部重置",
+      "animation": "动画",
+      "animationN": "动画 {{index}}",
+      "theme": "主题",
+      "themeNone": "无",
+      "marker": "标记",
+      "markerPlaceholder": "跳转到标记…"
     },
     "cornerPinSection": {
       "title": "边角定位",

--- a/src/i18n/locales/partials/zh/editor.json
+++ b/src/i18n/locales/partials/zh/editor.json
@@ -285,7 +285,8 @@
       "marker": "标记",
       "markerPlaceholder": "跳转到标记…",
       "properties": "属性",
-      "resetProperties": "全部重置"
+      "resetProperties": "全部重置",
+      "otherColors": "其他颜色 ({{count}})"
     },
     "cornerPinSection": {
       "title": "边角定位",

--- a/src/infrastructure/gpu-compositor/compositor-pipeline.test.ts
+++ b/src/infrastructure/gpu-compositor/compositor-pipeline.test.ts
@@ -88,22 +88,6 @@ describe('CompositorPipeline', () => {
     ).toBe(true)
   })
 
-  it('samples regular layer textures from texel centers to avoid edge seams', () => {
-    const { device } = createPipelineHarness()
-
-    const shaderSources = (
-      device.createShaderModule.mock.calls as unknown as Array<[GPUShaderModuleDescriptor]>
-    ).map(([descriptor]) => descriptor.code)
-    expect(
-      shaderSources.some(
-        (code) =>
-          code.includes('let layerDimensions = textureDimensions(layerTex)') &&
-          code.includes('let layerTexelInset = vec2f(0.5)') &&
-          code.includes('let sampleUV = clamp(layerUV, layerTexelInset'),
-      ),
-    ).toBe(true)
-  })
-
   it('binds independent uniforms for masked and unmasked layers encoded in one command buffer', () => {
     const { commandEncoder, device, pipeline, queue } = createPipelineHarness()
     const maskedLayerUniform = {

--- a/src/infrastructure/gpu-compositor/compositor-pipeline.test.ts
+++ b/src/infrastructure/gpu-compositor/compositor-pipeline.test.ts
@@ -88,6 +88,22 @@ describe('CompositorPipeline', () => {
     ).toBe(true)
   })
 
+  it('samples regular layer textures from texel centers to avoid edge seams', () => {
+    const { device } = createPipelineHarness()
+
+    const shaderSources = (
+      device.createShaderModule.mock.calls as unknown as Array<[GPUShaderModuleDescriptor]>
+    ).map(([descriptor]) => descriptor.code)
+    expect(
+      shaderSources.some(
+        (code) =>
+          code.includes('let layerDimensions = textureDimensions(layerTex)') &&
+          code.includes('let layerTexelInset = vec2f(0.5)') &&
+          code.includes('let sampleUV = clamp(layerUV, layerTexelInset'),
+      ),
+    ).toBe(true)
+  })
+
   it('binds independent uniforms for masked and unmasked layers encoded in one command buffer', () => {
     const { commandEncoder, device, pipeline, queue } = createPipelineHarness()
     const maskedLayerUniform = {

--- a/src/infrastructure/gpu-compositor/compositor-pipeline.ts
+++ b/src/infrastructure/gpu-compositor/compositor-pipeline.ts
@@ -117,10 +117,7 @@ fn compositeFragment(input: VertexOutput) -> @location(0) vec4f {
   // Transform UV to sample layer texture
   let layerUV = transformUV(input.uv);
   let inBounds = layerUV.x >= 0.0 && layerUV.x <= 1.0 && layerUV.y >= 0.0 && layerUV.y <= 1.0;
-  let layerDimensions = textureDimensions(layerTex);
-  let layerTextureSize = vec2f(f32(layerDimensions.x), f32(layerDimensions.y));
-  let layerTexelInset = vec2f(0.5) / max(layerTextureSize, vec2f(1.0));
-  let sampleUV = clamp(layerUV, layerTexelInset, vec2f(1.0) - layerTexelInset);
+  let sampleUV = clamp(layerUV, vec2f(0.0), vec2f(1.0));
   var layerColor = textureSampleLevel(layerTex, texSampler, sampleUV, 0.0);
 
   // Apply mask

--- a/src/infrastructure/gpu-compositor/compositor-pipeline.ts
+++ b/src/infrastructure/gpu-compositor/compositor-pipeline.ts
@@ -117,7 +117,10 @@ fn compositeFragment(input: VertexOutput) -> @location(0) vec4f {
   // Transform UV to sample layer texture
   let layerUV = transformUV(input.uv);
   let inBounds = layerUV.x >= 0.0 && layerUV.x <= 1.0 && layerUV.y >= 0.0 && layerUV.y <= 1.0;
-  let sampleUV = clamp(layerUV, vec2f(0.0), vec2f(1.0));
+  let layerDimensions = textureDimensions(layerTex);
+  let layerTextureSize = vec2f(f32(layerDimensions.x), f32(layerDimensions.y));
+  let layerTexelInset = vec2f(0.5) / max(layerTextureSize, vec2f(1.0));
+  let sampleUV = clamp(layerUV, layerTexelInset, vec2f(1.0) - layerTexelInset);
   var layerColor = textureSampleLevel(layerTex, texSampler, sampleUV, 0.0);
 
   // Apply mask

--- a/src/infrastructure/gpu-effects/effects-pipeline.ts
+++ b/src/infrastructure/gpu-effects/effects-pipeline.ts
@@ -31,7 +31,13 @@ ${FULLSCREEN_VERTEX}
 @group(0) @binding(1) var inputTex: texture_2d<f32>;
 @fragment
 fn blitFragment(input: VertexOutput) -> @location(0) vec4f {
-  return textureSample(inputTex, texSampler, input.uv);
+  // Effect textures carry straight (non-premultiplied) alpha, but the output
+  // canvas is configured alphaMode:'premultiplied'. Premultiply here so that a
+  // pixel an effect left with colour at alpha 0 (e.g. a gradient map over a
+  // transparent Lottie) reads as fully transparent instead of leaking that
+  // colour over the layers below. Opaque pixels (a = 1) are unchanged.
+  let c = textureSample(inputTex, texSampler, input.uv);
+  return vec4f(c.rgb * c.a, c.a);
 }
 `
 

--- a/src/infrastructure/gpu-effects/effects/stylize.ts
+++ b/src/infrastructure/gpu-effects/effects/stylize.ts
@@ -1147,7 +1147,12 @@ fn halftoneFragment(input: VertexOutput) -> @location(0) vec4f {
 
   opacity = clamp(opacity, 0.0, 1.0) * sourceAlpha;
 
-  return vec4f(clamp(color, vec3f(0.0), vec3f(1.0)) * sourceAlpha, opacity);
+  // Output STRAIGHT alpha (RGB not premultiplied) — the final blit premultiplies
+  // once for the premultiplied output canvas. Multiplying RGB by sourceAlpha here
+  // too would premultiply twice on masked/transparent content (sourceAlpha^2),
+  // darkening the mask edge into a visible seam. Opaque pixels (sourceAlpha = 1)
+  // are unchanged.
+  return vec4f(clamp(color, vec3f(0.0), vec3f(1.0)), opacity);
 }`,
   params: {
     colorFront: { type: 'color', label: 'Front Color', default: '#2b2b2b' },

--- a/src/infrastructure/gpu-media/media-render-pipeline.test.ts
+++ b/src/infrastructure/gpu-media/media-render-pipeline.test.ts
@@ -29,6 +29,20 @@ function createPipelineHarness() {
 }
 
 describe('MediaRenderPipeline', () => {
+  it('samples media texture pixels from texel centers to avoid edge seams', () => {
+    const { device } = createPipelineHarness()
+    const shaderCode = device.createShaderModule.mock.calls[0]?.[0]?.code as string
+
+    expect(shaderCode).toContain('let unclampedSourcePixel')
+    expect(shaderCode).toContain('let sourceMin = u.sourceRect.xy + vec2f(0.5)')
+    expect(shaderCode).toContain(
+      'let sourceMax = u.sourceRect.xy + max(u.sourceRect.zw - vec2f(0.5), vec2f(0.5))',
+    )
+    expect(shaderCode).toContain(
+      'let sourcePixel = clamp(unclampedSourcePixel, sourceMin, sourceMax)',
+    )
+  })
+
   it('uploads a media source and renders it into the output texture', () => {
     const { commandEncoder, device, inputTexture, outputTexture, pass, pipeline, queue } =
       createPipelineHarness()

--- a/src/infrastructure/gpu-media/media-render-pipeline.test.ts
+++ b/src/infrastructure/gpu-media/media-render-pipeline.test.ts
@@ -29,6 +29,16 @@ function createPipelineHarness() {
 }
 
 describe('MediaRenderPipeline', () => {
+  it('samples media texture pixels from texel centers to avoid edge seams', () => {
+    const { device } = createPipelineHarness()
+    const shaderCode = device.createShaderModule.mock.calls[0]?.[0]?.code as string
+
+    expect(shaderCode).toContain('let unclampedSourcePixel')
+    expect(shaderCode).toContain('let sourceMin = u.sourceRect.xy + vec2f(0.5)')
+    expect(shaderCode).toContain('let sourceMax = u.sourceRect.xy + max(u.sourceRect.zw - vec2f(0.5), vec2f(0.5))')
+    expect(shaderCode).toContain('let sourcePixel = clamp(unclampedSourcePixel, sourceMin, sourceMax)')
+  })
+
   it('uploads a media source and renders it into the output texture', () => {
     const { commandEncoder, device, inputTexture, outputTexture, pass, pipeline, queue } =
       createPipelineHarness()

--- a/src/infrastructure/gpu-media/media-render-pipeline.test.ts
+++ b/src/infrastructure/gpu-media/media-render-pipeline.test.ts
@@ -29,16 +29,6 @@ function createPipelineHarness() {
 }
 
 describe('MediaRenderPipeline', () => {
-  it('samples media texture pixels from texel centers to avoid edge seams', () => {
-    const { device } = createPipelineHarness()
-    const shaderCode = device.createShaderModule.mock.calls[0]?.[0]?.code as string
-
-    expect(shaderCode).toContain('let unclampedSourcePixel')
-    expect(shaderCode).toContain('let sourceMin = u.sourceRect.xy + vec2f(0.5)')
-    expect(shaderCode).toContain('let sourceMax = u.sourceRect.xy + max(u.sourceRect.zw - vec2f(0.5), vec2f(0.5))')
-    expect(shaderCode).toContain('let sourcePixel = clamp(unclampedSourcePixel, sourceMin, sourceMax)')
-  })
-
   it('uploads a media source and renders it into the output texture', () => {
     const { commandEncoder, device, inputTexture, outputTexture, pass, pipeline, queue } =
       createPipelineHarness()

--- a/src/infrastructure/gpu-media/media-render-pipeline.ts
+++ b/src/infrastructure/gpu-media/media-render-pipeline.ts
@@ -116,7 +116,10 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
   if (u.flip.y < 0.0) {
     localUv.y = 1.0 - localUv.y;
   }
-  let sourcePixel = u.sourceRect.xy + localUv * u.sourceRect.zw;
+  let unclampedSourcePixel = u.sourceRect.xy + localUv * u.sourceRect.zw;
+  let sourceMin = u.sourceRect.xy + vec2f(0.5);
+  let sourceMax = u.sourceRect.xy + max(u.sourceRect.zw - vec2f(0.5), vec2f(0.5));
+  let sourcePixel = clamp(unclampedSourcePixel, sourceMin, sourceMax);
   let sourceUv = sourcePixel / max(u.sourceSize, vec2f(0.001));
   let color = textureSampleLevel(sourceTex, texSampler, sourceUv, 0.0);
   let viewportLocal = samplePixel - u.destRect.xy;

--- a/src/infrastructure/gpu-media/media-render-pipeline.ts
+++ b/src/infrastructure/gpu-media/media-render-pipeline.ts
@@ -116,10 +116,7 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
   if (u.flip.y < 0.0) {
     localUv.y = 1.0 - localUv.y;
   }
-  let unclampedSourcePixel = u.sourceRect.xy + localUv * u.sourceRect.zw;
-  let sourceMin = u.sourceRect.xy + vec2f(0.5);
-  let sourceMax = u.sourceRect.xy + max(u.sourceRect.zw - vec2f(0.5), vec2f(0.5));
-  let sourcePixel = clamp(unclampedSourcePixel, sourceMin, sourceMax);
+  let sourcePixel = u.sourceRect.xy + localUv * u.sourceRect.zw;
   let sourceUv = sourcePixel / max(u.sourceSize, vec2f(0.001));
   let color = textureSampleLevel(sourceTex, texSampler, sourceUv, 0.0);
   let viewportLocal = samplePixel - u.destRect.xy;

--- a/src/infrastructure/lottie/lottie-color.test.ts
+++ b/src/infrastructure/lottie/lottie-color.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  extractLottieColorLayers,
+  applyLottieColorOverrides,
+  hexToLottieRgb,
+  lottieRgbToHex,
+} from './lottie-color'
+
+// A Lottie with a text layer (no shapes), plus a shape layer whose group holds a
+// static red fill (c0) and a static black stroke with alpha (c1), followed by an
+// animated fill (c.a === 1) that must be skipped.
+function animation() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    ip: 0,
+    op: 60,
+    layers: [
+      { ty: 5, nm: 'Title', t: { d: { k: [{ s: { t: 'Hi' } }] } } },
+      {
+        ty: 4,
+        nm: 'Circle',
+        shapes: [
+          {
+            ty: 'gr',
+            nm: 'Group',
+            it: [
+              { ty: 'fl', nm: 'Fill 1', c: { a: 0, k: [1, 0, 0] } },
+              { ty: 'st', nm: 'Stroke 1', c: { a: 0, k: [0, 0, 0, 1] } },
+            ],
+          },
+          { ty: 'fl', nm: 'Animated', c: { a: 1, k: [] } },
+        ],
+      },
+    ],
+  }
+}
+
+describe('hex <-> lottie rgb', () => {
+  it('round-trips an 8-bit color through normalized floats', () => {
+    expect(lottieRgbToHex([1, 0, 0])).toBe('#ff0000')
+    expect(lottieRgbToHex([0, 0.50196, 0])).toBe('#008000')
+    const rgb = hexToLottieRgb('#ff8000')!
+    expect(rgb[0]).toBe(1)
+    expect(rgb[2]).toBe(0)
+    expect(lottieRgbToHex(rgb)).toBe('#ff8000')
+  })
+
+  it('rejects malformed hex', () => {
+    expect(hexToLottieRgb('#fff')).toBeNull()
+    expect(hexToLottieRgb('nope')).toBeNull()
+  })
+})
+
+describe('extractLottieColorLayers', () => {
+  it('lists static solids in depth-first order, skipping animated and non-shape layers', () => {
+    expect(extractLottieColorLayers(animation())).toEqual([
+      { key: 'c0', color: '#ff0000', label: 'Fill 1' },
+      { key: 'c1', color: '#000000', label: 'Stroke 1' },
+    ])
+  })
+
+  it('accepts a JSON string and returns [] for non-shape input', () => {
+    expect(extractLottieColorLayers(JSON.stringify(animation()))).toHaveLength(2)
+    expect(extractLottieColorLayers('not json')).toEqual([])
+    expect(extractLottieColorLayers({ foo: 'bar' })).toEqual([])
+  })
+})
+
+describe('applyLottieColorOverrides', () => {
+  it('patches only the addressed color and preserves the alpha channel', () => {
+    const patched = applyLottieColorOverrides(animation(), { c0: '#00ff00', c1: '#0000ff' })
+    expect(patched).not.toBeNull()
+    const shapes = JSON.parse(patched!).layers[1].shapes
+    expect(shapes[0].it[0].c.k).toEqual([0, 1, 0]) // fill recolored, no alpha added
+    expect(shapes[0].it[1].c.k).toEqual([0, 0, 1, 1]) // stroke recolored, alpha kept
+    expect(shapes[1].c.k).toEqual([]) // animated fill untouched
+  })
+
+  it('returns null when there is nothing to change', () => {
+    expect(applyLottieColorOverrides(animation(), {})).toBeNull()
+    // Unknown key → no change.
+    expect(applyLottieColorOverrides(animation(), { c9: '#ffffff' })).toBeNull()
+    // Malformed value → ignored.
+    expect(applyLottieColorOverrides(animation(), { c0: 'red' })).toBeNull()
+  })
+})
+
+// A group holding a static solid fill (c0) and an animated solid stroke (c1,
+// two keyframes). Gradients are intentionally not editable inline (slots only).
+function mixed() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    ip: 0,
+    op: 60,
+    layers: [
+      {
+        ty: 4,
+        nm: 'Art',
+        shapes: [
+          {
+            ty: 'gr',
+            nm: 'Group',
+            it: [
+              { ty: 'fl', nm: 'Solid', c: { a: 0, k: [1, 1, 1] } },
+              {
+                ty: 'st',
+                nm: 'Pulse',
+                c: {
+                  a: 1,
+                  k: [
+                    { t: 0, s: [1, 0, 0] },
+                    { t: 30, s: [0, 0, 1] },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('extractLottieColorLayers — animated', () => {
+  it('yields static and animated solid colors in document order', () => {
+    expect(extractLottieColorLayers(mixed())).toEqual([
+      { key: 'c0', color: '#ffffff', label: 'Solid' },
+      { key: 'c1', color: '#ff0000', label: 'Pulse' }, // first keyframe's color
+    ])
+  })
+
+  it('skips animated colors with no readable keyframe', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      layers: [{ ty: 4, shapes: [{ ty: 'fl', c: { a: 1, k: [] } }] }],
+    }
+    expect(extractLottieColorLayers(anim)).toEqual([])
+  })
+
+  it('does not surface gradient fills (gf/gs) — those are recolored via slots', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      layers: [
+        { ty: 4, shapes: [{ ty: 'gf', nm: 'Ramp', g: { p: 2, k: { a: 0, k: [0, 1, 0, 0] } } }] },
+      ],
+    }
+    expect(extractLottieColorLayers(anim)).toEqual([])
+  })
+})
+
+describe('applyLottieColorOverrides — animated', () => {
+  it('freezes every keyframe of an animated color to the override', () => {
+    const patched = applyLottieColorOverrides(mixed(), { c1: '#00ff00' })
+    const kf = JSON.parse(patched!).layers[0].shapes[0].it[1].c.k
+    expect(kf[0].s).toEqual([0, 1, 0])
+    expect(kf[1].s).toEqual([0, 1, 0])
+  })
+
+  it('keeps ordinal keys aligned — overriding the solid leaves the animated color', () => {
+    const parsed = JSON.parse(applyLottieColorOverrides(mixed(), { c0: '#000000' })!)
+    const it = parsed.layers[0].shapes[0].it
+    expect(it[0].c.k).toEqual([0, 0, 0])
+    expect(it[1].c.k[0].s).toEqual([1, 0, 0]) // animated untouched
+  })
+})
+
+// A themeable animation: an `accent` color slot (red) referenced by a fill via
+// `sid` (no inline `c.k`), plus a separate inline blue fill.
+function slotted() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    ip: 0,
+    op: 60,
+    slots: { accent: { p: { a: 0, k: [1, 0, 0, 1] } } },
+    layers: [
+      {
+        ty: 4,
+        nm: 'Art',
+        shapes: [
+          {
+            ty: 'gr',
+            it: [
+              { ty: 'fl', nm: 'Bound', c: { sid: 'accent' } },
+              { ty: 'fl', nm: 'Plain', c: { a: 0, k: [0, 0, 1] } },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('color slots', () => {
+  it('surfaces color slots first (by id), and skips the slot-bound inline fill', () => {
+    expect(extractLottieColorLayers(slotted())).toEqual([
+      { key: 's:accent', color: '#ff0000', label: 'accent' },
+      { key: 'c0', color: '#0000ff', label: 'Plain' }, // only the unbound fill
+    ])
+  })
+
+  it('patches the slot value AND bakes it into the referencing fill', () => {
+    const parsed = JSON.parse(applyLottieColorOverrides(slotted(), { 's:accent': '#00ff00' })!)
+    expect(parsed.slots.accent.p.k).toEqual([0, 1, 0, 1]) // slot RGBA, alpha kept
+    expect(parsed.layers[0].shapes[0].it[0].c.k).toEqual([0, 1, 0, 1]) // baked inline
+    expect(parsed.layers[0].shapes[0].it[1].c.k).toEqual([0, 0, 1]) // plain fill untouched
+  })
+
+  it('leaves slots untouched when only an inline color is overridden', () => {
+    const parsed = JSON.parse(applyLottieColorOverrides(slotted(), { c0: '#00ffff' })!)
+    expect(parsed.slots.accent.p.k).toEqual([1, 0, 0, 1])
+    expect(parsed.layers[0].shapes[0].it[1].c.k).toEqual([0, 1, 1])
+  })
+})

--- a/src/infrastructure/lottie/lottie-color.test.ts
+++ b/src/infrastructure/lottie/lottie-color.test.ts
@@ -57,8 +57,21 @@ describe('hex <-> lottie rgb', () => {
 describe('extractLottieColorLayers', () => {
   it('lists static solids in depth-first order, skipping animated and non-shape layers', () => {
     expect(extractLottieColorLayers(animation())).toEqual([
-      { key: 'c0', color: '#ff0000', label: 'Fill 1' },
-      { key: 'c1', color: '#000000', label: 'Stroke 1' },
+      { key: 'c0', color: '#ff0000', label: 'Fill 1', named: true },
+      { key: 'c1', color: '#000000', label: 'Stroke 1', named: true },
+    ])
+  })
+
+  it('marks fills without an author name as not-named (generated fallback label)', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      layers: [{ ty: 4, shapes: [{ ty: 'fl', c: { a: 0, k: [1, 1, 1] } }] }],
+    }
+    expect(extractLottieColorLayers(anim)).toEqual([
+      { key: 'c0', color: '#ffffff', label: 'Fill', named: false },
     ])
   })
 
@@ -130,8 +143,8 @@ function mixed() {
 describe('extractLottieColorLayers — animated', () => {
   it('yields static and animated solid colors in document order', () => {
     expect(extractLottieColorLayers(mixed())).toEqual([
-      { key: 'c0', color: '#ffffff', label: 'Solid' },
-      { key: 'c1', color: '#ff0000', label: 'Pulse' }, // first keyframe's color
+      { key: 'c0', color: '#ffffff', label: 'Solid', named: true },
+      { key: 'c1', color: '#ff0000', label: 'Pulse', named: true }, // first keyframe's color
     ])
   })
 
@@ -208,8 +221,8 @@ function slotted() {
 describe('color slots', () => {
   it('surfaces color slots first (by id), and skips the slot-bound inline fill', () => {
     expect(extractLottieColorLayers(slotted())).toEqual([
-      { key: 's:accent', color: '#ff0000', label: 'accent' },
-      { key: 'c0', color: '#0000ff', label: 'Plain' }, // only the unbound fill
+      { key: 's:accent', color: '#ff0000', label: 'accent', named: true },
+      { key: 'c0', color: '#0000ff', label: 'Plain', named: true }, // only the unbound fill
     ])
   })
 

--- a/src/infrastructure/lottie/lottie-color.test.ts
+++ b/src/infrastructure/lottie/lottie-color.test.ts
@@ -56,9 +56,10 @@ describe('hex <-> lottie rgb', () => {
 
 describe('extractLottieColorLayers', () => {
   it('lists static solids in depth-first order, skipping animated and non-shape layers', () => {
+    // "Fill 1" / "Stroke 1" are editor-generated defaults, not author names.
     expect(extractLottieColorLayers(animation())).toEqual([
-      { key: 'c0', color: '#ff0000', label: 'Fill 1', named: true },
-      { key: 'c1', color: '#000000', label: 'Stroke 1', named: true },
+      { key: 'c0', color: '#ff0000', label: 'Fill 1', named: false },
+      { key: 'c1', color: '#000000', label: 'Stroke 1', named: false },
     ])
   })
 
@@ -72,6 +73,30 @@ describe('extractLottieColorLayers', () => {
     }
     expect(extractLottieColorLayers(anim)).toEqual([
       { key: 'c0', color: '#ffffff', label: 'Fill', named: false },
+    ])
+  })
+
+  it('treats generated names (Fill 1, Stroke) as not-named but real names as named', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      layers: [
+        {
+          ty: 4,
+          shapes: [
+            { ty: 'fl', nm: 'Fill 2', c: { a: 0, k: [1, 0, 0] } },
+            { ty: 'st', nm: 'Stroke', c: { a: 0, k: [0, 1, 0] } },
+            { ty: 'fl', nm: 'coat-back', c: { a: 0, k: [0, 0, 1] } },
+          ],
+        },
+      ],
+    }
+    expect(extractLottieColorLayers(anim).map((c) => [c.label, c.named])).toEqual([
+      ['Fill 2', false],
+      ['Stroke', false],
+      ['coat-back', true],
     ])
   })
 

--- a/src/infrastructure/lottie/lottie-color.ts
+++ b/src/infrastructure/lottie/lottie-color.ts
@@ -1,0 +1,318 @@
+/**
+ * WASM-free helpers for reading and overriding shape colors in a Lottie
+ * animation object. Covers solid fills (`ty:'fl'`) and strokes (`ty:'st'`),
+ * static (`c.a !== 1`) or animated (`c.a === 1`; overriding freezes every
+ * keyframe to the chosen color). Gradients (`gf`/`gs`) are intentionally not
+ * edited inline — themeable gradients are recolored through their color slots
+ * instead, which is the author-intended and renderer-reliable path.
+ * Colors are normalized `[r, g, b]` floats. Shapes nest inside group shapes
+ * (`ty:'gr'`, `item.it`), which are walked recursively. Author-defined color
+ * *slots* (the canonical theming mechanism — a top-level `slots` table
+ * referenced by `sid`) are also surfaced and patched (keyed `s:<id>`). Kept
+ * separate from the dotlottie renderer so import/editing can inspect and patch
+ * colors without the WASM.
+ *
+ * Callers pass an already-parsed animation object (see
+ * `extractLottieAnimation` / `fetchLottieAnimation`, which handle `.json` and
+ * `.lottie` archives). Extraction and patching walk in the same deterministic
+ * order so ordinal keys (`c0`, `c1`, …) stay aligned. Animated gradients are out
+ * of scope.
+ */
+
+/** A single editable color discovered in a Lottie animation. */
+export interface LottieColorLayer {
+  /** Stable ordinal key (document-order index of the color) addressing the override. */
+  key: string
+  /** Current color as `#rrggbb`. */
+  color: string
+  /** Human-readable label (shape/layer name, or a positional fallback). */
+  label: string
+}
+
+type Rgb = [number, number, number]
+
+/** A color the traversal can read and rewrite in place. */
+interface ColorSlot {
+  read: () => Rgb
+  write: (rgb: Rgb) => void
+  label: string
+}
+
+interface AnimatedValue {
+  a?: unknown
+  k?: unknown
+  /** Slot reference — when set, the value is themed via the top-level `slots` table. */
+  sid?: unknown
+}
+interface LottieShapeItem {
+  ty?: unknown
+  nm?: unknown
+  c?: AnimatedValue // solid fill/stroke color
+  it?: unknown // group children
+}
+
+function parseJson(json: unknown): Record<string, unknown> | null {
+  if (typeof json === 'string') {
+    try {
+      return JSON.parse(json) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+  return json && typeof json === 'object' ? (json as Record<string, unknown>) : null
+}
+
+function clamp01(n: number): number {
+  return n < 0 ? 0 : n > 1 ? 1 : n
+}
+
+function channelToHex(c: number): string {
+  return Math.round(clamp01(c) * 255)
+    .toString(16)
+    .padStart(2, '0')
+}
+
+/** Normalized `[r, g, b]` floats (0..1) → `#rrggbb`. */
+export function lottieRgbToHex(k: readonly number[]): string {
+  return `#${channelToHex(k[0] ?? 0)}${channelToHex(k[1] ?? 0)}${channelToHex(k[2] ?? 0)}`
+}
+
+/** `#rrggbb` → normalized `[r, g, b]` floats (0..1), or null if malformed. */
+export function hexToLottieRgb(hex: string): Rgb | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!match) return null
+  const value = Number.parseInt(match[1] ?? '', 16)
+  return [((value >> 16) & 0xff) / 255, ((value >> 8) & 0xff) / 255, (value & 0xff) / 255]
+}
+
+function isRgbArray(v: unknown): v is number[] {
+  return Array.isArray(v) && v.length >= 3 && typeof v[0] === 'number'
+}
+
+function trimmedName(v: unknown): string {
+  return typeof v === 'string' && v.trim() ? v.trim() : ''
+}
+
+/**
+ * The color slot of one fill/stroke shape item, or none for non-color/gradient
+ * shapes. Solid fills/strokes contribute one slot (static or animated).
+ */
+function slotsForShapeItem(item: LottieShapeItem, label: string): ColorSlot[] {
+  // Solid fill / stroke.
+  if (item.ty === 'fl' || item.ty === 'st') {
+    const c = item.c
+    if (!c || typeof c !== 'object') return []
+    // Slot-bound color: exposed/patched via the top-level `slots` table instead.
+    if (typeof c.sid === 'string') return []
+    if (c.a === 1) {
+      // Animated color: read the first keyframe, write every keyframe's value.
+      const keyframes = c.k
+      if (!Array.isArray(keyframes) || !isRgbArray((keyframes[0] as { s?: unknown })?.s)) return []
+      return [
+        {
+          label,
+          read: () => {
+            const s = (keyframes[0] as { s: number[] }).s
+            return [s[0]!, s[1]!, s[2]!]
+          },
+          write: (rgb) => {
+            for (const kf of keyframes as Array<{ s?: unknown; e?: unknown }>) {
+              if (isRgbArray(kf.s)) [kf.s[0], kf.s[1], kf.s[2]] = rgb
+              if (isRgbArray(kf.e)) [kf.e[0], kf.e[1], kf.e[2]] = rgb
+            }
+          },
+        },
+      ]
+    }
+    if (!isRgbArray(c.k)) return []
+    const k = c.k
+    return [
+      {
+        label,
+        read: () => [k[0]!, k[1]!, k[2]!],
+        write: (rgb) => {
+          ;[k[0], k[1], k[2]] = rgb
+        },
+      },
+    ]
+  }
+
+  return []
+}
+
+/**
+ * Visit every editable color in the animation in a deterministic depth-first
+ * order, assigning each a stable ordinal `key` (`c0`, `c1`, …). Shared by
+ * extraction and patching so keys line up between the two passes.
+ */
+function walkColorSlots(
+  data: Record<string, unknown> | null,
+  visit: (slot: ColorSlot, key: string) => void,
+): void {
+  const layers = data?.layers
+  if (!Array.isArray(layers)) return
+
+  let ordinal = 0
+  const walkShapes = (shapes: unknown, layerName: string) => {
+    if (!Array.isArray(shapes)) return
+    for (const raw of shapes) {
+      const item = raw as LottieShapeItem
+      if (item?.ty === 'gr' && Array.isArray(item.it)) {
+        walkShapes(item.it, layerName)
+        continue
+      }
+      const kind = item?.ty === 'st' ? 'Stroke' : 'Fill'
+      const shapeName = trimmedName(item?.nm)
+      const label = shapeName || (layerName ? `${layerName} ${kind}` : kind)
+      for (const slot of slotsForShapeItem(item, label)) {
+        visit(slot, `c${ordinal}`)
+        ordinal += 1
+      }
+    }
+  }
+
+  for (const raw of layers) {
+    const layer = raw as { shapes?: unknown; nm?: unknown }
+    if (!Array.isArray(layer?.shapes)) continue
+    walkShapes(layer.shapes, trimmedName(layer.nm))
+  }
+}
+
+// --- Lottie slots (the canonical theming mechanism) --------------------------
+// A themeable Lottie defines colors once in a top-level `slots` table and points
+// shape colors at them via `sid`. Those colors have no inline `c.k`, so the
+// tree-walk above skips them; we surface and patch them here instead, keyed
+// `s:<slotId>`. On write we also bake the value into every referencing fill/
+// stroke so the change renders regardless of whether the renderer resolves slots.
+
+interface SlotDef {
+  p?: AnimatedValue
+  nm?: unknown
+}
+
+/** Read a slot property's color, whether static (`p.k`) or animated (`p.k[0].s`). */
+function slotColorValue(p: AnimatedValue | undefined): Rgb | null {
+  if (!p || typeof p !== 'object') return null
+  if (p.a === 1) {
+    const first = Array.isArray(p.k) ? (p.k[0] as { s?: unknown } | undefined) : undefined
+    return isRgbArray(first?.s) ? [first!.s[0]!, first!.s[1]!, first!.s[2]!] : null
+  }
+  return isRgbArray(p.k) ? [p.k[0]!, p.k[1]!, p.k[2]!] : null
+}
+
+function slotColorLayers(data: Record<string, unknown>): LottieColorLayer[] {
+  const slots = data.slots
+  if (!slots || typeof slots !== 'object') return []
+  const result: LottieColorLayer[] = []
+  for (const [id, def] of Object.entries(slots as Record<string, SlotDef>)) {
+    const rgb = slotColorValue(def?.p)
+    if (!rgb) continue
+    result.push({ key: `s:${id}`, color: lottieRgbToHex(rgb), label: trimmedName(def?.nm) || id })
+  }
+  return result
+}
+
+/** Visit every fill/stroke shape item in document order (for slot baking). */
+function forEachShapeItem(
+  data: Record<string, unknown>,
+  fn: (item: LottieShapeItem) => void,
+): void {
+  const layers = data.layers
+  if (!Array.isArray(layers)) return
+  const walk = (shapes: unknown) => {
+    if (!Array.isArray(shapes)) return
+    for (const raw of shapes) {
+      const item = raw as LottieShapeItem
+      if (item?.ty === 'gr' && Array.isArray(item.it)) walk(item.it)
+      else fn(item)
+    }
+  }
+  for (const raw of layers) {
+    const layer = raw as { shapes?: unknown }
+    if (Array.isArray(layer?.shapes)) walk(layer.shapes)
+  }
+}
+
+/** Patch a color slot's value and bake it into every fill/stroke that references it. */
+function applyColorSlot(data: Record<string, unknown>, slotId: string, rgb: Rgb): boolean {
+  let changed = false
+  const slots = data.slots as Record<string, SlotDef> | undefined
+  const p = slots?.[slotId]?.p
+  if (p && typeof p === 'object') {
+    if (p.a === 1 && Array.isArray(p.k)) {
+      for (const kf of p.k as Array<{ s?: unknown }>) {
+        if (isRgbArray(kf.s)) {
+          ;[kf.s[0], kf.s[1], kf.s[2]] = rgb
+          changed = true
+        }
+      }
+    } else if (isRgbArray(p.k)) {
+      ;[p.k[0], p.k[1], p.k[2]] = rgb
+      changed = true
+    } else {
+      p.a = 0
+      p.k = [rgb[0], rgb[1], rgb[2], 1]
+      changed = true
+    }
+  }
+  // Bake into referencing fills/strokes so non-slot-aware renderers show it too.
+  forEachShapeItem(data, (item) => {
+    if (item.ty !== 'fl' && item.ty !== 'st') return
+    const c = item.c
+    if (!c || typeof c !== 'object' || c.sid !== slotId) return
+    if (isRgbArray(c.k)) [c.k[0], c.k[1], c.k[2]] = rgb
+    else c.k = [rgb[0], rgb[1], rgb[2], 1]
+    changed = true
+  })
+  return changed
+}
+
+/**
+ * List the editable colors of a Lottie animation object. Author-defined color
+ * slots come first (keyed `s:<id>`), then every inline shape color in document
+ * order (keyed `c<n>`). Returns an empty array for non-shape or unparseable input.
+ */
+export function extractLottieColorLayers(json: unknown): LottieColorLayer[] {
+  const data = parseJson(json)
+  if (!data) return []
+  const result: LottieColorLayer[] = slotColorLayers(data)
+  walkColorSlots(data, (slot, key) => {
+    result.push({ key, color: lottieRgbToHex(slot.read()), label: slot.label })
+  })
+  return result
+}
+
+/**
+ * Apply per-color overrides to a Lottie animation object and return the patched
+ * JSON string. Overrides are keyed by the color's stable ordinal key (see
+ * {@link extractLottieColorLayers}) with `#rrggbb` hex values; unknown or
+ * malformed values are ignored. Returns null when the input can't be parsed or
+ * nothing changes.
+ */
+export function applyLottieColorOverrides(
+  json: unknown,
+  overrides: Record<string, string>,
+): string | null {
+  const data = parseJson(json)
+  if (!data) return null
+  if (Object.keys(overrides).length === 0) return null
+
+  let changed = false
+  // Slot overrides (keyed `s:<id>`): patch the slot value + bake references.
+  for (const [key, hex] of Object.entries(overrides)) {
+    if (!key.startsWith('s:')) continue
+    const rgb = hexToLottieRgb(hex)
+    if (rgb && applyColorSlot(data, key.slice(2), rgb)) changed = true
+  }
+  // Inline shape overrides (keyed `c<n>`).
+  walkColorSlots(data, (slot, key) => {
+    const hex = overrides[key]
+    if (hex === undefined) return
+    const rgb = hexToLottieRgb(hex)
+    if (!rgb) return
+    slot.write(rgb)
+    changed = true
+  })
+
+  return changed ? JSON.stringify(data) : null
+}

--- a/src/infrastructure/lottie/lottie-color.ts
+++ b/src/infrastructure/lottie/lottie-color.ts
@@ -27,6 +27,13 @@ export interface LottieColorLayer {
   color: string
   /** Human-readable label (shape/layer name, or a positional fallback). */
   label: string
+  /**
+   * Whether `label` is an author-given name (a color slot, or a shape with its
+   * own `nm`) rather than a generated fallback like `Fill`/`Stroke`. Named
+   * colors are the template's intended customization points; the UI surfaces
+   * them first and tucks the rest away.
+   */
+  named: boolean
 }
 
 type Rgb = [number, number, number]
@@ -36,6 +43,8 @@ interface ColorSlot {
   read: () => Rgb
   write: (rgb: Rgb) => void
   label: string
+  /** True when `label` is the shape's own `nm` (not a generated fallback). */
+  named: boolean
 }
 
 interface AnimatedValue {
@@ -97,7 +106,7 @@ function trimmedName(v: unknown): string {
  * The color slot of one fill/stroke shape item, or none for non-color/gradient
  * shapes. Solid fills/strokes contribute one slot (static or animated).
  */
-function slotsForShapeItem(item: LottieShapeItem, label: string): ColorSlot[] {
+function slotsForShapeItem(item: LottieShapeItem, label: string, named: boolean): ColorSlot[] {
   // Solid fill / stroke.
   if (item.ty === 'fl' || item.ty === 'st') {
     const c = item.c
@@ -111,6 +120,7 @@ function slotsForShapeItem(item: LottieShapeItem, label: string): ColorSlot[] {
       return [
         {
           label,
+          named,
           read: () => {
             const s = (keyframes[0] as { s: number[] }).s
             return [s[0]!, s[1]!, s[2]!]
@@ -129,6 +139,7 @@ function slotsForShapeItem(item: LottieShapeItem, label: string): ColorSlot[] {
     return [
       {
         label,
+        named,
         read: () => [k[0]!, k[1]!, k[2]!],
         write: (rgb) => {
           ;[k[0], k[1], k[2]] = rgb
@@ -164,7 +175,7 @@ function walkColorSlots(
       const kind = item?.ty === 'st' ? 'Stroke' : 'Fill'
       const shapeName = trimmedName(item?.nm)
       const label = shapeName || (layerName ? `${layerName} ${kind}` : kind)
-      for (const slot of slotsForShapeItem(item, label)) {
+      for (const slot of slotsForShapeItem(item, label, !!shapeName)) {
         visit(slot, `c${ordinal}`)
         ordinal += 1
       }
@@ -207,7 +218,13 @@ function slotColorLayers(data: Record<string, unknown>): LottieColorLayer[] {
   for (const [id, def] of Object.entries(slots as Record<string, SlotDef>)) {
     const rgb = slotColorValue(def?.p)
     if (!rgb) continue
-    result.push({ key: `s:${id}`, color: lottieRgbToHex(rgb), label: trimmedName(def?.nm) || id })
+    // A slot is an explicit author theming point — always treated as named.
+    result.push({
+      key: `s:${id}`,
+      color: lottieRgbToHex(rgb),
+      label: trimmedName(def?.nm) || id,
+      named: true,
+    })
   }
   return result
 }
@@ -277,7 +294,7 @@ export function extractLottieColorLayers(json: unknown): LottieColorLayer[] {
   if (!data) return []
   const result: LottieColorLayer[] = slotColorLayers(data)
   walkColorSlots(data, (slot, key) => {
-    result.push({ key, color: lottieRgbToHex(slot.read()), label: slot.label })
+    result.push({ key, color: lottieRgbToHex(slot.read()), label: slot.label, named: slot.named })
   })
   return result
 }

--- a/src/infrastructure/lottie/lottie-color.ts
+++ b/src/infrastructure/lottie/lottie-color.ts
@@ -102,6 +102,16 @@ function trimmedName(v: unknown): string {
   return typeof v === 'string' && v.trim() ? v.trim() : ''
 }
 
+// After Effects / Lottie editors auto-name every fill/stroke "Fill", "Fill 1",
+// "Stroke 2", etc. Those defaults are noise, not author intent, so they don't
+// count as a "named" (customization-point) color.
+const GENERATED_COLOR_NAME = /^(fill|stroke)(\s+\d+)?$/i
+
+/** True when `name` is a real author name rather than an editor-generated default. */
+function isAuthorColorName(name: string): boolean {
+  return name.length > 0 && !GENERATED_COLOR_NAME.test(name)
+}
+
 /**
  * The color slot of one fill/stroke shape item, or none for non-color/gradient
  * shapes. Solid fills/strokes contribute one slot (static or animated).
@@ -175,7 +185,7 @@ function walkColorSlots(
       const kind = item?.ty === 'st' ? 'Stroke' : 'Fill'
       const shapeName = trimmedName(item?.nm)
       const label = shapeName || (layerName ? `${layerName} ${kind}` : kind)
-      for (const slot of slotsForShapeItem(item, label, !!shapeName)) {
+      for (const slot of slotsForShapeItem(item, label, isAuthorColorName(shapeName))) {
         visit(slot, `c${ordinal}`)
         ordinal += 1
       }

--- a/src/infrastructure/lottie/lottie-frame-provider.test.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { mapTimelineFrameToLottieFrame } from './lottie-frame-provider'
+
+// Base input: project fps === animation fps and totalFrames 100, so 1 project
+// frame maps to 1 lottie frame at speed 1 (elapsed === localFrame).
+const base = {
+  projectFps: 30,
+  speed: 1,
+  totalFrames: 100,
+  frameRate: 30,
+  loop: false,
+}
+
+describe('mapTimelineFrameToLottieFrame', () => {
+  it('maps 1:1 when fps match and speed is 1', () => {
+    expect(mapTimelineFrameToLottieFrame({ ...base, localFrame: 0 })).toBe(0)
+    expect(mapTimelineFrameToLottieFrame({ ...base, localFrame: 42 })).toBe(42)
+  })
+
+  it('holds the final frame past the end when not looping', () => {
+    // maxFrame = 99; segLen defaults to 99.
+    expect(mapTimelineFrameToLottieFrame({ ...base, localFrame: 250 })).toBe(99)
+  })
+
+  it('wraps within the animation when looping', () => {
+    // segLen = 99, so frame 120 wraps to 120 % 99 = 21.
+    expect(mapTimelineFrameToLottieFrame({ ...base, loop: true, localFrame: 120 })).toBe(21)
+  })
+
+  it('scales by speed', () => {
+    expect(mapTimelineFrameToLottieFrame({ ...base, speed: 2, localFrame: 10 })).toBe(20)
+    // speed 0 freezes at the start frame.
+    expect(mapTimelineFrameToLottieFrame({ ...base, speed: 0, localFrame: 50 })).toBe(0)
+  })
+
+  it('reverses playback from the segment end', () => {
+    expect(mapTimelineFrameToLottieFrame({ ...base, reversed: true, localFrame: 0 })).toBe(99)
+    expect(mapTimelineFrameToLottieFrame({ ...base, reversed: true, localFrame: 10 })).toBe(89)
+  })
+
+  it('confines playback to an in/out segment', () => {
+    const seg = { ...base, segmentStart: 20, segmentEnd: 60 }
+    expect(mapTimelineFrameToLottieFrame({ ...seg, localFrame: 0 })).toBe(20)
+    expect(mapTimelineFrameToLottieFrame({ ...seg, localFrame: 15 })).toBe(35)
+    // Past segment end without loop, holds segEnd.
+    expect(mapTimelineFrameToLottieFrame({ ...seg, localFrame: 500 })).toBe(60)
+    // Loop wraps within [20, 60] (segLen 40): elapsed 50 → 20 + (50 % 40) = 30.
+    expect(mapTimelineFrameToLottieFrame({ ...seg, loop: true, localFrame: 50 })).toBe(30)
+  })
+
+  it('freezes on a zero-length segment (poster frame)', () => {
+    expect(
+      mapTimelineFrameToLottieFrame({ ...base, segmentStart: 30, segmentEnd: 30, localFrame: 99 }),
+    ).toBe(30)
+  })
+
+  it('ping-pong bounces at the segment ends', () => {
+    const pp = { ...base, loop: true, loopMode: 'pingpong' as const }
+    // segLen 99, period 198. At elapsed 99 it hits the far end (99).
+    expect(mapTimelineFrameToLottieFrame({ ...pp, localFrame: 99 })).toBe(99)
+    // At elapsed 150 it is on the way back: 198 - 150 = 48.
+    expect(mapTimelineFrameToLottieFrame({ ...pp, localFrame: 150 })).toBe(48)
+  })
+
+  it('returns 0 for degenerate inputs', () => {
+    expect(mapTimelineFrameToLottieFrame({ ...base, totalFrames: 0, localFrame: 10 })).toBe(0)
+    expect(mapTimelineFrameToLottieFrame({ ...base, frameRate: 0, localFrame: 10 })).toBe(0)
+  })
+})

--- a/src/infrastructure/lottie/lottie-frame-provider.test.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.test.ts
@@ -23,8 +23,15 @@ describe('mapTimelineFrameToLottieFrame', () => {
   })
 
   it('wraps within the animation when looping', () => {
-    // segLen = 99, so frame 120 wraps to 120 % 99 = 21.
-    expect(mapTimelineFrameToLottieFrame({ ...base, loop: true, localFrame: 120 })).toBe(21)
+    // 100 frames (0..99), so the loop period is 100: frame 120 wraps to 120 % 100 = 20.
+    expect(mapTimelineFrameToLottieFrame({ ...base, loop: true, localFrame: 120 })).toBe(20)
+  })
+
+  it('reaches the final frame before wrapping (no skipped last frame)', () => {
+    // 10 frames (0..9): the last frame must render, then wrap back to 0.
+    const tiny = { ...base, totalFrames: 10, loop: true }
+    expect(mapTimelineFrameToLottieFrame({ ...tiny, localFrame: 9 })).toBe(9)
+    expect(mapTimelineFrameToLottieFrame({ ...tiny, localFrame: 10 })).toBe(0)
   })
 
   it('scales by speed', () => {
@@ -44,8 +51,8 @@ describe('mapTimelineFrameToLottieFrame', () => {
     expect(mapTimelineFrameToLottieFrame({ ...seg, localFrame: 15 })).toBe(35)
     // Past segment end without loop, holds segEnd.
     expect(mapTimelineFrameToLottieFrame({ ...seg, localFrame: 500 })).toBe(60)
-    // Loop wraps within [20, 60] (segLen 40): elapsed 50 → 20 + (50 % 40) = 30.
-    expect(mapTimelineFrameToLottieFrame({ ...seg, loop: true, localFrame: 50 })).toBe(30)
+    // Loop wraps within [20, 60] (41 frames): elapsed 50 → 20 + (50 % 41) = 29.
+    expect(mapTimelineFrameToLottieFrame({ ...seg, loop: true, localFrame: 50 })).toBe(29)
   })
 
   it('freezes on a zero-length segment (poster frame)', () => {

--- a/src/infrastructure/lottie/lottie-frame-provider.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.ts
@@ -13,6 +13,7 @@
  * Preview uses {@link LottieRenderer} directly against a visible canvas.
  */
 import { DotLottie } from '@lottiefiles/dotlottie-web'
+import type { LottieSlotValue } from './lottie-slots'
 // Bundle the WASM alongside the app so it resolves without the default CDN.
 // Use the package's `exports`-mapped subpath (NOT `/dist/...`) so Node's strict
 // exports resolution (Vitest) can resolve it too, not just Vite.
@@ -127,6 +128,12 @@ export class LottieRenderer {
      */
     themeData?: string
     /**
+     * Scalar/vector slot overrides applied natively (`setScalarSlot` /
+     * `setVectorSlot`) once the animation loads, after the theme so an explicit
+     * override wins. Keyed by slot id.
+     */
+    slots?: Record<string, LottieSlotValue>
+    /**
      * Track the canvas's display size and re-render crisply on resize. Enable
      * for a visible preview canvas; leave off (default) for a fixed-size
      * OffscreenCanvas (export), which has no client size to observe.
@@ -154,8 +161,8 @@ export class LottieRenderer {
     this._ready = new Promise<void>((resolve) => {
       const onLoad = () => {
         this._loaded = true
-        // Apply the theme to the loaded animation's slots before the first
-        // render; the external setFrame that follows draws it themed.
+        // Apply the theme + slot overrides to the loaded animation before the
+        // first render; the external setFrame that follows draws them.
         if (config.themeData) {
           try {
             this.dotLottie.setThemeData(config.themeData)
@@ -163,6 +170,7 @@ export class LottieRenderer {
             // ignore a malformed/unsupported theme — render stays as-authored
           }
         }
+        this.applySlots(config.slots)
         resolve()
       }
       // Guard against a load that already completed synchronously.
@@ -202,6 +210,28 @@ export class LottieRenderer {
   get frameRate(): number {
     const d = this.duration
     return d > 0 ? this.totalFrames / d : 30
+  }
+
+  /**
+   * Apply scalar/vector slot overrides via dotlottie's native setters, routing
+   * each by the slot's declared type. Unknown ids / type mismatches are ignored.
+   */
+  private applySlots(slots: Record<string, LottieSlotValue> | undefined): void {
+    if (!slots) return
+    for (const [id, value] of Object.entries(slots)) {
+      try {
+        // `getSlotType` reports position slots as 'vector'; `setVectorSlot`
+        // handles both.
+        const type = this.dotLottie.getSlotType(id)
+        if (type === 'scalar' && typeof value === 'number') {
+          this.dotLottie.setScalarSlot(id, value)
+        } else if (type === 'vector' && Array.isArray(value)) {
+          this.dotLottie.setVectorSlot(id, value)
+        }
+      } catch {
+        // ignore a single bad slot — the rest still apply
+      }
+    }
   }
 
   /** Render a specific Lottie frame synchronously into the bound canvas. */
@@ -271,11 +301,12 @@ export class LottieExportProvider {
     data?: string,
     signature?: string,
     themeData?: string,
+    slots?: Record<string, LottieSlotValue>,
   ): Promise<void> {
     if (this.renderers.has(key)) return
     const canvas = new OffscreenCanvas(Math.max(1, width), Math.max(1, height))
     const renderer = new LottieRenderer(
-      data ? { canvas, data, themeData } : { canvas, src, themeData },
+      data ? { canvas, data, themeData, slots } : { canvas, src, themeData, slots },
     )
     this.renderers.set(key, renderer)
     if (signature !== undefined) this.signatures.set(key, signature)
@@ -302,6 +333,7 @@ export class LottieExportProvider {
     data: string | undefined,
     signature: string,
     themeData?: string,
+    slots?: Record<string, LottieSlotValue>,
   ): Promise<void> {
     if (this.signatures.get(key) === signature) return
     const inFlight = this.rebuilds.get(key)
@@ -310,7 +342,7 @@ export class LottieExportProvider {
     const promise = (async () => {
       const canvas = new OffscreenCanvas(Math.max(1, width), Math.max(1, height))
       const renderer = new LottieRenderer(
-        data ? { canvas, data, themeData } : { canvas, src, themeData },
+        data ? { canvas, data, themeData, slots } : { canvas, src, themeData, slots },
       )
       await renderer.ready
       const previous = this.renderers.get(key)

--- a/src/infrastructure/lottie/lottie-frame-provider.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.ts
@@ -80,9 +80,9 @@ export function mapTimelineFrameToLottieFrame({
   // Resolve and sanitize the active segment [segStart, segEnd] within the range.
   const segStart = Math.max(0, Math.min(segmentStart ?? 0, maxFrame))
   const segEnd = Math.max(segStart, Math.min(segmentEnd ?? maxFrame, maxFrame))
-  const segLen = segEnd - segStart
+  const segSpan = segEnd - segStart
   // A zero-length segment is a frozen poster frame.
-  if (segLen <= 0) return segStart
+  if (segSpan <= 0) return segStart
 
   // Frames elapsed within the segment at the requested speed.
   const elapsed = (localFrame / projectFps) * (speed ?? 1) * frameRate
@@ -90,15 +90,20 @@ export function mapTimelineFrameToLottieFrame({
   let offset: number
   if (loop) {
     if (loopMode === 'pingpong') {
-      const period = segLen * 2
+      // Ping-pong reflects at the endpoints, so segEnd is reached at m === segSpan.
+      const period = segSpan * 2
       const m = ((elapsed % period) + period) % period
-      offset = m <= segLen ? m : period - m
+      offset = m <= segSpan ? m : period - m
     } else {
-      offset = ((elapsed % segLen) + segLen) % segLen
+      // A loop cycles through all frames segStart..segEnd inclusive, then wraps —
+      // so the period is the frame *count* (span + 1), not the span, or the final
+      // frame is skipped before wrapping.
+      const frameCount = segSpan + 1
+      offset = ((elapsed % frameCount) + frameCount) % frameCount
     }
   } else {
     // Past the end, hold the final frame (dotlottie clamps anyway).
-    offset = Math.max(0, Math.min(elapsed, segLen))
+    offset = Math.max(0, Math.min(elapsed, segSpan))
   }
 
   const frame = reversed ? segEnd - offset : segStart + offset

--- a/src/infrastructure/lottie/lottie-frame-provider.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.ts
@@ -46,11 +46,20 @@ export interface LottieFrameMapInput {
   frameRate: number
   /** Whether to loop when the clip outlives the animation. */
   loop: boolean
+  /** Play the segment backward (default false). */
+  reversed?: boolean
+  /** Repeat style while looping (default 'loop'). */
+  loopMode?: 'loop' | 'pingpong'
+  /** First source frame to play (default 0). */
+  segmentStart?: number
+  /** Last source frame to play (default totalFrames - 1). */
+  segmentEnd?: number
 }
 
 /**
- * Map a clip-local timeline frame to a Lottie frame index.
- * Clamped to `[0, totalFrames - 1]` — dotlottie's valid seek range.
+ * Map a clip-local timeline frame to a Lottie frame index, honoring speed,
+ * reverse, an in/out segment, and loop style. The result is always clamped to
+ * the active segment and to `[0, totalFrames - 1]` (dotlottie's valid range).
  */
 export function mapTimelineFrameToLottieFrame({
   localFrame,
@@ -59,15 +68,40 @@ export function mapTimelineFrameToLottieFrame({
   totalFrames,
   frameRate,
   loop,
+  reversed = false,
+  loopMode = 'loop',
+  segmentStart,
+  segmentEnd,
 }: LottieFrameMapInput): number {
   if (totalFrames <= 0 || projectFps <= 0 || frameRate <= 0) return 0
-  const seconds = (localFrame / projectFps) * (speed ?? 1)
-  let lottieFrame = seconds * frameRate
   const maxFrame = totalFrames - 1
+
+  // Resolve and sanitize the active segment [segStart, segEnd] within the range.
+  const segStart = Math.max(0, Math.min(segmentStart ?? 0, maxFrame))
+  const segEnd = Math.max(segStart, Math.min(segmentEnd ?? maxFrame, maxFrame))
+  const segLen = segEnd - segStart
+  // A zero-length segment is a frozen poster frame.
+  if (segLen <= 0) return segStart
+
+  // Frames elapsed within the segment at the requested speed.
+  const elapsed = (localFrame / projectFps) * (speed ?? 1) * frameRate
+
+  let offset: number
   if (loop) {
-    lottieFrame = ((lottieFrame % totalFrames) + totalFrames) % totalFrames
+    if (loopMode === 'pingpong') {
+      const period = segLen * 2
+      const m = ((elapsed % period) + period) % period
+      offset = m <= segLen ? m : period - m
+    } else {
+      offset = ((elapsed % segLen) + segLen) % segLen
+    }
+  } else {
+    // Past the end, hold the final frame (dotlottie clamps anyway).
+    offset = Math.max(0, Math.min(elapsed, segLen))
   }
-  return Math.max(0, Math.min(lottieFrame, maxFrame))
+
+  const frame = reversed ? segEnd - offset : segStart + offset
+  return Math.max(segStart, Math.min(frame, segEnd))
 }
 
 /**
@@ -205,11 +239,21 @@ export async function renderLottieThumbnail(
 export class LottieExportProvider {
   private readonly renderers = new Map<string, LottieRenderer>()
 
-  /** Warm a renderer for a source at a target size. Safe to call repeatedly. */
-  async preload(key: string, src: string, width: number, height: number): Promise<void> {
+  /**
+   * Warm a renderer for a source at a target size. Safe to call repeatedly.
+   * Pass `data` (patched JSON string) to render text-overridden content instead
+   * of loading `src` directly.
+   */
+  async preload(
+    key: string,
+    src: string,
+    width: number,
+    height: number,
+    data?: string,
+  ): Promise<void> {
     if (this.renderers.has(key)) return
     const canvas = new OffscreenCanvas(Math.max(1, width), Math.max(1, height))
-    const renderer = new LottieRenderer({ canvas, src })
+    const renderer = new LottieRenderer(data ? { canvas, data } : { canvas, src })
     this.renderers.set(key, renderer)
     await renderer.ready
   }

--- a/src/infrastructure/lottie/lottie-frame-provider.ts
+++ b/src/infrastructure/lottie/lottie-frame-provider.ts
@@ -122,6 +122,11 @@ export class LottieRenderer {
     /** Raw animation JSON string. */
     data?: string
     /**
+     * dotLottie theme rule JSON (`{ rules: [...] }`) applied via `setThemeData`
+     * once the animation loads — recolors/retexts the animation's slots.
+     */
+    themeData?: string
+    /**
      * Track the canvas's display size and re-render crisply on resize. Enable
      * for a visible preview canvas; leave off (default) for a fixed-size
      * OffscreenCanvas (export), which has no client size to observe.
@@ -149,6 +154,15 @@ export class LottieRenderer {
     this._ready = new Promise<void>((resolve) => {
       const onLoad = () => {
         this._loaded = true
+        // Apply the theme to the loaded animation's slots before the first
+        // render; the external setFrame that follows draws it themed.
+        if (config.themeData) {
+          try {
+            this.dotLottie.setThemeData(config.themeData)
+          } catch {
+            // ignore a malformed/unsupported theme — render stays as-authored
+          }
+        }
         resolve()
       }
       // Guard against a load that already completed synchronously.
@@ -238,11 +252,16 @@ export async function renderLottieThumbnail(
  */
 export class LottieExportProvider {
   private readonly renderers = new Map<string, LottieRenderer>()
+  /** Override signature the current renderer for a key was built with. */
+  private readonly signatures = new Map<string, string>()
+  /** In-flight rebuilds, keyed by item key, so concurrent renders dedupe. */
+  private readonly rebuilds = new Map<string, { signature: string; promise: Promise<void> }>()
 
   /**
    * Warm a renderer for a source at a target size. Safe to call repeatedly.
-   * Pass `data` (patched JSON string) to render text-overridden content instead
-   * of loading `src` directly.
+   * Pass `data` (patched JSON string) to render text/color-overridden content
+   * instead of loading `src` directly, and `signature` to record which override
+   * state that data represents (see {@link getSignature} / {@link rebuild}).
    */
   async preload(
     key: string,
@@ -250,12 +269,61 @@ export class LottieExportProvider {
     width: number,
     height: number,
     data?: string,
+    signature?: string,
+    themeData?: string,
   ): Promise<void> {
     if (this.renderers.has(key)) return
     const canvas = new OffscreenCanvas(Math.max(1, width), Math.max(1, height))
-    const renderer = new LottieRenderer(data ? { canvas, data } : { canvas, src })
+    const renderer = new LottieRenderer(
+      data ? { canvas, data, themeData } : { canvas, src, themeData },
+    )
     this.renderers.set(key, renderer)
+    if (signature !== undefined) this.signatures.set(key, signature)
     await renderer.ready
+  }
+
+  /** The override signature the key's current renderer was built with. */
+  getSignature(key: string): string | undefined {
+    return this.signatures.get(key)
+  }
+
+  /**
+   * Rebuild a key's renderer with fresh override `data` (or the raw `src` when
+   * null) after its text/color overrides changed. Concurrent calls for the same
+   * signature share one rebuild; the previous renderer is disposed once the new
+   * one is ready so a render mid-rebuild still draws the old frame. Used by the
+   * live preview — export preloads final overrides once and never rebuilds.
+   */
+  async rebuild(
+    key: string,
+    src: string,
+    width: number,
+    height: number,
+    data: string | undefined,
+    signature: string,
+    themeData?: string,
+  ): Promise<void> {
+    if (this.signatures.get(key) === signature) return
+    const inFlight = this.rebuilds.get(key)
+    if (inFlight && inFlight.signature === signature) return inFlight.promise
+
+    const promise = (async () => {
+      const canvas = new OffscreenCanvas(Math.max(1, width), Math.max(1, height))
+      const renderer = new LottieRenderer(
+        data ? { canvas, data, themeData } : { canvas, src, themeData },
+      )
+      await renderer.ready
+      const previous = this.renderers.get(key)
+      this.renderers.set(key, renderer)
+      this.signatures.set(key, signature)
+      previous?.destroy()
+    })()
+    this.rebuilds.set(key, { signature, promise })
+    try {
+      await promise
+    } finally {
+      if (this.rebuilds.get(key)?.promise === promise) this.rebuilds.delete(key)
+    }
   }
 
   /** Render `lottieFrame` and return the OffscreenCanvas to composite, or null. */
@@ -273,5 +341,7 @@ export class LottieExportProvider {
   destroy(): void {
     for (const r of this.renderers.values()) r.destroy()
     this.renderers.clear()
+    this.signatures.clear()
+    this.rebuilds.clear()
   }
 }

--- a/src/infrastructure/lottie/lottie-metadata.test.ts
+++ b/src/infrastructure/lottie/lottie-metadata.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { parseLottieMetadata, parseLottieFileBytes } from './lottie-metadata'
+import {
+  parseLottieMetadata,
+  parseLottieFileBytes,
+  extractLottieAnimation,
+  extractLottieManifest,
+  extractLottieThemeData,
+  readLottieMarkers,
+} from './lottie-metadata'
+
+// A `.lottie` archive with an image asset (images/img.png = bytes 0x89 'PNG' …),
+// pre-built with fflate in Node (see parseLottieFileBytes fixtures note).
+const IMAGE_ARCHIVE_B64 =
+  'UEsDBBQAAAAIAFCr5lzzzTiqHQAAABsAAAANAAAAbWFuaWZlc3QuanNvbqtWSszLzE0syczPK1ayiq5WykxRslJKVKqNrQUAUEsDBBQAAAAIAFCr5lw9+VcAgQAAAMgAAAARAAAAYW5pbWF0aW9ucy9hLmpzb25djlsKwjAQRfdyv4cYFRFmB65BigSc1qCtJalKCdm7k1o/2q/LPM6ZSXiDcTBHY0GoA3hvCb4Hazw1SvkBb63mbc6uVca3jRIuRhki+Jzgr1PXNXIprgmaGcLrP4sbnam38KbvikP0WK4IDzdK+LmGEbwjBKlPS+vqs7uup5yr/AVQSwMEFAAAAAgAUKvmXGULmf4LAAAACQAAAA4AAABpbWFnZXMvaW1nLnBuZ+sM8HNnZGJmYQUAUEsBAhQAFAAAAAgAUKvmXPPNOKodAAAAGwAAAA0AAAAAAAAAAAAAAAAAAAAAAG1hbmlmZXN0Lmpzb25QSwECFAAUAAAACABQq+ZcPflXAIEAAADIAAAAEQAAAAAAAAAAAAAAAABIAAAAYW5pbWF0aW9ucy9hLmpzb25QSwECFAAUAAAACABQq+ZcZQuZ/gsAAAAJAAAADgAAAAAAAAAAAAAAAAD4AAAAaW1hZ2VzL2ltZy5wbmdQSwUGAAAAAAMAAwC2AAAALwEAAAAA'
 
 function lottieJson(overrides: Record<string, unknown> = {}) {
   return {
@@ -32,6 +44,11 @@ const FIXTURES = {
   // manifest with empty animations, no animation files
   empty:
     'UEsDBBQAAAAIAFVH5lx1pkWvEwAAABEAAAANAAAAbWFuaWZlc3QuanNvbqtWSszLzE0syczPK1ayio6tBQBQSwECFAAUAAAACABVR+ZcdaZFrxMAAAARAAAADQAAAAAAAAAAAAAAAAAAAAAAbWFuaWZlc3QuanNvblBLBQYAAAAAAQABADsAAAA+AAAAAAA=',
+  // manifest {animations:[{id:'a',themes:['dark','light']}], themes:[{id:'dark'},{id:'light'}]};
+  // animations/a.json (512x512) carries markers intro/loop/cue; themes/dark.json +
+  // themes/light.json each hold a `bg` Color rule.
+  themed:
+    'UEsDBBQAAAAAAGMC51zS4vB/XQAAAF0AAAANAAAAbWFuaWZlc3QuanNvbnsiYW5pbWF0aW9ucyI6W3siaWQiOiJhIiwidGhlbWVzIjpbImRhcmsiLCJsaWdodCJdfV0sInRoZW1lcyI6W3siaWQiOiJkYXJrIn0seyJpZCI6ImxpZ2h0In1dfVBLAwQUAAAAAABjAudcJw8I9NUAAADVAAAAEQAAAGFuaW1hdGlvbnMvYS5qc29ueyJ2IjoiNS43LjAiLCJmciI6MzAsImlwIjowLCJvcCI6NjAsInciOjUxMiwiaCI6NTEyLCJubSI6ImEiLCJsYXllcnMiOlt7InR5Ijo0LCJubSI6ImwiLCJpcCI6MCwib3AiOjYwLCJrcyI6e319XSwibWFya2VycyI6W3sidG0iOjAsImNtIjoiaW50cm8iLCJkciI6MzB9LHsidG0iOjMwLCJjbSI6Imxvb3AiLCJkciI6MzB9LHsidG0iOjU5LCJjbSI6ImN1ZSIsImRyIjowfV19UEsDBBQAAAAAAGMC51w0nok/OAAAADgAAAAQAAAAdGhlbWVzL2RhcmsuanNvbnsicnVsZXMiOlt7ImlkIjoiYmciLCJ0eXBlIjoiQ29sb3IiLCJ2YWx1ZSI6WzAsMCwwLDFdfV19UEsDBBQAAAAAAGMC51wDXgtPOAAAADgAAAARAAAAdGhlbWVzL2xpZ2h0Lmpzb257InJ1bGVzIjpbeyJpZCI6ImJnIiwidHlwZSI6IkNvbG9yIiwidmFsdWUiOlsxLDEsMSwxXX1dfVBLAQIUABQAAAAAAGMC51zS4vB/XQAAAF0AAAANAAAAAAAAAAAAAAAAAAAAAABtYW5pZmVzdC5qc29uUEsBAhQAFAAAAAAAYwLnXCcPCPTVAAAA1QAAABEAAAAAAAAAAAAAAAAAiAAAAGFuaW1hdGlvbnMvYS5qc29uUEsBAhQAFAAAAAAAYwLnXDSeiT84AAAAOAAAABAAAAAAAAAAAAAAAAAAjAEAAHRoZW1lcy9kYXJrLmpzb25QSwECFAAUAAAAAABjAudcA14LTzgAAAA4AAAAEQAAAAAAAAAAAAAAAADyAQAAdGhlbWVzL2xpZ2h0Lmpzb25QSwUGAAAAAAQABAD3AAAAWQIAAAAA',
 }
 
 const decodeB64 = (b64: string): Uint8Array => Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
@@ -83,6 +100,14 @@ describe('parseLottieFileBytes', () => {
     expect(parseLottieFileBytes(decodeB64(FIXTURES.multi))?.width).toBe(999)
   })
 
+  it('reads a specific animation by id (overriding manifest order)', () => {
+    // 'first' is second in manifest order but must still be selectable by id
+    expect(parseLottieFileBytes(decodeB64(FIXTURES.multi), 'first')?.width).toBe(100)
+    expect(parseLottieFileBytes(decodeB64(FIXTURES.multi), 'second')?.width).toBe(999)
+    // Unknown id falls back to the manifest-primary animation
+    expect(parseLottieFileBytes(decodeB64(FIXTURES.multi), 'nope')?.width).toBe(999)
+  })
+
   it('falls back to the first animation entry when the manifest is absent', () => {
     expect(parseLottieFileBytes(decodeB64(FIXTURES.noManifest))?.width).toBe(256)
   })
@@ -94,5 +119,120 @@ describe('parseLottieFileBytes', () => {
   it('returns null for non-Lottie bytes', () => {
     expect(parseLottieFileBytes(new TextEncoder().encode('not json at all'))).toBeNull()
     expect(parseLottieFileBytes(new Uint8Array([1, 2, 3, 4]))).toBeNull()
+  })
+})
+
+describe('extractLottieAnimation', () => {
+  it('parses raw .json bytes into the animation object', () => {
+    const bytes = new TextEncoder().encode(JSON.stringify(lottieJson()))
+    const anim = extractLottieAnimation(bytes)
+    expect(anim?.w).toBe(400)
+    expect(Array.isArray(anim?.layers)).toBe(true)
+  })
+
+  it('unzips a .lottie archive to the primary animation object', () => {
+    const anim = extractLottieAnimation(decodeB64(FIXTURES.single))
+    expect(anim?.w).toBe(512)
+    expect(Array.isArray(anim?.layers)).toBe(true)
+  })
+
+  it('selects a specific animation by id from a multi-animation archive', () => {
+    const bytes = decodeB64(FIXTURES.multi)
+    expect(extractLottieAnimation(bytes)?.w).toBe(999) // manifest-primary
+    expect(extractLottieAnimation(bytes, false, 'first')?.w).toBe(100)
+    expect(extractLottieAnimation(bytes, false, 'second')?.w).toBe(999)
+  })
+
+  it('returns null for non-Lottie bytes', () => {
+    expect(extractLottieAnimation(new TextEncoder().encode('nope'))).toBeNull()
+    expect(extractLottieAnimation(new Uint8Array([1, 2, 3, 4]))).toBeNull()
+  })
+
+  it('inlines archive images as data URIs only when requested', () => {
+    const bytes = decodeB64(IMAGE_ARCHIVE_B64)
+
+    const withoutInline = extractLottieAnimation(bytes, false)!
+    const asset0 = (withoutInline.assets as Array<Record<string, unknown>>)[0]!
+    expect(asset0.p).toBe('img.png') // untouched reference
+
+    const withInline = extractLottieAnimation(bytes, true)!
+    const inlined = (withInline.assets as Array<Record<string, unknown>>)[0]!
+    expect(inlined.p).toBe('data:image/png;base64,iVBORwECAwQF')
+    expect(inlined.u).toBe('')
+    expect(inlined.e).toBe(1)
+  })
+})
+
+describe('extractLottieManifest', () => {
+  it('lists an archive’s animations and the union of its theme ids', () => {
+    expect(extractLottieManifest(decodeB64(FIXTURES.themed))).toEqual({
+      animations: [{ id: 'a' }],
+      themes: ['dark', 'light'],
+    })
+  })
+
+  it('lists animations in manifest order with no themes when none are declared', () => {
+    expect(extractLottieManifest(decodeB64(FIXTURES.multi))).toEqual({
+      animations: [{ id: 'second' }, { id: 'first' }],
+      themes: [],
+    })
+  })
+
+  it('returns null for raw .json (no archive/manifest) and non-Lottie bytes', () => {
+    const raw = new TextEncoder().encode(JSON.stringify(lottieJson()))
+    expect(extractLottieManifest(raw)).toBeNull()
+    expect(extractLottieManifest(new Uint8Array([1, 2, 3, 4]))).toBeNull()
+  })
+})
+
+describe('extractLottieThemeData', () => {
+  it('reads a theme’s rule JSON by id', () => {
+    const dark = extractLottieThemeData(decodeB64(FIXTURES.themed), 'dark')
+    expect(dark).not.toBeNull()
+    expect(JSON.parse(dark!)).toEqual({
+      rules: [{ id: 'bg', type: 'Color', value: [0, 0, 0, 1] }],
+    })
+    const light = JSON.parse(extractLottieThemeData(decodeB64(FIXTURES.themed), 'light')!)
+    expect(light.rules[0].value).toEqual([1, 1, 1, 1])
+  })
+
+  it('returns null for an unknown theme id or a themeless archive', () => {
+    expect(extractLottieThemeData(decodeB64(FIXTURES.themed), 'missing')).toBeNull()
+    expect(extractLottieThemeData(decodeB64(FIXTURES.multi), 'dark')).toBeNull()
+    expect(extractLottieThemeData(new TextEncoder().encode('{}'), 'dark')).toBeNull()
+  })
+})
+
+describe('readLottieMarkers', () => {
+  it('reads named markers with start + duration in source frames', () => {
+    const anim = extractLottieAnimation(decodeB64(FIXTURES.themed))
+    expect(readLottieMarkers(anim)).toEqual([
+      { name: 'intro', start: 0, duration: 30 },
+      { name: 'loop', start: 30, duration: 30 },
+      { name: 'cue', start: 59, duration: 0 }, // zero-duration cue point
+    ])
+  })
+
+  it('skips unnamed markers and tolerates missing/negative fields', () => {
+    const markers = readLottieMarkers({
+      markers: [
+        { tm: 10, cm: 'named', dr: 5 },
+        { tm: 20, cm: '   ', dr: 5 }, // blank name -> skipped
+        { tm: 30 }, // no name -> skipped
+        { cm: 'origin' }, // no tm/dr -> defaults to 0/0
+        { tm: -4, cm: 'clamped', dr: -2 }, // negative -> 0/0
+      ],
+    })
+    expect(markers).toEqual([
+      { name: 'named', start: 10, duration: 5 },
+      { name: 'origin', start: 0, duration: 0 },
+      { name: 'clamped', start: 0, duration: 0 },
+    ])
+  })
+
+  it('returns [] when there are no markers or the input is not a Lottie', () => {
+    expect(readLottieMarkers(lottieJson())).toEqual([])
+    expect(readLottieMarkers(null)).toEqual([])
+    expect(readLottieMarkers('nope')).toEqual([])
   })
 })

--- a/src/infrastructure/lottie/lottie-metadata.ts
+++ b/src/infrastructure/lottie/lottie-metadata.ts
@@ -72,53 +72,66 @@ function isZipArchive(bytes: Uint8Array): boolean {
   )
 }
 
+/** The archive entry path for an animation id, or undefined if absent. */
+function animationEntryForId(entries: string[], id: string): string | undefined {
+  // Plain string match (not a manifest-controlled RegExp) to avoid ReDoS and
+  // regex-metacharacter mismatches on the id.
+  const suffix = `animations/${id}.json`.toLowerCase()
+  return entries.find((p) => {
+    const lower = p.toLowerCase()
+    return lower === suffix || lower.endsWith(`/${suffix}`)
+  })
+}
+
 /**
- * Read the first embedded animation's metadata from a `.lottie` (dotLottie ZIP).
+ * Animation JSON entries in a `.lottie` (dotLottie ZIP), best-match first.
  * dotLottie stores animations at `animations/<id>.json` and lists them in
- * `manifest.json`; we honor the manifest order when present, else fall back to
- * the first `animations/*.json` entry.
+ * `manifest.json`. When `preferredId` is given (a user-selected animation) it
+ * is moved to the front; otherwise the manifest's first animation leads, so we
+ * probe the animation that actually plays by default. Shared by metadata
+ * parsing and full-animation extraction.
  */
-function parseDotLottieArchive(bytes: Uint8Array): LottieMetadata | null {
+function orderedAnimationEntries(
+  files: Record<string, Uint8Array>,
+  preferredId?: string,
+): string[] {
+  const animationEntries = Object.keys(files).filter((p) =>
+    /(^|\/)animations\/[^/]+\.json$/i.test(p),
+  )
+  if (animationEntries.length === 0) return []
+
+  const front = (id: string | undefined): string[] | null => {
+    if (!id) return null
+    const entry = animationEntryForId(animationEntries, id)
+    return entry ? [entry, ...animationEntries.filter((p) => p !== entry)] : null
+  }
+
+  const preferred = front(preferredId)
+  if (preferred) return preferred
+
+  const manifestKey = Object.keys(files).find((p) => /(^|\/)manifest\.json$/i.test(p))
+  if (!manifestKey) return animationEntries
+  try {
+    const manifest = JSON.parse(new TextDecoder().decode(files[manifestKey]!)) as {
+      animations?: Array<{ id?: string }>
+    }
+    return front(manifest.animations?.[0]?.id) ?? animationEntries
+  } catch {
+    // ignore a malformed manifest — fall back to entry order
+    return animationEntries
+  }
+}
+
+/** Read an animation's metadata from a `.lottie` (dotLottie ZIP). */
+function parseDotLottieArchive(bytes: Uint8Array, animationId?: string): LottieMetadata | null {
   let files: Record<string, Uint8Array>
   try {
     files = unzipSync(bytes)
   } catch {
     return null
   }
-
   const decoder = new TextDecoder()
-  const animationEntries = Object.keys(files).filter((p) =>
-    /(^|\/)animations\/[^/]+\.json$/i.test(p),
-  )
-  if (animationEntries.length === 0) return null
-
-  // Prefer the manifest's first animation id so we probe the animation that
-  // actually plays by default (matters for multi-animation archives).
-  let orderedEntries = animationEntries
-  const manifestKey = Object.keys(files).find((p) => /(^|\/)manifest\.json$/i.test(p))
-  if (manifestKey) {
-    try {
-      const manifest = JSON.parse(decoder.decode(files[manifestKey]!)) as {
-        animations?: Array<{ id?: string }>
-      }
-      const firstId = manifest.animations?.[0]?.id
-      if (firstId) {
-        // Plain string match (not a manifest-controlled RegExp) to avoid ReDoS
-        // and regex-metacharacter mismatches on the id.
-        const suffix = `animations/${firstId}.json`.toLowerCase()
-        const preferred = animationEntries.find((p) => {
-          const lower = p.toLowerCase()
-          return lower === suffix || lower.endsWith(`/${suffix}`)
-        })
-        if (preferred)
-          orderedEntries = [preferred, ...animationEntries.filter((p) => p !== preferred)]
-      }
-    } catch {
-      // ignore a malformed manifest — fall back to entry order
-    }
-  }
-
-  for (const entry of orderedEntries) {
+  for (const entry of orderedAnimationEntries(files, animationId)) {
     try {
       const meta = parseLottieMetadata(JSON.parse(decoder.decode(files[entry]!)))
       if (meta) return meta
@@ -129,13 +142,273 @@ function parseDotLottieArchive(bytes: Uint8Array): LottieMetadata | null {
   return null
 }
 
+const IMAGE_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  bmp: 'image/bmp',
+}
+
+function mimeFromName(name: string): string {
+  const ext = name.split('.').pop()?.toLowerCase() ?? ''
+  return IMAGE_MIME[ext] ?? 'application/octet-stream'
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunk = 0x8000 // chunk the spread so we never blow the call-stack arg limit
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
+/**
+ * Rewrite a `.lottie` animation's `images/*` assets as inline data URIs, using
+ * the archive's file bytes, so the animation JSON renders standalone (no side
+ * channel). Assets already inlined (`data:`) or missing from the archive are
+ * left untouched.
+ */
+function inlineArchiveImages(
+  data: Record<string, unknown>,
+  files: Record<string, Uint8Array>,
+): void {
+  const assets = data.assets
+  if (!Array.isArray(assets)) return
+  const keys = Object.keys(files)
+  for (const raw of assets) {
+    const asset = raw as { p?: unknown; u?: unknown; e?: unknown }
+    const p = asset?.p
+    if (typeof p !== 'string' || p.startsWith('data:')) continue
+    const dir = typeof asset.u === 'string' ? asset.u : ''
+    const candidates = [`${dir}${p}`, `images/${p}`, p].map((c) => c.toLowerCase())
+    const entry = keys.find((k) => {
+      const lower = k.toLowerCase()
+      return candidates.includes(lower) || candidates.some((c) => lower.endsWith(`/${c}`))
+    })
+    if (!entry) continue
+    try {
+      asset.p = `data:${mimeFromName(p)};base64,${bytesToBase64(files[entry]!)}`
+      asset.u = ''
+      asset.e = 1
+    } catch {
+      // leave the asset reference as-is if encoding fails
+    }
+  }
+}
+
+function asLottieObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && Array.isArray((value as { layers?: unknown }).layers)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * Parse an animation of a Lottie source into a plain object, auto-detecting raw
+ * `.json` vs a `.lottie` ZIP archive. `animationId` selects a specific animation
+ * from a multi-animation archive (falls back to the primary animation when the
+ * id is absent); ignored for raw `.json`. When `inlineImages` is set, embedded
+ * `images/*` archive assets are rewritten as data URIs so the returned JSON
+ * renders standalone — needed to patch and render `.lottie` overrides without
+ * re-zipping. Returns null when the bytes are not a valid Lottie.
+ */
+export function extractLottieAnimation(
+  bytes: Uint8Array,
+  inlineImages = false,
+  animationId?: string,
+): Record<string, unknown> | null {
+  if (isZipArchive(bytes)) {
+    let files: Record<string, Uint8Array>
+    try {
+      files = unzipSync(bytes)
+    } catch {
+      return null
+    }
+    const decoder = new TextDecoder()
+    for (const entry of orderedAnimationEntries(files, animationId)) {
+      try {
+        const data = asLottieObject(JSON.parse(decoder.decode(files[entry]!)))
+        if (!data) continue
+        if (inlineImages) inlineArchiveImages(data, files)
+        return data
+      } catch {
+        // try the next animation entry
+      }
+    }
+    return null
+  }
+  try {
+    return asLottieObject(JSON.parse(new TextDecoder().decode(bytes)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetch a Lottie `src` (blob/URL) and return its primary animation as a plain
+ * object, auto-detecting `.json` vs `.lottie`. See {@link extractLottieAnimation}
+ * for `inlineImages`. Returns null on any fetch/parse failure.
+ */
+export async function fetchLottieAnimation(
+  src: string,
+  inlineImages = false,
+  animationId?: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const buffer = await (await fetch(src)).arrayBuffer()
+    return extractLottieAnimation(new Uint8Array(buffer), inlineImages, animationId)
+  } catch {
+    return null
+  }
+}
+
+// --- Manifest, themes, markers (dotLottie packaging metadata) ----------------
+// A `.lottie` archive can bundle several animations, named color/text *themes*
+// (rule sets targeting the animation's slots), and each animation can carry
+// named *markers* (labelled frame ranges). We surface these so the editor can
+// offer animation/theme pickers and marker-based segment selection.
+
+/** A named animation in a dotLottie archive. */
+export interface LottieAnimationEntry {
+  id: string
+}
+
+/** dotLottie manifest summary: the animations and themes it bundles. */
+export interface LottieManifestInfo {
+  animations: LottieAnimationEntry[]
+  /** Theme ids applicable across the archive. */
+  themes: string[]
+}
+
+/** A labelled frame range inside a Lottie animation (`markers[]`). */
+export interface LottieMarker {
+  name: string
+  /** First frame of the marked range (source frames). */
+  start: number
+  /** Length of the marked range in source frames (0 = a single-frame cue). */
+  duration: number
+}
+
+function readArchiveFiles(bytes: Uint8Array): Record<string, Uint8Array> | null {
+  if (!isZipArchive(bytes)) return null
+  try {
+    return unzipSync(bytes)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Summarize a `.lottie` archive's manifest: its animation ids and theme ids.
+ * Returns null for raw `.json` (no manifest) or an unreadable/absent manifest.
+ * Theme ids come from the top-level `themes[]`, unioned with any referenced by
+ * individual animations, so a picker sees every theme regardless of nesting.
+ */
+export function extractLottieManifest(bytes: Uint8Array): LottieManifestInfo | null {
+  const files = readArchiveFiles(bytes)
+  if (!files) return null
+  const manifestKey = Object.keys(files).find((p) => /(^|\/)manifest\.json$/i.test(p))
+  if (!manifestKey) return null
+  try {
+    const manifest = JSON.parse(new TextDecoder().decode(files[manifestKey]!)) as {
+      animations?: Array<{ id?: unknown; themes?: unknown }>
+      themes?: Array<{ id?: unknown }>
+    }
+    const animations: LottieAnimationEntry[] = []
+    const themeIds = new Set<string>()
+    for (const raw of manifest.themes ?? []) {
+      if (typeof raw?.id === 'string' && raw.id) themeIds.add(raw.id)
+    }
+    for (const raw of manifest.animations ?? []) {
+      if (typeof raw?.id !== 'string' || !raw.id) continue
+      animations.push({ id: raw.id })
+      if (Array.isArray(raw.themes)) {
+        for (const t of raw.themes) if (typeof t === 'string' && t) themeIds.add(t)
+      }
+    }
+    if (animations.length === 0 && themeIds.size === 0) return null
+    return { animations, themes: [...themeIds] }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read a theme's rule JSON (`{ rules: [...] }`) from a `.lottie` archive, ready
+ * to hand to dotlottie's `setThemeData`. dotLottie stores themes at
+ * `themes/<id>.json`. Returns null when the archive or theme is absent.
+ */
+export function extractLottieThemeData(bytes: Uint8Array, themeId: string): string | null {
+  const files = readArchiveFiles(bytes)
+  if (!files) return null
+  const suffix = `themes/${themeId}.json`.toLowerCase()
+  const key = Object.keys(files).find((p) => {
+    const lower = p.toLowerCase()
+    return lower === suffix || lower.endsWith(`/${suffix}`)
+  })
+  if (!key) return null
+  try {
+    return new TextDecoder().decode(files[key]!)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the named markers of an already-parsed Lottie animation object. Lottie
+ * stores markers at the top-level `markers[]` as `{ tm, cm, dr }` (time,
+ * comment/name, duration — all in source frames). Unnamed markers are skipped.
+ */
+export function readLottieMarkers(animation: unknown): LottieMarker[] {
+  const markers = (animation as { markers?: unknown } | null)?.markers
+  if (!Array.isArray(markers)) return []
+  const result: LottieMarker[] = []
+  for (const raw of markers) {
+    const m = raw as { tm?: unknown; cm?: unknown; dr?: unknown }
+    const name = typeof m?.cm === 'string' ? m.cm.trim() : ''
+    if (!name) continue
+    const start = typeof m.tm === 'number' && m.tm >= 0 ? m.tm : 0
+    const duration = typeof m.dr === 'number' && m.dr > 0 ? m.dr : 0
+    result.push({ name, start, duration })
+  }
+  return result
+}
+
+/** Fetch a Lottie `src` and summarize its dotLottie manifest. Null on failure. */
+export async function fetchLottieManifest(src: string): Promise<LottieManifestInfo | null> {
+  try {
+    const buffer = await (await fetch(src)).arrayBuffer()
+    return extractLottieManifest(new Uint8Array(buffer))
+  } catch {
+    return null
+  }
+}
+
+/** Fetch a Lottie `src` and read a theme's rule JSON. Null on failure/absence. */
+export async function fetchLottieThemeData(src: string, themeId: string): Promise<string | null> {
+  try {
+    const buffer = await (await fetch(src)).arrayBuffer()
+    return extractLottieThemeData(new Uint8Array(buffer), themeId)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Extract Lottie metadata from raw file bytes, auto-detecting `.json` vs the
- * `.lottie` ZIP archive. Returns null when the bytes are not a valid Lottie.
+ * `.lottie` ZIP archive. When `animationId` is given, reads that animation's
+ * timing from a multi-animation archive (else the primary animation). Returns
+ * null when the bytes are not a valid Lottie.
  */
-export function parseLottieFileBytes(bytes: Uint8Array): LottieMetadata | null {
+export function parseLottieFileBytes(
+  bytes: Uint8Array,
+  animationId?: string,
+): LottieMetadata | null {
   if (isZipArchive(bytes)) {
-    return parseDotLottieArchive(bytes)
+    return parseDotLottieArchive(bytes, animationId)
   }
   try {
     return parseLottieMetadata(new TextDecoder().decode(bytes))

--- a/src/infrastructure/lottie/lottie-slots.test.ts
+++ b/src/infrastructure/lottie/lottie-slots.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { extractLottieValueSlots } from './lottie-slots'
+
+// An animation whose `slots` table mixes every value shape: a static scalar, an
+// animated scalar (read from its first keyframe), a static 2D vector, plus a
+// color (RGBA), a gradient (object) and a text document — the last three must be
+// ignored here (handled by lottie-color / lottie-text).
+function slotted() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    op: 60,
+    slots: {
+      opacity: { p: { a: 0, k: 80 } },
+      spin: {
+        p: {
+          a: 1,
+          k: [
+            { t: 0, s: 45 },
+            { t: 30, s: 360 },
+          ],
+        },
+      },
+      offset: { p: { a: 0, k: [12, -4] } },
+      accent: { p: { a: 0, k: [1, 0, 0, 1] } }, // color -> skipped
+      ramp: { p: { a: 0, k: { p: 2, k: [0, 1, 0, 0, 1, 0, 0, 1] } } }, // gradient -> skipped
+      headline: { p: { a: 0, k: { t: 'Hi' } } }, // text -> skipped
+    },
+    layers: [{ ty: 4, shapes: [] }],
+  }
+}
+
+describe('extractLottieValueSlots', () => {
+  it('surfaces static + animated scalars and 2D vectors, skipping color/gradient/text', () => {
+    expect(extractLottieValueSlots(slotted())).toEqual([
+      { id: 'opacity', type: 'scalar', label: 'opacity', value: 80 },
+      { id: 'spin', type: 'scalar', label: 'spin', value: 45 }, // first keyframe
+      { id: 'offset', type: 'vector', label: 'offset', value: [12, -4] },
+    ])
+  })
+
+  it('prefers a slot name over its id for the label', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      slots: { s1: { nm: 'Stroke width', p: { a: 0, k: 4 } } },
+      layers: [{ ty: 4, shapes: [] }],
+    }
+    expect(extractLottieValueSlots(anim)[0]).toEqual({
+      id: 's1',
+      type: 'scalar',
+      label: 'Stroke width',
+      value: 4,
+    })
+  })
+
+  it('accepts a JSON string and returns [] for slotless / non-Lottie input', () => {
+    expect(extractLottieValueSlots(JSON.stringify(slotted()))).toHaveLength(3)
+    expect(extractLottieValueSlots({ w: 1, h: 1, layers: [] })).toEqual([])
+    expect(extractLottieValueSlots('not json')).toEqual([])
+    expect(extractLottieValueSlots(null)).toEqual([])
+  })
+
+  it('ignores a length-3 array (ambiguous with RGB) and malformed slot props', () => {
+    const anim = {
+      w: 1,
+      h: 1,
+      fr: 30,
+      op: 1,
+      slots: {
+        vec3: { p: { a: 0, k: [1, 2, 3] } }, // 3D/ RGB ambiguity -> skipped
+        broken: { p: { a: 1, k: [] } }, // animated, no keyframe -> skipped
+        empty: {}, // no prop -> skipped
+      },
+      layers: [{ ty: 4, shapes: [] }],
+    }
+    expect(extractLottieValueSlots(anim)).toEqual([])
+  })
+})

--- a/src/infrastructure/lottie/lottie-slots.ts
+++ b/src/infrastructure/lottie/lottie-slots.ts
@@ -1,0 +1,100 @@
+/**
+ * WASM-free discovery of a Lottie's editable *value* slots — the numeric
+ * (`scalar`) and 2D (`vector`) entries of its top-level `slots` table. Unlike
+ * colors and text (which we bake into the animation JSON), these are applied at
+ * render time through dotlottie-web's native slot setters (`setScalarSlot` /
+ * `setVectorSlot`), the only reliable path for them. Color, gradient and text
+ * slots are handled elsewhere (see `lottie-color` / `lottie-text`) and skipped
+ * here.
+ *
+ * Slot type is inferred from the default value's shape: a number is a scalar; a
+ * length-2 number array is a vector. Length 3–4 arrays (RGB/RGBA colors) and
+ * object values (gradients/text documents) are intentionally left out so a color
+ * slot is never mistaken for a vector.
+ */
+
+/** A scalar (single number) or 2D vector value carried by a value slot. */
+export type LottieSlotValue = number | [number, number]
+
+interface LottieSlotBase {
+  /** Slot id, addressing the override (`setScalarSlot`/`setVectorSlot`). */
+  id: string
+  /** Human-readable label (the slot's name, or its id). */
+  label: string
+}
+/** An editable single-number slot (opacity, rotation, stroke width, …). */
+export interface LottieScalarSlot extends LottieSlotBase {
+  type: 'scalar'
+  /** Current default value (static, or the first keyframe of an animated slot). */
+  value: number
+}
+/** An editable 2D slot (position, scale, size, …). */
+export interface LottieVectorSlot extends LottieSlotBase {
+  type: 'vector'
+  /** Current default `[x, y]` (static, or the first keyframe if animated). */
+  value: [number, number]
+}
+/** An editable numeric/2D slot discovered in a Lottie animation. */
+export type LottieValueSlot = LottieScalarSlot | LottieVectorSlot
+
+interface SlotProp {
+  a?: unknown
+  k?: unknown
+}
+interface SlotDef {
+  p?: SlotProp
+  nm?: unknown
+}
+
+function parseJson(json: unknown): Record<string, unknown> | null {
+  if (typeof json === 'string') {
+    try {
+      return JSON.parse(json) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+  return json && typeof json === 'object' ? (json as Record<string, unknown>) : null
+}
+
+function isVec2(v: unknown): v is [number, number] {
+  return Array.isArray(v) && v.length === 2 && typeof v[0] === 'number' && typeof v[1] === 'number'
+}
+
+/** The static value of a slot property, resolving the first keyframe if animated. */
+function slotStaticValue(p: SlotProp | undefined): unknown {
+  if (!p || typeof p !== 'object') return undefined
+  if (p.a === 1) {
+    const first = Array.isArray(p.k) ? (p.k[0] as { s?: unknown } | undefined) : undefined
+    return first?.s
+  }
+  return p.k
+}
+
+function trimmedName(v: unknown): string {
+  return typeof v === 'string' && v.trim() ? v.trim() : ''
+}
+
+/**
+ * List the editable scalar/vector value slots of a Lottie animation object,
+ * keyed by slot id. Returns an empty array for animations with no such slots or
+ * for unparseable input.
+ */
+export function extractLottieValueSlots(json: unknown): LottieValueSlot[] {
+  const data = parseJson(json)
+  const slots = data?.slots
+  if (!slots || typeof slots !== 'object') return []
+
+  const result: LottieValueSlot[] = []
+  for (const [id, def] of Object.entries(slots as Record<string, SlotDef>)) {
+    const value = slotStaticValue(def?.p)
+    const label = trimmedName(def?.nm) || id
+    if (typeof value === 'number') {
+      result.push({ id, type: 'scalar', label, value })
+    } else if (isVec2(value)) {
+      result.push({ id, type: 'vector', label, value: [value[0], value[1]] })
+    }
+    // Colors (len 3–4), gradients and text (objects) are handled elsewhere.
+  }
+  return result
+}

--- a/src/infrastructure/lottie/lottie-text.test.ts
+++ b/src/infrastructure/lottie/lottie-text.test.ts
@@ -50,3 +50,38 @@ describe('applyLottieTextOverrides', () => {
     expect(applyLottieTextOverrides(animation(), { '0': 'x' })).toBeNull()
   })
 })
+
+// A themeable animation: a `headline` text slot whose live value is in the slot
+// document, referenced by a text layer via `t.d.sid` (with its own fallback).
+function slottedText() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    ip: 0,
+    op: 60,
+    slots: { headline: { p: { a: 1, k: [{ t: 0, s: { t: 'Hello Slot' } }] } } },
+    layers: [
+      { ty: 4, nm: 'Shape' },
+      { ty: 5, nm: 'Title', t: { d: { sid: 'headline', k: [{ s: { t: 'FALLBACK' } }] } } },
+      { ty: 5, t: { d: { k: [{ s: { t: 'Plain' } }] } } },
+    ],
+  }
+}
+
+describe('text slots', () => {
+  it('reads the slot value (not the layer fallback) and hides the bound layer', () => {
+    expect(extractLottieTextLayers(slottedText())).toEqual([
+      { key: 's:headline', text: 'Hello Slot', label: 'headline' },
+      { key: '2', text: 'Plain', label: 'Text 3' }, // unbound layer still listed
+    ])
+  })
+
+  it('writes the slot document and every bound layer', () => {
+    const parsed = JSON.parse(applyLottieTextOverrides(slottedText(), { 's:headline': 'Changed' })!)
+    expect(parsed.slots.headline.p.k[0].s.t).toBe('Changed') // slot document
+    expect(parsed.layers[1].t.d.k[0].s.t).toBe('Changed') // bound layer fallback baked
+    expect(parsed.layers[2].t.d.k[0].s.t).toBe('Plain') // unbound layer untouched
+  })
+})

--- a/src/infrastructure/lottie/lottie-text.test.ts
+++ b/src/infrastructure/lottie/lottie-text.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { extractLottieTextLayers, applyLottieTextOverrides } from './lottie-text'
+
+// Minimal Lottie with two text layers (ty:5) and one shape layer (ty:4).
+function animation() {
+  return {
+    v: '5.7.0',
+    w: 100,
+    h: 100,
+    fr: 30,
+    ip: 0,
+    op: 60,
+    layers: [
+      { ty: 4, nm: 'Shape' },
+      { ty: 5, nm: 'Title', t: { d: { k: [{ s: { t: 'Hello' } }] } } },
+      { ty: 5, t: { d: { k: [{ s: { t: 'Subtitle' } }] } } },
+    ],
+  }
+}
+
+describe('extractLottieTextLayers', () => {
+  it('returns text layers with stable keys and labels, skipping non-text layers', () => {
+    expect(extractLottieTextLayers(animation())).toEqual([
+      { key: '1', text: 'Hello', label: 'Title' },
+      { key: '2', text: 'Subtitle', label: 'Text 3' },
+    ])
+  })
+
+  it('accepts a JSON string and returns [] for non-Lottie input', () => {
+    expect(extractLottieTextLayers(JSON.stringify(animation()))).toHaveLength(2)
+    expect(extractLottieTextLayers('not json')).toEqual([])
+    expect(extractLottieTextLayers({ foo: 'bar' })).toEqual([])
+  })
+})
+
+describe('applyLottieTextOverrides', () => {
+  it('patches only the addressed text layer and preserves others', () => {
+    const patched = applyLottieTextOverrides(animation(), { '1': 'Goodbye' })
+    expect(patched).not.toBeNull()
+    const parsed = JSON.parse(patched!)
+    expect(parsed.layers[1].t.d.k[0].s.t).toBe('Goodbye')
+    expect(parsed.layers[2].t.d.k[0].s.t).toBe('Subtitle')
+  })
+
+  it('returns null when there is nothing to change', () => {
+    expect(applyLottieTextOverrides(animation(), {})).toBeNull()
+    // Unknown key → no change.
+    expect(applyLottieTextOverrides(animation(), { '99': 'x' })).toBeNull()
+    // Non-text layer index → no change.
+    expect(applyLottieTextOverrides(animation(), { '0': 'x' })).toBeNull()
+  })
+})

--- a/src/infrastructure/lottie/lottie-text.ts
+++ b/src/infrastructure/lottie/lottie-text.ts
@@ -198,6 +198,8 @@ export interface LottieRenderInput {
   themeId?: string
   textOverrides?: Record<string, string>
   colorOverrides?: Record<string, string>
+  /** Scalar/vector slot overrides applied natively after load (id → value). */
+  slotOverrides?: Record<string, number | [number, number]>
 }
 
 /** Everything the renderer needs beyond `src` to reflect the item's edits. */
@@ -209,6 +211,8 @@ export interface LottieRenderSpec {
   data: string | null
   /** Theme rule JSON to apply via `setThemeData` after load, or null. */
   themeData: string | null
+  /** Scalar/vector slot overrides applied natively after load, or null. */
+  slots: Record<string, number | [number, number]> | null
 }
 
 /**
@@ -246,5 +250,7 @@ export async function resolveLottieRenderSpec(
   }
 
   const themeData = input.themeId ? await fetchLottieThemeData(src, input.themeId) : null
-  return { data, themeData }
+  const slots =
+    input.slotOverrides && Object.keys(input.slotOverrides).length > 0 ? input.slotOverrides : null
+  return { data, themeData, slots }
 }

--- a/src/infrastructure/lottie/lottie-text.ts
+++ b/src/infrastructure/lottie/lottie-text.ts
@@ -1,0 +1,122 @@
+/**
+ * WASM-free helpers for reading and overriding text layers in a raw Lottie
+ * (`.json`) animation. Lottie text layers have `ty === 5` and store their string
+ * at `layer.t.d.k[*].s.t`. Kept separate from the dotlottie renderer so the
+ * import/editing path can inspect and patch text without loading the WASM.
+ *
+ * Only top-level layers of raw `.json` Lotties are handled — nested precomp
+ * assets and `.lottie` ZIP archives are out of scope.
+ */
+
+/** A single editable text layer discovered in a Lottie animation. */
+export interface LottieTextLayer {
+  /** Stable key (the layer's index) used to address the override. */
+  key: string
+  /** Current text content. */
+  text: string
+  /** Human-readable label (the layer name, or a positional fallback). */
+  label: string
+}
+
+interface LottieTextData {
+  d?: { k?: Array<{ s?: { t?: unknown } }> }
+}
+interface LottieLayer {
+  ty?: unknown
+  nm?: unknown
+  t?: LottieTextData
+}
+
+function parseJson(json: unknown): Record<string, unknown> | null {
+  if (typeof json === 'string') {
+    try {
+      return JSON.parse(json) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+  return json && typeof json === 'object' ? (json as Record<string, unknown>) : null
+}
+
+function firstTextString(layer: LottieLayer): string | null {
+  const keyframes = layer.t?.d?.k
+  if (!Array.isArray(keyframes)) return null
+  for (const kf of keyframes) {
+    if (typeof kf?.s?.t === 'string') return kf.s.t
+  }
+  return null
+}
+
+/**
+ * List the editable text layers of a raw Lottie animation, in document order.
+ * Returns an empty array for non-text or unparseable input.
+ */
+export function extractLottieTextLayers(json: unknown): LottieTextLayer[] {
+  const data = parseJson(json)
+  const layers = data?.layers
+  if (!Array.isArray(layers)) return []
+
+  const result: LottieTextLayer[] = []
+  layers.forEach((raw, index) => {
+    const layer = raw as LottieLayer
+    if (layer?.ty !== 5) return
+    const text = firstTextString(layer)
+    if (text === null) return
+    const name = typeof layer.nm === 'string' && layer.nm.trim() ? layer.nm.trim() : ''
+    result.push({ key: String(index), text, label: name || `Text ${index + 1}` })
+  })
+  return result
+}
+
+/**
+ * Apply per-layer text overrides to a raw Lottie animation and return the
+ * patched JSON string. Overrides are keyed by layer index (see
+ * {@link extractLottieTextLayers}); unknown keys are ignored. Returns null when
+ * the input can't be parsed or has no layers to patch.
+ */
+export function applyLottieTextOverrides(
+  json: unknown,
+  overrides: Record<string, string>,
+): string | null {
+  const data = parseJson(json)
+  const layers = data?.layers
+  if (!Array.isArray(layers)) return null
+  if (Object.keys(overrides).length === 0) return null
+
+  let changed = false
+  layers.forEach((raw, index) => {
+    const override = overrides[String(index)]
+    if (override === undefined) return
+    const layer = raw as LottieLayer
+    if (layer?.ty !== 5) return
+    const keyframes = layer.t?.d?.k
+    if (!Array.isArray(keyframes)) return
+    for (const kf of keyframes) {
+      if (kf?.s && typeof kf.s.t === 'string') {
+        kf.s.t = override
+        changed = true
+      }
+    }
+  })
+
+  return changed ? JSON.stringify(data) : null
+}
+
+/**
+ * Fetch a Lottie's source JSON and return it patched with `overrides`, or null
+ * when there are no overrides, the source can't be read, or it isn't a raw
+ * `.json` Lottie (e.g. a `.lottie` archive). Callers fall back to loading `src`
+ * directly on null. Shared by the preview and export render paths.
+ */
+export async function resolveLottieOverrideData(
+  src: string,
+  overrides: Record<string, string> | undefined,
+): Promise<string | null> {
+  if (!overrides || Object.keys(overrides).length === 0) return null
+  try {
+    const text = await (await fetch(src)).text()
+    return applyLottieTextOverrides(text, overrides)
+  } catch {
+    return null
+  }
+}

--- a/src/infrastructure/lottie/lottie-text.ts
+++ b/src/infrastructure/lottie/lottie-text.ts
@@ -1,12 +1,17 @@
 /**
- * WASM-free helpers for reading and overriding text layers in a raw Lottie
- * (`.json`) animation. Lottie text layers have `ty === 5` and store their string
+ * WASM-free helpers for reading and overriding text layers in a Lottie
+ * animation object. Lottie text layers have `ty === 5` and store their string
  * at `layer.t.d.k[*].s.t`. Kept separate from the dotlottie renderer so the
  * import/editing path can inspect and patch text without loading the WASM.
  *
- * Only top-level layers of raw `.json` Lotties are handled — nested precomp
- * assets and `.lottie` ZIP archives are out of scope.
+ * The extract/apply helpers take an already-parsed animation object; the source
+ * may be a raw `.json` or a `.lottie` archive (see `extractLottieAnimation` /
+ * `fetchLottieAnimation`). Author-defined text *slots* (a top-level `slots`
+ * table referenced by `t.d.sid`) are surfaced and patched too (keyed `s:<id>`).
+ * Only top-level text layers are handled — nested precomp assets are out of scope.
  */
+import { applyLottieColorOverrides } from './lottie-color'
+import { fetchLottieAnimation, fetchLottieThemeData } from './lottie-metadata'
 
 /** A single editable text layer discovered in a Lottie animation. */
 export interface LottieTextLayer {
@@ -18,13 +23,20 @@ export interface LottieTextLayer {
   label: string
 }
 
+interface TextDocument {
+  t?: unknown
+}
 interface LottieTextData {
-  d?: { k?: Array<{ s?: { t?: unknown } }> }
+  d?: { k?: Array<{ s?: TextDocument }>; sid?: unknown }
 }
 interface LottieLayer {
   ty?: unknown
   nm?: unknown
   t?: LottieTextData
+}
+interface SlotDef {
+  p?: { a?: unknown; k?: unknown; p?: { t?: unknown } }
+  nm?: unknown
 }
 
 function parseJson(json: unknown): Record<string, unknown> | null {
@@ -47,19 +59,89 @@ function firstTextString(layer: LottieLayer): string | null {
   return null
 }
 
+// --- Lottie text slots -------------------------------------------------------
+// A themeable Lottie keeps editable copy in a top-level `slots` table; text
+// layers point at it via `t.d.sid`. The editable string lives at
+// `slots[id].p.k[0].s.t` (plus an older `slots[id].p.p.t` fallback), and each
+// bound layer carries its own `t.d.k[*].s.t` fallback. We surface these as
+// entries keyed `s:<id>` and, on write, patch the slot document AND every bound
+// layer so the change renders whether or not the renderer resolves slots.
+
+function slotTextDocument(k: unknown): TextDocument | undefined {
+  if (!Array.isArray(k)) return undefined
+  return (k[0] as { s?: TextDocument } | undefined)?.s
+}
+
+function boundTextLayers(data: Record<string, unknown>, slotId: string): LottieLayer[] {
+  const layers = data.layers
+  if (!Array.isArray(layers)) return []
+  return (layers as LottieLayer[]).filter((l) => l?.ty === 5 && l.t?.d?.sid === slotId)
+}
+
+function readSlotText(data: Record<string, unknown>, slotId: string): string | undefined {
+  const p = (data.slots as Record<string, SlotDef> | undefined)?.[slotId]?.p
+  const slotText = slotTextDocument(p?.k)?.t
+  if (typeof slotText === 'string') return slotText
+  if (typeof p?.p?.t === 'string') return p.p.t
+  for (const layer of boundTextLayers(data, slotId)) {
+    const layerText = slotTextDocument(layer.t?.d?.k)?.t
+    if (typeof layerText === 'string') return layerText
+  }
+  return undefined
+}
+
+function writeSlotText(data: Record<string, unknown>, slotId: string, text: string): boolean {
+  let changed = false
+  const p = (data.slots as Record<string, SlotDef> | undefined)?.[slotId]?.p
+  const slotDoc = slotTextDocument(p?.k)
+  if (slotDoc) {
+    slotDoc.t = text
+    changed = true
+  }
+  if (p?.p && typeof p.p === 'object') {
+    p.p.t = text
+    changed = true
+  }
+  for (const layer of boundTextLayers(data, slotId)) {
+    const layerDoc = slotTextDocument(layer.t?.d?.k)
+    if (layerDoc) {
+      layerDoc.t = text
+      changed = true
+    }
+  }
+  return changed
+}
+
+/** Editable text slots (only slots whose value resolves to a string). */
+function slotTextLayers(data: Record<string, unknown>): LottieTextLayer[] {
+  const slots = data.slots
+  if (!slots || typeof slots !== 'object') return []
+  const result: LottieTextLayer[] = []
+  for (const [id, def] of Object.entries(slots as Record<string, SlotDef>)) {
+    const text = readSlotText(data, id)
+    if (typeof text !== 'string') continue
+    const name = typeof def?.nm === 'string' && def.nm.trim() ? def.nm.trim() : ''
+    result.push({ key: `s:${id}`, text, label: name || id })
+  }
+  return result
+}
+
 /**
- * List the editable text layers of a raw Lottie animation, in document order.
- * Returns an empty array for non-text or unparseable input.
+ * List the editable text of a Lottie animation object. Author-defined text
+ * slots come first (keyed `s:<id>`), then every unbound text layer in document
+ * order (keyed by index). Slot-bound layers are omitted here — they're edited
+ * through their slot. Returns an empty array for non-text or unparseable input.
  */
 export function extractLottieTextLayers(json: unknown): LottieTextLayer[] {
   const data = parseJson(json)
   const layers = data?.layers
-  if (!Array.isArray(layers)) return []
+  if (!data || !Array.isArray(layers)) return []
 
-  const result: LottieTextLayer[] = []
+  const result: LottieTextLayer[] = slotTextLayers(data)
   layers.forEach((raw, index) => {
     const layer = raw as LottieLayer
     if (layer?.ty !== 5) return
+    if (typeof layer.t?.d?.sid === 'string') return // slot-bound; shown as a slot
     const text = firstTextString(layer)
     if (text === null) return
     const name = typeof layer.nm === 'string' && layer.nm.trim() ? layer.nm.trim() : ''
@@ -80,15 +162,21 @@ export function applyLottieTextOverrides(
 ): string | null {
   const data = parseJson(json)
   const layers = data?.layers
-  if (!Array.isArray(layers)) return null
+  if (!data || !Array.isArray(layers)) return null
   if (Object.keys(overrides).length === 0) return null
 
   let changed = false
+  // Slot overrides (keyed `s:<id>`): patch the slot document + bound layers.
+  for (const [key, value] of Object.entries(overrides)) {
+    if (!key.startsWith('s:')) continue
+    if (writeSlotText(data, key.slice(2), value)) changed = true
+  }
   layers.forEach((raw, index) => {
     const override = overrides[String(index)]
     if (override === undefined) return
     const layer = raw as LottieLayer
     if (layer?.ty !== 5) return
+    if (typeof layer.t?.d?.sid === 'string') return // handled via its slot
     const keyframes = layer.t?.d?.k
     if (!Array.isArray(keyframes)) return
     for (const kf of keyframes) {
@@ -102,21 +190,61 @@ export function applyLottieTextOverrides(
   return changed ? JSON.stringify(data) : null
 }
 
+/** The animation-level selections + overrides that shape a Lottie render. */
+export interface LottieRenderInput {
+  /** Selected animation id in a multi-animation `.lottie` (default: primary). */
+  animationId?: string
+  /** Selected dotLottie theme id, applied via `setThemeData` after load. */
+  themeId?: string
+  textOverrides?: Record<string, string>
+  colorOverrides?: Record<string, string>
+}
+
+/** Everything the renderer needs beyond `src` to reflect the item's edits. */
+export interface LottieRenderSpec {
+  /**
+   * Patched/selected animation JSON to load as `data`, or null to load `src`
+   * directly (nothing to patch and the primary animation is selected).
+   */
+  data: string | null
+  /** Theme rule JSON to apply via `setThemeData` after load, or null. */
+  themeData: string | null
+}
+
 /**
- * Fetch a Lottie's source JSON and return it patched with `overrides`, or null
- * when there are no overrides, the source can't be read, or it isn't a raw
- * `.json` Lottie (e.g. a `.lottie` archive). Callers fall back to loading `src`
- * directly on null. Shared by the preview and export render paths.
+ * Resolve a Lottie item's render spec from its source: the animation JSON to
+ * load (patched with text/color overrides and/or a selected animation) and any
+ * theme data to apply after load. Handles both raw `.json` and `.lottie` ZIP
+ * archives (images are inlined so the patched JSON renders standalone). Shared
+ * by the preview and export render paths so edits apply identically in both.
+ *
+ * `data` is null when nothing needs patching and the primary animation is
+ * selected — the caller then loads `src` directly (cheapest path). A theme-only
+ * edit keeps `data` null and just carries `themeData`, since a theme applies to
+ * the src-loaded animation's slots without re-extraction.
  */
-export async function resolveLottieOverrideData(
+export async function resolveLottieRenderSpec(
   src: string,
-  overrides: Record<string, string> | undefined,
-): Promise<string | null> {
-  if (!overrides || Object.keys(overrides).length === 0) return null
-  try {
-    const text = await (await fetch(src)).text()
-    return applyLottieTextOverrides(text, overrides)
-  } catch {
-    return null
+  input: LottieRenderInput,
+): Promise<LottieRenderSpec> {
+  const hasText = !!input.textOverrides && Object.keys(input.textOverrides).length > 0
+  const hasColor = !!input.colorOverrides && Object.keys(input.colorOverrides).length > 0
+  // Extract/patch the animation JSON only when overrides apply or a specific
+  // (non-primary) animation is selected; a theme alone rides on the src load.
+  const needsData = hasText || hasColor || !!input.animationId
+
+  let data: string | null = null
+  if (needsData) {
+    // Inline archive images so the patched JSON is self-contained for the renderer.
+    const animation = await fetchLottieAnimation(src, true, input.animationId)
+    if (animation) {
+      // Appliers mutate the object in place; we re-serialize once at the end.
+      if (hasText) applyLottieTextOverrides(animation, input.textOverrides!)
+      if (hasColor) applyLottieColorOverrides(animation, input.colorOverrides!)
+      data = JSON.stringify(animation)
+    }
   }
+
+  const themeData = input.themeId ? await fetchLottieThemeData(src, input.themeId) : null
+  return { data, themeData }
 }

--- a/src/runtime/composition-runtime/components/composition-content.keyframes.test.tsx
+++ b/src/runtime/composition-runtime/components/composition-content.keyframes.test.tsx
@@ -302,45 +302,6 @@ describe('CompositionContent keyframes', () => {
     expect(screen.getByTestId('sub-item-sub-audio-audio-only')).toBeInTheDocument()
   })
 
-  it('lays out nested composition visuals at the parent size without a transformed clip wrapper', () => {
-    const subComp = makeTestSubComposition({
-      id: 'sub-comp-direct-layout',
-      name: 'Direct layout precomp',
-      width: 1920,
-      height: 1080,
-      items: [makeNestedVideoItem({ id: 'sub-video-direct-layout' })],
-    })
-
-    storeTestSubComposition(subComp)
-
-    const compositionItem = makeParentCompositionItem({
-      id: 'parent-comp-item-direct-layout',
-      compositionId: subComp.id,
-      compositionWidth: 1920,
-      compositionHeight: 1080,
-    })
-
-    const { container } = render(
-      <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
-        <CompositionContent item={compositionItem} />
-      </VideoConfigProvider>,
-    )
-
-    const styles = Array.from(container.querySelectorAll('div[style]')).map(
-      (element) => element.getAttribute('style') ?? '',
-    )
-
-    expect(styles.some((style) => style.includes('transform: scale('))).toBe(false)
-    expect(
-      styles.some(
-        (style) =>
-          style.includes('width: 1280px') &&
-          style.includes('height: 720px') &&
-          style.includes('overflow: hidden'),
-      ),
-    ).toBe(true)
-  })
-
   it('clears stale nested media src until fresh blob urls exist', () => {
     const subComp = makeTestSubComposition({
       id: 'sub-comp-stale-audio',

--- a/src/runtime/composition-runtime/components/composition-content.keyframes.test.tsx
+++ b/src/runtime/composition-runtime/components/composition-content.keyframes.test.tsx
@@ -302,6 +302,45 @@ describe('CompositionContent keyframes', () => {
     expect(screen.getByTestId('sub-item-sub-audio-audio-only')).toBeInTheDocument()
   })
 
+  it('lays out nested composition visuals at the parent size without a transformed clip wrapper', () => {
+    const subComp = makeTestSubComposition({
+      id: 'sub-comp-direct-layout',
+      name: 'Direct layout precomp',
+      width: 1920,
+      height: 1080,
+      items: [makeNestedVideoItem({ id: 'sub-video-direct-layout' })],
+    })
+
+    storeTestSubComposition(subComp)
+
+    const compositionItem = makeParentCompositionItem({
+      id: 'parent-comp-item-direct-layout',
+      compositionId: subComp.id,
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+    })
+
+    const { container } = render(
+      <VideoConfigProvider fps={30} width={1280} height={720} durationInFrames={120}>
+        <CompositionContent item={compositionItem} />
+      </VideoConfigProvider>,
+    )
+
+    const styles = Array.from(container.querySelectorAll('div[style]')).map(
+      (element) => element.getAttribute('style') ?? '',
+    )
+
+    expect(styles.some((style) => style.includes('transform: scale('))).toBe(false)
+    expect(
+      styles.some(
+        (style) =>
+          style.includes('width: 1280px') &&
+          style.includes('height: 720px') &&
+          style.includes('overflow: hidden'),
+      ),
+    ).toBe(true)
+  })
+
   it('clears stale nested media src until fresh blob urls exist', () => {
     const subComp = makeTestSubComposition({
       id: 'sub-comp-stale-audio',

--- a/src/runtime/composition-runtime/components/composition-content.tsx
+++ b/src/runtime/composition-runtime/components/composition-content.tsx
@@ -539,14 +539,17 @@ export const CompositionContent = React.memo<CompositionContentProps>(
       )
     }
 
-    const containerRenderWidth = Math.max(1, containerDims.width)
-    const containerRenderHeight = Math.max(1, containerDims.height)
+    // CSS scale from sub-comp native resolution to parent container dimensions
+    const scaleX = subComp.width > 0 ? containerDims.width / subComp.width : 1
+    const scaleY = subComp.height > 0 ? containerDims.height / subComp.height : 1
 
     return (
       <div
         style={{
-          width: containerRenderWidth,
-          height: containerRenderHeight,
+          width: subComp.width,
+          height: subComp.height,
+          transform: `scale(${scaleX}, ${scaleY})`,
+          transformOrigin: '0 0',
           overflow: 'hidden',
           position: 'relative',
           visibility: parentVisible ? 'visible' : 'hidden',
@@ -555,12 +558,12 @@ export const CompositionContent = React.memo<CompositionContentProps>(
         <CompositionSpaceProvider
           projectWidth={subComp.width}
           projectHeight={subComp.height}
-          renderWidth={containerRenderWidth}
-          renderHeight={containerRenderHeight}
+          renderWidth={subComp.width}
+          renderHeight={subComp.height}
         >
           <VideoConfigProvider
-            width={containerRenderWidth}
-            height={containerRenderHeight}
+            width={subComp.width}
+            height={subComp.height}
             fps={subComp.fps}
             durationInFrames={subComp.durationInFrames}
           >

--- a/src/runtime/composition-runtime/components/composition-content.tsx
+++ b/src/runtime/composition-runtime/components/composition-content.tsx
@@ -539,17 +539,14 @@ export const CompositionContent = React.memo<CompositionContentProps>(
       )
     }
 
-    // CSS scale from sub-comp native resolution to parent container dimensions
-    const scaleX = subComp.width > 0 ? containerDims.width / subComp.width : 1
-    const scaleY = subComp.height > 0 ? containerDims.height / subComp.height : 1
+    const containerRenderWidth = Math.max(1, containerDims.width)
+    const containerRenderHeight = Math.max(1, containerDims.height)
 
     return (
       <div
         style={{
-          width: subComp.width,
-          height: subComp.height,
-          transform: `scale(${scaleX}, ${scaleY})`,
-          transformOrigin: '0 0',
+          width: containerRenderWidth,
+          height: containerRenderHeight,
           overflow: 'hidden',
           position: 'relative',
           visibility: parentVisible ? 'visible' : 'hidden',
@@ -558,12 +555,12 @@ export const CompositionContent = React.memo<CompositionContentProps>(
         <CompositionSpaceProvider
           projectWidth={subComp.width}
           projectHeight={subComp.height}
-          renderWidth={subComp.width}
-          renderHeight={subComp.height}
+          renderWidth={containerRenderWidth}
+          renderHeight={containerRenderHeight}
         >
           <VideoConfigProvider
-            width={subComp.width}
-            height={subComp.height}
+            width={containerRenderWidth}
+            height={containerRenderHeight}
             fps={subComp.fps}
             durationInFrames={subComp.durationInFrames}
           >

--- a/src/runtime/composition-runtime/components/lottie-player/index.tsx
+++ b/src/runtime/composition-runtime/components/lottie-player/index.tsx
@@ -5,7 +5,7 @@ import {
   LottieRenderer,
   mapTimelineFrameToLottieFrame,
 } from '@/infrastructure/lottie/lottie-frame-provider'
-import { resolveLottieOverrideData } from '@/infrastructure/lottie/lottie-text'
+import { resolveLottieRenderSpec } from '@/infrastructure/lottie/lottie-text'
 import type { LottieItem } from '@/types/timeline'
 
 interface LottiePlayerProps {
@@ -30,10 +30,17 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
   const localFrame = sequenceContext?.localFrame ?? 0
   const { fps } = useVideoConfig()
 
-  // Serialize overrides so the renderer only rebuilds when the text changes.
+  // Serialize the render inputs so the renderer only rebuilds when the selected
+  // animation/theme or text/color edits change.
   const overridesKey = useMemo(
-    () => JSON.stringify(item.textOverrides ?? null),
-    [item.textOverrides],
+    () =>
+      JSON.stringify({
+        a: item.animationId ?? null,
+        m: item.themeId ?? null,
+        t: item.textOverrides ?? null,
+        c: item.colorOverrides ?? null,
+      }),
+    [item.animationId, item.themeId, item.textOverrides, item.colorOverrides],
   )
 
   // (Re)create the renderer when the source (or text overrides) change.
@@ -49,14 +56,16 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
     let renderer: LottieRenderer | null = null
 
     void (async () => {
-      // Patch template text before render; falls back to the raw src on null.
-      const overrideData = await resolveLottieOverrideData(item.src, item.textOverrides)
+      // Resolve the selected animation/theme + text/color edits before render;
+      // `data` is null when nothing needs patching (load `src` directly).
+      const spec = await resolveLottieRenderSpec(item.src, item)
       if (cancelled) return
-      renderer = new LottieRenderer(
-        overrideData
-          ? { canvas, data: overrideData, autoResize: true }
-          : { canvas, src: item.src, autoResize: true },
-      )
+      renderer = new LottieRenderer({
+        canvas,
+        autoResize: true,
+        themeData: spec.themeData ?? undefined,
+        ...(spec.data ? { data: spec.data } : { src: item.src }),
+      })
       rendererRef.current = renderer
       await renderer.ready
       if (cancelled) return

--- a/src/runtime/composition-runtime/components/lottie-player/index.tsx
+++ b/src/runtime/composition-runtime/components/lottie-player/index.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { AbsoluteFill, useSequenceContext } from '@/runtime/composition-runtime/deps/player'
 import { useVideoConfig } from '../../hooks/use-player-compat'
 import {
   LottieRenderer,
   mapTimelineFrameToLottieFrame,
 } from '@/infrastructure/lottie/lottie-frame-provider'
+import { resolveLottieOverrideData } from '@/infrastructure/lottie/lottie-text'
 import type { LottieItem } from '@/types/timeline'
 
 interface LottiePlayerProps {
@@ -29,8 +30,14 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
   const localFrame = sequenceContext?.localFrame ?? 0
   const { fps } = useVideoConfig()
 
-  // (Re)create the renderer when the source changes. autoResize lets dotlottie
-  // size its render target to the displayed canvas (crisp on clip resize).
+  // Serialize overrides so the renderer only rebuilds when the text changes.
+  const overridesKey = useMemo(
+    () => JSON.stringify(item.textOverrides ?? null),
+    [item.textOverrides],
+  )
+
+  // (Re)create the renderer when the source (or text overrides) change.
+  // autoResize lets dotlottie size its render target to the displayed canvas.
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas || !item.src) return
@@ -38,22 +45,32 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
     setLoaded(false)
     setFailed(false)
 
-    const renderer = new LottieRenderer({ canvas, src: item.src, autoResize: true })
-    rendererRef.current = renderer
-
     let cancelled = false
-    renderer.ready.then(() => {
+    let renderer: LottieRenderer | null = null
+
+    void (async () => {
+      // Patch template text before render; falls back to the raw src on null.
+      const overrideData = await resolveLottieOverrideData(item.src, item.textOverrides)
+      if (cancelled) return
+      renderer = new LottieRenderer(
+        overrideData
+          ? { canvas, data: overrideData, autoResize: true }
+          : { canvas, src: item.src, autoResize: true },
+      )
+      rendererRef.current = renderer
+      await renderer.ready
       if (cancelled) return
       if (renderer.isLoaded) setLoaded(true)
       else setFailed(true)
-    })
+    })()
 
     return () => {
       cancelled = true
-      renderer.destroy()
+      renderer?.destroy()
       rendererRef.current = null
     }
-  }, [item.src])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- overridesKey stands in for item.textOverrides
+  }, [item.src, overridesKey])
 
   // Seek to the frame for the current timeline position.
   useEffect(() => {
@@ -66,9 +83,25 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
       totalFrames: item.totalFrames,
       frameRate: item.frameRate,
       loop: item.loop ?? true,
+      reversed: item.reversed,
+      loopMode: item.loopMode,
+      segmentStart: item.segmentStart,
+      segmentEnd: item.segmentEnd,
     })
     renderer.renderFrame(lottieFrame)
-  }, [localFrame, loaded, fps, item.speed, item.totalFrames, item.frameRate, item.loop])
+  }, [
+    localFrame,
+    loaded,
+    fps,
+    item.speed,
+    item.totalFrames,
+    item.frameRate,
+    item.loop,
+    item.reversed,
+    item.loopMode,
+    item.segmentStart,
+    item.segmentEnd,
+  ])
 
   if (failed) {
     return (

--- a/src/runtime/composition-runtime/components/lottie-player/index.tsx
+++ b/src/runtime/composition-runtime/components/lottie-player/index.tsx
@@ -39,8 +39,9 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
         m: item.themeId ?? null,
         t: item.textOverrides ?? null,
         c: item.colorOverrides ?? null,
+        s: item.slotOverrides ?? null,
       }),
-    [item.animationId, item.themeId, item.textOverrides, item.colorOverrides],
+    [item.animationId, item.themeId, item.textOverrides, item.colorOverrides, item.slotOverrides],
   )
 
   // (Re)create the renderer when the source (or text overrides) change.
@@ -64,6 +65,7 @@ export const LottiePlayer: React.FC<LottiePlayerProps> = ({ item }) => {
         canvas,
         autoResize: true,
         themeData: spec.themeData ?? undefined,
+        slots: spec.slots ?? undefined,
         ...(spec.data ? { data: spec.data } : { src: item.src }),
       })
       rendererRef.current = renderer

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -214,6 +214,23 @@ export type LottieItem = BaseTimelineItem & {
   totalFrames: number
   // Loop the animation when the clip outlives one playthrough (default true)
   loop?: boolean
+  // --- Editing controls (all optional; consumed by mapTimelineFrameToLottieFrame) ---
+  // `speed` and `isReversed` are inherited from BaseTimelineItem but note: Lottie
+  // uses a dedicated `reversed` flag so it never triggers video reverse-conform.
+  /** Play the animation backward. */
+  reversed?: boolean
+  /** How the animation repeats while looping (default 'loop'). */
+  loopMode?: 'loop' | 'pingpong'
+  /** First source frame of the animation to play (default 0). */
+  segmentStart?: number
+  /** Last source frame of the animation to play (default totalFrames - 1). */
+  segmentEnd?: number
+  /**
+   * Per-layer text replacements for template Lotties, keyed by the text layer's
+   * stable key (see `extractLottieTextLayers`). Applied to raw `.json` Lotties
+   * before render; `.lottie` archives are not supported for text edits.
+   */
+  textOverrides?: Record<string, string>
 }
 
 export type ShapeType =

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -226,11 +226,31 @@ export type LottieItem = BaseTimelineItem & {
   /** Last source frame of the animation to play (default totalFrames - 1). */
   segmentEnd?: number
   /**
+   * Selected animation id for a multi-animation `.lottie` archive (default: the
+   * manifest's primary animation). Switching this re-derives the clip's
+   * timing/size from the chosen animation.
+   */
+  animationId?: string
+  /**
+   * Selected dotLottie theme id — a named rule set (from the `.lottie` manifest)
+   * recoloring/retexting the animation's slots, applied via `setThemeData`.
+   * Undefined renders the animation as authored.
+   */
+  themeId?: string
+  /**
    * Per-layer text replacements for template Lotties, keyed by the text layer's
-   * stable key (see `extractLottieTextLayers`). Applied to raw `.json` Lotties
-   * before render; `.lottie` archives are not supported for text edits.
+   * stable key (see `extractLottieTextLayers`). Applied before render to both
+   * raw `.json` and `.lottie` archives (images inlined).
    */
   textOverrides?: Record<string, string>
+  /**
+   * Per-color solid fill/stroke replacements for template Lotties, keyed by the
+   * color's stable ordinal key (see `extractLottieColorLayers`) with `#rrggbb`
+   * hex values. Applied before render to both raw `.json` and `.lottie`
+   * archives. Animated colors freeze to the chosen color; gradients are
+   * recolored via themes/slots, not here.
+   */
+  colorOverrides?: Record<string, string>
 }
 
 export type ShapeType =

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -251,6 +251,12 @@ export type LottieItem = BaseTimelineItem & {
    * recolored via themes/slots, not here.
    */
   colorOverrides?: Record<string, string>
+  /**
+   * Scalar/vector value-slot overrides keyed by slot id (see
+   * `extractLottieValueSlots`): a number for a scalar slot, `[x, y]` for a
+   * vector slot. Applied natively via dotlottie's slot setters after load.
+   */
+  slotOverrides?: Record<string, number | [number, number]>
 }
 
 export type ShapeType =


### PR DESCRIPTION
Promotes the pending `develop` work to `staging`. Headline is the **Lottie editing suite**; it also carries the preview/GPU-effects fixes already committed on `develop`.

## Lottie editing suite
Expands Lottie beyond playback/text into a full template-editing surface. Every edit flows through one `resolveLottieRenderSpec` → `LottieRenderer` path, so preview and export stay in parity. Extraction stays WASM-free; rendering uses dotlottie-web.

- **Colors** — recolor solid fills/strokes, inline + color slots; animated colors freeze to the chosen color. Author-named colors (slots / named shapes) surface first; editor-generated `Fill 1`/`Stroke 1` defaults collapse under an "Other colors" disclosure.
- **Themes** — apply a dotLottie manifest theme via native `setThemeData` (verified live: recolors slots red→black).
- **Multi-animation** — pick which animation in a multi-animation `.lottie`; timing/size re-derived.
- **Markers** — apply a named marker as the in/out segment.
- **Value slots** — edit scalar (opacity/rotation/…) and 2D vector (position/scale) slots natively via `setScalarSlot`/`setVectorSlot`.
- **Live preview** — dragging a color/slot or typing text updates the canvas live through the gizmo preview channel; the whole drag is a single undo entry (no timeline-store thrash), committed on release.
- `.lottie` archive edits inline `images/*` as data URIs so patched JSON renders standalone.

Not included by design: **fonts** (no font bytes exist in-app; all Google Fonts via CSS — a fragile, net-new fetch/parse project) and **gradient slots** (don't render reliably in thorvg — recolor gradients via themes instead). Both verified, not guessed.

## Also included (pending preview/GPU fixes)
- `fix(preview)`: repaint settled scrub overlay after resize; aspect-stable auto-fit on the device pixel grid.
- `fix(gpu-effects)`: premultiply effect output so effects don't leak over lower layers; stop halftone double-premultiplying on masked edges; clamp GPU media edge sampling; eliminate compound preview edge seams.
- `perf(preview)`: keep the GPU effects overlay warm so effects apply instantly.

## Verification
- Typecheck 0 errors · Oxlint clean · formatted · feature-boundary check passes.
- Unit tests: Lottie extraction/metadata/slots/color (markers, themes, animation-by-id, named-vs-generated colors, scalar/vector slots) + the preview-sync suite — all green.
- Live browser pixel-checks through the real render path: theme recolor, animation switch, scalar+vector slots, `.lottie` archive theme extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lottie editing support in the editor, including playback controls, trimming, animation/theme selection, text edits, color changes, and value slot adjustments.
  * Preview and export now reflect live Lottie overrides more reliably, so edits show up during playback and rendering.
  * Added support for multi-animation Lottie files, themes, markers, and embedded assets.

* **Bug Fixes**
  * Improved preview canvas sizing and alignment for sharper, more consistent rendering.
  * Fixed several transparency and sampling issues in GPU/media rendering to reduce visual seams and color artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->