### PR TITLE
fix(pwa): only prompt on vite:preloadError for a real version change

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -120,7 +120,14 @@ function getBuildAssetSignature(documentToInspect: Document): string {
 // injects anything, so it matches the pristine HTML that checkForAppShellUpdate re-fetches.
 const currentBuildAssetSignature = getBuildAssetSignature(document)
 
+let appShellUpdateCheckInFlight = false
 async function checkForAppShellUpdate() {
+  // Guard against overlapping checks — the interval, visibilitychange, and a burst of
+  // vite:preloadError events can otherwise fire several concurrent fetches of `/`.
+  if (appShellUpdateCheckInFlight) {
+    return
+  }
+  appShellUpdateCheckInFlight = true
   try {
     const response = await fetch(`/?__freecut_update_check=${Date.now()}`, {
       cache: 'no-store',
@@ -150,6 +157,8 @@ async function checkForAppShellUpdate() {
     }
   } catch (error) {
     log.warn('App update check failed:', error)
+  } finally {
+    appShellUpdateCheckInFlight = false
   }
 }
 
@@ -202,11 +211,17 @@ window.addEventListener('error', (event) => {
   log.error('Uncaught error:', event.error)
 })
 
-// Handle stale asset errors after new deployments.
-// When Vercel deploys a new version, old chunk hashes become 404s.
-// Prompt the user to save before reloading so they don't lose work.
+// A failed lazy-chunk load has two very different causes:
+//   (a) a new deployment removed the old chunk hash — a real stale version, worth
+//       prompting the user to save + reload, or
+//   (b) a transient network blip while fetching an otherwise-present chunk.
+// Blindly toasting treated every blip as a version change, so a flaky connection while
+// opening a workspace or panel popped a scary "new version available". Instead, verify
+// against the server: checkForAppShellUpdate re-fetches the app shell and only surfaces
+// the toast when the live entry-script hash actually differs from ours. A transient
+// failure leaves the signature unchanged, so it stays silent and the user can retry.
 window.addEventListener('vite:preloadError', () => {
-  void showUpdateAvailableToast()
+  void checkForAppShellUpdate()
 })
 
 // IMPORTANT: Intentionally do not dispose filmstrip cache on beforeunload.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -121,10 +121,16 @@ function getBuildAssetSignature(documentToInspect: Document): string {
 const currentBuildAssetSignature = getBuildAssetSignature(document)
 
 let appShellUpdateCheckInFlight = false
+let appShellUpdateRecheckQueued = false
 async function checkForAppShellUpdate() {
-  // Guard against overlapping checks — the interval, visibilitychange, and a burst of
-  // vite:preloadError events can otherwise fire several concurrent fetches of `/`.
+  // Coalesce overlapping checks — the interval, visibilitychange, and a burst of
+  // vite:preloadError events would otherwise fire several concurrent fetches of `/`.
+  // Rather than drop the extras (which would lose the signal if the in-flight fetch
+  // transiently fails or gets a stale `/`), queue a single trailing re-check so a real
+  // deploy is still caught after the current fetch settles instead of only at the next
+  // interval/visibility event.
   if (appShellUpdateCheckInFlight) {
+    appShellUpdateRecheckQueued = true
     return
   }
   appShellUpdateCheckInFlight = true
@@ -159,6 +165,11 @@ async function checkForAppShellUpdate() {
     log.warn('App update check failed:', error)
   } finally {
     appShellUpdateCheckInFlight = false
+  }
+
+  if (appShellUpdateRecheckQueued) {
+    appShellUpdateRecheckQueued = false
+    await checkForAppShellUpdate()
   }
 }
 


### PR DESCRIPTION
Direct-to-`main` promotion (per request) of the follow-up to #307.

## Problem

The `vite:preloadError` handler fired the "new version available" toast **unconditionally**, so a transient network blip while lazy-loading a workspace/panel looked identical to a real stale-version deploy and popped a scary prompt for no reason. The current production deploy is chunk-complete (all 128 referenced chunks resolve), so this transient path was the only remaining way to see the toast on a workspace switch.

## Fix

Route `preloadError` through the existing `checkForAppShellUpdate`: it re-fetches the app shell and only surfaces the toast when the live entry-script hash actually differs from ours. Transient failures leave the signature unchanged → silent, user just retries. Also added an in-flight guard so the interval, `visibilitychange`, and a burst of `preloadError` events can't fire overlapping `/` fetches.

## Verification

- `vp check` — no type/lint errors.
- Full pre-push gate green: **460 test files / 3191 tests passed**.

## File

- `src/main.tsx`

---
Note: also open as #308 against `staging` — close whichever you don't use to avoid the same commit merging twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate app update checks from running at the same time.
  * Improved update notifications so they only appear when a real app update is detected.
  * Reduced false “update available” messages caused by temporary loading or network issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->