### PR TITLE
docs(audio): mic voiceover guide + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to FreeCut. Weekly CalVer: `YYYY.MM.DD` = the Monday of the 
 ## [Current] — week of 2026-07-06
 
 ### Added
+- Record a voiceover from your microphone, synced live to the timeline
 - Lottie animations — import .json and .lottie files and play them on the timeline
 - Customize Lottie colors, themes, text, and value slots, with live preview
 - Browse and import free LottieFiles animations from inside the editor
 
 ### Fixed
+- No more false "new version available" prompts while editing
 - Fixed edge seams and shimmer on GPU effects in the preview
 - Copied, generated, and imported media now save reliably to your workspace folder
 - Missing media shows a relink prompt on the clip instead of failing silently

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,9 +1,12 @@
 {
   "current": {
     "version": "current",
-    "date": "2026-07-08",
+    "date": "2026-07-09",
     "groups": {
       "added": [
+        {
+          "title": "Record a voiceover from your microphone, synced live to the timeline"
+        },
         {
           "title": "Lottie animations — import .json and .lottie files and play them on the timeline"
         },
@@ -15,6 +18,9 @@
         }
       ],
       "fixed": [
+        {
+          "title": "No more false \"new version available\" prompts while editing"
+        },
         {
           "title": "Fixed edge seams and shimmer on GPU effects in the preview"
         },

--- a/src/features/docs/pages/12-audio.ts
+++ b/src/features/docs/pages/12-audio.ts
@@ -5,7 +5,7 @@ const page = {
   slug: 'audio',
   title: 'Audio Editing',
   description:
-    'Clip gain and fades, pitch, per-clip EQ, the mixer and meters, and silence and filler-word cleanup.',
+    'Record a voiceover, adjust clip gain and fades, pitch, per-clip EQ, the mixer and meters, and silence and filler-word cleanup.',
   category: 'Creative Tools',
   related: ['properties', 'local-ai'],
   sections: [
@@ -58,6 +58,54 @@ const page = {
           kind: 'note',
           tone: 'info',
           text: 'Monitor volume in the preview affects local playback only and never changes the exported mix.',
+        },
+      ],
+    },
+    {
+      title: 'Record a voiceover',
+      blocks: [
+        {
+          kind: 'paragraph',
+          text: 'The **Record voiceover** (microphone) button in the timeline toolbar records narration in time with your project. Capture runs **while the timeline plays**, and the finished take lands on a new audio track anchored to the playhead position where you started.',
+        },
+        {
+          kind: 'steps',
+          items: [
+            'Move the playhead to where the voiceover should begin.',
+            'Click the **microphone** button — the timeline starts playing and recording begins.',
+            'Use **Pause recording** to stop the playhead and mic together, **Resume recording** to continue, and **Stop and save** to finish and drop the clip onto a new audio track.',
+            'Click **Cancel recording** (the ✕) to discard the take without adding anything.',
+          ],
+        },
+        {
+          kind: 'paragraph',
+          text: 'Open **Microphone settings** (the ▾ next to the button) to choose an input device and tune capture. The level meter there is live, so you can check your mic before recording.',
+        },
+        {
+          kind: 'table',
+          headers: ['Setting', 'What it does'],
+          rows: [
+            ['Noise suppression', 'Reduces steady background noise. On by default.'],
+            ['Auto gain', 'Keeps your voice at a consistent level. On by default.'],
+            [
+              'Mute timeline while recording',
+              'Silences the timeline monitor so speaker audio does not bleed into the mic. On by default.',
+            ],
+            [
+              'Sync offset',
+              'Nudges the recorded clip earlier or later to compensate for input latency (up to ±1000 ms).',
+            ],
+          ],
+        },
+        {
+          kind: 'note',
+          tone: 'tip',
+          text: 'Use headphones so your project audio is never captured by the mic — then you can turn **Mute timeline while recording** off to hear the mix as you narrate.',
+        },
+        {
+          kind: 'note',
+          tone: 'warning',
+          text: 'Seeking is disabled while recording, and pressing `Space` or reaching the end of the timeline finishes the take. This keeps the recording locked to the playhead so it can never drift out of sync.',
         },
       ],
     },


### PR DESCRIPTION
## Summary

Follows up the merged mic-voiceover work (#310) with user documentation and changelog entries.

- **Audio user guide** — new "Record a voiceover" section covering the workflow (position → record → pause/resume/stop → cancel), the **Microphone settings** capture options (noise suppression, auto gain, mute-timeline-while-recording, sync offset), a headphones tip, and the sync-lock behavior (seeking disabled; `Space`/timeline-end finalizes the take). Page description updated to mention voiceover recording.
- **Changelog** (`current`, week of 2026-07-06) — added *"Record a voiceover from your microphone, synced live to the timeline"* (Added) and *"No more false 'new version available' prompts while editing"* (Fixed). `CHANGELOG.md` and `src/data/changelog.json` kept in sync.

## Testing

- `npx vp run check` — 0 errors
- Full suite via pre-push gate — 461 files / 3199 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to record a voiceover from your microphone and keep it synced to the timeline.
  * Updated the audio feature guide with a new section covering setup, microphone options, and recording tips.

* **Bug Fixes**
  * Fixed false “new version available” prompts that could appear while editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->