### PR TITLE
docs: user-guide catch-up, changelog rollup, and README sync

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -68,8 +68,9 @@ The user asks "draft changelog bullets for this week" or similar. Produce bullet
 2. `git log <branch> --no-merges --pretty=format:"%H|%ad|%s" --date=short --since=<week-start> --until=<week-end>` — `--no-merges` filters out PR merge commits, which carry no useful subject. Range is usually `<last-rollup>..HEAD` or explicit `--since`/`--until`.
 3. Sanity-check: if the user just mentioned a specific commit you don't see in the output, you're on the wrong branch. Re-query.
 4. Apply curation rules (below). Drop noise, rewrite dev-speak into user language, dedupe revisits.
-5. Group into Added / Fixed / Improved.
-6. Show the result. Wait for approval before touching files.
+5. **Verify net state.** Before locking bullets, run the added-then-removed check ([Verify the net state, not the commit stream](#verify-the-net-state-not-the-commit-stream)): drop any Added/Improved bullet whose feature was torn out again before HEAD. This is a distinct pass from step 4 — the `feat` commit passes curation on its own; only cross-checking it against later teardown commits reveals it should go.
+6. Group into Added / Fixed / Improved.
+7. Show the result. Wait for approval before touching files.
 
 ### Append mode
 
@@ -147,6 +148,21 @@ When you spot a launch:
 - List the supporting facets only if they're not obviously implied (a language picker is implied by "translated UI"; ASS subtitle support inside subtitle editing might be worth its own bullet).
 - Resist the urge to itemize every commit just because they're all in the Added group.
 
+## Verify the net state, not the commit stream
+
+Commits are a *stream of deltas*; the changelog describes the *net difference* between the last release and HEAD. A feature added on Tuesday and ripped back out on Thursday is, to the user, as if it never shipped — there is nothing to announce. But the naive draft still emits an "Added" bullet, because the `feat(...)` commit is sitting right there in the log and nothing downstream cancels it *in the text*. The removal happened in the code, not in the commit subject you're reading.
+
+Before finalizing any **Added** or **Improved** bullet, confirm the thing it describes still exists at HEAD:
+
+1. **Find the teardown commits in the window.** Scan subjects for `/\b(remove|delete|drop|revert|roll ?back|back out|undo|kill|rip out|disable)\b/i`, and list file deletions with `git log <branch> --no-merges --diff-filter=D --since=<week-start> --until=<week-end> --name-only`.
+2. **Pair each candidate Added bullet against them by feature area, not literal path.** A feature can be dismantled by deleting a route, a menu entry, a flag, or a registry line without deleting the file that introduced it. Match on what the user would touch, not the filename.
+3. **Added and removed within the same window → drop the bullet entirely.** Not Added, not Fixed, not Removed. It nets to zero for the user; announcing it and then never shipping it is worse than silence.
+4. **When unsure whether it survived, verify against HEAD directly** — don't trust the `feat` commit alone. `git cat-file -e HEAD:<path>` for a file's existence, or grep HEAD for the symbol / route / UI label the feature exposes. If it's gone from HEAD, it's gone from the changelog.
+
+This generalizes the "reverts paired with a re-fix" rule below. It also catches the cases that rule misses: an add later removed with **no** replacement, an add superseded by a **differently-named** replacement (log only the survivor, worded as the survivor), and an experiment merged in one PR then reverted in another.
+
+**The one exception — removing something that already shipped.** If the removed feature was in a *prior release*, the user has been using it, so its removal is itself a user-facing change: they had it yesterday, it's gone today. That is worth announcing (and any migration note that comes with it). The JSON schema has no `Removed` group, so **surface it to the user** and let them decide wording and placement rather than silently dropping it or inventing a group. The added-then-removed-same-window case above is the opposite: the user never had it, so nothing is announced.
+
 ## Curation rules
 
 ### Drop
@@ -163,6 +179,7 @@ When you spot a launch:
 - **Hit-zone / drop-zone / ghost-position adjustments** — fold into the parent drag/drop feature. Never their own bullet.
 - **Internal perf on this week's new work** — perf commits that optimize code shipped earlier in the same week. The user experiences the feature once, smoothly. No separate "Improved" bullet.
 - Reverts paired with a subsequent re-fix in the same week — skip both, keep only the final correct implementation.
+- **Added-then-removed within the window** — any feature introduced and then torn out before HEAD (with or without a replacement). See [Verify the net state](#verify-the-net-state-not-the-commit-stream): it nets to zero, so drop the Added bullet. The exception is a feature that shipped in a *prior* release and is removed this week — that removal is user-facing; surface it.
 - "Update src/..." auto-subject merges (GitHub web-edit artifacts)
 - Revisits: if the same feature is improved multiple times in one week, dedupe to one bullet describing the final state.
 - Duplicates worded differently — drag overlays sticking, drag overlays hijacking lanes, stale drop overlays are all "dragging works better now." One bullet, not three.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the 
 
 <!-- Entries below are generated via the `changelog` skill. Newest first. -->
 
-## [Current] — week of 2026-06-29
+## [Current] — week of 2026-07-06
+
+### Added
+- Lottie animations — import .json and .lottie files and play them on the timeline
+- Customize Lottie colors, themes, text, and value slots, with live preview
+
+### Fixed
+- Fixed edge seams and shimmer on GPU effects in the preview
+
+### Improved
+- Effects apply to the preview instantly, without a warm-up delay
+
+## [2026.06.29] — week of 2026-06-29 to 2026-07-05
 
 ### Added
 - Sequences — build multiple timelines in one project and switch between them in tabs
@@ -15,10 +27,11 @@ All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the 
 - Optional interface sounds with a voice picker
 - Redesigned keyboard-shortcut editor in Settings
 - Subtitle export modes: off, burn in, sidecar file, or embedded track
-- Edit ProRes footage — import, preview, thumbnails, and export
+- Edit ProRes footage — import, preview, and thumbnails
 - Procedural motion modifiers — drift, breath, shake, sway, and spin, with one-click bake to keyframes
 - New GPU effects: gradient map, VHS, CRT, Droste, block glitch, glass distortion, ink, and pixel sort
 - ASCII effect now supports custom text, fonts, and glyph character sets
+- Browse and jump to markers from a list in the properties sidebar
 
 ### Fixed
 - Fixed an export crash triggered by certain layered effects

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ request features, report bugs, and give feedback on browser-based editing workfl
 
 ### Timeline & Editing
 
-- Multi-track timeline with video, audio, text, image, shape, mask, and compound clip items
+- Multi-track timeline with video, audio, text, image, shape, mask, Lottie, and compound clip items
+- Multiple timelines per project as Sequences with tabs, unified with compound clips (open a compound clip as its own sequence)
 - Linked audio/video editing with split, join, ripple, rolling, slip, slide, and rate-stretch tools
 - Cut-centered transitions with live resize, alignment, source-time anchoring, and preview overlays
 - Track mute/visibility/lock controls, linked sync badges, track push/pull, and close-gap workflows
@@ -95,12 +96,13 @@ request features, report bugs, and give feedback on browser-based editing workfl
 All visual effects and compositing paths are WebGPU-first, with fallbacks where practical.
 
 - **Blur:** gaussian, box, motion, radial, zoom
-- **Color:** brightness, contrast, exposure, hue shift, saturation, vibrance, temperature/tint, levels, curves, color wheels, grayscale, sepia, invert
-- **Distortion:** pixelate, RGB split, twirl, wave, bulge/pinch, kaleidoscope, mirror, fluted glass
-- **Stylize:** vignette, film grain, sharpen, posterize, glow, edge detect, scanlines, color glitch
+- **Color:** brightness, contrast, exposure, hue shift, saturation, vibrance, temperature/tint, levels, curves, color wheels, gradient map, LUT (`.cube`), grayscale, sepia, invert
+- **Distortion:** pixelate, RGB split, twirl, wave, bulge/pinch, kaleidoscope, mirror, fluted glass, ripple glass, glass mosaic, droste
+- **Stylize:** vignette, film grain, sharpen, posterize, glow, edge detect, scanlines, halftone, ASCII art, color glitch, block glitch, VHS, CRT, ink, pixel sort
 - **Keying:** chroma key with tolerance, softness, and spill suppression
 - 25 blend modes, including multiply, screen, overlay, soft light, difference, hue, saturation, color, and luminosity
 - Clip masks and pen paths with keyframeable geometry transforms
+- Color picker with hex and alpha input, plus an in-app eyedropper with loupe
 
 ### Transitions
 
@@ -111,15 +113,24 @@ All visual effects and compositing paths are WebGPU-first, with fallbacks where 
 ### Keyframe Animation
 
 - Bezier graph editor, dopesheet, split view, and multi-curve overlays
-- Easing presets: linear, ease-in, ease-out, ease-in-out, cubic-bezier, spring
+- Easing presets (linear, ease-in/out, cubic-bezier, spring) with a live-preview editor and saved custom presets
+- Procedural motion modifiers (drift, sway, breath, spin, shake) evaluated at render time, with one-click bake to keyframes
+- Motion text: per-character, per-word, and per-line text animation
 - Auto-keyframe mode, tangent mirroring, property accordions, and marquee selection
 - Animated transform, crop, mask, text, effect, and color properties
 
-### Media, AI & Analysis
+### Media & Import
 
-- Import videos, audio, images, GIFs, SVGs, and generated assets without copying originals
+- Import videos, audio, images, GIFs, SVGs, Lottie animations, and generated assets without copying originals
+- Edit imported Lottie animations (`.json` and `.lottie`): remap colors and themes, edit text, and adjust value slots with live preview
+- Apple ProRes decode for import, preview, and thumbnails, including variants browsers cannot natively decode
 - Proxy generation, thumbnail extraction, waveform caching, and media relinking
-- Browser Whisper transcription with generated caption text items
+
+### Local AI & Analysis
+
+Runs on-device in the browser — nothing is uploaded.
+
+- On-device transcription with the Parakeet engine (Whisper fallback) and generated caption text items
 - AI captioning with local vision-language providers and configurable sample cadence
 - Scene detection with histogram, optical-flow, and optional model verification workflows
 - Scene Browser for searching captioned media and reusing detected moments
@@ -139,9 +150,11 @@ All visual effects and compositing paths are WebGPU-first, with fallbacks where 
 ### Export
 
 - In-browser rendering through WebCodecs and worker-backed render paths
+- Export any sequence, not just the main timeline
 - **Video containers:** MP4, WebM, MOV, MKV
-- **Video codecs:** H.264, H.265, VP8, VP9, AV1, ProRes where supported
+- **Video codecs:** H.264, H.265, VP8, VP9, AV1 (where the browser provides an encoder)
 - **Audio export formats:** MP3, AAC, WAV/PCM
+- **Subtitles:** off, burn-in, sidecar file, or embedded soft track (container-dependent)
 - Quality presets from low to ultra, with runtime capability checks and fallbacks
 
 ## Quick Start
@@ -180,48 +193,6 @@ Brave may disable the File System Access API. To enable it:
 2. Change the setting from **Disabled** to **Enabled**
 3. Click **Relaunch** to restart the browser
 
-## Keyboard Shortcuts
-
-| Action | Shortcut |
-|---|---|
-| Play / Pause | `Space` |
-| Previous / Next frame | `Left` / `Right` |
-| Previous / Next snap point | `Up` / `Down` |
-| Go to start / end | `Home` / `End` |
-| Split at playhead | `Ctrl+K` / `Alt+C` |
-| Split at cursor | `Shift+C` |
-| Join clips | `Shift+J` |
-| Delete selected | `Delete` |
-| Ripple delete | `Ctrl+Delete` |
-| Freeze frame | `Shift+F` |
-| Nudge item (1px / 10px) | `Shift+Arrow` / `Ctrl+Shift+Arrow` |
-| Undo / Redo | `Ctrl+Z` / `Ctrl+Shift+Z` |
-| Copy / Cut / Paste | `Ctrl+C` / `Ctrl+X` / `Ctrl+V` |
-| Selection tool | `V` |
-| Razor tool | `C` |
-| Rate stretch tool | `R` |
-| Rolling edit tool | `N` |
-| Ripple edit tool | `B` |
-| Slip tool | `Y` |
-| Slide tool | `U` |
-| Toggle snap | `S` |
-| Add / Remove marker | `M` / `Shift+M` |
-| Previous / Next marker | `[` / `]` |
-| Add keyframe | `A` |
-| Clear keyframes | `Shift+A` |
-| Toggle keyframe editor | `Ctrl+Shift+A` |
-| Keyframe view: graph / dopesheet / split | `1` / `2` / `3` |
-| Group / Ungroup tracks | `Ctrl+G` / `Ctrl+Shift+G` |
-| Mark In / Out | `I` / `O` |
-| Clear In/Out | `Alt+X` |
-| Insert / Overwrite edit | `,` / `.` |
-| Open Scene Browser | `Ctrl+Shift+F` |
-| Zoom in / out | `Ctrl+=` / `Ctrl+-` |
-| Zoom to fit | `\` |
-| Zoom to 100% | `Shift+\` |
-| Save | `Ctrl+S` |
-| Export | `Ctrl+Shift+E` |
-
 ## Tech Stack
 
 - [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
@@ -244,47 +215,20 @@ Most commands are npm scripts backed by `vite-plus` (`vp`).
 
 ```bash
 npm run dev                 # Dev server on port 5173
-npm run dev:quiet           # Dev server with perf-focused env
-npm run dev:compare         # Run dev and local perf preview together
 npm run build               # Production build
-npm run build:perf          # Production build using `.env.perf`
 npm run preview             # Preview the production build
-npm run preview:perf        # Serve production build on port 4173
 npm run perf                # Build + serve a production-like perf target
 
 npm run lint                # Oxlint through Vite+
-npm run lint:fix            # Oxlint autofix
 npm run format              # Oxfmt
-npm run format:check        # Check formatting with Oxfmt
-npm run check               # Vite+ check without formatting
-npm run check:fix           # Vite+ check with fixes
+npm run test:run            # Run the test suite once (npm run test to watch)
+npm run verify              # Full local quality gate (lint, types, tests, arch checks)
 
-npm run test                # Vite+ test watch mode
-npm run test:run            # Vite+ test single run
-npm run test:coverage       # Vite+ coverage
-npm run test:preview-sync   # Focused preview sync suite
-npm run test:preview-sync:stress # Repeated preview sync stress runner
-
-npm run check:boundaries            # Feature boundary architecture check
-npm run check:deps-contracts        # Enforce deps contract adapter routing
-npm run check:legacy-lib-imports    # Tripwire: block any "@/lib/*" import (layer removed)
-npm run check:deps-wrapper-health   # Fail on unused pass-through deps wrappers
-npm run check:changed-health        # Fail on newly introduced dead code, complexity, or duplication
-npm run check:edge-budgets          # Feature coupling budget check
-npm run report:feature-edges        # Human-readable feature edge report
-npm run report:feature-edges:json   # JSON feature edge report
-npm run report:deps-wrapper-health:json # JSON deps wrapper health report
-npm run verify                      # Full local quality gate
-
-npm run routes              # Regenerate TanStack Router route tree
-npm run changelog:append    # Append generated changelog data
-npm run changelog:rollup    # Roll changelog data into release notes
+npm run routes              # Regenerate the TanStack Router route tree
 ```
 
-`npm run verify` and the pre-push hook both include `check:changed-health`. The gate runs
-`fallow audit --base HEAD` by default and fails only on issues introduced by the current
-diff. Use `npm run check:changed-health -- --base <ref>` or set `FALLOW_AUDIT_BASE=<ref>`
-to compare against another branch or commit.
+`npm run verify` runs the complete quality gate, including architecture and
+dead-code checks scoped to the current diff; the pre-push hook runs the same set.
 
 ### Performance Checks
 
@@ -301,64 +245,20 @@ VITE_SHOW_DEBUG_PANEL=true   # Show debug panel in dev
 
 ## Project Structure
 
-```text
-src/
-|- app/                     # App bootstrap, error boundary, PWA install prompt, debug utilities
-|- components/              # shadcn/ui components and brand assets
-|- config/                  # Hotkeys and editor layout configuration
-|- data/                    # Generated app data, including changelog JSON
-|- features/                # User-facing UI modules
-|  |- editor/                # Editor shell, toolbar, panels, dialogs, deps adapters
-|  |- effects/               # Effect registry and effect UI
-|  |- export/                # WebCodecs export pipeline and canvas fallback rendering
-|  |- keyframes/             # Graph editor, dopesheet, animation resolvers
-|  |- media-library/         # Import, metadata, proxies, transcription, captioning
-|  |- preview/               # Program/source monitors, overlays, gizmos, scopes
-|  |- project-bundle/        # ZIP and JSON project import/export
-|  |- projects/              # Project list, templates, migration, trash
-|  |- scene-browser/         # Caption and scene search UI
-|  |- settings/              # Settings store, hotkey editor, model cache controls
-|  |- timeline/              # Timeline UI, tools, stores, services, workers
-|  \- workspace-gate/        # Workspace picker, permission gate, workspace switcher
-|- runtime/                 # Playback and rendering engines (not user-facing UI)
-|  |- composition-runtime/   # Composition renderer, media layout, audio graph, masks
-|  \- player/                # Clock, player primitives, video source pools
-|- infrastructure/          # Platform adapters: browser, storage, GPU, analysis, audio, thumbnails
-|  |- analysis/              # Scene detection, captioning, embeddings, optical flow
-|  |- audio/                 # SoundTouch-based time-stretch
-|  |- browser/               # Blob/object URL and Mediabunny input adapters
-|  |- gpu-effects/           # WebGPU effect pipeline + shader definitions
-|  |- gpu-transitions/       # WebGPU transition pipeline + shaders
-|  |- gpu-compositor/        # WebGPU blend-mode compositor
-|  |- gpu-masks/             # Mask combine pipeline + texture manager
-|  |- gpu-media/             # Media render/blend pipelines
-|  |- gpu-scopes/            # Waveform/vectorscope/histogram renderers
-|  |- gpu-shapes/            # Shape render pipeline
-|  |- gpu-text/              # Glyph-atlas text pipeline
-|  |- gpu-shared/            # WGSL fragments shared across GPU modules
-|  |- storage/               # Workspace FS, handles DB, legacy IDB migration
-|  \- thumbnails/            # GPU-backed thumbnail generation adapters
-|- routes/                  # TanStack Router file routes
-|- shared/                  # Framework-agnostic primitives + cross-feature state
-|  |- timeline/              # Transition engine/registry/renderers, defaults
-|  |- projects/              # Schema migrations and normalization
-|  |- state/                 # Cross-feature Zustand stores
-|  |- marquee/               # Marquee-selection hook + overlay (paired)
-|  |- ui/                    # cn helper, property controls
-|  |- logging/               # Structured logger
-|  |- typography/            # Font loading, text style presets
-|  |- graphics/              # Shape generators and path helpers
-|  \- utils/                 # Workers, color/curve math, easing, time helpers
-|- test/                    # Test setup
-\- types/                   # Shared TypeScript types
-```
+The `src/` tree is organized into a few layers:
 
-Feature modules should use their local `deps/` adapters for cross-feature
-imports. Platform-coupled code (GPU, ML, audio, storage, browser) lives in
+- **`features/`** — user-facing UI modules (editor, timeline, preview, media library, effects, keyframes, export, projects, settings, scene browser, and more)
+- **`runtime/`** — playback and rendering engines (composition runtime, player, clock) that are not user-facing UI
+- **`infrastructure/`** — platform adapters for GPU (effects, transitions, compositor, masks, text, scopes), analysis, audio, browser, storage, and thumbnails
+- **`shared/`** — framework-agnostic primitives and cross-feature state (transition engine, schema migrations, Zustand stores, utils)
+- **`app/`, `components/`, `config/`, `routes/`, `types/`** — bootstrap, shadcn/ui components, configuration, file-based routes, and shared types
+
+Feature modules use their local `deps/` adapters for cross-feature imports.
+Platform-coupled code (GPU, ML, audio, storage, browser) lives in
 `@/infrastructure/*` and is imported directly; there is no separate `lib/`
 layer.
 
-Layer notes:
+For the full directory breakdown, see the layer notes:
 
 - [src/infrastructure/README.md](src/infrastructure/README.md)
 - [src/shared/README.md](src/shared/README.md)

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,65 +1,92 @@
 {
   "current": {
     "version": "current",
-    "date": "2026-07-05",
+    "date": "2026-07-08",
     "groups": {
       "added": [
         {
-          "title": "Sequences — build multiple timelines in one project and switch between them in tabs"
+          "title": "Lottie animations — import .json and .lottie files and play them on the timeline"
         },
         {
-          "title": "Export any sequence, not just the main timeline"
-        },
-        {
-          "title": "Motion text — animate text by character, word, or line"
-        },
-        {
-          "title": "Per-clip easing editor: preset curves, draggable handles, live preview, and custom presets"
-        },
-        {
-          "title": "Color picker gains hex/alpha input and an in-app eyedropper"
-        },
-        {
-          "title": "Optional interface sounds with a voice picker"
-        },
-        {
-          "title": "Redesigned keyboard-shortcut editor in Settings"
-        },
-        {
-          "title": "Subtitle export modes: off, burn in, sidecar file, or embedded track"
-        },
-        {
-          "title": "Edit ProRes footage — import, preview, thumbnails, and export"
-        },
-        {
-          "title": "Procedural motion modifiers — drift, breath, shake, sway, and spin, with one-click bake to keyframes"
-        },
-        {
-          "title": "New GPU effects: gradient map, VHS, CRT, Droste, block glitch, glass distortion, ink, and pixel sort"
-        },
-        {
-          "title": "ASCII effect now supports custom text, fonts, and glyph character sets"
+          "title": "Customize Lottie colors, themes, text, and value slots, with live preview"
         }
       ],
       "fixed": [
         {
-          "title": "Fixed an export crash triggered by certain layered effects"
-        },
-        {
-          "title": "Preview no longer hangs mid-clip during playback"
+          "title": "Fixed edge seams and shimmer on GPU effects in the preview"
         }
       ],
       "improved": [
         {
-          "title": "Keyframe graph editor gains fit-to-view, a grid, and smoother scrolling"
-        },
-        {
-          "title": "Clearer Animate workflow with procedural and keyframe state indicators"
+          "title": "Effects apply to the preview instantly, without a warm-up delay"
         }
       ]
     }
   },
   "releases": [
+    {
+      "version": "2026.06.29",
+      "date": "2026-06-29",
+      "groups": {
+        "added": [
+          {
+            "title": "Sequences — build multiple timelines in one project and switch between them in tabs"
+          },
+          {
+            "title": "Export any sequence, not just the main timeline"
+          },
+          {
+            "title": "Motion text — animate text by character, word, or line"
+          },
+          {
+            "title": "Per-clip easing editor: preset curves, draggable handles, live preview, and custom presets"
+          },
+          {
+            "title": "Color picker gains hex/alpha input and an in-app eyedropper"
+          },
+          {
+            "title": "Optional interface sounds with a voice picker"
+          },
+          {
+            "title": "Redesigned keyboard-shortcut editor in Settings"
+          },
+          {
+            "title": "Subtitle export modes: off, burn in, sidecar file, or embedded track"
+          },
+          {
+            "title": "Edit ProRes footage — import, preview, and thumbnails"
+          },
+          {
+            "title": "Procedural motion modifiers — drift, breath, shake, sway, and spin, with one-click bake to keyframes"
+          },
+          {
+            "title": "New GPU effects: gradient map, VHS, CRT, Droste, block glitch, glass distortion, ink, and pixel sort"
+          },
+          {
+            "title": "ASCII effect now supports custom text, fonts, and glyph character sets"
+          },
+          {
+            "title": "Browse and jump to markers from a list in the properties sidebar"
+          }
+        ],
+        "fixed": [
+          {
+            "title": "Fixed an export crash triggered by certain layered effects"
+          },
+          {
+            "title": "Preview no longer hangs mid-clip during playback"
+          }
+        ],
+        "improved": [
+          {
+            "title": "Keyframe graph editor gains fit-to-view, a grid, and smoother scrolling"
+          },
+          {
+            "title": "Clearer Animate workflow with procedural and keyframe state indicators"
+          }
+        ]
+      }
+    },
     {
       "version": "2026.06.22",
       "date": "2026-06-22",

--- a/src/features/docs/docs-shell.tsx
+++ b/src/features/docs/docs-shell.tsx
@@ -125,7 +125,9 @@ function DocsNavigation({ currentSlug }: { currentSlug?: string }) {
 
         return (
           <div key={group} className="space-y-1">
-            <p className="px-2 text-xs font-medium text-muted-foreground">{group}</p>
+            <p className="px-2 text-xs font-semibold uppercase tracking-wide text-primary">
+              {group}
+            </p>
             {pages.map((page) => (
               <Link
                 key={page.slug}

--- a/src/features/docs/pages/03-projects.ts
+++ b/src/features/docs/pages/03-projects.ts
@@ -23,6 +23,50 @@ const page = {
       ],
     },
     {
+      title: 'Canvas size and aspect ratio',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'The canvas defines the frame your video is composed and exported in. Pick a size when you create a project, or change it any time from the **Canvas** panel while editing.',
+        },
+        {
+          kind: 'paragraph',
+          text: 'On **New Project**, the **Resolution** section offers ready-made presets for common platforms. Each preset card shows its pixel size and aspect ratio. Choose **Custom** to type an exact width and height instead.',
+        },
+        {
+          kind: 'table',
+          headers: ['Preset', 'Resolution', 'Aspect ratio'],
+          rows: [
+            ['YouTube 1080p', '`1920x1080`', '`16:9` landscape'],
+            ['Shorts / TikTok / Reels', '`1080x1920`', '`9:16` vertical'],
+            ['Instagram Square', '`1080x1080`', '`1:1` square'],
+            ['Instagram Portrait', '`1080x1350`', '`4:5` portrait'],
+            ['Twitter/X', '`1200x675`', '`16:9` landscape'],
+            ['LinkedIn', '`1200x627`', 'landscape'],
+            ['Custom', 'Your own values', 'Anything you enter'],
+          ],
+        },
+        {
+          kind: 'paragraph',
+          text: 'To change the size after the project exists:',
+        },
+        {
+          kind: 'steps',
+          items: [
+            'Deselect any clip so the properties sidebar shows the **Canvas** panel.',
+            'Edit the **W** and **H** fields to set the frame width and height in pixels.',
+            'Use **Swap** to flip width and height, for example to turn a landscape project into a vertical one.',
+            'Use **Reset** to return the canvas to `1920x1080`.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'Dimensions snap to even numbers and range from `320x240` up to `7680x4320`. Existing clips keep their current position and scale when the canvas changes, so reposition anything that now sits outside the new frame.',
+        },
+      ],
+    },
+    {
       title: 'Organize the project list',
       blocks: [
         {

--- a/src/features/docs/pages/05-media.ts
+++ b/src/features/docs/pages/05-media.ts
@@ -7,7 +7,7 @@ const page = {
   description:
     'Import media, inspect files, and generate proxies, transcripts, captions, and AI scene data.',
   category: 'Core Editing',
-  related: ['source-monitor', 'timeline', 'scene-browser'],
+  related: ['source-monitor', 'timeline', 'scene-browser', 'export'],
   sections: [
     {
       title: 'Import media',
@@ -16,14 +16,24 @@ const page = {
           kind: 'list',
           items: [
             'Open the **Media** tab and use **Import** to pick files, or drag files straight into the library.',
-            'FreeCut handles video, audio, images, GIFs, SVGs, and generated assets. GIFs import as image items.',
+            'FreeCut handles video, audio, images, GIFs, SVGs, Lottie animations (`.json` and `.lottie`), and generated assets. GIFs import as image items.',
             'Use **Import Media From URL** for a direct link to a media file — the URL must point at the file itself, not a page that embeds it.',
           ],
         },
         {
           kind: 'note',
           tone: 'info',
+          text: 'Apple ProRes footage imports, previews, and generates thumbnails like any other clip — including formats browsers cannot decode on their own. When you export, ProRes clips are re-encoded to your chosen output codec; there is no ProRes output format.',
+        },
+        {
+          kind: 'note',
+          tone: 'info',
           text: 'Folder import is not supported yet — drop the media files directly. What decodes depends on your browser; if a file will not import, try a different format or transcode it first.',
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'Log footage (S-Log3 and similar) looks flat and washed out by design — that is how it is captured. Add a LUT or color grade to bring it back; nothing is wrong with the file.',
         },
       ],
     },
@@ -80,6 +90,30 @@ const page = {
           kind: 'note',
           tone: 'info',
           text: 'Compound clips can be nested — one can contain another — as long as the chain never loops back on itself.',
+        },
+      ],
+    },
+    {
+      title: 'Lottie animations',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'Import Lottie files — raw `.json` or packaged `.lottie` archives — as timeline items that render frame-accurately in preview and export. Select a Lottie clip to reveal its editing controls in the properties panel **Lottie** section.',
+        },
+        {
+          kind: 'list',
+          items: [
+            'Control **Speed**, **Reverse**, **Loop**, and **Ping-pong** playback.',
+            'Set a **Start frame** / **End frame** segment to play only part of the animation, or pick a named **Marker** to jump the segment to it.',
+            'Recolor the animation — author-named **Colors** are surfaced first, with the remaining shapes tucked under a disclosure; a shared color edits every shape that used it, and **Reset all** restores the originals.',
+            'Edit template **Text** layers in place, and adjust exposed scalar and vector value slots under **Properties**.',
+            'For `.lottie` archives that bundle more than one animation, switch between them with the **Animation** picker; swap palettes with the **Theme** picker when the file ships themes.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'Color, text, slot, and segment edits preview live on the canvas as you drag or type, and commit as a single undo step. Animation, theme, marker, segment, and template editing apply to one selected Lottie clip at a time.',
         },
       ],
     },

--- a/src/features/docs/pages/06-timeline.ts
+++ b/src/features/docs/pages/06-timeline.ts
@@ -7,7 +7,7 @@ const page = {
   description:
     'Tracks, adding clips, selection, split and join, deleting, snapping, markers, ranges, sequences, and zoom.',
   category: 'Core Editing',
-  related: ['editing-tools', 'preview', 'keyboard-shortcuts'],
+  related: ['editing-tools', 'preview', 'media', 'export', 'keyboard-shortcuts'],
   sections: [
     {
       title: 'Tracks',
@@ -79,10 +79,12 @@ const page = {
         {
           kind: 'list',
           items: [
-            'Create a sequence with **+** on the tab bar; it opens as its own tab.',
-            'Double-click a tab to **rename** it; the **⋯** menu lets you **Close tab** (keeps it in the Media panel) or **Delete sequence** entirely.',
-            'A **compound clip** can be opened in a sequence tab — in the Media panel, right-click a compound clip and choose **Open as tab** to edit it as a standalone timeline.',
-            'Drop a sequence onto the timeline to nest it as a clip (shown with a **SEQUENCE** badge); double-click that clip to jump to its tab.',
+            'Create a sequence with the **+** button at the end of the tab bar; it opens as its own tab.',
+            'Switch sequences by clicking a tab; the **Main** tab is always first.',
+            'Double-click a tab to **rename** it, or use the tab options menu (⋮) for **Rename**, **Close tab**, and **Delete sequence**.',
+            '**Close tab** only removes the tab — the sequence stays available in the Media panel and in any clips that reference it. **Delete sequence** removes it entirely (undoable), along with any clips that reference it.',
+            'A **compound clip** can be opened as a sequence tab — in the Media panel, right-click a compound clip and choose **Open as tab** to edit it as a standalone timeline.',
+            'Drop a sequence onto the timeline to nest it as a clip (labelled **Sequence**); double-click that clip to jump to its tab.',
           ],
         },
         {

--- a/src/features/docs/pages/10-properties.ts
+++ b/src/features/docs/pages/10-properties.ts
@@ -65,6 +65,33 @@ const page = {
         },
       ],
     },
+    {
+      title: 'Markers',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'The properties panel lists every marker in the project under a **Markers** heading, sorted by time. The list is always available — it shows below the canvas settings when nothing is selected, and below the marker editor when a marker is selected — so you can browse and reach your markers regardless of what is selected.',
+        },
+        {
+          kind: 'list',
+          items: [
+            'Each row shows the marker color, its label (or a default name if it has none), and its timecode.',
+            'Select a row to make it the active marker and jump the playhead to that point.',
+            'Use the trash icon on a row to remove that single marker.',
+            '**Clear all** removes every marker at once.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'Press `M` to drop a marker at the playhead. When the list is empty it shows this hint.',
+        },
+        {
+          kind: 'paragraph',
+          text: 'Selecting a marker opens its editor above the list, where you can change the **Frame** position, edit the **Label**, and set the **Color** from a preset swatch or reset it to the default. The **Time** field shows the marker timecode as read-only, and **Delete Marker** removes it.',
+        },
+      ],
+    },
   ],
 } satisfies DocPageContent
 

--- a/src/features/docs/pages/11-text-captions-subtitles.ts
+++ b/src/features/docs/pages/11-text-captions-subtitles.ts
@@ -36,8 +36,42 @@ const page = {
             'Open the **Text** tab, then click **Add text** or a template to place text at the playhead — or drag a template onto the timeline or canvas.',
             'Choose a layout (**Single**, **2 Spans**, **3 Spans**) and a style preset such as Clean, Lower Third, Cinematic, or Neon.',
             'In the **Text** section set font, size (8–500 px), weight, color, background, alignment, spacing, line height, padding, and radius.',
-            'Add shadow or stroke under **Effects**, and Intro/Outro animation presets for motion.',
+            'Add shadow or stroke under **Effects**, and animate the text under **Text Animation**.',
           ],
+        },
+      ],
+    },
+    {
+      title: 'Motion text',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'In the **Text Animation** section (in the text clip properties, or the Text stage of the **Animate** workspace) each character, word, or line can animate independently. Motion is evaluated at render time, so there are no keyframes to manage.',
+        },
+        {
+          kind: 'steps',
+          items: [
+            'Select a text clip and open the **Text Animation** section.',
+            'Pick a preset in the **In**, **Out**, or **Loop** row. **In** plays at the clip start, **Out** at the clip end, and **Loop** runs continuously between them.',
+            'Click the active preset again (or its ✕) to remove it — one preset per row.',
+            'Tune the controls that appear under the active preset.',
+          ],
+        },
+        {
+          kind: 'table',
+          headers: ['Control', 'What it does'],
+          rows: [
+            ['Applies to', 'The unit each preset animates: Character, Word, Line, or Whole clip.'],
+            ['Duration', 'Length, in frames, of each unit’s animation.'],
+            ['Stagger', 'Frames of delay between each unit, for a cascading effect.'],
+            ['Order', 'Which unit animates first: Forward, Backward, Center out, or Random.'],
+            ['Intensity', 'Scales the effect strength, from 0 to 200 percent.'],
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'In presets include Typewriter, Fade Up, Rise, Cascade, Pop, Blur In, Slide Reveal, and Wave In; Out presets include Fade Down, Sink, Pop Out, Blur Out, and Erase; Loop presets include Pulse, Wave, Shimmer, and Swing.',
         },
       ],
     },

--- a/src/features/docs/pages/13-effects-color.ts
+++ b/src/features/docs/pages/13-effects-color.ts
@@ -37,14 +37,42 @@ const page = {
             ['Blur', 'Gaussian, Box, Motion, Radial, Zoom'],
             [
               'Distort',
-              'Pixelate, RGB Split, Twirl, Wave, Bulge/Pinch, Kaleidoscope, Mirror, Fluted Glass, and more',
+              'Pixelate, RGB Split, Twirl, Wave, Bulge/Pinch, Kaleidoscope, Mirror, Fluted Glass, Ripple Glass, Glass Mosaic, Blocks, Droste, and more',
             ],
             [
               'Stylize',
-              'Vignette, Film Grain, Sharpen, Glow, Scanlines, CRT, Halftone, Dither, ASCII, VHS, glitch looks',
+              'Vignette, Film Grain, Sharpen, Glow, Scanlines, CRT, VHS, Halftone, Dither, ASCII, Ink, Pixel Sort, Block Glitch, Color Glitch',
             ],
             ['Keying', 'Chroma Key (green- and blue-screen removal)'],
           ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'All effects render on the GPU (WebGPU). Recent additions include **Gradient Map**, **VHS**, **CRT**, **Droste**, **Block Glitch**, the **Ripple Glass** and **Glass Mosaic** distortions, **Ink**, and **Pixel Sort**.',
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: '**ASCII** can render its own characters: set **Character Set** to **Custom**, type your **Custom Characters** (the ramp goes densest to lightest), and choose a **Font** (Monospace, Courier, Consolas, or Lucida Console). Built-in sets include ASCII Ramp, Dense, Binary, and Symbols.',
+        },
+      ],
+    },
+    {
+      title: 'Color inputs and the eyedropper',
+      blocks: [
+        {
+          kind: 'list',
+          items: [
+            'Every color control accepts a **hex** value; type it directly into the field (it updates the preview as you go).',
+            'Where transparency is supported, the field takes 8-digit hex (`#rrggbbaa`) and the picker adds an alpha slider.',
+            'Click the **eyedropper** (pipette) to sample a color from anywhere in the app or preview; a magnifier loupe follows the cursor so you can land on the exact pixel, then click to apply.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'The eyedropper is a built-in in-app sampler (not the browser native one) and needs no permission prompt. The same tool backs the wheels in the Color workspace.',
         },
       ],
     },

--- a/src/features/docs/pages/15-keyframes.ts
+++ b/src/features/docs/pages/15-keyframes.ts
@@ -71,11 +71,26 @@ const page = {
           kind: 'list',
           items: [
             'Click the **connector** between two keyframes to open the **easing editor**.',
-            'Browse a catalog of cubic-bezier and spring presets — filter by direction (**In / Out / In-Out**), and each tile shows an animated preview on hover. **Hold** freezes the value until the next key.',
+            'Browse preset curves under two tabs — **Cubic Easing** and **Spring**. Filter the easing presets by direction (**All / In / Out / In-Out**); each tile shows an animated preview on hover, and **Hold** freezes the value until the next key.',
             'Switch to **Edit** to shape the curve directly: drag the two control handles on the graph, or type exact values. Springs expose **tension**, **friction**, and **mass** and preview their real bounce.',
             'Feel the timing on **Position**, **Scale**, **Rotate**, or **Opacity** in the live preview, and **Pause** the loop.',
             'Save a tweaked curve as a **custom preset** with **Save As**, **Update** it later, or **Reset** back to the preset it came from. Custom presets are stored on your device and appear in every project.',
             'Copy, cut, paste, and delete keyframes, marquee-select groups, drag to retime, and `Alt`-drag to duplicate.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Work in the value graph',
+      blocks: [
+        {
+          kind: 'list',
+          items: [
+            'Pick a property from the dropdown to edit its curve, or leave it on all to see the others as faded overlay curves. The keyframe count for the active property shows beside it.',
+            'The graph draws a labelled **grid** — frames or seconds across, values up — so you can read positions at a glance.',
+            'Frame the curve with **Fit to content**, or nudge the view with **Zoom in** / **Zoom out** and the mouse wheel. **Reset view** returns to the default fit.',
+            'Step through keys with the **previous** / **next** arrows, then type an exact frame (**F**) and value (**V**) for the selected keyframe.',
+            'While dragging a keyframe, hold **Shift** to lock it to one axis, or **Alt** to fine-adjust.',
           ],
         },
       ],

--- a/src/features/docs/pages/18-export.ts
+++ b/src/features/docs/pages/18-export.ts
@@ -34,7 +34,7 @@ const page = {
       ],
     },
     {
-      title: 'Formats and subtitles',
+      title: 'Formats',
       blocks: [
         {
           kind: 'table',
@@ -42,15 +42,43 @@ const page = {
           rows: [
             ['Video containers', 'MP4, MOV, WebM, MKV'],
             ['Audio only', 'MP3, AAC, WAV'],
-            ['Embedded subtitles', 'MP4, MKV, WebM'],
+            ['Soft subtitle track', 'WebM, MKV'],
           ],
         },
         {
-          kind: 'list',
-          items: [
-            'Which codecs are available depends on your browser; FreeCut warns or falls back when one is not.',
-            'Turn on **Embed subtitles** to include transcript captions as a subtitle track.',
+          kind: 'note',
+          tone: 'info',
+          text: 'Which codecs are available depends on your browser; FreeCut warns or falls back when one is not.',
+        },
+      ],
+    },
+    {
+      title: 'Subtitles',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'When a video export has a transcript, the **Subtitles** control chooses how captions are included. The options adapt to the container you picked.',
+        },
+        {
+          kind: 'table',
+          headers: ['Mode', 'What it does'],
+          rows: [
+            ['**Off**', 'No captions in the exported video.'],
+            ['**Burn in**', 'Captions are drawn into the frame, so they show in every player.'],
+            [
+              '**Sidecar** `.srt`',
+              'Clean video plus a separate `.srt` subtitle file downloaded alongside it.',
+            ],
+            [
+              '**Embedded track**',
+              'A soft, toggleable subtitle track carried inside the container.',
+            ],
           ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'The embedded-track option appears only for `WebM` and `MKV`. On `MP4` and `MOV`, choose burn-in or a sidecar file, or switch container for a toggleable track.',
         },
         {
           kind: 'note',

--- a/src/features/docs/pages/20-keyboard-shortcuts.ts
+++ b/src/features/docs/pages/20-keyboard-shortcuts.ts
@@ -122,18 +122,22 @@ const page = {
       title: 'Customize shortcuts',
       blocks: [
         {
+          kind: 'paragraph',
+          text: 'Every binding above is a shipped default. Open the redesigned shortcut editor from the **Keyboard Shortcuts** button (keyboard icon) in the editor toolbar to remap any command to the keys you prefer.',
+        },
+        {
           kind: 'steps',
           items: [
-            'Open **Keyboard Shortcuts** from the toolbar to search commands and bindings.',
-            'Select a command and record a new key, resolving any conflict it reports.',
-            'Export a preset for backup or transfer, and import one on another machine.',
-            'Use **Reset** to restore the defaults.',
+            'Search commands by name, or filter to the **Custom**, **Conflicts**, or **Unassigned** groups.',
+            'Pick a command and press **Record**, then hold your modifiers and press the final key.',
+            'If the combo is already in use, the editor flags the conflict — choose **Overwrite** to reassign it, or pick different keys.',
+            'Use **Unbind** to clear a binding, or add an alternate binding alongside the primary one.',
           ],
         },
         {
           kind: 'note',
           tone: 'tip',
-          text: 'Every binding above is the shipped default and can be remapped to whatever you prefer.',
+          text: 'Use **Reset** to restore a single command, or **Reset All** to return every shortcut to its default. You can also **Export** your bindings to a preset file and **Import** it on another machine.',
         },
       ],
     },

--- a/src/features/docs/pages/21-settings.ts
+++ b/src/features/docs/pages/21-settings.ts
@@ -18,7 +18,7 @@ const page = {
           rows: [
             [
               'General',
-              'Auto-save on/off and interval (5–30 min); undo history depth (10–200 steps).',
+              'Auto-save on/off and interval (5–30 min); undo history depth (10–200 steps); interface sounds (on/off, volume, sound theme).',
             ],
             [
               'Timeline',
@@ -39,13 +39,49 @@ const page = {
       ],
     },
     {
+      title: 'Interface sounds',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'FreeCut can play subtle synthesized interface sounds — short cues that confirm actions like selecting, confirming, toggling, and deleting. They are **off by default**, opt-in, and never affect exported audio.',
+        },
+        {
+          kind: 'steps',
+          items: [
+            'Open **Settings** and go to the **General** tab.',
+            'Turn on **Interface sounds**.',
+            'Set **Sound volume** to taste (0–100%).',
+            'Pick a **Sound theme** — **Signature**, **Velvet**, or **Crisp** — and use the **Preview** button to audition it.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'Sounds are suppressed while the preview is playing, so they never bleed into the audio you are monitoring; exports are silent by design. Turning the toggle on plays a short confirmation.',
+        },
+      ],
+    },
+    {
+      title: 'Customizing keyboard shortcuts',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'Keyboard shortcuts are fully customizable, but the editor is its own dialog opened from the **Keyboard** button in the toolbar — not this Settings dialog. It has an interactive on-screen keyboard, search and **Custom** / **Conflicts** / **Unassigned** filters, record-to-rebind, alternate bindings, per-command and **Reset All** defaults, conflict detection, and JSON preset **Import** / **Export**.',
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'See the **Keyboard shortcuts** page for the full command list and a step-by-step rebinding walkthrough.',
+        },
+      ],
+    },
+    {
       title: 'Set elsewhere',
       blocks: [
         {
           kind: 'list',
           items: [
             'Interface **language** is a separate control in the toolbar, not part of this dialog; FreeCut ships in 9 languages.',
-            'Keyboard shortcuts are customized in their own **Keyboard Shortcuts** panel.',
           ],
         },
         {

--- a/src/features/docs/pages/24-concepts.ts
+++ b/src/features/docs/pages/24-concepts.ts
@@ -37,8 +37,30 @@ const page = {
             'A **project** holds a timeline, its settings (resolution and frame rate), and references to the media you use.',
             'The timeline stacks **tracks**; higher tracks render over lower ones.',
             'A **clip** on the timeline is a window into a source file — trimming a clip changes which part of the source plays, it does not alter the file.',
-            'Group a section into a **compound clip** to reuse it — or open it as a **sequence**, a self-contained timeline you switch to from the tab bar — and use an **adjustment layer** to affect every clip below it.',
+            'An **adjustment layer** is a clip that carries no media of its own — it applies its effects and color to every clip below it.',
           ],
+        },
+      ],
+    },
+    {
+      title: 'Sequences and compound clips',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'FreeCut has one primitive for **a timeline inside your project** — a composition. It shows up in two ways depending on how you use it.',
+        },
+        {
+          kind: 'list',
+          items: [
+            'A **sequence** is a standalone timeline in the same project, opened from a tab in the tab bar. Each sequence has its own tracks, clips, and edit history — the main timeline is itself a sequence.',
+            'A **compound clip** takes a section of the timeline and folds it into a single reusable media item. On the timeline it behaves like one clip — move, trim, add effects — while its contents live in their own timeline.',
+            'The two are the same thing seen differently: open a compound clip to edit its contents as a sequence, and any sequence can be dropped into another timeline as a compound clip.',
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'A composition can contain other compositions, but never itself — FreeCut blocks circular references, so a compound clip can never end up nested inside its own contents.',
         },
       ],
     },

--- a/src/features/docs/pages/25-animate.ts
+++ b/src/features/docs/pages/25-animate.ts
@@ -66,10 +66,17 @@ const page = {
         {
           kind: 'list',
           items: [
-            'Click a modulator tile to apply it with sensible defaults; a **Live** dot marks active ones.',
-            'Open an applied tile to adjust **Intensity** and **Duration**, or **Remove** it.',
+            'Each tile shows an animated preview of the motion, so you can read the feel before applying it.',
+            'Click a modulator tile to apply it with sensible defaults; a **Live** dot appears on active tiles.',
+            'Open an applied tile to adjust **Intensity** (0–200%) and **Duration** (25–300%), or **Remove** it. Dragging a slider previews live and folds into a single undo.',
+            'A modulator that would rescale the box (Breath pulse) is disabled for text clips, with a reason on hover.',
             'Applying to several clips staggers the phase per clip so they do not move in lockstep.',
           ],
+        },
+        {
+          kind: 'note',
+          tone: 'info',
+          text: 'An **Applied** summary lists what the selected clip carries: a keyframed-count chip for baked or hand-set properties versus one chip per **live** modulator — so you can tell procedural motion from keyframes at a glance. Each chip has a remove control.',
         },
       ],
     },
@@ -80,8 +87,8 @@ const page = {
           kind: 'list',
           items: [
             'Use **Bake to keyframes** to flatten procedural motion on the selected clips into editable keyframes.',
-            'Baking removes the procedural source and leaves plain keyframes you can reshape in the graph.',
-            'It is available whenever the selection has bakeable motion (a modulator or an audio pulse).',
+            'Baking samples the live modulators across the clip, removes the procedural source, and leaves plain keyframes you can reshape in the graph.',
+            'The button is enabled whenever the selection carries a live modulator; it is disabled when there is nothing procedural to bake.',
           ],
         },
         {

--- a/src/runtime/player/Player.behavior.test.tsx
+++ b/src/runtime/player/Player.behavior.test.tsx
@@ -1,0 +1,56 @@
+import { createRef } from 'react'
+import { act, render } from '@testing-library/react'
+import { describe, expect, it } from 'vite-plus/test'
+import { HeadlessPlayer, type PlayerRef } from './Player'
+
+/**
+ * Regression: pressing "Go To Start" (a seek to frame 0) must land on frame 0
+ * and stay there, even when the player was mounted with a non-zero
+ * `initialFrame` (e.g. restoring a saved playhead on project load).
+ *
+ * The original "sync initial frame" effect depended on the live clock frame and
+ * re-fired every time the clock returned to 0, snapping the playhead back to the
+ * stale mount-time `initialFrame`. This bit older projects whose saved playhead
+ * was non-zero (a full reload masked it because the preview then mounted at 0).
+ */
+describe('Player initial-frame sync', () => {
+  it('starts at initialFrame on mount', () => {
+    const ref = createRef<PlayerRef>()
+    render(
+      <HeadlessPlayer ref={ref} durationInFrames={300} fps={30} initialFrame={100}>
+        <div />
+      </HeadlessPlayer>,
+    )
+    expect(ref.current?.getCurrentFrame()).toBe(100)
+  })
+
+  it('stays at 0 after seeking to start (does not snap back to initialFrame)', () => {
+    const ref = createRef<PlayerRef>()
+    render(
+      <HeadlessPlayer ref={ref} durationInFrames={300} fps={30} initialFrame={100}>
+        <div />
+      </HeadlessPlayer>,
+    )
+
+    act(() => {
+      ref.current?.seekTo(0)
+    })
+
+    expect(ref.current?.getCurrentFrame()).toBe(0)
+  })
+
+  it('still honors ordinary seeks to a non-zero frame', () => {
+    const ref = createRef<PlayerRef>()
+    render(
+      <HeadlessPlayer ref={ref} durationInFrames={300} fps={30} initialFrame={100}>
+        <div />
+      </HeadlessPlayer>,
+    )
+
+    act(() => {
+      ref.current?.seekTo(42)
+    })
+
+    expect(ref.current?.getCurrentFrame()).toBe(42)
+  })
+})

--- a/src/runtime/player/Player.tsx
+++ b/src/runtime/player/Player.tsx
@@ -398,12 +398,22 @@ const PlayerInner = forwardRef<PlayerRef, PlayerProps>(
     } = useBridgedTimelineContext()
     const emitter = usePlayerEmitter()
 
-    // Sync initial frame
+    // Sync initial frame — ONCE on mount only. The Clock is already created with
+    // `initialFrame` (see ClockBridgeProvider), so this is a belt-and-suspenders
+    // catch for the rare case it started at 0. It must NOT depend on
+    // `currentFrame`: doing so re-fires this seek every time the clock later
+    // reaches frame 0 (e.g. pressing "Go To Start"), yanking the playhead back to
+    // the stale mount-time `initialFrame`.
+    const hasSyncedInitialFrameRef = useRef(false)
     useEffect(() => {
-      if (initialFrame > 0 && currentFrame === 0) {
+      if (hasSyncedInitialFrameRef.current) return
+      hasSyncedInitialFrameRef.current = true
+      if (initialFrame > 0 && player.getCurrentFrame() === 0) {
         player.seek(initialFrame)
       }
-    }, [initialFrame, currentFrame, player])
+      // Mount-only: intentionally no reactive deps.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     // Sync autoPlay
     useEffect(() => {


### PR DESCRIPTION
## Summary

Documentation and changelog maintenance — no product code changes (one small pre-existing player fix rides along on `develop`).

### In-app user guide (12 pages)
Brought the guide current with everything from the `2026.06.29` release plus this week's Lottie launch:
- **Lottie** import + editing (colors/themes/text/value slots, live preview)
- **Sequences** — multi-timeline tabs
- **Motion text** (per-character/word/line)
- **Eyedropper** + hex/alpha color input
- New **GPU effects** catalog + ASCII options
- **Interface sounds**, **marker list**, redesigned **easing editor**
- **Subtitle export modes**, **procedural motion**, shortcut customization
- **Canvas size & aspect ratio** (presets + how to change it)

### Corrections found while writing
- **ProRes is decode-only** — the export codec dropdown maps `prores → 'avc'` (H.264 fallback). Fixed the docs, the changelog bullet, and the README (was wrongly listed as an export codec).
- **Shortcut editor** opens from the toolbar, not the Settings dialog.

### Changelog
- Rolled up the closed week into release `2026.06.29` and started a fresh `current` for this week (Lottie launch, preview seam fixes).
- Taught the changelog skill **net-state awareness**: features added and then removed within the same window net to zero and are dropped (except removing something that already shipped).

### README
- Synced the feature lists; corrected ProRes and Whisper→Parakeet.
- Trimmed contributor-only content for a no-contribution repo: dropped the keyboard-shortcuts table, collapsed the `src/` tree into a short layer overview, slimmed the Development section, split Media/AI.

### Docs UI
- Sidebar category subheaders now use the brand orange for differentiation.

## Test plan
- `tsc --noEmit`, oxlint, and oxfmt all clean on the docs feature.
- Content verified against real implementation by the authoring pass (no invented labels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback so the starting frame stays correct after using “Go To Start” or other seek actions.
  * Improved consistency when opening projects at a non-zero starting frame.

* **Documentation**
  * Expanded help content for projects, media import, timelines, markers, effects, keyframes, export options, settings, shortcuts, and motion text.
  * Added new guidance for canvas sizing, Lottie animations, and interface sounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->