### PR TITLE
fix(export): stream long renders and restore Linux AAC audio

### DIFF
--- a/scripts/fallow-unused-exports.allowlist.json
+++ b/scripts/fallow-unused-exports.allowlist.json
@@ -197,11 +197,6 @@
     },
     {
       "path": "src/features/export/utils/canvas-audio.ts",
-      "exportName": "clearAudioDecodeCache",
-      "reason": "Called through the canvas-audio namespace from the render orchestrator."
-    },
-    {
-      "path": "src/features/export/utils/canvas-audio.ts",
       "exportName": "createAudioBuffer",
       "reason": "Called through the canvas-audio namespace from export rendering."
     },

--- a/src/features/export/hooks/use-client-render.ts
+++ b/src/features/export/hooks/use-client-render.ts
@@ -9,7 +9,7 @@
  * lockstep.
  */
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import type { ExportSettings, ExtendedExportSettings } from '@/types/export'
 import type { RenderProgress, ClientRenderResult, ClientCodec } from '../utils/client-renderer'
 import {
@@ -23,6 +23,7 @@ import { isExtendedSettings, resolveClientSettings, runRender } from '../utils/r
 import { convertTimelineToComposition } from '../utils/timeline-to-composition'
 import { buildTranscriptSubtitleCues } from '../utils/embedded-subtitle-export'
 import { serializeSrt } from '@/shared/utils/subtitles'
+import { scheduleTemporaryExportOutputRelease } from '../utils/export-output-target'
 import { useTimelineStore } from '@/features/export/deps/timeline'
 import { useProjectStore } from '@/features/export/deps/projects'
 import { DEFAULT_PROJECT_HEIGHT, DEFAULT_PROJECT_WIDTH } from '@/shared/projects/defaults'
@@ -75,6 +76,7 @@ export function useClientRender(): UseClientRenderReturn {
   const [status, setStatus] = useState<ClientRenderStatus>('idle')
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<ClientRenderResult | null>(null)
+  const resultRef = useRef<ClientRenderResult | null>(null)
 
   // AbortController for cancellation
   const abortControllerRef = useRef<AbortController | null>(null)
@@ -113,6 +115,9 @@ export function useClientRender(): UseClientRenderReturn {
       const event = log.startEvent('render', opId)
 
       try {
+        const previousResult = resultRef.current
+        resultRef.current = null
+        scheduleTemporaryExportOutputRelease(previousResult)
         setIsExporting(true)
         setProgress(0)
         setError(null)
@@ -261,6 +266,7 @@ export function useClientRender(): UseClientRenderReturn {
           }
         }
 
+        resultRef.current = finalResult
         setResult(finalResult)
         setStatus('completed')
         setProgress(100)
@@ -360,8 +366,19 @@ export function useClientRender(): UseClientRenderReturn {
     setTotalFrames(undefined)
     setStatus('idle')
     setError(null)
+    const previousResult = resultRef.current
+    resultRef.current = null
+    scheduleTemporaryExportOutputRelease(previousResult)
     setResult(null)
   }, [])
+
+  useEffect(
+    () => () => {
+      scheduleTemporaryExportOutputRelease(resultRef.current)
+      resultRef.current = null
+    },
+    [],
+  )
 
   /**
    * Get supported codecs for the current resolution

--- a/src/features/export/hooks/use-client-render.ts
+++ b/src/features/export/hooks/use-client-render.ts
@@ -23,7 +23,7 @@ import { isExtendedSettings, resolveClientSettings, runRender } from '../utils/r
 import { convertTimelineToComposition } from '../utils/timeline-to-composition'
 import { buildTranscriptSubtitleCues } from '../utils/embedded-subtitle-export'
 import { serializeSrt } from '@/shared/utils/subtitles'
-import { scheduleTemporaryExportOutputRelease } from '../utils/export-output-target'
+import { releaseTemporaryExportOutput } from '../utils/export-output-target'
 import { useTimelineStore } from '@/features/export/deps/timeline'
 import { useProjectStore } from '@/features/export/deps/projects'
 import { DEFAULT_PROJECT_HEIGHT, DEFAULT_PROJECT_WIDTH } from '@/shared/projects/defaults'
@@ -117,7 +117,7 @@ export function useClientRender(): UseClientRenderReturn {
       try {
         const previousResult = resultRef.current
         resultRef.current = null
-        scheduleTemporaryExportOutputRelease(previousResult)
+        void releaseTemporaryExportOutput(previousResult)
         setIsExporting(true)
         setProgress(0)
         setError(null)
@@ -368,13 +368,13 @@ export function useClientRender(): UseClientRenderReturn {
     setError(null)
     const previousResult = resultRef.current
     resultRef.current = null
-    scheduleTemporaryExportOutputRelease(previousResult)
+    void releaseTemporaryExportOutput(previousResult)
     setResult(null)
   }, [])
 
   useEffect(
     () => () => {
-      scheduleTemporaryExportOutputRelease(resultRef.current)
+      void releaseTemporaryExportOutput(resultRef.current)
       resultRef.current = null
     },
     [],

--- a/src/features/export/hooks/use-render-queue-runner.ts
+++ b/src/features/export/hooks/use-render-queue-runner.ts
@@ -39,6 +39,7 @@ async function renderQueuedJob(job: RenderJob): Promise<void> {
   })
 
   const controller = new AbortController()
+  let temporaryResult: import('../utils/client-renderer').ClientRenderResult | null = null
   registerJobController(job.id, controller)
   store.markRendering(job.id)
 
@@ -82,6 +83,7 @@ async function renderQueuedJob(job: RenderJob): Promise<void> {
       signal: controller.signal,
       onProgress: (progress) => useRenderQueueStore.getState().updateJobProgress(job.id, progress),
     })
+    temporaryResult = result
     if (fallbackReason) event.set('workerFallbackReason', fallbackReason)
 
     const saved = await saveExportFile(job.projectId, job.fileName, result.blob)
@@ -107,7 +109,14 @@ async function renderQueuedJob(job: RenderJob): Promise<void> {
       event.failure(err)
     }
   } finally {
-    unregisterJobController(job.id)
+    try {
+      if (temporaryResult) {
+        const { releaseTemporaryExportOutput } = await import('../utils/export-output-target')
+        await releaseTemporaryExportOutput(temporaryResult)
+      }
+    } finally {
+      unregisterJobController(job.id)
+    }
   }
 }
 

--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -30,7 +30,10 @@ vi.mock('mediabunny', () => {
     constructor(private readonly track: { src: string }) {}
 
     async *samples(startTime = 0, endTime = 0) {
-      const sampleRate = 48000
+      if (this.track.src.includes('mediabunny-fails')) {
+        throw new Error('Mediabunny range decode failed')
+      }
+      const sampleRate = this.track.src.includes('44100') ? 44100 : 48000
       const frameCount = Math.max(1, Math.round((endTime - startTime) * sampleRate))
       const makePlane = () => new Float32Array(frameCount).fill(0.1)
       const planes = [makePlane(), makePlane()]
@@ -57,6 +60,7 @@ vi.mock('mediabunny', () => {
 })
 
 import {
+  clearAudioDecodeCache,
   downmixToOutputChannels,
   extractAudioSegments,
   processAudio,
@@ -533,11 +537,109 @@ describe('windowed audio processing', () => {
     expect(windows[0]?.samples[0]?.[24_000]).toBeCloseTo(0.1, 4)
   })
 
+  it('uses the Web Audio fallback when a window range cannot be decoded', async () => {
+    const fallbackSamples = new Float32Array(10 * 48_000).fill(0.2)
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    }))
+    class FallbackOfflineAudioContext {
+      async decodeAudioData() {
+        return {
+          sampleRate: 48_000,
+          numberOfChannels: 2,
+          duration: 10,
+          getChannelData: () => fallbackSamples,
+        }
+      }
+    }
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('OfflineAudioContext', FallbackOfflineAudioContext)
+
+    try {
+      const windows = []
+      for await (const window of processAudioWindows(
+        simpleComposition({ src: 'blob:mediabunny-fails' }),
+      )) {
+        windows.push(window)
+      }
+
+      expect(windows[0]?.samples[0]?.[24_000]).toBeCloseTo(0.2, 4)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      clearAudioDecodeCache()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('applies 44.1 kHz fades before resampling, matching full processing', async () => {
+    class ResamplingOfflineAudioContext {
+      readonly destination = {}
+      private sourceBuffer: AudioBuffer | null = null
+
+      constructor(
+        _channels: number,
+        private readonly length: number,
+        private readonly sampleRate: number,
+      ) {}
+
+      createBuffer(channels: number, length: number, sampleRate: number): AudioBuffer {
+        const channelData = Array.from({ length: channels }, () => new Float32Array(length))
+        return {
+          length,
+          sampleRate,
+          duration: length / sampleRate,
+          numberOfChannels: channels,
+          getChannelData: (channel: number) => channelData[channel]!,
+        } as AudioBuffer
+      }
+
+      createBufferSource() {
+        const context = this
+        return {
+          set buffer(value: AudioBuffer | null) {
+            context.sourceBuffer = value
+          },
+          connect() {},
+          start() {},
+        }
+      }
+
+      async startRendering(): Promise<AudioBuffer> {
+        const source = this.sourceBuffer!
+        const output = this.createBuffer(1, this.length, this.sampleRate)
+        const sourceSamples = source.getChannelData(0)
+        const outputSamples = output.getChannelData(0)
+        for (let i = 0; i < outputSamples.length; i++) {
+          outputSamples[i] =
+            sourceSamples[
+              Math.min(
+                sourceSamples.length - 1,
+                Math.floor((i * source.sampleRate) / this.sampleRate),
+              )
+            ]!
+        }
+        return output
+      }
+    }
+    vi.stubGlobal('OfflineAudioContext', ResamplingOfflineAudioContext)
+
+    try {
+      const composition = simpleComposition({ src: 'blob:audio-44100', audioFadeIn: 1 })
+      const full = await processAudio(composition)
+      const windows = []
+      for await (const window of processAudioWindows(composition)) windows.push(window)
+
+      expect(full).not.toBeNull()
+      expect(windows[0]?.samples[0]?.[23_999]).toBeCloseTo(full!.samples[0]![23_999]!, 7)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('retains full-segment processing for stateful DSP clips', () => {
     expect(supportsWindowedAudioProcessing(simpleComposition({ speed: 1.25 }))).toBe(false)
-    expect(
-      supportsWindowedAudioProcessing(simpleComposition({ audioEqHighGainDb: 3 })),
-    ).toBe(false)
+    expect(supportsWindowedAudioProcessing(simpleComposition({ audioEqHighGainDb: 3 }))).toBe(false)
   })
 })
 

--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -56,7 +56,13 @@ vi.mock('mediabunny', () => {
   }
 })
 
-import { downmixToOutputChannels, extractAudioSegments, processAudio } from './canvas-audio'
+import {
+  downmixToOutputChannels,
+  extractAudioSegments,
+  processAudio,
+  processAudioWindows,
+  supportsWindowedAudioProcessing,
+} from './canvas-audio'
 
 function makeTrack(params: {
   id: string
@@ -493,6 +499,45 @@ describe('extractAudioSegments', () => {
       expect.objectContaining({ lowGainDb: 4 }),
       expect.objectContaining({ highGainDb: 3, outputGainDb: 2 }),
     ])
+  })
+})
+
+describe('windowed audio processing', () => {
+  function simpleComposition(itemOverrides: Partial<AudioItem> = {}): CompositionInputProps {
+    return {
+      fps: 30,
+      durationInFrames: 90,
+      width: 1920,
+      height: 1080,
+      tracks: [
+        makeTrack({
+          id: 'track-a1',
+          order: 0,
+          kind: 'audio',
+          items: [makeAudioItem(itemOverrides)],
+        }),
+      ],
+    }
+  }
+
+  it('uses bounded windows for ordinary long-form clips', async () => {
+    const composition = simpleComposition()
+
+    expect(supportsWindowedAudioProcessing(composition)).toBe(true)
+
+    const windows = []
+    for await (const window of processAudioWindows(composition)) windows.push(window)
+
+    expect(windows).toHaveLength(1)
+    expect(windows[0]?.samples[0]).toHaveLength(3 * 48_000)
+    expect(windows[0]?.samples[0]?.[24_000]).toBeCloseTo(0.1, 4)
+  })
+
+  it('retains full-segment processing for stateful DSP clips', () => {
+    expect(supportsWindowedAudioProcessing(simpleComposition({ speed: 1.25 }))).toBe(false)
+    expect(
+      supportsWindowedAudioProcessing(simpleComposition({ audioEqHighGainDb: 3 })),
+    ).toBe(false)
   })
 })
 

--- a/src/features/export/utils/canvas-audio.ts
+++ b/src/features/export/utils/canvas-audio.ts
@@ -47,6 +47,7 @@ import {
   applyAudioEqStages,
   areAudioEqStagesEqual,
   getAudioEqSettings,
+  isAudioEqStageActive,
 } from '@/shared/utils/audio-eq'
 import {
   getAudioPitchRatioFromSemitones,
@@ -1026,6 +1027,7 @@ async function decodeAudioFromSource(
   endTime?: number,
   audioCodec?: string,
   ac3RetryAttempted: boolean = false,
+  allowWebAudioFallback: boolean = true,
 ): Promise<DecodedAudio> {
   // Check cache first (only for full file decodes for backward compatibility)
   if (startTime === undefined && endTime === undefined) {
@@ -1186,11 +1188,21 @@ async function decodeAudioFromSource(
     if (!ac3RetryAttempted && !isAc3AudioCodec(audioCodec)) {
       try {
         await ensureAc3DecoderRegistered()
-        return await decodeAudioFromSource(src, itemId, startTime, endTime, audioCodec, true)
+        return await decodeAudioFromSource(
+          src,
+          itemId,
+          startTime,
+          endTime,
+          audioCodec,
+          true,
+          allowWebAudioFallback,
+        )
       } catch {
         // Ignore and continue to Web Audio fallback below.
       }
     }
+
+    if (!allowWebAudioFallback) throw error
 
     // Fall back to Web Audio API for full decode
     log.warn('Mediabunny audio decode failed, using fallback', { itemId, error })
@@ -1709,48 +1721,38 @@ function reverseAudioChannels(channels: Float32Array[]): Float32Array[] {
  * @param config - Audio processing configuration
  * @returns Mixed stereo audio samples
  */
-function mixAudioTracks(
-  segments: Array<{
-    samples: Float32Array[]
-    startSample: number
-    muted: boolean
-  }>,
-  config: AudioProcessingConfig,
-): Float32Array[] {
+function createAudioMixBuffer(config: AudioProcessingConfig): Float32Array[] {
   const { sampleRate, channels, fps, totalFrames } = config
   const totalSamples = Math.ceil((totalFrames / fps) * sampleRate)
-
-  // Create output buffers (stereo)
   const output: Float32Array[] = []
   for (let c = 0; c < channels; c++) {
     output.push(new Float32Array(totalSamples))
   }
+  return output
+}
 
-  // Mix each segment, downmixing source channels to the output layout.
-  for (const segment of segments) {
-    if (segment.muted) continue
+function mixAudioSegmentInto(
+  output: Float32Array[],
+  segment: { samples: Float32Array[]; startSample: number },
+  config: AudioProcessingConfig,
+): void {
+  const { channels } = config
+  const totalSamples = output[0]?.length ?? 0
+  const downmixed = downmixToOutputChannels(segment.samples, channels)
 
-    const downmixed = downmixToOutputChannels(segment.samples, channels)
-
-    for (let c = 0; c < channels; c++) {
-      const channelSamples = downmixed[c]
-      if (!channelSamples) continue
-
-      const outputChannel = output[c]!
-
-      for (let i = 0; i < channelSamples.length; i++) {
-        const outputIndex = segment.startSample + i
-        if (outputIndex < 0 || outputIndex >= totalSamples) continue
-
-        const sample = channelSamples[i]
-        const currentValue = outputChannel[outputIndex]
-        if (sample !== undefined && currentValue !== undefined) {
-          outputChannel[outputIndex] = currentValue + sample
-        }
-      }
+  for (let c = 0; c < channels; c++) {
+    const channelSamples = downmixed[c]!
+    const outputChannel = output[c]!
+    const sourceStart = Math.max(0, -segment.startSample)
+    const sourceEnd = Math.min(channelSamples.length, totalSamples - segment.startSample)
+    for (let i = sourceStart; i < sourceEnd; i++) {
+      const outputIndex = segment.startSample + i
+      outputChannel[outputIndex] = outputChannel[outputIndex]! + channelSamples[i]!
     }
   }
+}
 
+function softClipAudioMix(output: Float32Array[]): void {
   // Soft-clip to prevent harsh digital clipping while preserving overall loudness.
   // This matches browser preview behavior where audio peaks are naturally saturated
   // rather than the entire mix being reduced in volume.
@@ -1768,8 +1770,6 @@ function mixAudioTracks(
   if (clippedSamples > 0) {
     log.debug('Soft-clipped audio peaks', { clippedSamples })
   }
-
-  return output
 }
 
 /**
@@ -1795,6 +1795,336 @@ async function resolveSubCompMediaUrls(composition: CompositionInputProps): Prom
   if (urlResolutions.length > 0) {
     log.debug('Pre-resolving sub-comp audio URLs', { count: urlResolutions.length })
     await Promise.all(urlResolutions)
+  }
+}
+
+const STREAMING_AUDIO_CHUNK_SECONDS = 30
+
+function supportsWindowedAudioSegment(segment: AudioSegment): boolean {
+  return (
+    Math.abs(segment.speed - 1) <= 0.0001 &&
+    !segment.isReversed &&
+    !isAudioPitchShiftActive(segment.pitchShiftSemitones) &&
+    !segment.audioEqStages?.some(isAudioEqStageActive)
+  )
+}
+
+/**
+ * Long, ordinary clips can be mixed in bounded windows. Stateful DSP paths
+ * retain the full-segment implementation so speed/pitch/EQ continuity remains
+ * identical to preview.
+ */
+export function supportsWindowedAudioProcessing(composition: CompositionInputProps): boolean {
+  const segments = extractAudioSegments(composition, composition.fps).filter(
+    (segment) => !segment.muted,
+  )
+  return segments.length > 0 && segments.every(supportsWindowedAudioSegment)
+}
+
+type FramesToSamples = (frames: number | undefined) => number
+
+function applyClipFadeSpanToWindow(
+  output: Float32Array,
+  span: AudioClipFadeSpan,
+  segmentOffsetSamples: number,
+  toSamples: FramesToSamples,
+): void {
+  const spanStart = toSamples(span.startFrame)
+  const spanEnd = spanStart + toSamples(span.durationInFrames)
+  const fadeInSamples = Math.min(spanEnd - spanStart, toSamples(span.fadeInFrames))
+  const fadeOutSamples = Math.min(spanEnd - spanStart, toSamples(span.fadeOutFrames))
+
+  for (let i = 0; i < output.length; i++) {
+    const globalIndex = segmentOffsetSamples + i
+    if (globalIndex < spanStart || globalIndex >= spanEnd) continue
+    if (fadeInSamples > 0 && globalIndex < spanStart + fadeInSamples) {
+      const progress = (globalIndex - spanStart) / Math.max(1, fadeInSamples)
+      output[i] =
+        output[i]! * evaluateAudioFadeInCurve(progress, span.fadeInCurve, span.fadeInCurveX)
+    }
+    const fadeOutStart = spanEnd - fadeOutSamples
+    if (fadeOutSamples > 0 && globalIndex >= fadeOutStart) {
+      const progress = (globalIndex - fadeOutStart) / Math.max(1, fadeOutSamples)
+      output[i] =
+        output[i]! * evaluateAudioFadeOutCurve(progress, span.fadeOutCurve, span.fadeOutCurveX)
+    }
+  }
+}
+
+function applyClipFadeSpansToWindow(
+  output: Float32Array,
+  segment: AudioSegment,
+  segmentOffsetSamples: number,
+  toSamples: FramesToSamples,
+): void {
+  for (const span of segment.clipFadeSpans ?? []) {
+    applyClipFadeSpanToWindow(output, span, segmentOffsetSamples, toSamples)
+  }
+}
+
+function applyBasicFadesToWindow(
+  output: Float32Array,
+  segment: AudioSegment,
+  segmentOffsetSamples: number,
+  totalSegmentSamples: number,
+  toSamples: FramesToSamples,
+): void {
+  const contentStart =
+    toSamples(segment.contentStartOffsetFrames) + toSamples(segment.fadeInDelayFrames)
+  const contentEnd = Math.max(
+    contentStart,
+    totalSegmentSamples -
+      toSamples(segment.contentEndOffsetFrames) -
+      toSamples(segment.fadeOutLeadFrames),
+  )
+  const fadeInSamples = toSamples(segment.fadeInFrames)
+  const fadeOutSamples = toSamples(segment.fadeOutFrames)
+  const fadeOutStart = Math.max(contentStart, contentEnd - fadeOutSamples)
+
+  for (let i = 0; i < output.length; i++) {
+    const globalIndex = segmentOffsetSamples + i
+    if (globalIndex < contentStart || globalIndex >= contentEnd) {
+      output[i] = 0
+    } else if (fadeInSamples > 0 && globalIndex < contentStart + fadeInSamples) {
+      const progress = (globalIndex - contentStart) / fadeInSamples
+      output[i] =
+        output[i]! * evaluateAudioFadeInCurve(progress, segment.fadeInCurve, segment.fadeInCurveX)
+    } else if (fadeOutSamples > 0 && globalIndex >= fadeOutStart) {
+      const progress = (globalIndex - fadeOutStart) / fadeOutSamples
+      output[i] =
+        output[i]! *
+        evaluateAudioFadeOutCurve(progress, segment.fadeOutCurve, segment.fadeOutCurveX)
+    }
+  }
+}
+
+function applyCrossfadesToWindow(
+  output: Float32Array,
+  segment: AudioSegment,
+  segmentOffsetSamples: number,
+  totalSegmentSamples: number,
+  toSamples: FramesToSamples,
+): void {
+  const crossfadeIn = toSamples(segment.crossfadeFadeInFrames)
+  const crossfadeOut = toSamples(segment.crossfadeFadeOutFrames)
+  const fadeOutStart = totalSegmentSamples - crossfadeOut
+  for (let i = 0; i < output.length; i++) {
+    const globalIndex = segmentOffsetSamples + i
+    if (crossfadeIn > 0 && globalIndex < crossfadeIn) {
+      output[i] = output[i]! * Math.sin(((globalIndex / crossfadeIn) * Math.PI) / 2)
+    }
+    if (crossfadeOut > 0 && globalIndex >= fadeOutStart) {
+      output[i] =
+        output[i]! * Math.cos((((globalIndex - fadeOutStart) / crossfadeOut) * Math.PI) / 2)
+    }
+  }
+}
+
+function applyWindowedSegmentFades(
+  samples: Float32Array,
+  segment: AudioSegment,
+  segmentOffsetSamples: number,
+  totalSegmentSamples: number,
+  sampleRate: number,
+  fps: number,
+): Float32Array {
+  const output = new Float32Array(samples)
+  const toSamples: FramesToSamples = (frames) =>
+    Math.max(0, Math.floor(((frames ?? 0) / fps) * sampleRate))
+
+  if (segment.clipFadeSpans?.length) {
+    applyClipFadeSpansToWindow(output, segment, segmentOffsetSamples, toSamples)
+  } else {
+    applyBasicFadesToWindow(output, segment, segmentOffsetSamples, totalSegmentSamples, toSamples)
+  }
+  applyCrossfadesToWindow(output, segment, segmentOffsetSamples, totalSegmentSamples, toSamples)
+
+  return output
+}
+
+interface AudioWindowIntersection {
+  segmentStart: number
+  segmentLength: number
+  intersectionStart: number
+  intersectionEnd: number
+}
+
+function resolveAudioWindowIntersection(
+  segment: AudioSegment,
+  chunkStart: number,
+  chunkEnd: number,
+  sampleRate: number,
+  fps: number,
+): AudioWindowIntersection | null {
+  const segmentStart = Math.floor((segment.startFrame / fps) * sampleRate)
+  const segmentLength = Math.max(0, Math.ceil((segment.durationFrames / fps) * sampleRate))
+  const intersectionStart = Math.max(chunkStart, segmentStart)
+  const intersectionEnd = Math.min(chunkEnd, segmentStart + segmentLength)
+  if (intersectionEnd <= intersectionStart) return null
+  return { segmentStart, segmentLength, intersectionStart, intersectionEnd }
+}
+
+async function processAudioWindowChannels(
+  decoded: DecodedAudio,
+  segment: AudioSegment,
+  intersection: AudioWindowIntersection,
+  sampleRate: number,
+  fps: number,
+): Promise<Float32Array[]> {
+  const processed = decoded.samples
+  for (let channel = 0; channel < processed.length; channel++) {
+    let samples = processed[channel]!
+    if (segment.volumeKeyframes?.length) {
+      samples = applyAnimatedVolume(
+        samples,
+        segment.volumeKeyframes,
+        segment.volume,
+        (intersection.intersectionStart / sampleRate) * fps,
+        segment.itemFrom,
+        fps,
+        decoded.sampleRate,
+      )
+    } else if (segment.volume !== 0) {
+      samples = applyVolume(samples, segment.volume)
+    }
+    if (decoded.sampleRate !== sampleRate) {
+      samples = await resample(samples, decoded.sampleRate, sampleRate)
+    }
+    processed[channel] = applyWindowedSegmentFades(
+      samples,
+      segment,
+      intersection.intersectionStart - intersection.segmentStart,
+      intersection.segmentLength,
+      sampleRate,
+      fps,
+    )
+  }
+  return processed
+}
+
+function mixAudioWindowChannels(
+  mixed: Float32Array[],
+  processed: Float32Array[],
+  destinationOffset: number,
+  requestedFrames: number,
+): void {
+  const downmixed = downmixToOutputChannels(processed, mixed.length)
+  for (let channel = 0; channel < mixed.length; channel++) {
+    const source = downmixed[channel]!
+    const destination = mixed[channel]!
+    const framesToMix = Math.min(
+      requestedFrames,
+      source.length,
+      destination.length - destinationOffset,
+    )
+    for (let i = 0; i < framesToMix; i++) {
+      destination[destinationOffset + i] = destination[destinationOffset + i]! + source[i]!
+    }
+  }
+}
+
+async function mixSegmentIntoAudioWindow(params: {
+  segment: AudioSegment
+  mixed: Float32Array[]
+  chunkStart: number
+  chunkEnd: number
+  sampleRate: number
+  fps: number
+}): Promise<void> {
+  const { segment, mixed, chunkStart, chunkEnd, sampleRate, fps } = params
+  const intersection = resolveAudioWindowIntersection(
+    segment,
+    chunkStart,
+    chunkEnd,
+    sampleRate,
+    fps,
+  )
+  if (!intersection) return
+
+  const segmentOffset = intersection.intersectionStart - intersection.segmentStart
+  const requestedFrames = intersection.intersectionEnd - intersection.intersectionStart
+  const sourceStartTime = segment.sourceStartFrame / segment.sourceFps + segmentOffset / sampleRate
+  const decoded = await decodeAudioFromSource(
+    segment.src,
+    segment.itemId,
+    sourceStartTime,
+    sourceStartTime + requestedFrames / sampleRate,
+    segment.audioCodec,
+    false,
+    false,
+  )
+  const processed = await processAudioWindowChannels(
+    decoded,
+    segment,
+    intersection,
+    sampleRate,
+    fps,
+  )
+  mixAudioWindowChannels(
+    mixed,
+    processed,
+    intersection.intersectionStart - chunkStart,
+    requestedFrames,
+  )
+}
+
+function applyAudioWindowMasterGain(mixed: Float32Array[], masterGain: number): void {
+  for (const channel of mixed) {
+    for (let i = 0; i < channel.length; i++) channel[i] = channel[i]! * masterGain
+  }
+}
+
+/**
+ * Mix long, non-stateful audio timelines in fixed windows. Every yielded chunk
+ * begins exactly where the previous one ended, including silent windows.
+ */
+export async function* processAudioWindows(
+  composition: CompositionInputProps,
+  signal?: AbortSignal,
+): AsyncGenerator<{ samples: Float32Array[]; sampleRate: number; channels: number }> {
+  const { fps, durationInFrames = 0 } = composition
+  await resolveSubCompMediaUrls(composition)
+
+  const segments = extractAudioSegments(composition, fps).filter((segment) => !segment.muted)
+  if (segments.length === 0 || !segments.every(supportsWindowedAudioSegment)) {
+    throw new Error('Audio timeline requires full-segment processing')
+  }
+
+  if (segments.some((segment) => isAc3AudioCodec(segment.audioCodec))) {
+    await ensureAc3DecoderRegistered()
+  }
+
+  const sampleRate = 48_000
+  const channels = 2
+  const totalSamples = Math.ceil((durationInFrames / fps) * sampleRate)
+  const chunkSamples = STREAMING_AUDIO_CHUNK_SECONDS * sampleRate
+  const masterGain =
+    typeof composition.masterBusDb === 'number' && composition.masterBusDb !== 0
+      ? dbToGain(composition.masterBusDb)
+      : 1
+
+  for (let chunkStart = 0; chunkStart < totalSamples; chunkStart += chunkSamples) {
+    if (signal?.aborted) throw new DOMException('Audio processing cancelled', 'AbortError')
+
+    const chunkLength = Math.min(chunkSamples, totalSamples - chunkStart)
+    const chunkEnd = chunkStart + chunkLength
+    const mixed = [new Float32Array(chunkLength), new Float32Array(chunkLength)]
+
+    for (const segment of segments) {
+      await mixSegmentIntoAudioWindow({
+        segment,
+        mixed,
+        chunkStart,
+        chunkEnd,
+        sampleRate,
+        fps,
+      })
+    }
+
+    softClipAudioMix(mixed)
+    applyAudioWindowMasterGain(mixed, masterGain)
+
+    yield { samples: mixed, sampleRate, channels }
   }
 }
 
@@ -1849,12 +2179,11 @@ export async function processAudio(
     durationSeconds: durationInFrames / fps,
   })
 
-  // Decode and process each segment
-  const processedSegments: Array<{
-    samples: Float32Array[]
-    startSample: number
-    muted: boolean
-  }> = []
+  // Allocate the final mix once, then fold each processed segment into it
+  // immediately. Keeping every decoded segment alive until the end multiplies
+  // memory use on long, multi-clip timelines.
+  const mixedSamples = createAudioMixBuffer(config)
+  let processedSegmentCount = 0
 
   for (const segment of activeSegments) {
     if (signal?.aborted) {
@@ -1989,11 +2318,8 @@ export async function processAudio(
       // Calculate start position in output
       const startSample = Math.floor((segment.startFrame / fps) * config.sampleRate)
 
-      processedSegments.push({
-        samples: processedChannels,
-        startSample,
-        muted: segment.muted,
-      })
+      mixAudioSegmentInto(mixedSamples, { samples: processedChannels, startSample }, config)
+      processedSegmentCount++
 
       log.debug('Processed audio segment', {
         itemId: segment.itemId,
@@ -2010,13 +2336,12 @@ export async function processAudio(
     }
   }
 
-  if (processedSegments.length === 0) {
+  if (processedSegmentCount === 0) {
     log.warn('No audio segments were successfully processed')
     return null
   }
 
-  // Mix all segments
-  const mixedSamples = mixAudioTracks(processedSegments, config)
+  softClipAudioMix(mixedSamples)
 
   // Apply project-scoped master bus gain to the final mix. Monitor volume
   // (per-device) is intentionally NOT applied during export — it's a

--- a/src/features/export/utils/canvas-audio.ts
+++ b/src/features/export/utils/canvas-audio.ts
@@ -1204,21 +1204,51 @@ async function decodeAudioFromSource(
 
     if (!allowWebAudioFallback) throw error
 
-    // Fall back to Web Audio API for full decode
+    // Fall back to Web Audio API. It must decode the full source, but returns
+    // only the requested range so windowed callers keep their bounded shape.
     log.warn('Mediabunny audio decode failed, using fallback', { itemId, error })
-    return decodeAudioFallback(src, itemId)
+    return decodeAudioFallback(src, itemId, startTime, endTime)
+  }
+}
+
+function sliceDecodedAudioRange(
+  decoded: DecodedAudio,
+  itemId: string,
+  startTime?: number,
+  endTime?: number,
+): DecodedAudio {
+  if (startTime === undefined && endTime === undefined) return { ...decoded, itemId }
+
+  const startFrame = Math.max(0, Math.floor((startTime ?? 0) * decoded.sampleRate))
+  const endFrame = Math.max(
+    startFrame,
+    Math.min(
+      decoded.samples[0]?.length ?? 0,
+      Math.ceil((endTime ?? decoded.duration) * decoded.sampleRate),
+    ),
+  )
+  return {
+    ...decoded,
+    itemId,
+    samples: decoded.samples.map((samples) => samples.subarray(startFrame, endFrame)),
+    duration: (endFrame - startFrame) / decoded.sampleRate,
   }
 }
 
 /**
  * Fallback audio decoder using Web Audio API (decodes entire file)
  */
-async function decodeAudioFallback(src: string, itemId: string): Promise<DecodedAudio> {
+async function decodeAudioFallback(
+  src: string,
+  itemId: string,
+  startTime?: number,
+  endTime?: number,
+): Promise<DecodedAudio> {
   // Check cache
   const cached = audioDecodeCache.get(src)
   if (cached) {
     log.debug('Using cached decoded audio (fallback)', { itemId })
-    return { ...cached, itemId }
+    return sliceDecodedAudioRange(cached, itemId, startTime, endTime)
   }
 
   log.debug('Decoding audio with Web Audio API fallback', { itemId, src: src.substring(0, 50) })
@@ -1257,7 +1287,7 @@ async function decodeAudioFallback(src: string, itemId: string): Promise<Decoded
     samples: samples[0]?.length,
   })
 
-  return result
+  return sliceDecodedAudioRange(result, itemId, startTime, endTime)
 }
 
 /**
@@ -1972,6 +2002,13 @@ async function processAudioWindowChannels(
   fps: number,
 ): Promise<Float32Array[]> {
   const processed = decoded.samples
+  const decodedSegmentOffset = Math.floor(
+    ((intersection.intersectionStart - intersection.segmentStart) / sampleRate) *
+      decoded.sampleRate,
+  )
+  const decodedSegmentLength = Math.ceil(
+    (intersection.segmentLength / sampleRate) * decoded.sampleRate,
+  )
   for (let channel = 0; channel < processed.length; channel++) {
     let samples = processed[channel]!
     if (segment.volumeKeyframes?.length) {
@@ -1987,17 +2024,18 @@ async function processAudioWindowChannels(
     } else if (segment.volume !== 0) {
       samples = applyVolume(samples, segment.volume)
     }
+    samples = applyWindowedSegmentFades(
+      samples,
+      segment,
+      decodedSegmentOffset,
+      decodedSegmentLength,
+      decoded.sampleRate,
+      fps,
+    )
     if (decoded.sampleRate !== sampleRate) {
       samples = await resample(samples, decoded.sampleRate, sampleRate)
     }
-    processed[channel] = applyWindowedSegmentFades(
-      samples,
-      segment,
-      intersection.intersectionStart - intersection.segmentStart,
-      intersection.segmentLength,
-      sampleRate,
-      fps,
-    )
+    processed[channel] = samples
   }
   return processed
 }
@@ -2050,8 +2088,6 @@ async function mixSegmentIntoAudioWindow(params: {
     sourceStartTime,
     sourceStartTime + requestedFrames / sampleRate,
     segment.audioCodec,
-    false,
-    false,
   )
   const processed = await processAudioWindowChannels(
     decoded,

--- a/src/features/export/utils/canvas-render-orchestrator.ts
+++ b/src/features/export/utils/canvas-render-orchestrator.ts
@@ -17,12 +17,14 @@ import type { ClientExportSettings, RenderProgress, ClientRenderResult } from '.
 import { createOutputFormat, getDefaultAudioCodec, getMimeType } from './client-renderer'
 import { createMediabunnyInputSource } from '@/infrastructure/browser/mediabunny-input-source'
 import { createLogger } from '@/shared/logging/logger'
+import { ensureAudioEncoderSupport } from '@/shared/media/audio-encoder-support'
 import { hasMediaCrop } from '@/shared/utils/media-crop'
 import { DEFAULT_PROJECT_HEIGHT, DEFAULT_PROJECT_WIDTH } from '@/shared/projects/defaults'
 import {
   buildTranscriptSubtitleWebVtt,
   omitTranscriptSubtitleItemsForSoftSubtitleExport,
 } from './embedded-subtitle-export'
+import { createExportOutputTarget } from './export-output-target'
 
 // Subsystems
 import { createCompositionRenderer } from './client-render-engine'
@@ -46,6 +48,110 @@ async function loadCanvasAudio(): Promise<CanvasAudioModule> {
     canvasAudioModulePromise = import('./canvas-audio')
   }
   return canvasAudioModulePromise
+}
+
+const AUDIO_ENCODE_CHUNK_FRAMES = 48_000
+
+async function addAudioDataInChunks(
+  audioSource: InstanceType<MediabunnyModule['AudioSampleSource']>,
+  AudioSample: MediabunnyModule['AudioSample'],
+  audioData: { samples: Float32Array[]; sampleRate: number; channels: number },
+  signal?: AbortSignal,
+  startTimestamp = 0,
+): Promise<void> {
+  const totalFrames = audioData.samples[0]?.length ?? 0
+
+  for (let offset = 0; offset < totalFrames; offset += AUDIO_ENCODE_CHUNK_FRAMES) {
+    if (signal?.aborted) throw new DOMException('Audio encoding cancelled', 'AbortError')
+
+    const frameCount = Math.min(AUDIO_ENCODE_CHUNK_FRAMES, totalFrames - offset)
+    const planar = new Float32Array(frameCount * audioData.channels)
+    for (let channel = 0; channel < audioData.channels; channel++) {
+      const samples = audioData.samples[channel]
+      if (samples) planar.set(samples.subarray(offset, offset + frameCount), channel * frameCount)
+    }
+
+    const sample = new AudioSample({
+      data: planar,
+      format: 'f32-planar',
+      numberOfChannels: audioData.channels,
+      sampleRate: audioData.sampleRate,
+      timestamp: startTimestamp + offset / audioData.sampleRate,
+    })
+    try {
+      await audioSource.add(sample)
+    } finally {
+      sample.close()
+    }
+  }
+}
+
+async function addCompositionAudio(params: {
+  audioSource: InstanceType<MediabunnyModule['AudioSampleSource']>
+  AudioSample: MediabunnyModule['AudioSample']
+  canvasAudio: CanvasAudioModule
+  composition: CompositionInputProps
+  audioData: { samples: Float32Array[]; sampleRate: number; channels: number } | null
+  useWindowedAudio: boolean
+  signal?: AbortSignal
+}): Promise<number> {
+  const { audioSource, AudioSample, canvasAudio, composition, audioData, signal } = params
+  if (params.useWindowedAudio) {
+    let encodedFrames = 0
+    for await (const window of canvasAudio.processAudioWindows(composition, signal)) {
+      await addAudioDataInChunks(
+        audioSource,
+        AudioSample,
+        window,
+        signal,
+        encodedFrames / window.sampleRate,
+      )
+      encodedFrames += window.samples[0]?.length ?? 0
+    }
+    return encodedFrames
+  }
+
+  if (!audioData) return 0
+  await addAudioDataInChunks(audioSource, AudioSample, audioData, signal)
+  return audioData.samples[0]?.length ?? 0
+}
+
+function getAudioOnlyCodec(
+  container: ClientExportSettings['container'],
+): 'mp3' | 'aac' | 'pcm-s16' {
+  if (container === 'mp3') return 'mp3'
+  if (container === 'aac') return 'aac'
+  return 'pcm-s16'
+}
+
+async function registerMp3EncoderIfNeeded(container: ClientExportSettings['container']) {
+  if (container !== 'mp3') return
+  try {
+    const { registerMp3Encoder } = await import('@mediabunny/mp3-encoder')
+    registerMp3Encoder()
+    getLog().info('MP3 encoder registered')
+  } catch (error) {
+    getLog().warn('Failed to load MP3 encoder extension', error)
+  }
+}
+
+async function assertAudioOnlyEncoderSupported(
+  codec: 'mp3' | 'aac' | 'pcm-s16',
+  bitrate: number,
+): Promise<void> {
+  if (codec === 'pcm-s16') return
+  const supported = await ensureAudioEncoderSupport(codec, {
+    bitrate,
+    numberOfChannels: 2,
+    sampleRate: 48_000,
+  })
+  if (!supported) {
+    throw new Error(
+      `${codec.toUpperCase()} encoding is not supported in this browser. ` +
+        'Try exporting as WAV (lossless) instead.',
+    )
+  }
+  getLog().info(`Using ${codec.toUpperCase()} codec`)
 }
 
 export interface RenderEngineOptions {
@@ -184,9 +290,9 @@ async function tryPacketRemuxComposition(
   }
 
   const mediabunny: MediabunnyModule = await import('mediabunny')
-  const { Input, Output, BufferTarget, Conversion, ALL_FORMATS } = mediabunny
+  const { Input, Output, Conversion, ALL_FORMATS } = mediabunny
 
-  const format = (await createOutputFormat(settings.container, { fastStart: true })) as {
+  const validationFormat = (await createOutputFormat(settings.container, { fastStart: false })) as {
     getSupportedVideoCodecs?: () => string[]
     getSupportedAudioCodecs?: () => string[]
   }
@@ -215,7 +321,7 @@ async function tryPacketRemuxComposition(
       return null
     }
 
-    const supportedVideoCodecs = format.getSupportedVideoCodecs?.() ?? []
+    const supportedVideoCodecs = validationFormat.getSupportedVideoCodecs?.() ?? []
     if (!supportedVideoCodecs.includes(videoTrack.codec) || videoTrack.codec !== settings.codec) {
       return null
     }
@@ -230,7 +336,7 @@ async function tryPacketRemuxComposition(
     if (plan.includeAudio) {
       const audioTrack = await input.getPrimaryAudioTrack()
       if (audioTrack?.codec) {
-        const supportedAudioCodecs = format.getSupportedAudioCodecs?.() ?? []
+        const supportedAudioCodecs = validationFormat.getSupportedAudioCodecs?.() ?? []
         if (!supportedAudioCodecs.includes(audioTrack.codec)) {
           return null
         }
@@ -244,12 +350,18 @@ async function tryPacketRemuxComposition(
       message: 'Preparing packet remux...',
     })
 
-    // Create output resources only after all validation checks pass.
-    const target = new BufferTarget()
+    // Create output resources only after all validation checks pass. File-backed
+    // output keeps long remuxes out of the renderer process heap.
+    const mimeType = getMimeType(settings.container, settings.codec)
+    const outputTarget = await createExportOutputTarget(mediabunny, settings.container, mimeType)
+    const format = await createOutputFormat(settings.container, {
+      fastStart: outputTarget.kind === 'buffer',
+    })
     const output = new Output({
       format: format as unknown as ConstructorParameters<typeof Output>[0]['format'],
-      target,
+      target: outputTarget.target,
     })
+    let outputCompleted = false
 
     try {
       conversion = await Conversion.init({
@@ -284,12 +396,9 @@ async function tryPacketRemuxComposition(
 
       await conversion.execute()
 
-      const buffer = target.buffer
-      if (!buffer) {
-        throw new Error('No output buffer generated')
-      }
-
-      const blob = new Blob([buffer], { type: getMimeType(settings.container, settings.codec) })
+      const completed = await outputTarget.complete()
+      outputCompleted = true
+      const { blob } = completed
 
       onProgress({
         phase: 'finalizing',
@@ -309,12 +418,14 @@ async function tryPacketRemuxComposition(
 
       return {
         blob,
-        mimeType: getMimeType(settings.container, settings.codec),
+        mimeType,
         duration: durationSeconds,
         fileSize: blob.size,
+        temporaryOutput: completed.temporaryOutput,
       }
     } finally {
       ;(output as unknown as { dispose?: () => void }).dispose?.()
+      if (!outputCompleted) await outputTarget.discard()
     }
   } catch (error) {
     const isCanceled =
@@ -385,10 +496,10 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
   const mediabunny: MediabunnyModule = await import('mediabunny')
   const {
     Output,
-    BufferTarget,
     VideoSampleSource,
     VideoSample,
-    AudioBufferSource,
+    AudioSampleSource,
+    AudioSample,
     TextSubtitleSource,
   } = mediabunny
 
@@ -401,17 +512,18 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
 
   // Process audio in parallel with setup
   let audioData: { samples: Float32Array[]; sampleRate: number; channels: number } | null = null
-  if (await canvasAudio.hasAudioContent(composition)) {
-    try {
-      audioData = await canvasAudio.processAudio(composition, signal)
-      getLog().info('Audio processed', {
-        hasAudio: !!audioData,
-        sampleRate: audioData?.sampleRate,
-        channels: audioData?.channels,
-      })
-    } catch (error) {
-      getLog().error('Audio processing failed, continuing without audio', { error })
-    }
+  const compositionHasAudio = await canvasAudio.hasAudioContent(composition)
+  const useWindowedAudio =
+    compositionHasAudio &&
+    durationInFrames / fps >= 5 * 60 &&
+    canvasAudio.supportsWindowedAudioProcessing(composition)
+  if (compositionHasAudio && !useWindowedAudio) {
+    audioData = await canvasAudio.processAudio(composition, signal)
+    if (!audioData) throw new Error('Audio processing produced no output')
+    getLog().info('Audio processed', {
+      sampleRate: audioData.sampleRate,
+      channels: audioData.channels,
+    })
   }
 
   onProgress({
@@ -421,16 +533,16 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     message: 'Creating encoder...',
   })
 
-  // Create output format
-  const format = await createOutputFormat(settings.container, { fastStart: true })
-
-  // Create buffer target to collect the output
-  const target = new BufferTarget()
+  const mimeType = getMimeType(settings.container, settings.codec)
+  const outputTarget = await createExportOutputTarget(mediabunny, settings.container, mimeType)
+  const format = await createOutputFormat(settings.container, {
+    fastStart: outputTarget.kind === 'buffer',
+  })
 
   // Create output
   const output = new Output({
     format,
-    target,
+    target: outputTarget.target,
   })
 
   // Subtitle handling per mode:
@@ -532,15 +644,10 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     frameRate: fps,
   })
 
-  // Prepare audio source and buffer (stored outside try block for access after start)
-  let audioSource: InstanceType<typeof AudioBufferSource> | null = null
-  let audioBuffer: AudioBuffer | null = null
+  let audioSource: InstanceType<typeof AudioSampleSource> | null = null
 
-  if (audioData) {
+  if (audioData || useWindowedAudio) {
     try {
-      // Create audio buffer from processed samples
-      audioBuffer = canvasAudio.createAudioBuffer(audioData)
-
       // Select the container-compatible audio codec for the muxer.
       const audioCodec = getDefaultAudioCodec(settings.container)
       if (audioCodec !== 'aac' && audioCodec !== 'opus') {
@@ -548,9 +655,20 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
           `Unsupported audio codec ${audioCodec} for ${settings.container.toUpperCase()} export`,
         )
       }
+      const supported = await ensureAudioEncoderSupport(audioCodec, {
+        bitrate: settings.audioBitrate ?? 192_000,
+        numberOfChannels: audioData?.channels ?? 2,
+        sampleRate: audioData?.sampleRate ?? 48_000,
+      })
+      if (!supported) {
+        throw new Error(
+          `${audioCodec.toUpperCase()} audio encoding is not supported in this browser. ` +
+            'Choose WebM or MKV with Opus audio.',
+        )
+      }
 
       // Create audio source for encoding
-      audioSource = new AudioBufferSource({
+      audioSource = new AudioSampleSource({
         codec: audioCodec,
         bitrate: settings.audioBitrate ?? 192000,
       })
@@ -558,37 +676,61 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
       // Add audio track to output (audio data fed after start())
       output.addAudioTrack(audioSource)
       getLog().info('Audio track added to output', {
-        duration: audioBuffer.duration,
-        channels: audioBuffer.numberOfChannels,
-        sampleRate: audioBuffer.sampleRate,
+        duration: durationInFrames / fps,
+        channels: audioData?.channels ?? 2,
+        sampleRate: audioData?.sampleRate ?? 48_000,
         codec: audioCodec,
+        windowed: useWindowedAudio,
       })
     } catch (error) {
       getLog().error('Failed to setup audio track', { error })
-      audioSource = null
-      audioBuffer = null
+      await outputTarget.discard()
+      throw error
     }
   }
 
-  // Start the output
-  await output.start()
+  try {
+    await output.start()
 
-  if (transcriptSubtitleSource && transcriptSubtitleVtt) {
-    await transcriptSubtitleSource.add(transcriptSubtitleVtt)
-    transcriptSubtitleSource.close()
+    if (transcriptSubtitleSource && transcriptSubtitleVtt) {
+      await transcriptSubtitleSource.add(transcriptSubtitleVtt)
+      transcriptSubtitleSource.close()
+    }
+  } catch (error) {
+    await outputTarget.discard()
+    throw error
   }
 
-  // Feed audio buffer after output has started
-  // AudioBufferSource.add() must be called after output.start()
-  if (audioSource && audioBuffer) {
+  // Feed bounded planar chunks after output has started. This avoids a second
+  // full-timeline AudioBuffer allocation and respects encoder backpressure.
+  if (audioSource && (audioData || useWindowedAudio)) {
     try {
-      await audioSource.add(audioBuffer)
-      getLog().info('Audio buffer fed to encoder', {
-        duration: audioBuffer.duration,
-        samples: audioBuffer.length,
+      const encodedFrames = await addCompositionAudio({
+        audioSource,
+        AudioSample,
+        canvasAudio,
+        composition,
+        audioData,
+        useWindowedAudio,
+        signal,
       })
+      getLog().info('Audio chunks fed to encoder', {
+        duration: encodedFrames / 48_000,
+        samples: encodedFrames,
+        windowed: useWindowedAudio,
+      })
+      audioSource.close()
+      audioSource = null
+      audioData = null
     } catch (error) {
       getLog().error('Failed to feed audio to encoder', { error })
+      try {
+        if (output.state === 'started') await output.cancel()
+      } catch {
+        // Ignore cancellation errors; preserve the encoder failure.
+      }
+      await outputTarget.discard()
+      throw error
     }
   }
 
@@ -600,10 +742,10 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     message: 'Rendering frames...',
   })
 
-  // Create a composition renderer
-  const frameRenderer = await createCompositionRenderer(renderCompositionInput, renderCanvas, ctx)
+  let frameRenderer: Awaited<ReturnType<typeof createCompositionRenderer>> | null = null
 
   try {
+    frameRenderer = await createCompositionRenderer(renderCompositionInput, renderCanvas, ctx)
     // Preload media
     await frameRenderer.preload()
 
@@ -693,7 +835,7 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
       message: 'Finalizing video...',
     })
 
-    // Close audio source before finalizing (signals no more audio data)
+    // Close an audio source that did not finish during preparation.
     if (audioSource) {
       try {
         audioSource.close()
@@ -706,13 +848,8 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     // Finalize output
     await output.finalize()
 
-    // Get the buffer
-    const buffer = target.buffer
-    if (!buffer) {
-      throw new Error('No output buffer generated')
-    }
-
-    const blob = new Blob([buffer], { type: getMimeType(settings.container, settings.codec) })
+    const completed = await outputTarget.complete()
+    const { blob } = completed
 
     onProgress({
       phase: 'finalizing',
@@ -728,13 +865,14 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
 
     return {
       blob,
-      mimeType: getMimeType(settings.container, settings.codec),
+      mimeType,
       duration: durationSeconds,
       fileSize: blob.size,
+      temporaryOutput: completed.temporaryOutput,
     }
   } catch (error) {
     // Cleanup on error
-    frameRenderer.dispose()
+    frameRenderer?.dispose()
     canvasAudio.clearAudioDecodeCache()
 
     // Attempt to cancel the output on error
@@ -745,6 +883,7 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     } catch {
       // Ignore cancel errors
     }
+    await outputTarget.discard()
     throw error
   }
 }
@@ -874,18 +1013,9 @@ export async function renderAudioOnly(options: AudioRenderOptions): Promise<Clie
 
   // Dynamically import mediabunny (AC-3 decoder is loaded lazily by canvas-audio when needed)
   const mediabunny = await import('mediabunny')
-  const { Output, BufferTarget, AudioBufferSource } = mediabunny
+  const { Output, AudioSampleSource, AudioSample } = mediabunny
 
-  // Register MP3 encoder if exporting to MP3
-  if (settings.container === 'mp3') {
-    try {
-      const { registerMp3Encoder } = await import('@mediabunny/mp3-encoder')
-      registerMp3Encoder()
-      getLog().info('MP3 encoder registered')
-    } catch (err) {
-      getLog().warn('Failed to load MP3 encoder extension', err)
-    }
-  }
+  await registerMp3EncoderIfNeeded(settings.container)
 
   onProgress({
     phase: 'preparing',
@@ -899,8 +1029,10 @@ export async function renderAudioOnly(options: AudioRenderOptions): Promise<Clie
     throw new Error('No audio content found in composition')
   }
 
-  const audioData = await canvasAudio.processAudio(composition, signal)
-  if (!audioData) {
+  const useWindowedAudio =
+    durationSeconds >= 5 * 60 && canvasAudio.supportsWindowedAudioProcessing(composition)
+  let audioData = useWindowedAudio ? null : await canvasAudio.processAudio(composition, signal)
+  if (!audioData && !useWindowedAudio) {
     throw new Error('Failed to process audio')
   }
 
@@ -911,69 +1043,32 @@ export async function renderAudioOnly(options: AudioRenderOptions): Promise<Clie
     message: 'Creating encoder...',
   })
 
-  // Create output format
-  const format = await createOutputFormat(settings.container, { fastStart: true })
+  const audioCodec = getAudioOnlyCodec(settings.container)
+  const audioBitrate = settings.audioBitrate ?? 192_000
+  await assertAudioOnlyEncoderSupported(audioCodec, audioBitrate)
 
-  // Create buffer target to collect the output
-  const target = new BufferTarget()
-
-  // Create output
-  const output = new Output({
-    format,
-    target,
+  const mimeType = getMimeType(settings.container)
+  const outputTarget = await createExportOutputTarget(mediabunny, settings.container, mimeType)
+  const format = await createOutputFormat(settings.container, {
+    fastStart: outputTarget.kind === 'buffer',
   })
-
-  // Determine audio codec based on container (container = codec for audio-only)
-  let audioCodec: 'mp3' | 'aac' | 'pcm-s16'
-  switch (settings.container) {
-    case 'mp3':
-      audioCodec = 'mp3'
-      break
-    case 'aac':
-      audioCodec = 'aac'
-      break
-    default:
-      audioCodec = 'pcm-s16'
-  }
-
-  // PCM codecs don't need browser encoding support – they're raw samples
-  const isPcmCodec = audioCodec === 'pcm-s16'
-
-  if (!isPcmCodec) {
-    // Check if codec is supported
-    const { canEncodeAudio } = mediabunny
-    const isSupported = await canEncodeAudio(audioCodec, {
-      bitrate: settings.audioBitrate ?? 192000,
-      numberOfChannels: 2,
-      sampleRate: 48000,
-    })
-
-    if (!isSupported) {
-      throw new Error(
-        `${audioCodec.toUpperCase()} encoding is not supported in this browser. ` +
-          `Try exporting as WAV (lossless) instead.`,
-      )
-    }
-    getLog().info(`Using ${audioCodec.toUpperCase()} codec`)
-  }
-
-  // Create audio buffer from processed samples
-  const audioBuffer = canvasAudio.createAudioBuffer(audioData)
+  const output = new Output({ format, target: outputTarget.target })
 
   // Create audio source for encoding
-  const audioSource = new AudioBufferSource({
+  const audioSource = new AudioSampleSource({
     codec: audioCodec,
-    bitrate: settings.audioBitrate ?? 192000,
+    bitrate: audioBitrate,
   })
 
   // Add audio track to output
   output.addAudioTrack(audioSource)
 
   getLog().info('Audio track configured', {
-    duration: audioBuffer.duration,
-    channels: audioBuffer.numberOfChannels,
-    sampleRate: audioBuffer.sampleRate,
+    duration: durationSeconds,
+    channels: audioData?.channels ?? 2,
+    sampleRate: audioData?.sampleRate ?? 48_000,
     codec: audioCodec,
+    windowed: useWindowedAudio,
   })
 
   onProgress({
@@ -983,32 +1078,41 @@ export async function renderAudioOnly(options: AudioRenderOptions): Promise<Clie
     message: 'Encoding audio...',
   })
 
-  // Start the output
-  await output.start()
+  let completed: Awaited<ReturnType<typeof outputTarget.complete>>
+  try {
+    await output.start()
+    await addCompositionAudio({
+      audioSource,
+      AudioSample,
+      canvasAudio,
+      composition,
+      audioData,
+      useWindowedAudio,
+      signal,
+    })
+    audioData = null
 
-  // Feed audio buffer
-  await audioSource.add(audioBuffer)
+    onProgress({
+      phase: 'finalizing',
+      progress: 90,
+      totalFrames: durationInFrames,
+      message: 'Finalizing audio...',
+    })
 
-  onProgress({
-    phase: 'finalizing',
-    progress: 90,
-    totalFrames: durationInFrames,
-    message: 'Finalizing audio...',
-  })
-
-  // Close audio source
-  audioSource.close()
-
-  // Finalize output
-  await output.finalize()
-
-  // Get the buffer
-  const buffer = target.buffer
-  if (!buffer) {
-    throw new Error('No output buffer generated')
+    audioSource.close()
+    await output.finalize()
+    completed = await outputTarget.complete()
+  } catch (error) {
+    try {
+      if (output.state === 'started') await output.cancel()
+    } catch {
+      // Ignore cancellation errors; preserve the original failure.
+    }
+    await outputTarget.discard()
+    throw error
   }
 
-  const blob = new Blob([buffer], { type: getMimeType(settings.container) })
+  const { blob } = completed
 
   onProgress({
     phase: 'finalizing',
@@ -1019,8 +1123,9 @@ export async function renderAudioOnly(options: AudioRenderOptions): Promise<Clie
 
   return {
     blob,
-    mimeType: getMimeType(settings.container),
+    mimeType,
     duration: durationSeconds,
     fileSize: blob.size,
+    temporaryOutput: completed.temporaryOutput,
   }
 }

--- a/src/features/export/utils/client-renderer.ts
+++ b/src/features/export/utils/client-renderer.ts
@@ -58,6 +58,8 @@ export interface ClientRenderResult {
   mimeType: string
   duration: number
   fileSize: number
+  /** OPFS scratch backing for large streamed outputs; remove when no longer used. */
+  temporaryOutput?: import('./export-output-target').TemporaryExportOutput
   /** Separate subtitle file to download alongside the video (sidecar mode). */
   subtitleSidecar?: { filename: string; content: string }
 }

--- a/src/features/export/utils/export-output-target.ts
+++ b/src/features/export/utils/export-output-target.ts
@@ -1,0 +1,149 @@
+import type { ClientContainer, ClientRenderResult } from './client-renderer'
+
+type MediabunnyModule = typeof import('mediabunny')
+
+const EXPORT_SCRATCH_DIR = 'freecut-export-output'
+const STREAM_CHUNK_SIZE_BYTES = 4 * 1024 * 1024
+const STALE_OUTPUT_AGE_MS = 24 * 60 * 60 * 1000
+const DOWNLOAD_CLEANUP_DELAY_MS = 30 * 60 * 1000
+let staleCleanupStarted = false
+
+export interface TemporaryExportOutput {
+  directory: string
+  fileName: string
+}
+
+export interface ExportOutputTarget {
+  target:
+    | InstanceType<MediabunnyModule['BufferTarget']>
+    | InstanceType<MediabunnyModule['StreamTarget']>
+  kind: 'buffer' | 'file'
+  complete: () => Promise<{
+    blob: Blob
+    temporaryOutput?: TemporaryExportOutput
+  }>
+  discard: () => Promise<void>
+}
+
+function randomOutputName(container: ClientContainer): string {
+  const id =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `${id}.${container}`
+}
+
+async function createFileBackedTarget(
+  mediabunny: MediabunnyModule,
+  container: ClientContainer,
+  mimeType: string,
+): Promise<ExportOutputTarget | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.getDirectory) return null
+
+  const root = await navigator.storage.getDirectory()
+  const directory = await root.getDirectoryHandle(EXPORT_SCRATCH_DIR, { create: true })
+  if (!staleCleanupStarted) {
+    staleCleanupStarted = true
+    void (async () => {
+      for await (const [name, handle] of directory.entries()) {
+        if (handle.kind !== 'file') continue
+        try {
+          const file = await (handle as FileSystemFileHandle).getFile()
+          if (Date.now() - file.lastModified >= STALE_OUTPUT_AGE_MS) {
+            await directory.removeEntry(name)
+          }
+        } catch {
+          // Another export context may have removed the file already.
+        }
+      }
+    })()
+  }
+  const fileName = randomOutputName(container)
+  const fileHandle = await directory.getFileHandle(fileName, { create: true })
+  const writable = await fileHandle.createWritable()
+  let settled = false
+
+  const removeFile = async () => {
+    try {
+      await directory.removeEntry(fileName)
+    } catch {
+      // Already removed or unavailable.
+    }
+  }
+
+  return {
+    target: new mediabunny.StreamTarget(writable, {
+      chunked: true,
+      chunkSize: STREAM_CHUNK_SIZE_BYTES,
+    }),
+    kind: 'file',
+    complete: async () => {
+      settled = true
+      const file = await fileHandle.getFile()
+      return {
+        // Blob composition keeps the OPFS-backed File as its immutable backing
+        // store while supplying the MIME type that OPFS files don't preserve.
+        blob: new Blob([file], { type: mimeType }),
+        temporaryOutput: { directory: EXPORT_SCRATCH_DIR, fileName },
+      }
+    },
+    discard: async () => {
+      if (!settled) {
+        await writable.abort().catch(() => undefined)
+      }
+      await removeFile()
+    },
+  }
+}
+
+/**
+ * Prefer an OPFS-backed Mediabunny target so encoded bytes are flushed to disk
+ * instead of accumulating in one renderer-process ArrayBuffer. BufferTarget is
+ * retained as a compatibility fallback for environments without OPFS.
+ */
+export async function createExportOutputTarget(
+  mediabunny: MediabunnyModule,
+  container: ClientContainer,
+  mimeType: string,
+): Promise<ExportOutputTarget> {
+  try {
+    const fileTarget = await createFileBackedTarget(mediabunny, container, mimeType)
+    if (fileTarget) return fileTarget
+  } catch {
+    // Preserve export support where OPFS exists but is temporarily unavailable.
+  }
+
+  const target = new mediabunny.BufferTarget()
+  return {
+    target,
+    kind: 'buffer',
+    complete: async () => {
+      if (!target.buffer) throw new Error('No output buffer generated')
+      return { blob: new Blob([target.buffer], { type: mimeType }) }
+    },
+    discard: async () => {},
+  }
+}
+
+export async function releaseTemporaryExportOutput(
+  result: Pick<ClientRenderResult, 'temporaryOutput'> | null | undefined,
+): Promise<void> {
+  const temporary = result?.temporaryOutput
+  if (!temporary || typeof navigator === 'undefined' || !navigator.storage?.getDirectory) return
+
+  try {
+    const root = await navigator.storage.getDirectory()
+    const directory = await root.getDirectoryHandle(temporary.directory)
+    await directory.removeEntry(temporary.fileName)
+  } catch {
+    // Cleanup is best-effort; the file may already have been removed.
+  }
+}
+
+/** Keep a completed download's backing file alive while the browser consumes it. */
+export function scheduleTemporaryExportOutputRelease(
+  result: Pick<ClientRenderResult, 'temporaryOutput'> | null | undefined,
+): void {
+  if (!result?.temporaryOutput) return
+  setTimeout(() => void releaseTemporaryExportOutput(result), DOWNLOAD_CLEANUP_DELAY_MS)
+}

--- a/src/features/export/utils/export-output-target.ts
+++ b/src/features/export/utils/export-output-target.ts
@@ -5,7 +5,6 @@ type MediabunnyModule = typeof import('mediabunny')
 const EXPORT_SCRATCH_DIR = 'freecut-export-output'
 const STREAM_CHUNK_SIZE_BYTES = 4 * 1024 * 1024
 const STALE_OUTPUT_AGE_MS = 24 * 60 * 60 * 1000
-const DOWNLOAD_CLEANUP_DELAY_MS = 30 * 60 * 1000
 let staleCleanupStarted = false
 
 export interface TemporaryExportOutput {
@@ -138,12 +137,4 @@ export async function releaseTemporaryExportOutput(
   } catch {
     // Cleanup is best-effort; the file may already have been removed.
   }
-}
-
-/** Keep a completed download's backing file alive while the browser consumes it. */
-export function scheduleTemporaryExportOutputRelease(
-  result: Pick<ClientRenderResult, 'temporaryOutput'> | null | undefined,
-): void {
-  if (!result?.temporaryOutput) return
-  setTimeout(() => void releaseTemporaryExportOutput(result), DOWNLOAD_CLEANUP_DELAY_MS)
 }

--- a/src/features/export/utils/export-preflight.test.ts
+++ b/src/features/export/utils/export-preflight.test.ts
@@ -168,6 +168,7 @@ describe('assessExportPreflight', () => {
       supportedVideoCodecs: ['avc'],
       workerAvailable: true,
       offlineAudioContextAvailable: false,
+      audioEncoderSupported: true,
     })
 
     expect(result.canExport).toBe(true)
@@ -176,6 +177,49 @@ describe('assessExportPreflight', () => {
       expect.objectContaining({
         id: 'worker-audio-context-fallback',
         severity: 'info',
+      }),
+    )
+  })
+
+  it('blocks an audible video export when its audio codec cannot be encoded', async () => {
+    const result = await assessExportPreflight({
+      settings: baseSettings,
+      fps: 30,
+      composition: composition([audioItem()]),
+      durationFrames: 300,
+      supportedVideoCodecs: ['avc'],
+      workerAvailable: true,
+      offlineAudioContextAvailable: true,
+      audioEncoderSupported: false,
+    })
+
+    expect(result.canExport).toBe(false)
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'audio-codec-unavailable',
+        severity: 'error',
+        detailParams: { codec: 'AAC', container: 'MP4' },
+      }),
+    )
+  })
+
+  it('reports supported audio for audible video exports', async () => {
+    const result = await assessExportPreflight({
+      settings: baseSettings,
+      fps: 30,
+      composition: composition([audioItem()]),
+      durationFrames: 300,
+      supportedVideoCodecs: ['avc'],
+      workerAvailable: true,
+      offlineAudioContextAvailable: true,
+      audioEncoderSupported: true,
+    })
+
+    expect(result.canExport).toBe(true)
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'audio-codec-supported',
+        severity: 'ok',
       }),
     )
   })
@@ -211,6 +255,7 @@ describe('assessExportPreflight', () => {
       supportedVideoCodecs: ['avc'],
       workerAvailable: true,
       offlineAudioContextAvailable: true,
+      audioEncoderSupported: true,
       brokenMediaIds: ['missing-media', 'unused-media'],
     })
 
@@ -233,6 +278,7 @@ describe('assessExportPreflight', () => {
       supportedVideoCodecs: ['avc'],
       workerAvailable: true,
       offlineAudioContextAvailable: true,
+      audioEncoderSupported: true,
     })
 
     expect(result.estimatedFileSizeBytes).toBeGreaterThan(2 * 1024 * 1024 * 1024)
@@ -254,6 +300,7 @@ describe('assessExportPreflight', () => {
       supportedVideoCodecs: ['avc'],
       workerAvailable: true,
       offlineAudioContextAvailable: true,
+      audioEncoderSupported: true,
     })
 
     expect(result.canExport).toBe(true)

--- a/src/features/export/utils/export-preflight.ts
+++ b/src/features/export/utils/export-preflight.ts
@@ -2,6 +2,7 @@ import type { CompositionInputProps, ExtendedExportSettings } from '@/types/expo
 import type { TimelineTrack } from '@/types/timeline'
 import { framesToSeconds } from '@/shared/utils/time-utils'
 import { isGifUrl, isWebpUrl } from '@/shared/utils/media-utils'
+import { ensureAudioEncoderSupport } from '@/shared/media/audio-encoder-support'
 import type { ClientCodec, ClientExportSettings, ClientVideoContainer } from './client-renderer'
 import {
   getPreferredContainerForCodec,
@@ -35,6 +36,7 @@ export interface AssessExportPreflightOptions {
   supportedVideoCodecs?: ClientCodec[]
   workerAvailable?: boolean
   offlineAudioContextAvailable?: boolean
+  audioEncoderSupported?: boolean
   brokenMediaIds?: string[]
 }
 
@@ -200,6 +202,44 @@ async function resolveSettingsForPreflight(
     : { error: postFallbackValidation.error, supportedVideoCodecs: codecs }
 }
 
+async function assessVideoAudioCodec(
+  clientSettings: ClientExportSettings,
+  tracks: TimelineTrack[],
+  audioEncoderSupported?: boolean,
+): Promise<ExportPreflightCheck | null> {
+  if (clientSettings.mode !== 'video' || !hasAudibleItem(tracks)) return null
+
+  const audioCodec = getDefaultAudioCodec(clientSettings.container)
+  const isSupported =
+    audioEncoderSupported ??
+    (await ensureAudioEncoderSupport(audioCodec, {
+      bitrate: clientSettings.audioBitrate ?? 192_000,
+      numberOfChannels: 2,
+      sampleRate: 48_000,
+    }))
+  const detailParams = {
+    codec: audioCodec.toUpperCase(),
+    container: clientSettings.container.toUpperCase(),
+  }
+
+  return isSupported
+    ? {
+        id: 'audio-codec-supported',
+        severity: 'ok',
+        titleKey: 'export.preflight.checks.audio-codec-supported.title',
+        detailKey: 'export.preflight.checks.audio-codec-supported.detail',
+        detailParams,
+      }
+    : {
+        id: 'audio-codec-unavailable',
+        severity: 'error',
+        titleKey: 'export.preflight.checks.audio-codec-unavailable.title',
+        detailKey: 'export.preflight.checks.audio-codec-unavailable.detail',
+        detailParams,
+        fixKey: 'export.preflight.checks.audio-codec-unavailable.fix',
+      }
+}
+
 export async function assessExportPreflight({
   settings,
   fps,
@@ -208,6 +248,7 @@ export async function assessExportPreflight({
   supportedVideoCodecs,
   workerAvailable = typeof Worker !== 'undefined',
   offlineAudioContextAvailable = typeof OfflineAudioContext !== 'undefined',
+  audioEncoderSupported,
   brokenMediaIds = [],
 }: AssessExportPreflightOptions): Promise<ExportPreflightResult> {
   const checks: ExportPreflightCheck[] = []
@@ -308,6 +349,13 @@ export async function assessExportPreflight({
       },
     })
   }
+
+  const audioCodecCheck = await assessVideoAudioCodec(
+    resolved.clientSettings,
+    tracks,
+    audioEncoderSupported,
+  )
+  if (audioCodecCheck) checks.push(audioCodecCheck)
 
   let predictedRenderPath: ExportPreflightResult['predictedRenderPath'] = 'worker'
 

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -104,34 +104,8 @@ interface HeadlessRenderSummary {
   fileSize: number
   durationSeconds: number
   fileName: string
-  /** Non-fatal issues (e.g. audio codec not encodable here, so audio was omitted). */
+  /** Non-fatal issues encountered while adapting the render settings. */
   warnings: string[]
-}
-
-/**
- * Ensure AAC can be encoded. Linux Chrome has no native WebCodecs AAC encoder,
- * so register the @mediabunny/aac-encoder WASM polyfill when native support is
- * absent — mediabunny then uses it automatically. (mp3/PCM are handled by the
- * export pipeline / need no encoder; opus is native in Chrome.)
- */
-async function ensureAudioEncoder(audioCodec: string | undefined): Promise<void> {
-  if (audioCodec !== 'aac') return
-  const { canEncodeAudio } = await import('mediabunny')
-  if (await canEncodeAudio('aac')) return
-  const { registerAacEncoder } = await import('@mediabunny/aac-encoder')
-  registerAacEncoder()
-  log.info('Registered @mediabunny/aac-encoder (no native AAC encoder in this environment)')
-}
-
-/** True if the audio codec can't be encoded here (after any polyfill registration). */
-async function audioCodecUnsupported(audioCodec: string | undefined): Promise<boolean> {
-  if (!audioCodec || audioCodec === 'mp3' || audioCodec.startsWith('pcm')) return false
-  const { canEncodeAudio } = await import('mediabunny')
-  try {
-    return !(await canEncodeAudio(audioCodec as Parameters<typeof canEncodeAudio>[0]))
-  } catch {
-    return true
-  }
 }
 
 type ProgressSink = (progress: RenderProgress) => void
@@ -299,17 +273,7 @@ async function renderTimeline(input: HeadlessTimelineInput): Promise<HeadlessRen
   seedMediaLibrary(media)
 
   await adaptVideoSettings(settings)
-  // Register the WASM AAC encoder if this environment lacks a native one.
-  await ensureAudioEncoder(settings.audioCodec)
-
   const warnings: string[] = []
-  if (settings.mode === 'video' && (await audioCodecUnsupported(settings.audioCodec))) {
-    const msg =
-      `Audio codec "${settings.audioCodec}" cannot be encoded in this environment; any audio will be omitted. ` +
-      `Use vp9/webm (Opus) for audio.`
-    warnings.push(msg)
-    log.warn(msg)
-  }
 
   const composition: CompositionInputProps = convertTimelineToComposition(
     tracks,

--- a/src/i18n/locales/partials/de/export.json
+++ b/src/i18n/locales/partials/de/export.json
@@ -139,6 +139,15 @@
           "title": "Videocodec unterstützt",
           "detail": "{{codec}} kann in diesem Browser als {{container}} kodiert werden."
         },
+        "audio-codec-supported": {
+          "title": "Audiocodec unterstützt",
+          "detail": "{{codec}}-Audio kann in diesem Browser in {{container}} kodiert werden."
+        },
+        "audio-codec-unavailable": {
+          "title": "Audiocodec nicht verfügbar",
+          "detail": "Dieser Browser kann {{codec}}-Audio für {{container}} nicht kodieren.",
+          "fix": "Wähle WebM oder MKV für Opus-Audio oder aktualisiere auf einen unterstützten Browser."
+        },
         "worker-unavailable-fallback": {
           "title": "Worker-Export nicht verfügbar",
           "detail": "Dieser Browser oder diese Sitzung kann keine Export-Worker starten, daher läuft das Rendering im Hauptthread.",

--- a/src/i18n/locales/partials/en/export.json
+++ b/src/i18n/locales/partials/en/export.json
@@ -139,6 +139,15 @@
           "title": "Video codec supported",
           "detail": "{{codec}} can be encoded as {{container}} in this browser."
         },
+        "audio-codec-supported": {
+          "title": "Audio codec supported",
+          "detail": "{{codec}} audio can be encoded in {{container}} in this browser."
+        },
+        "audio-codec-unavailable": {
+          "title": "Audio codec unavailable",
+          "detail": "This browser cannot encode {{codec}} audio for {{container}}.",
+          "fix": "Choose WebM or MKV to use Opus audio, or update to a supported browser."
+        },
         "worker-unavailable-fallback": {
           "title": "Worker export unavailable",
           "detail": "This browser/session cannot start export workers, so rendering will run on the main thread.",

--- a/src/i18n/locales/partials/es/export.json
+++ b/src/i18n/locales/partials/es/export.json
@@ -139,6 +139,15 @@
           "title": "Códec de vídeo compatible",
           "detail": "{{codec}} se puede codificar como {{container}} en este navegador."
         },
+        "audio-codec-supported": {
+          "title": "Códec de audio compatible",
+          "detail": "El audio {{codec}} se puede codificar en {{container}} en este navegador."
+        },
+        "audio-codec-unavailable": {
+          "title": "Códec de audio no disponible",
+          "detail": "Este navegador no puede codificar audio {{codec}} para {{container}}.",
+          "fix": "Elige WebM o MKV para usar audio Opus, o actualiza a un navegador compatible."
+        },
         "worker-unavailable-fallback": {
           "title": "Exportación en worker no disponible",
           "detail": "Este navegador o sesión no puede iniciar workers de exportación, así que el renderizado se ejecutará en el hilo principal.",

--- a/src/i18n/locales/partials/fr/export.json
+++ b/src/i18n/locales/partials/fr/export.json
@@ -139,6 +139,15 @@
           "title": "Codec vidéo pris en charge",
           "detail": "{{codec}} peut être encodé en {{container}} dans ce navigateur."
         },
+        "audio-codec-supported": {
+          "title": "Codec audio pris en charge",
+          "detail": "L’audio {{codec}} peut être encodé dans {{container}} avec ce navigateur."
+        },
+        "audio-codec-unavailable": {
+          "title": "Codec audio indisponible",
+          "detail": "Ce navigateur ne peut pas encoder l’audio {{codec}} pour {{container}}.",
+          "fix": "Choisissez WebM ou MKV pour utiliser l’audio Opus, ou mettez à jour votre navigateur."
+        },
         "worker-unavailable-fallback": {
           "title": "Exportation par worker indisponible",
           "detail": "Ce navigateur ou cette session ne peut pas démarrer les workers d’exportation ; le rendu s’exécutera donc sur le thread principal.",

--- a/src/i18n/locales/partials/ja/export.json
+++ b/src/i18n/locales/partials/ja/export.json
@@ -139,6 +139,15 @@
           "title": "動画コーデックに対応しています",
           "detail": "{{codec}} はこのブラウザーで {{container}} としてエンコードできます。"
         },
+        "audio-codec-supported": {
+          "title": "音声コーデックに対応しています",
+          "detail": "このブラウザーでは {{codec}} 音声を {{container}} にエンコードできます。"
+        },
+        "audio-codec-unavailable": {
+          "title": "音声コーデックを利用できません",
+          "detail": "このブラウザーでは {{container}} 用の {{codec}} 音声をエンコードできません。",
+          "fix": "Opus 音声を使用するには WebM または MKV を選ぶか、対応ブラウザーに更新してください。"
+        },
         "worker-unavailable-fallback": {
           "title": "ワーカー書き出しを利用できません",
           "detail": "このブラウザー/セッションでは書き出しワーカーを開始できないため、レンダリングはメインスレッドで実行されます。",

--- a/src/i18n/locales/partials/ko/export.json
+++ b/src/i18n/locales/partials/ko/export.json
@@ -139,6 +139,15 @@
           "title": "비디오 코덱 지원됨",
           "detail": "{{codec}}은(는) 이 브라우저에서 {{container}}로 인코딩할 수 있습니다."
         },
+        "audio-codec-supported": {
+          "title": "오디오 코덱 지원됨",
+          "detail": "이 브라우저에서 {{codec}} 오디오를 {{container}}로 인코딩할 수 있습니다."
+        },
+        "audio-codec-unavailable": {
+          "title": "오디오 코덱을 사용할 수 없음",
+          "detail": "이 브라우저는 {{container}}용 {{codec}} 오디오를 인코딩할 수 없습니다.",
+          "fix": "Opus 오디오를 사용하려면 WebM 또는 MKV를 선택하거나 지원되는 브라우저로 업데이트하세요."
+        },
         "worker-unavailable-fallback": {
           "title": "워커 내보내기를 사용할 수 없습니다",
           "detail": "이 브라우저/세션은 내보내기 워커를 시작할 수 없어 렌더링이 메인 스레드에서 실행됩니다.",

--- a/src/i18n/locales/partials/pt-BR/export.json
+++ b/src/i18n/locales/partials/pt-BR/export.json
@@ -139,6 +139,15 @@
           "title": "Codec de vídeo compatível",
           "detail": "{{codec}} pode ser codificado como {{container}} neste navegador."
         },
+        "audio-codec-supported": {
+          "title": "Codec de áudio compatível",
+          "detail": "O áudio {{codec}} pode ser codificado em {{container}} neste navegador."
+        },
+        "audio-codec-unavailable": {
+          "title": "Codec de áudio indisponível",
+          "detail": "Este navegador não pode codificar áudio {{codec}} para {{container}}.",
+          "fix": "Escolha WebM ou MKV para usar áudio Opus ou atualize para um navegador compatível."
+        },
         "worker-unavailable-fallback": {
           "title": "Exportação por worker indisponível",
           "detail": "Este navegador/sessão não consegue iniciar workers de exportação, então a renderização será executada na thread principal.",

--- a/src/i18n/locales/partials/tr/export.json
+++ b/src/i18n/locales/partials/tr/export.json
@@ -139,6 +139,15 @@
           "title": "Video kodeği destekleniyor",
           "detail": "{{codec}} bu tarayıcıda {{container}} olarak kodlanabilir."
         },
+        "audio-codec-supported": {
+          "title": "Ses kodeği destekleniyor",
+          "detail": "{{codec}} ses bu tarayıcıda {{container}} içinde kodlanabilir."
+        },
+        "audio-codec-unavailable": {
+          "title": "Ses kodeği kullanılamıyor",
+          "detail": "Bu tarayıcı {{container}} için {{codec}} ses kodlayamıyor.",
+          "fix": "Opus ses için WebM veya MKV seçin ya da desteklenen bir tarayıcıya güncelleyin."
+        },
         "worker-unavailable-fallback": {
           "title": "Worker ile dışa aktarma kullanılamıyor",
           "detail": "Bu tarayıcı/oturum dışa aktarma worker’larını başlatamıyor, bu yüzden render ana iş parçacığında çalışacak.",

--- a/src/i18n/locales/partials/zh/export.json
+++ b/src/i18n/locales/partials/zh/export.json
@@ -139,6 +139,15 @@
           "title": "支持视频编解码器",
           "detail": "{{codec}} 可在此浏览器中编码为 {{container}}。"
         },
+        "audio-codec-supported": {
+          "title": "支持音频编解码器",
+          "detail": "此浏览器可将 {{codec}} 音频编码到 {{container}}。"
+        },
+        "audio-codec-unavailable": {
+          "title": "音频编解码器不可用",
+          "detail": "此浏览器无法为 {{container}} 编码 {{codec}} 音频。",
+          "fix": "请选择 WebM 或 MKV 以使用 Opus 音频，或更新到受支持的浏览器。"
+        },
         "worker-unavailable-fallback": {
           "title": "Worker 导出不可用",
           "detail": "此浏览器/会话无法启动导出 worker，因此渲染将在主线程运行。",

--- a/src/shared/media/audio-encoder-support.ts
+++ b/src/shared/media/audio-encoder-support.ts
@@ -1,0 +1,46 @@
+export type ExportAudioCodec = 'aac' | 'opus' | 'mp3' | 'pcm-s16'
+
+export interface AudioEncoderSupportOptions {
+  bitrate?: number
+  numberOfChannels?: number
+  sampleRate?: number
+}
+
+let aacRegistrationPromise: Promise<void> | null = null
+
+async function registerAacEncoderOnce(): Promise<void> {
+  if (!aacRegistrationPromise) {
+    aacRegistrationPromise = import('@mediabunny/aac-encoder').then(({ registerAacEncoder }) => {
+      registerAacEncoder()
+    })
+  }
+  return aacRegistrationPromise
+}
+
+/**
+ * Check audio encoder availability and install Mediabunny's AAC WASM fallback
+ * when Chromium cannot provide a native AAC encoder (notably on Linux).
+ */
+export async function ensureAudioEncoderSupport(
+  codec: ExportAudioCodec,
+  options: AudioEncoderSupportOptions = {},
+): Promise<boolean> {
+  if (codec === 'pcm-s16') return true
+
+  const { canEncodeAudio } = await import('mediabunny')
+  const config = {
+    bitrate: options.bitrate,
+    numberOfChannels: options.numberOfChannels ?? 2,
+    sampleRate: options.sampleRate ?? 48_000,
+  }
+
+  try {
+    if (await canEncodeAudio(codec, config)) return true
+    if (codec !== 'aac') return false
+
+    await registerAacEncoderOnce()
+    return await canEncodeAudio(codec, config)
+  } catch {
+    return false
+  }
+}

--- a/src/shared/utils/audio-eq.ts
+++ b/src/shared/utils/audio-eq.ts
@@ -694,7 +694,9 @@ export function resolvePreviewAudioEqStages(
   return stages
 }
 
-function isAudioEqStageActive(stage?: AudioEqSettings | ResolvedAudioEqSettings | null): boolean {
+export function isAudioEqStageActive(
+  stage?: AudioEqSettings | ResolvedAudioEqSettings | null,
+): boolean {
   if (!stage) return false
   return (
     Math.abs(stage.outputGainDb ?? 0) > AUDIO_EQ_ACTIVE_EPSILON ||


### PR DESCRIPTION
## Summary

- stream Mediabunny export output to OPFS instead of retaining the full muxed file in one renderer-process buffer
- mix ordinary long-form audio in bounded windows and feed the encoder in chunks, while preserving the existing full-segment path for stateful DSP
- register the Mediabunny AAC WASM fallback when Linux Chrome has no native AAC encoder
- validate audible video audio codecs during preflight and fail exports loudly instead of silently producing video-only files
- add translated preflight messages and scratch-output lifecycle cleanup

## Root cause

Long exports used `BufferTarget` and full-duration audio buffers, causing memory use to grow with output size. MP4 audio setup failures were caught and discarded, so Linux Chrome could report a successful export without an audio track when native AAC encoding was unavailable.

## Validation

- 478 test files / 3,350 tests passed
- production build passed
- locale coverage passed for all supported languages
- feature boundaries, dependency contracts, unused-code, edge-budget, and changed-code health checks passed
- Linux Docker probe confirmed native AAC support is unavailable while Opus is available
- Linux MP4 smoke render produced AAC, 48 kHz stereo audio with a finite signal level (mean -21.1 dB, peak -17.6 dB)

Closes #316
Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved export performance for long, audio-heavy projects with streaming-style, windowed audio processing when supported.
  * Added preflight checks for audio codec availability, including the expected codec/container status.
* **Bug Fixes**
  * More reliable handling of exported output lifecycles, including better cleanup on cancellation, failure, and reset to reduce temporary-file retention.
* **Localization**
  * Added new audio codec support/unavailable preflight messages across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->