### PR TITLE
perf(media-library): faster media loading on editor open

### DIFF
--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -531,7 +531,7 @@ const MediaCardInternal = memo(function MediaCardInternal({
 
     const loadThumbnail = async () => {
       const { mediaLibraryService } = await importMediaLibraryService()
-      const url = await mediaLibraryService.getThumbnailBlobUrl(media.id)
+      const url = await mediaLibraryService.getThumbnailBlobUrl(media.id, media.thumbnailId)
       if (mounted) {
         setThumbnailUrl(url)
       }

--- a/src/features/media-library/components/media-picker-dialog.tsx
+++ b/src/features/media-library/components/media-picker-dialog.tsx
@@ -39,7 +39,7 @@ function MediaPickerItem({ media, onSelect }: { media: MediaMetadata; onSelect: 
 
     const loadThumbnail = async () => {
       const { mediaLibraryService } = await importMediaLibraryService()
-      const url = await mediaLibraryService.getThumbnailBlobUrl(media.id)
+      const url = await mediaLibraryService.getThumbnailBlobUrl(media.id, media.thumbnailId)
       if (mounted) {
         setThumbnailUrl(url)
       }
@@ -50,7 +50,7 @@ function MediaPickerItem({ media, onSelect }: { media: MediaMetadata; onSelect: 
     return () => {
       mounted = false
     }
-  }, [media.id])
+  }, [media.id, media.thumbnailId])
 
   return (
     <button

--- a/src/features/media-library/deps/storage.ts
+++ b/src/features/media-library/deps/storage.ts
@@ -19,6 +19,7 @@ export {
   getProjectMediaIds,
   getProjectsUsingMedia,
   getThumbnailByMediaId,
+  getThumbnailsByMediaIds,
   hasMediaSource,
   incrementContentRef,
   mirrorBlobToWorkspace,

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -894,6 +894,32 @@ describe('MediaLibraryService', () => {
       const result = await mediaLibraryService.getThumbnailBlobUrl('thumb-nope')
       expect(result).toBeNull()
     })
+
+    it('re-reads when the change-marker differs (regenerated thumbnail)', async () => {
+      indexedDbMocks.getThumbnailByMediaId.mockResolvedValue({
+        blob: new Blob(['thumb'], { type: 'image/webp' }),
+      })
+
+      await mediaLibraryService.getThumbnailBlobUrl('thumb-m1', 'v1')
+      // Same marker → cache hit, no second disk read.
+      await mediaLibraryService.getThumbnailBlobUrl('thumb-m1', 'v1')
+      expect(indexedDbMocks.getThumbnailByMediaId).toHaveBeenCalledTimes(1)
+
+      // New marker (thumbnail regenerated) → must bypass the stale cache.
+      await mediaLibraryService.getThumbnailBlobUrl('thumb-m1', 'v2')
+      expect(indexedDbMocks.getThumbnailByMediaId).toHaveBeenCalledTimes(2)
+    })
+
+    it('serves a marker-less request from a marked cache entry', async () => {
+      indexedDbMocks.getThumbnailByMediaId.mockResolvedValue({
+        blob: new Blob(['thumb'], { type: 'image/webp' }),
+      })
+
+      await mediaLibraryService.getThumbnailBlobUrl('thumb-m1', 'v1')
+      // A caller without a marker accepts whatever is cached — no extra read.
+      await mediaLibraryService.getThumbnailBlobUrl('thumb-m1')
+      expect(indexedDbMocks.getThumbnailByMediaId).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('needsPermission', () => {

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -46,6 +46,7 @@ import {
   deleteMedia as deleteMediaDB,
   saveThumbnail as saveThumbnailDB,
   getThumbnailByMediaId,
+  getThumbnailsByMediaIds,
   deleteThumbnailsByMediaId,
   // v3: Content-addressable storage
   incrementContentRef,
@@ -1792,9 +1793,36 @@ class MediaLibraryService {
       return null
     }
 
+    // The prefetch batch (or another caller) may have populated the cache
+    // during the await above — reuse it rather than leaking a second URL.
+    const raced = this.thumbnailUrlCache.get(mediaId)
+    if (raced) {
+      return raced
+    }
+
     const url = URL.createObjectURL(thumbnail.blob)
     this.thumbnailUrlCache.set(mediaId, url)
     return url
+  }
+
+  /**
+   * Warm the in-memory thumbnail-URL cache for many media in one batched pass.
+   *
+   * Called on project load so each card's mount is a synchronous cache hit
+   * instead of an independent async FSA read. Only fetches ids not already
+   * cached, and reuses the shared `media/` directory handle for all reads.
+   */
+  async prefetchThumbnails(mediaIds: string[]): Promise<void> {
+    const uncached = mediaIds.filter((id) => !this.thumbnailUrlCache.has(id))
+    if (uncached.length === 0) return
+
+    const blobs = await getThumbnailsByMediaIds(uncached)
+    for (const [mediaId, blob] of blobs) {
+      // A concurrent getThumbnailBlobUrl() may have populated the cache while
+      // this batch was in flight — don't leak a second object URL for it.
+      if (this.thumbnailUrlCache.has(mediaId)) continue
+      this.thumbnailUrlCache.set(mediaId, URL.createObjectURL(blob))
+    }
   }
 
   /**

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -236,8 +236,13 @@ function sanitizeLottieFileName(rawName: string | undefined): string {
  * sources and the workspace folder in sync.
  */
 class MediaLibraryService {
-  /** In-memory cache for thumbnail blob URLs to prevent flicker on re-renders */
-  private thumbnailUrlCache = new Map<string, string>()
+  /**
+   * In-memory cache for thumbnail blob URLs to prevent flicker on re-renders.
+   * `marker` is the media's `thumbnailId` change-token at the time the URL was
+   * created; a changed marker invalidates the entry so regenerated thumbnails
+   * are re-read from disk instead of served stale.
+   */
+  private thumbnailUrlCache = new Map<string, { url: string; marker: string | undefined }>()
   private preparationPromises = new Map<string, Set<Promise<void>>>()
 
   async waitForMediaPreparation(mediaIds: string[]): Promise<void> {
@@ -1780,11 +1785,13 @@ class MediaLibraryService {
   /**
    * Get thumbnail as blob URL (cached in memory to prevent flicker)
    */
-  async getThumbnailBlobUrl(mediaId: string): Promise<string | null> {
-    // Check cache first
+  async getThumbnailBlobUrl(mediaId: string, thumbnailId?: string): Promise<string | null> {
+    // Serve from cache only when the change-marker still matches. A caller
+    // without a marker (undefined) accepts whatever is cached; a caller with a
+    // marker that differs falls through to a fresh read.
     const cached = this.thumbnailUrlCache.get(mediaId)
-    if (cached) {
-      return cached
+    if (cached && (thumbnailId === undefined || cached.marker === thumbnailId)) {
+      return cached.url
     }
 
     const thumbnail = await this.getThumbnail(mediaId)
@@ -1794,14 +1801,27 @@ class MediaLibraryService {
     }
 
     // The prefetch batch (or another caller) may have populated the cache
-    // during the await above — reuse it rather than leaking a second URL.
+    // during the await above — reuse it when its marker matches rather than
+    // leaking a second URL.
     const raced = this.thumbnailUrlCache.get(mediaId)
-    if (raced) {
-      return raced
+    if (raced && (thumbnailId === undefined || raced.marker === thumbnailId)) {
+      return raced.url
     }
 
-    const url = URL.createObjectURL(thumbnail.blob)
-    this.thumbnailUrlCache.set(mediaId, url)
+    return this.cacheThumbnailUrl(mediaId, thumbnail.blob, thumbnailId)
+  }
+
+  /**
+   * Store a thumbnail blob URL for `mediaId`, revoking any prior URL (e.g. a
+   * stale entry from a superseded `thumbnailId`) so it can't leak.
+   */
+  private cacheThumbnailUrl(mediaId: string, blob: Blob, marker: string | undefined): string {
+    const existing = this.thumbnailUrlCache.get(mediaId)
+    if (existing) {
+      URL.revokeObjectURL(existing.url)
+    }
+    const url = URL.createObjectURL(blob)
+    this.thumbnailUrlCache.set(mediaId, { url, marker })
     return url
   }
 
@@ -1810,18 +1830,27 @@ class MediaLibraryService {
    *
    * Called on project load so each card's mount is a synchronous cache hit
    * instead of an independent async FSA read. Only fetches ids not already
-   * cached, and reuses the shared `media/` directory handle for all reads.
+   * cached with a matching change-marker, and reuses the shared `media/`
+   * directory handle for all reads.
    */
-  async prefetchThumbnails(mediaIds: string[]): Promise<void> {
-    const uncached = mediaIds.filter((id) => !this.thumbnailUrlCache.has(id))
+  async prefetchThumbnails(items: Array<{ id: string; thumbnailId?: string }>): Promise<void> {
+    const markerById = new Map(items.map((item) => [item.id, item.thumbnailId]))
+    const uncached = items
+      .filter((item) => {
+        const cached = this.thumbnailUrlCache.get(item.id)
+        return !cached || cached.marker !== item.thumbnailId
+      })
+      .map((item) => item.id)
     if (uncached.length === 0) return
 
     const blobs = await getThumbnailsByMediaIds(uncached)
     for (const [mediaId, blob] of blobs) {
-      // A concurrent getThumbnailBlobUrl() may have populated the cache while
-      // this batch was in flight — don't leak a second object URL for it.
-      if (this.thumbnailUrlCache.has(mediaId)) continue
-      this.thumbnailUrlCache.set(mediaId, URL.createObjectURL(blob))
+      const marker = markerById.get(mediaId)
+      // A concurrent getThumbnailBlobUrl() may have already cached this id with
+      // the same marker while the batch was in flight — don't re-create it.
+      const cached = this.thumbnailUrlCache.get(mediaId)
+      if (cached && cached.marker === marker) continue
+      this.cacheThumbnailUrl(mediaId, blob, marker)
     }
   }
 
@@ -1829,9 +1858,9 @@ class MediaLibraryService {
    * Clear thumbnail URL from cache (call when media is deleted)
    */
   clearThumbnailCache(mediaId: string): void {
-    const url = this.thumbnailUrlCache.get(mediaId)
-    if (url) {
-      URL.revokeObjectURL(url)
+    const cached = this.thumbnailUrlCache.get(mediaId)
+    if (cached) {
+      URL.revokeObjectURL(cached.url)
       this.thumbnailUrlCache.delete(mediaId)
     }
   }

--- a/src/features/media-library/stores/media-library-store.test.ts
+++ b/src/features/media-library/stores/media-library-store.test.ts
@@ -5,6 +5,7 @@ const mediaLibraryServiceMocks = vi.hoisted(() => ({
   getMediaForProject: vi.fn(),
   getMediaFile: vi.fn(),
   mirrorOpfsMediaToWorkspace: vi.fn(async () => ({ mirrored: 0 })),
+  prefetchThumbnails: vi.fn(async () => {}),
 }))
 
 const proxyStatusListenerRef = vi.hoisted(() => ({

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -203,6 +203,16 @@ const newStore: MediaLibraryStoreApi =
             })
 
             event.set('mediaCount', mediaItems.length)
+
+            // Warm the thumbnail cache in one batched pass so cards render
+            // their thumbnails on mount without each firing an independent
+            // FSA read. Best-effort; never blocks the grid.
+            void mediaLibraryService
+              .prefetchThumbnails(mediaItems.map((m) => m.id))
+              .catch((error) =>
+                logger.warn('[MediaLibraryStore] Thumbnail prefetch failed:', error),
+              )
+
             void get().scanMediaHealth()
 
             // Repair sweep: mirror any legacy OPFS-only source media into the

--- a/src/features/media-library/stores/media-library-store.ts
+++ b/src/features/media-library/stores/media-library-store.ts
@@ -208,7 +208,9 @@ const newStore: MediaLibraryStoreApi =
             // their thumbnails on mount without each firing an independent
             // FSA read. Best-effort; never blocks the grid.
             void mediaLibraryService
-              .prefetchThumbnails(mediaItems.map((m) => m.id))
+              .prefetchThumbnails(
+                mediaItems.map((m) => ({ id: m.id, thumbnailId: m.thumbnailId })),
+              )
               .catch((error) =>
                 logger.warn('[MediaLibraryStore] Thumbnail prefetch failed:', error),
               )

--- a/src/infrastructure/storage/index.ts
+++ b/src/infrastructure/storage/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   saveThumbnail,
   getThumbnailByMediaId,
+  getThumbnailsByMediaIds,
   deleteThumbnailsByMediaId,
   saveProjectThumbnail,
   loadProjectThumbnail,

--- a/src/infrastructure/storage/workspace-fs/paths.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.ts
@@ -89,7 +89,7 @@ const PROJECT_ANIMATION_PRESETS_FILENAME = 'animation-presets.json'
 const PROJECT_TRASHED_MARKER_FILENAME = '.freecut-trashed.json'
 
 const MEDIA_METADATA_FILENAME = 'metadata.json'
-const MEDIA_THUMBNAIL_FILENAME = 'thumbnail.jpg'
+export const MEDIA_THUMBNAIL_FILENAME = 'thumbnail.jpg'
 const MEDIA_CACHE_DIR = 'cache'
 
 const CACHE_WAVEFORM_DIR = 'waveform'

--- a/src/infrastructure/storage/workspace-fs/project-media.test.ts
+++ b/src/infrastructure/storage/workspace-fs/project-media.test.ts
@@ -9,6 +9,7 @@ vi.mock('./media', () => mediaMocks)
 
 import {
   associateMediaWithProject,
+  getMediaForProject,
   getProjectMediaIds,
   getProjectsUsingMedia,
   removeMediaBatchFromProject,
@@ -18,6 +19,7 @@ import { createProject } from './projects'
 import { setWorkspaceRoot } from './root'
 import { asHandle, createRoot, readFileText } from './__tests__/in-memory-handle'
 import type { Project } from '@/types/project'
+import type { MediaMetadata } from '@/types/storage'
 
 function makeProject(id: string, updatedAt = 1000): Project {
   return {
@@ -86,6 +88,45 @@ describe('workspace-fs project-media', () => {
     setWorkspaceRoot(asHandle(root))
     await createProject(makeProject('p1'))
     expect(await getProjectMediaIds('p1')).toEqual([])
+  })
+
+  it('getMediaForProject fails the load (and preserves the link) when a metadata read throws', async () => {
+    const root = createRoot()
+    setWorkspaceRoot(asHandle(root))
+    await createProject(makeProject('p1'))
+    await associateMediaWithProject('p1', 'm1')
+
+    mediaMocks.getMedia.mockReset()
+    mediaMocks.getMedia.mockRejectedValue(new Error('disk locked'))
+
+    // A genuine read error must reject rather than silently drop the item.
+    await expect(getMediaForProject('p1')).rejects.toThrow()
+    // The association must survive — the item is not a confirmed orphan.
+    expect(await getProjectMediaIds('p1')).toEqual(['m1'])
+
+    mediaMocks.getMedia.mockReset()
+    mediaMocks.getMedia.mockResolvedValue(null)
+  })
+
+  it('getMediaForProject orphans only media whose metadata is confirmed missing', async () => {
+    const root = createRoot()
+    setWorkspaceRoot(asHandle(root))
+    await createProject(makeProject('p1'))
+    await associateMediaWithProject('p1', 'good')
+    await associateMediaWithProject('p1', 'gone')
+
+    mediaMocks.getMedia.mockReset()
+    mediaMocks.getMedia.mockImplementation(async (id: string) =>
+      id === 'good' ? ({ id: 'good' } as MediaMetadata) : null,
+    )
+
+    const media = await getMediaForProject('p1')
+    expect(media.map((m) => m.id)).toEqual(['good'])
+    // 'gone' had no metadata → cleaned up as an orphan association.
+    expect(await getProjectMediaIds('p1')).toEqual(['good'])
+
+    mediaMocks.getMedia.mockReset()
+    mediaMocks.getMedia.mockResolvedValue(null)
   })
 
   it('getProjectsUsingMedia scans projects for reverse lookup', async () => {

--- a/src/infrastructure/storage/workspace-fs/project-media.ts
+++ b/src/infrastructure/storage/workspace-fs/project-media.ts
@@ -24,6 +24,7 @@ import { listDirectory } from './fs-primitives'
 import { getProject } from './projects'
 import { getMedia } from './media'
 import { withKeyLock } from './with-key-lock'
+import { mapWithConcurrency } from '@/shared/utils/async-utils'
 
 /**
  * Serialize mutations of `media-links.json` per project. Without this,
@@ -36,6 +37,9 @@ function linksLockKey(projectId: string): string {
 }
 
 const logger = createLogger('WorkspaceFS:ProjectMedia')
+
+/** Bound on parallel metadata.json reads — mirrors media.ts's global read. */
+const METADATA_READ_CONCURRENCY = 8
 
 const PROJECT_MEDIA_ITEM_TYPES = new Set(['video', 'audio', 'image'])
 
@@ -228,12 +232,23 @@ export async function getMediaForProject(projectId: string): Promise<MediaMetada
     }
 
     const finalIds = [...associated]
+    // Read every associated media's metadata.json concurrently. Each getMedia()
+    // re-walks the FSA dir tree (`media/{id}/metadata.json`), so a serial loop
+    // here cost N sequential round-trips before the grid could render. Bounded
+    // concurrency keeps this off the critical path for editor open.
+    const loaded = await mapWithConcurrency(
+      finalIds,
+      METADATA_READ_CONCURRENCY,
+      async (mediaId) => ({ mediaId, media: await getMedia(mediaId) }),
+    )
     const media: MediaMetadata[] = []
     const orphans: string[] = []
-    for (const mediaId of finalIds) {
-      const m = await getMedia(mediaId)
-      if (m) media.push(m)
-      else orphans.push(mediaId)
+    for (const result of loaded) {
+      // mapWithConcurrency yields null for an internal failure (already logged);
+      // treat those ids as unresolved rather than orphaning them.
+      if (!result) continue
+      if (result.media) media.push(result.media)
+      else orphans.push(result.mediaId)
     }
 
     if (orphans.length > 0) {

--- a/src/infrastructure/storage/workspace-fs/project-media.ts
+++ b/src/infrastructure/storage/workspace-fs/project-media.ts
@@ -41,6 +41,11 @@ const logger = createLogger('WorkspaceFS:ProjectMedia')
 /** Bound on parallel metadata.json reads — mirrors media.ts's global read. */
 const METADATA_READ_CONCURRENCY = 8
 
+type ProjectMediaReadResult =
+  | { kind: 'ok'; media: MediaMetadata }
+  | { kind: 'missing'; mediaId: string }
+  | { kind: 'error'; error: unknown }
+
 const PROJECT_MEDIA_ITEM_TYPES = new Set(['video', 'audio', 'image'])
 
 const LINKS_VERSION = '1.0'
@@ -236,18 +241,35 @@ export async function getMediaForProject(projectId: string): Promise<MediaMetada
     // re-walks the FSA dir tree (`media/{id}/metadata.json`), so a serial loop
     // here cost N sequential round-trips before the grid could render. Bounded
     // concurrency keeps this off the critical path for editor open.
+    //
+    // The mapper never throws — it returns a discriminated result so a genuine
+    // read error (`error`) is distinguishable from genuinely-absent metadata
+    // (`missing`). A real read failure must fail the whole load, exactly as the
+    // prior serial loop did: silently dropping the item would leave its
+    // media-links.json association dangling while the clip vanishes from the
+    // grid, and validation would then treat the media as missing. Only a
+    // confirmed-missing metadata file is cleaned up as an orphan.
     const loaded = await mapWithConcurrency(
       finalIds,
       METADATA_READ_CONCURRENCY,
-      async (mediaId) => ({ mediaId, media: await getMedia(mediaId) }),
+      async (mediaId): Promise<ProjectMediaReadResult> => {
+        try {
+          const media = await getMedia(mediaId)
+          return media ? { kind: 'ok', media } : { kind: 'missing', mediaId }
+        } catch (error) {
+          return { kind: 'error', error }
+        }
+      },
     )
     const media: MediaMetadata[] = []
     const orphans: string[] = []
     for (const result of loaded) {
-      // mapWithConcurrency yields null for an internal failure (already logged);
-      // treat those ids as unresolved rather than orphaning them.
-      if (!result) continue
-      if (result.media) media.push(result.media)
+      // The mapper never throws, so a null slot would only come from an
+      // internal mapWithConcurrency failure — surface it rather than silently
+      // treating the id as resolved.
+      if (!result) throw new Error(`Metadata read produced no result for project ${projectId}`)
+      if (result.kind === 'error') throw result.error
+      if (result.kind === 'ok') media.push(result.media)
       else orphans.push(result.mediaId)
     }
 

--- a/src/infrastructure/storage/workspace-fs/thumbnails.test.ts
+++ b/src/infrastructure/storage/workspace-fs/thumbnails.test.ts
@@ -6,6 +6,7 @@ import {
   deleteThumbnailsByMediaId,
   getThumbnail,
   getThumbnailByMediaId,
+  getThumbnailsByMediaIds,
   saveThumbnail,
 } from './thumbnails'
 import { setWorkspaceRoot } from './root'
@@ -72,6 +73,28 @@ describe('workspace-fs thumbnails', () => {
     await deleteThumbnailsByMediaId('m1')
     expect(await getThumbnailByMediaId('m1')).toBeUndefined()
     expect(await readFileText(root, 'media', 'm1', 'thumbnail.jpg')).toBeNull()
+  })
+
+  it('getThumbnailsByMediaIds batch-reads present thumbnails and skips missing ones', async () => {
+    const root = createRoot()
+    setWorkspaceRoot(asHandle(root))
+    await saveThumbnail(makeThumbnail('m1'))
+    await saveThumbnail(makeThumbnail('m3'))
+
+    // 'm2' has no thumbnail — it must be absent from the result, not throw.
+    const result = await getThumbnailsByMediaIds(['m1', 'm2', 'm3'])
+
+    expect([...result.keys()].sort()).toEqual(['m1', 'm3'])
+    expect(result.get('m1')!.size).toBeGreaterThan(0)
+    expect(result.get('m2')).toBeUndefined()
+  })
+
+  it('getThumbnailsByMediaIds returns an empty map for empty input or missing media dir', async () => {
+    const root = createRoot()
+    setWorkspaceRoot(asHandle(root))
+    expect((await getThumbnailsByMediaIds([])).size).toBe(0)
+    // media/ directory never created — must resolve to empty, not throw.
+    expect((await getThumbnailsByMediaIds(['nope'])).size).toBe(0)
   })
 
   it('saveThumbnail overwrites prior thumbnail for the same media', async () => {

--- a/src/infrastructure/storage/workspace-fs/thumbnails.ts
+++ b/src/infrastructure/storage/workspace-fs/thumbnails.ts
@@ -23,8 +23,9 @@ import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
 import { readBlob, removeEntry, writeBlob } from './fs-primitives'
-import { mediaThumbnailPath, projectThumbnailPath } from './paths'
+import { MEDIA_DIR, MEDIA_THUMBNAIL_FILENAME, mediaThumbnailPath, projectThumbnailPath } from './paths'
 import { blobToArrayBuffer } from './blob-utils'
+import { mapWithConcurrency } from '@/shared/utils/async-utils'
 
 const logger = createLogger('WorkspaceFS:Thumbnails')
 
@@ -67,6 +68,58 @@ export async function getThumbnailByMediaId(mediaId: string): Promise<ThumbnailD
     logger.error(`getThumbnailByMediaId(${mediaId}) failed`, error)
     return undefined
   }
+}
+
+/**
+ * Batch-read thumbnails for many media at once.
+ *
+ * Resolving the shared `media/` directory handle a single time and reusing it
+ * for every id avoids the per-id re-walk that `getThumbnailByMediaId` incurs
+ * (`readBlob` re-resolves `media/` on each call). Reads run with bounded
+ * concurrency; missing thumbnails are simply absent from the returned map.
+ * This warms callers' caches on project load so cards render without each
+ * mounting an independent async fetch.
+ */
+const THUMBNAIL_READ_CONCURRENCY = 8
+
+export async function getThumbnailsByMediaIds(
+  mediaIds: string[],
+): Promise<Map<string, Blob>> {
+  const result = new Map<string, Blob>()
+  if (mediaIds.length === 0) return result
+
+  const root = requireWorkspaceRoot()
+  let mediaDirHandle: FileSystemDirectoryHandle
+  try {
+    mediaDirHandle = await root.getDirectoryHandle(MEDIA_DIR, { create: false })
+  } catch (error) {
+    // No media/ directory yet — nothing to prefetch.
+    if (error instanceof DOMException && error.name === 'NotFoundError') return result
+    logger.warn('getThumbnailsByMediaIds: failed to open media directory', error)
+    return result
+  }
+
+  const reads = await mapWithConcurrency(
+    mediaIds,
+    THUMBNAIL_READ_CONCURRENCY,
+    async (mediaId): Promise<{ mediaId: string; blob: Blob } | null> => {
+      try {
+        const dir = await mediaDirHandle.getDirectoryHandle(mediaId, { create: false })
+        const fileHandle = await dir.getFileHandle(MEDIA_THUMBNAIL_FILENAME, { create: false })
+        return { mediaId, blob: await fileHandle.getFile() }
+      } catch (error) {
+        // A media dir without a thumbnail (or removed mid-read) is expected — skip.
+        if (error instanceof DOMException && error.name === 'NotFoundError') return null
+        logger.warn(`getThumbnailsByMediaIds(${mediaId}) failed`, error)
+        return null
+      }
+    },
+  )
+
+  for (const read of reads) {
+    if (read) result.set(read.mediaId, read.blob)
+  }
+  return result
 }
 
 export async function deleteThumbnailsByMediaId(mediaId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Speeds up the media library on editor open, where loading felt slower than expected even with few items. Two independent wins in the load path:

- **Parallelize per-project metadata reads** — `getMediaForProject()` read each associated media's `metadata.json` in a serial `for…await` loop. Every `getMedia()` re-walks the File System Access dir tree, so N items meant N sequential round-trips *before the grid could render* (it gates `isLoading`). Now read with bounded concurrency (8), mirroring the existing global `readAllSerializedMedia` path. Also more resilient: a transient FSA error on one item no longer rejects the whole project load or falsely marks it an orphan.
- **Batch-prefetch thumbnails** — each `MediaCard` fetched its own thumbnail on mount, and every `readBlob` re-walked `media/ → {id}` from the root. New `getThumbnailsByMediaIds()` resolves the shared `media/` directory handle once and reads each `{id}/thumbnail.jpg` with bounded concurrency; `loadMediaItems` warms the thumbnail-URL cache in one batched pass so cards render on mount as synchronous cache hits. Both the prefetcher and `getThumbnailBlobUrl` guard against racing on the same id to avoid leaking duplicate object URLs.

## Net effect

- Grid appears sooner (metadata gate no longer serial).
- Thumbnails appear sooner and more uniformly (one batched pass vs N independent card fetches each re-walking the tree).

## Testing

- `thumbnails.test.ts`: added batch-read + skip-missing + empty/missing-dir coverage.
- Full `workspace-fs` suite (130) + `media-library-service` suite pass; lint clean; boundary check passes (1327 files).

No behavior changes to media contents — purely how they're read/cached on load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch thumbnail loading by media IDs to retrieve thumbnails efficiently.
  * Background thumbnail prefetch now warms the cache after media items load.
* **Bug Fixes**
  * Thumbnail caching is now revision-aware, preventing stale thumbnails when thumbnails are regenerated.
  * Concurrency-related duplicate object URLs are avoided; missing thumbnails are skipped without failing.
* **Performance**
  * Media metadata loading and thumbnail reads now use bounded concurrency.
* **Tests**
  * Expanded unit test coverage for batch thumbnail reads and marker-aware caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->