### PR TITLE
feat(editor): shift-click a property section header to collapse all sections

### DIFF
--- a/src/shared/ui/property-controls/property-section.tsx
+++ b/src/shared/ui/property-controls/property-section.tsx
@@ -35,18 +35,34 @@ export function PropertySection({
     }
   }, [])
 
+  const setAllSectionsOpen = (next: boolean) => {
+    for (const setSectionOpen of openStateSubscribers) setSectionOpen(next)
+  }
+
   const handleTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!event.shiftKey) return
     // Radix skips its own toggle when the click is default-prevented, so this
     // header is driven by the broadcast like every other one.
     event.preventDefault()
-    for (const setSectionOpen of openStateSubscribers) setSectionOpen(!open)
+    setAllSectionsOpen(!open)
+  }
+
+  // Activating the button by key synthesizes a click, but only carries shiftKey
+  // if Shift is still held when that click is dispatched — and Space dispatches
+  // it on keyup. Read the modifier off the keydown, where it is unambiguous, and
+  // suppress the activation so no click follows.
+  const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!event.shiftKey || event.repeat) return
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    setAllSectionsOpen(!open)
   }
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger
         onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
         className="flex items-center gap-2 w-full py-2 hover:bg-secondary/50 rounded-md px-2 -mx-2 transition-colors"
       >
         <ChevronRight

--- a/src/shared/ui/property-controls/property-section.tsx
+++ b/src/shared/ui/property-controls/property-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ChevronRight, type LucideIcon } from 'lucide-react'
 import { cn } from '@/shared/ui/cn'
@@ -10,9 +10,15 @@ interface PropertySectionProps {
   children: React.ReactNode
 }
 
+/** Every mounted PropertySection, so a shift-click can drive all of them at once. */
+const openStateSubscribers = new Set<(open: boolean) => void>()
+
 /**
  * Collapsible section wrapper for property groups.
  * Used for Source, Layout, Fill, Video, Audio sections.
+ *
+ * Shift-clicking a header collapses every section (or expands them all, when the
+ * clicked header was already collapsed).
  */
 export function PropertySection({
   title,
@@ -22,9 +28,27 @@ export function PropertySection({
 }: PropertySectionProps) {
   const [open, setOpen] = useState(defaultOpen)
 
+  useEffect(() => {
+    openStateSubscribers.add(setOpen)
+    return () => {
+      openStateSubscribers.delete(setOpen)
+    }
+  }, [])
+
+  const handleTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!event.shiftKey) return
+    // Radix skips its own toggle when the click is default-prevented, so this
+    // header is driven by the broadcast like every other one.
+    event.preventDefault()
+    for (const setSectionOpen of openStateSubscribers) setSectionOpen(!open)
+  }
+
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger className="flex items-center gap-2 w-full py-2 hover:bg-secondary/50 rounded-md px-2 -mx-2 transition-colors">
+      <CollapsibleTrigger
+        onClick={handleTriggerClick}
+        className="flex items-center gap-2 w-full py-2 hover:bg-secondary/50 rounded-md px-2 -mx-2 transition-colors"
+      >
         <ChevronRight
           className={cn('w-3 h-3 text-muted-foreground transition-transform', open && 'rotate-90')}
         />


### PR DESCRIPTION
## What

Shift-clicking any header in the properties sidebar now collapses **every** property section at once. If the header you shift-click is already collapsed, it expands them all instead.

## How

Each `PropertySection` owns its open state locally, so there was no shared place to drive them from. The component now keeps a module-level set of the mounted sections' `setOpen` functions.

On a shift-click the handler calls `preventDefault()`, which makes Radix's `composeEventHandlers` skip its own single-section toggle, and then broadcasts the inverse of the clicked section's current state to every subscriber. The clicked header ends up in the same state as the rest rather than toggling twice.

This lands in the one shared component, so it covers every consumer without touching them: clip panel sections (layout, fill, text, video, audio, shape, lottie, gif, corner pin, subtitle), canvas, markers, transitions, effects, and color grade.

It also works from the keyboard — Shift+Enter/Space on a button produces a click event with `shiftKey` set.

## Testing

- `vp run check` and the full `vp test run` suite pass (via the pre-push hook).
- Not exercised in the browser yet; the interaction is a single click handler on the shared header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now use **Shift-click** on a section header to toggle the open/closed state of **all** property sections at once.
  * **Shift+Enter/Space** on the section header now provides the same “toggle all” behavior without triggering unintended click actions.
  * Normal (non-shift) clicks continue to expand/collapse only the selected section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->