### PR TITLE
fix(pwa): only prompt on vite:preloadError for a real version change

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -120,7 +120,14 @@ function getBuildAssetSignature(documentToInspect: Document): string {
 // injects anything, so it matches the pristine HTML that checkForAppShellUpdate re-fetches.
 const currentBuildAssetSignature = getBuildAssetSignature(document)
 
+let appShellUpdateCheckInFlight = false
 async function checkForAppShellUpdate() {
+  // Guard against overlapping checks — the interval, visibilitychange, and a burst of
+  // vite:preloadError events can otherwise fire several concurrent fetches of `/`.
+  if (appShellUpdateCheckInFlight) {
+    return
+  }
+  appShellUpdateCheckInFlight = true
   try {
     const response = await fetch(`/?__freecut_update_check=${Date.now()}`, {
       cache: 'no-store',
@@ -150,6 +157,8 @@ async function checkForAppShellUpdate() {
     }
   } catch (error) {
     log.warn('App update check failed:', error)
+  } finally {
+    appShellUpdateCheckInFlight = false
   }
 }
 
@@ -202,11 +211,17 @@ window.addEventListener('error', (event) => {
   log.error('Uncaught error:', event.error)
 })
 
-// Handle stale asset errors after new deployments.
-// When Vercel deploys a new version, old chunk hashes become 404s.
-// Prompt the user to save before reloading so they don't lose work.
+// A failed lazy-chunk load has two very different causes:
+//   (a) a new deployment removed the old chunk hash — a real stale version, worth
+//       prompting the user to save + reload, or
+//   (b) a transient network blip while fetching an otherwise-present chunk.
+// Blindly toasting treated every blip as a version change, so a flaky connection while
+// opening a workspace or panel popped a scary "new version available". Instead, verify
+// against the server: checkForAppShellUpdate re-fetches the app shell and only surfaces
+// the toast when the live entry-script hash actually differs from ours. A transient
+// failure leaves the signature unchanged, so it stays silent and the user can retry.
 window.addEventListener('vite:preloadError', () => {
-  void showUpdateAvailableToast()
+  void checkForAppShellUpdate()
 })
 
 // IMPORTANT: Intentionally do not dispose filmstrip cache on beforeunload.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -121,10 +121,16 @@ function getBuildAssetSignature(documentToInspect: Document): string {
 const currentBuildAssetSignature = getBuildAssetSignature(document)
 
 let appShellUpdateCheckInFlight = false
+let appShellUpdateRecheckQueued = false
 async function checkForAppShellUpdate() {
-  // Guard against overlapping checks — the interval, visibilitychange, and a burst of
-  // vite:preloadError events can otherwise fire several concurrent fetches of `/`.
+  // Coalesce overlapping checks — the interval, visibilitychange, and a burst of
+  // vite:preloadError events would otherwise fire several concurrent fetches of `/`.
+  // Rather than drop the extras (which would lose the signal if the in-flight fetch
+  // transiently fails or gets a stale `/`), queue a single trailing re-check so a real
+  // deploy is still caught after the current fetch settles instead of only at the next
+  // interval/visibility event.
   if (appShellUpdateCheckInFlight) {
+    appShellUpdateRecheckQueued = true
     return
   }
   appShellUpdateCheckInFlight = true
@@ -159,6 +165,11 @@ async function checkForAppShellUpdate() {
     log.warn('App update check failed:', error)
   } finally {
     appShellUpdateCheckInFlight = false
+  }
+
+  if (appShellUpdateRecheckQueued) {
+    appShellUpdateRecheckQueued = false
+    await checkForAppShellUpdate()
   }
 }
 


### PR DESCRIPTION
## Context

Follow-up to #307. After that landed, the `checkForAppShellUpdate` poller no longer false-positives, but a **third** trigger for the "new version available" toast remained untouched: the `vite:preloadError` handler.

## Problem

A failed lazy-chunk load fired the toast **unconditionally**:

```js
window.addEventListener('vite:preloadError', () => { void showUpdateAvailableToast() })
```

This can't tell apart:
- **(a)** a real new deployment that removed the old chunk hash (worth prompting — save + reload), from
- **(b)** a transient network blip while fetching an otherwise-present chunk.

So a flaky connection while opening a workspace/panel (which lazy-loads a chunk) popped a scary "A new version is available" even though nothing had changed. I verified the current production deploy is chunk-complete (all 128 referenced chunks resolve), so post-deploy the only remaining way to see this toast on a workspace switch was a transient failure through this path.

## Fix

Route `preloadError` through the existing `checkForAppShellUpdate`, which re-fetches the app shell and only surfaces the toast when the **live entry-script hash actually differs** from ours. A transient failure leaves the signature unchanged → stays silent, and the user can just retry the action.

Also added an in-flight guard to `checkForAppShellUpdate` so the interval, `visibilitychange`, and a burst of `preloadError` events don't fire overlapping `/` fetches.

## Verification

- `vp check` — no type/lint errors.
- Full pre-push gate green: **460 test files / 3191 tests passed**.

## File

- `src/main.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app update checks to coalesce overlapping refresh requests and perform at most one follow-up verification when needed, reducing redundant or conflicting update notifications.
  * Updated preload-error handling so the app runs the normal update verification flow before showing an “update available” toast.
  * Reduced false “new version available” alerts by re-checking the live entry-script signature, accounting for both stale cached chunks after deploy and transient network issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->