### PR TITLE
fix(pwa): stop false 'new version available' toast on editor pages

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,9 @@
-const CACHE_VERSION = 'freecut-app-shell-v1'
+// __FREECUT_BUILD_ID__ is replaced at build time (see serviceWorkerVersionPlugin in
+// vite.config.ts) with the hashed entry-chunk filename, so the cache name — and the SW
+// file bytes — change on every deploy. That lets registration.update() detect new
+// versions and lets `activate` purge the previous deploy's cached chunks. In dev the SW
+// is never registered (PROD-gated in main.tsx), so the unreplaced literal is harmless.
+const CACHE_VERSION = 'freecut-app-shell-__FREECUT_BUILD_ID__'
 const APP_SHELL_URLS = [
   '/',
   '/index.html',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,6 @@ const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const ACCEPTED_APP_UPDATE_SIGNATURE_KEY = 'freecut-accepted-app-update-signature'
 
 let updateToastVisible = false
-let currentBuildAssetSignature: string | null = null
 
 // Debug utilities are editor-heavy; keep them out of the production startup graph.
 if (import.meta.env.DEV) {
@@ -103,23 +102,25 @@ async function showUpdateAvailableToast(
 }
 
 function getBuildAssetSignature(documentToInspect: Document): string {
-  const assetUrls = [
-    ...Array.from(
-      documentToInspect.querySelectorAll<HTMLScriptElement>('script[type="module"][src]'),
-    ).map((element) => element.src),
-    ...Array.from(
-      documentToInspect.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"][href]'),
-    ).map((element) => element.href),
-  ]
+  // Build identity is the entry module script (e.g. /assets/main-[hash].js); its content
+  // hash changes on every deploy. We deliberately IGNORE <link rel="stylesheet"> tags:
+  // route/feature CSS is code-split and injected into the live DOM at runtime, so an
+  // editor session accumulates stylesheet links that the pristine server HTML never has.
+  // Comparing those made checkForAppShellUpdate fire a false "new version" toast on every
+  // editor load. Dynamic import()s inject <link rel="modulepreload">, never <script>, so
+  // the module-script set stays stable for a given build.
+  const scriptPaths = Array.from(
+    documentToInspect.querySelectorAll<HTMLScriptElement>('script[type="module"][src]'),
+  ).map((element) => new URL(element.src, window.location.href).pathname)
 
-  return JSON.stringify(
-    assetUrls.map((assetUrl) => new URL(assetUrl, window.location.href).pathname).sort(),
-  )
+  return JSON.stringify(scriptPaths.sort())
 }
 
-async function checkForAppShellUpdate() {
-  currentBuildAssetSignature ??= getBuildAssetSignature(document)
+// Snapshot the entry-script signature at startup, before React mounts or the router
+// injects anything, so it matches the pristine HTML that checkForAppShellUpdate re-fetches.
+const currentBuildAssetSignature = getBuildAssetSignature(document)
 
+async function checkForAppShellUpdate() {
   try {
     const response = await fetch(`/?__freecut_update_check=${Date.now()}`, {
       cache: 'no-store',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,48 @@
 import { defineConfig, lazyPlugins } from 'vite-plus'
+import type { Plugin } from 'vite-plus'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+// Stamps public/sw.js with the hashed entry-chunk filename at build time so the service
+// worker's CACHE_VERSION — and the sw.js bytes — change on every deploy. Without this the
+// SW file is byte-identical across deploys, so registration.update() never detects a new
+// version and old cached chunks are never purged. Uses the content hash (not a timestamp)
+// so identical builds produce an identical SW and avoid needless update churn.
+function serviceWorkerVersionPlugin(): Plugin {
+  const placeholder = '__FREECUT_BUILD_ID__'
+  let buildId = ''
+
+  return {
+    name: 'freecut-sw-version',
+    apply: 'build',
+    writeBundle(options, bundle) {
+      const mainEntry = Object.values(bundle).find(
+        (output) => output.type === 'chunk' && output.isEntry && output.name === 'main',
+      )
+      buildId =
+        mainEntry && mainEntry.type === 'chunk'
+          ? mainEntry.fileName.replace(/[^a-zA-Z0-9]/g, '-')
+          : buildId
+    },
+    // closeBundle runs after Vite has copied publicDir into the out dir, so dist/sw.js
+    // exists here with the placeholder intact.
+    closeBundle() {
+      if (!buildId) {
+        this.warn('serviceWorkerVersionPlugin: no main entry chunk found; sw.js not stamped')
+        return
+      }
+      const swPath = join(fileURLToPath(new URL('./dist', import.meta.url)), 'sw.js')
+      const source = readFileSync(swPath, 'utf8')
+      if (!source.includes(placeholder)) {
+        return
+      }
+      writeFileSync(swPath, source.replaceAll(placeholder, buildId))
+    },
+  }
+}
 
 const oxlintConfig = JSON.parse(readFileSync(new URL('./.oxlintrc.json', import.meta.url), 'utf8'))
 const oxfmtConfig = JSON.parse(readFileSync(new URL('./.oxfmtrc.json', import.meta.url), 'utf8'))
@@ -52,7 +92,7 @@ export default defineConfig({
       },
     },
   },
-  plugins: lazyPlugins(() => [react(), tailwindcss()]),
+  plugins: lazyPlugins(() => [react(), tailwindcss(), serviceWorkerVersionPlugin()]),
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Problem

Users kept seeing the **"A new version is available. Save your work and reload."** toast on editor pages (`/editor/:id`) with no actual deploy having happened. Reported against a live Vercel deployment.

Root cause is **client-side, not Vercel** — I confirmed Vercel serves `/` with a stable, identical ETag across requests.

The app-shell update checker in `src/main.tsx` compares a "build signature" of the **live DOM** against one computed from a freshly-fetched pristine `index.html`. The old `getBuildAssetSignature` folded in **every `<link rel="stylesheet">`**. But the build code-splits CSS per route (`_projectId-*.css` for the editor route, `export-render-*.css`, etc.), and those stylesheet links are injected into the live DOM at runtime. So on any editor page the live document always carried stylesheet links the pristine server HTML never had → signatures never matched → the toast fired on every editor session.

## Fix

- **Signature now tracks only the entry module script** (`/assets/main-[hash].js`), whose content hash changes on every deploy and is never runtime-injected (dynamic `import()`s add `<link rel="modulepreload">`, not `<script>`). Captured eagerly at startup so it reflects the pristine HTML.
- **Version the service-worker cache per build.** `sw.js` had a static `CACHE_VERSION = 'v1'`, so the file was byte-identical across deploys and `registration.update()` never detected new versions. A new `serviceWorkerVersionPlugin` in `vite.config.ts` stamps `CACHE_VERSION` with the hashed entry filename at build time, so the SW updates per deploy and `activate` purges stale cached chunks. This also makes the SW the reliable primary deploy signal.

## Verification

- `vp build` succeeds; verified `dist/sw.js` stamped to `freecut-app-shell-assets-main-<hash>-js` (placeholder fully replaced) and matches the entry script the signature reads.
- `vp check` — no type/lint errors (pre-existing repo-wide formatting untouched; the 3 changed files are clean).
- Full pre-push gate green: **460 test files / 3191 tests passed**.

## Files

- `src/main.tsx` — signature logic + eager capture
- `public/sw.js` — build-id placeholder in `CACHE_VERSION`
- `vite.config.ts` — `serviceWorkerVersionPlugin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App updates are now detected more reliably after each release, helping users receive the latest version sooner.
* **Bug Fixes**
  * Improved service worker cache versioning so old cached app files are cleared automatically on deployment.
  * Reduced the chance of update prompts missing a new build when only the app’s main script changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->