### PR TITLE
feat: add Electron local-directory workspace compatibility

### DIFF
--- a/scripts/fallow-unused-class-members.allowlist.json
+++ b/scripts/fallow-unused-class-members.allowlist.json
@@ -143,6 +143,113 @@
       ]
     },
     {
+      "path": "src/infrastructure/storage/local-directory/electron-directory-backend.ts",
+      "reason": "ElectronDirectoryBackend implements the LocalDirectoryBackend interface; these methods are invoked through the selected workspace backend abstraction.",
+      "members": [
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "readFile",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "getReadUrl",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "writeFile",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "listDirectory",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "createDirectory",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "exists",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "stat",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "move",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "remove",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "selectAndCopyFiles",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "ElectronDirectoryBackend",
+          "memberName": "subscribe",
+          "kind": "class_method"
+        }
+      ]
+    },
+    {
+      "path": "src/infrastructure/storage/local-directory/file-system-access-backend.ts",
+      "reason": "FileSystemAccessDirectoryBackend implements the LocalDirectoryBackend interface; these methods are invoked through the selected workspace backend abstraction.",
+      "members": [
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "getReadUrl",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "writeFile",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "listDirectory",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "createDirectory",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "exists",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "move",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "selectAndCopyFiles",
+          "kind": "class_method"
+        },
+        {
+          "parentName": "FileSystemAccessDirectoryBackend",
+          "memberName": "subscribe",
+          "kind": "class_method"
+        }
+      ]
+    },
+    {
       "path": "src/infrastructure/gpu-compositor/compositor-pipeline.ts",
       "reason": "Audited as a live GPU compositor API reached through typed render contexts.",
       "members": [

--- a/scripts/fallow-unused-class-members.allowlist.json
+++ b/scripts/fallow-unused-class-members.allowlist.json
@@ -214,11 +214,6 @@
         },
         {
           "parentName": "FileSystemAccessDirectoryBackend",
-          "memberName": "writeFile",
-          "kind": "class_method"
-        },
-        {
-          "parentName": "FileSystemAccessDirectoryBackend",
           "memberName": "listDirectory",
           "kind": "class_method"
         },
@@ -230,11 +225,6 @@
         {
           "parentName": "FileSystemAccessDirectoryBackend",
           "memberName": "exists",
-          "kind": "class_method"
-        },
-        {
-          "parentName": "FileSystemAccessDirectoryBackend",
-          "memberName": "move",
           "kind": "class_method"
         },
         {

--- a/src/features/media-library/deps/storage.ts
+++ b/src/features/media-library/deps/storage.ts
@@ -19,6 +19,7 @@ export {
   getAllMediaMetadata,
   getMedia,
   getMediaForProject,
+  getMediaSourceReadUrl,
   getProjectMediaIds,
   getProjectsUsingMedia,
   getThumbnailByMediaId,

--- a/src/features/media-library/deps/storage.ts
+++ b/src/features/media-library/deps/storage.ts
@@ -3,6 +3,7 @@
 // Keep direct workspace-fs imports out of media-library services; this facade is
 // intentionally thin and behavior-preserving.
 export {
+  adoptCopiedMediaSource,
   associateMediaWithProject,
   createMedia,
   decrementContentRef,
@@ -12,6 +13,8 @@ export {
   deleteScenes,
   deleteThumbnailsByMediaId,
   deleteTranscript,
+  getCopiedMediaReadUrl,
+  getWorkspaceRoot,
   getAllMedia,
   getAllMediaMetadata,
   getMedia,

--- a/src/features/media-library/services/media-asset-helpers.ts
+++ b/src/features/media-library/services/media-asset-helpers.ts
@@ -1,6 +1,7 @@
 import type { MediaMetadata } from '@/types/storage'
 import { createLogger, createOperationId } from '@/shared/logging/logger'
 import {
+  adoptCopiedMediaSource,
   associateMediaWithProject,
   createMedia as createMediaDB,
   deleteMedia as deleteMediaDB,
@@ -100,6 +101,69 @@ interface PersistGeneratedMediaOptions {
   thumbnailBlob?: Blob
   thumbnailWidth?: number
   thumbnailHeight?: number
+}
+
+interface PersistAdoptedMediaOptions {
+  stagedPath: readonly string[]
+  projectId: string
+  mediaMetadata: MediaMetadata
+  thumbnailBlob?: Blob
+  thumbnailWidth?: number
+  thumbnailHeight?: number
+}
+
+export async function persistAdoptedMediaAsset({
+  stagedPath,
+  projectId,
+  mediaMetadata,
+  thumbnailBlob,
+  thumbnailWidth,
+  thumbnailHeight,
+}: PersistAdoptedMediaOptions): Promise<MediaMetadata> {
+  let sourceAdopted = false
+  let thumbnailSaved = false
+  try {
+    await adoptCopiedMediaSource(stagedPath, mediaMetadata.id, mediaMetadata.fileName)
+    sourceAdopted = true
+
+    const rawWidth = Number(thumbnailWidth)
+    const rawHeight = Number(thumbnailHeight)
+    if (
+      thumbnailBlob &&
+      Number.isFinite(rawWidth) &&
+      rawWidth > 0 &&
+      Number.isFinite(rawHeight) &&
+      rawHeight > 0
+    ) {
+      const thumbnailId = crypto.randomUUID()
+      await saveThumbnailDB({
+        id: thumbnailId,
+        mediaId: mediaMetadata.id,
+        blob: thumbnailBlob,
+        timestamp: 0,
+        width: Math.max(1, Math.floor(Math.abs(rawWidth))),
+        height: Math.max(1, Math.floor(Math.abs(rawHeight))),
+      })
+      mediaMetadata.thumbnailId = thumbnailId
+      thumbnailSaved = true
+    }
+
+    await createMediaDB(mediaMetadata)
+    await associateMediaWithProject(projectId, mediaMetadata.id)
+    return mediaMetadata
+  } catch (error) {
+    if (sourceAdopted) {
+      await deleteMediaDB(mediaMetadata.id).catch((cleanupError) => {
+        logger.warn(`Failed to roll back adopted media ${mediaMetadata.id}:`, cleanupError)
+      })
+    }
+    if (thumbnailSaved) {
+      await deleteThumbnailsByMediaId(mediaMetadata.id).catch((cleanupError) => {
+        logger.warn(`Failed to roll back adopted thumbnail ${mediaMetadata.id}:`, cleanupError)
+      })
+    }
+    throw error
+  }
 }
 
 export async function persistGeneratedMediaAsset({

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -28,7 +28,11 @@ const indexedDbMocks = vi.hoisted(() => ({
   deleteScenes: vi.fn(async () => undefined),
   hasMediaSource: vi.fn(async () => false),
   readMediaSource: vi.fn(async () => null),
-  getCopiedMediaReadUrl: vi.fn(async () => 'http://127.0.0.1:9999/media-token/video.mp4'),
+  getCopiedMediaReadUrl: vi.fn(async () => ({
+    url: 'http://127.0.0.1:9999/media-token/video.mp4',
+    expiresAt: Date.now() + 60_000,
+    stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
+  })),
   adoptCopiedMediaSource: vi.fn(async () => undefined),
   removeWorkspaceCacheEntry: vi.fn(async () => undefined),
   writeMediaSource: vi.fn(async () => undefined),

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -2,6 +2,12 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
+type MockLocalReadUrl = {
+  url: string
+  expiresAt: number
+  stat: { kind: 'file'; size: number; modifiedAt: number; etag: string }
+}
+
 const indexedDbMocks = vi.hoisted(() => ({
   getAllMedia: vi.fn(),
   getAllMediaMetadata: vi.fn(),
@@ -33,11 +39,13 @@ const indexedDbMocks = vi.hoisted(() => ({
     expiresAt: Date.now() + 60_000,
     stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
   })),
-  getMediaSourceReadUrl: vi.fn(async () => ({
-    url: 'http://127.0.0.1:9999/media-token/adopted.mp4',
-    expiresAt: Date.now() + 60_000,
-    stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
-  })),
+  getMediaSourceReadUrl: vi.fn(
+    async (): Promise<MockLocalReadUrl | null> => ({
+      url: 'http://127.0.0.1:9999/media-token/adopted.mp4',
+      expiresAt: Date.now() + 60_000,
+      stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
+    }),
+  ),
   adoptCopiedMediaSource: vi.fn(async () => undefined),
   removeWorkspaceCacheEntry: vi.fn(async () => undefined),
   writeMediaSource: vi.fn(async () => undefined),
@@ -383,7 +391,100 @@ describe('MediaLibraryService', () => {
       expect(result.id).not.toBe('older-1')
     })
 
+    it('preserves staged bytes when a matching record is not workspace-backed', async () => {
+      indexedDbMocks.getAllMediaMetadata.mockResolvedValue([
+        makeMediaMetadata({
+          id: 'legacy-handle',
+          storageType: 'handle',
+          fileLastModified: 123,
+        }),
+      ])
+      mediaProcessorMocks.processMediaUrl.mockResolvedValue({
+        metadata: {
+          type: 'video',
+          duration: 12,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'avc1',
+          bitrate: 0,
+          audioCodecSupported: true,
+          videoCodecSupported: true,
+        },
+        thumbnail: null,
+      })
+      mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false })
+
+      const result = await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-1',
+      )
+
+      expect(result.id).not.toBe('legacy-handle')
+      expect(indexedDbMocks.adoptCopiedMediaSource).toHaveBeenCalledWith(
+        ['cache', 'imports', 'batch-1', 'video.mp4'],
+        result.id,
+        'video.mp4',
+      )
+      expect(indexedDbMocks.removeWorkspaceCacheEntry).not.toHaveBeenCalled()
+    })
+
+    it('preserves staged bytes when matching workspace metadata has no source file', async () => {
+      indexedDbMocks.getAllMediaMetadata.mockResolvedValue([
+        makeMediaMetadata({
+          id: 'missing-workspace-source',
+          storageType: 'workspace',
+          fileLastModified: 123,
+        }),
+      ])
+      indexedDbMocks.getMediaSourceReadUrl.mockResolvedValueOnce(null)
+      mediaProcessorMocks.processMediaUrl.mockResolvedValue({
+        metadata: {
+          type: 'video',
+          duration: 12,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'avc1',
+          bitrate: 0,
+          audioCodecSupported: true,
+          videoCodecSupported: true,
+        },
+        thumbnail: null,
+      })
+      mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false })
+
+      const result = await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-1',
+      )
+
+      expect(result.id).not.toBe('missing-workspace-source')
+      expect(indexedDbMocks.adoptCopiedMediaSource).toHaveBeenCalledWith(
+        ['cache', 'imports', 'batch-1', 'video.mp4'],
+        result.id,
+        'video.mp4',
+      )
+      expect(indexedDbMocks.removeWorkspaceCacheEntry).not.toHaveBeenCalled()
+    })
+
     it('schedules copied video audio preparation from its adopted workspace source', async () => {
+      const backgroundJobs: Promise<unknown>[] = []
+      backgroundMediaWorkMocks.enqueueBackgroundMediaWork.mockImplementation(
+        (run: () => unknown) => {
+          const job = Promise.resolve().then(run)
+          backgroundJobs.push(job)
+          return vi.fn()
+        },
+      )
       compositionRuntimeMocks.needsCustomAudioDecoder.mockReturnValue(true)
       fetchMock.mockResolvedValue({
         ok: true,
@@ -416,6 +517,9 @@ describe('MediaLibraryService', () => {
       )
 
       expect(backgroundMediaWorkMocks.enqueueBackgroundMediaWork).toHaveBeenCalledTimes(2)
+      await Promise.all(backgroundJobs)
+      expect(compositionRuntimeMocks.startPreviewAudioStartupWarm).toHaveBeenCalledTimes(1)
+      expect(compositionRuntimeMocks.startPreviewAudioConform).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -33,6 +33,11 @@ const indexedDbMocks = vi.hoisted(() => ({
     expiresAt: Date.now() + 60_000,
     stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
   })),
+  getMediaSourceReadUrl: vi.fn(async () => ({
+    url: 'http://127.0.0.1:9999/media-token/adopted.mp4',
+    expiresAt: Date.now() + 60_000,
+    stat: { kind: 'file', size: 1024, modifiedAt: 123, etag: '1024-123' },
+  })),
   adoptCopiedMediaSource: vi.fn(async () => undefined),
   removeWorkspaceCacheEntry: vi.fn(async () => undefined),
   writeMediaSource: vi.fn(async () => undefined),
@@ -311,6 +316,106 @@ describe('MediaLibraryService', () => {
         width: 1920,
         height: 1080,
       })
+    })
+
+    it('reuses matching workspace media across projects using modifiedAt', async () => {
+      const existing = makeMediaMetadata({
+        id: 'existing-1',
+        storageType: 'workspace',
+        fileLastModified: 123,
+      })
+      indexedDbMocks.getAllMediaMetadata.mockResolvedValue([existing])
+      indexedDbMocks.getMediaForProject.mockResolvedValue([])
+
+      const result = await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-2',
+      )
+
+      expect(indexedDbMocks.getAllMediaMetadata).toHaveBeenCalledTimes(1)
+      expect(indexedDbMocks.associateMediaWithProject).toHaveBeenCalledWith(
+        'project-2',
+        'existing-1',
+      )
+      expect(indexedDbMocks.removeWorkspaceCacheEntry).toHaveBeenCalled()
+      expect(mediaProcessorMocks.processMediaUrl).not.toHaveBeenCalled()
+      expect(result).toMatchObject({ id: 'existing-1', isDuplicate: false })
+    })
+
+    it('does not collapse copied files with a different modifiedAt', async () => {
+      indexedDbMocks.getAllMediaMetadata.mockResolvedValue([
+        makeMediaMetadata({
+          id: 'older-1',
+          storageType: 'workspace',
+          fileLastModified: 122,
+        }),
+      ])
+      mediaProcessorMocks.processMediaUrl.mockResolvedValue({
+        metadata: {
+          type: 'video',
+          duration: 12,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'avc1',
+          bitrate: 0,
+          audioCodecSupported: true,
+          videoCodecSupported: true,
+        },
+        thumbnail: null,
+      })
+      mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false })
+
+      const result = await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-1',
+      )
+
+      expect(mediaProcessorMocks.processMediaUrl).toHaveBeenCalledTimes(1)
+      expect(result.id).not.toBe('older-1')
+    })
+
+    it('schedules copied video audio preparation from its adopted workspace source', async () => {
+      compositionRuntimeMocks.needsCustomAudioDecoder.mockReturnValue(true)
+      fetchMock.mockResolvedValue({
+        ok: true,
+        blob: async () => new Blob(['video'], { type: 'video/mp4' }),
+      })
+      mediaProcessorMocks.processMediaUrl.mockResolvedValue({
+        metadata: {
+          type: 'video',
+          duration: 12,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'avc1',
+          bitrate: 0,
+          audioCodec: 'ac3',
+          audioCodecSupported: false,
+          videoCodecSupported: true,
+        },
+        thumbnail: null,
+      })
+      mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: true })
+
+      await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-1',
+      )
+
+      expect(backgroundMediaWorkMocks.enqueueBackgroundMediaWork).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/features/media-library/services/media-library-service.test.ts
+++ b/src/features/media-library/services/media-library-service.test.ts
@@ -28,6 +28,9 @@ const indexedDbMocks = vi.hoisted(() => ({
   deleteScenes: vi.fn(async () => undefined),
   hasMediaSource: vi.fn(async () => false),
   readMediaSource: vi.fn(async () => null),
+  getCopiedMediaReadUrl: vi.fn(async () => 'http://127.0.0.1:9999/media-token/video.mp4'),
+  adoptCopiedMediaSource: vi.fn(async () => undefined),
+  removeWorkspaceCacheEntry: vi.fn(async () => undefined),
   writeMediaSource: vi.fn(async () => undefined),
 }))
 
@@ -50,6 +53,7 @@ const proxyMocks = vi.hoisted(() => ({
 
 const mediaProcessorMocks = vi.hoisted(() => ({
   processMedia: vi.fn(),
+  processMediaUrl: vi.fn(),
   hasUnsupportedAudioCodec: vi.fn(),
 }))
 
@@ -213,6 +217,7 @@ describe('MediaLibraryService', () => {
     indexedDbMocks.getAllMedia.mockResolvedValue([])
     indexedDbMocks.getAllMediaMetadata.mockImplementation(() => indexedDbMocks.getAllMedia())
     indexedDbMocks.getProjectMediaIds.mockResolvedValue([])
+    indexedDbMocks.getMediaForProject.mockResolvedValue([])
     indexedDbMocks.readAiOutput.mockResolvedValue(undefined)
   })
 
@@ -241,6 +246,67 @@ describe('MediaLibraryService', () => {
 
       const result = await mediaLibraryService.getMedia('nonexistent')
       expect(result).toBeNull()
+    })
+  })
+
+  describe('importCopiedWorkspaceMedia', () => {
+    it('probes Electron-copied video through a Range URL and adopts the existing bytes', async () => {
+      mediaProcessorMocks.processMediaUrl.mockResolvedValue({
+        metadata: {
+          type: 'video',
+          duration: 12,
+          width: 1920,
+          height: 1080,
+          fps: 30,
+          codec: 'avc1',
+          bitrate: 0,
+          audioCodec: 'aac',
+          audioCodecSupported: true,
+          videoCodecSupported: true,
+        },
+        thumbnail: new Blob(['thumbnail'], { type: 'image/webp' }),
+      })
+      mediaProcessorMocks.hasUnsupportedAudioCodec.mockReturnValue({ unsupported: false })
+
+      const result = await mediaLibraryService.importCopiedWorkspaceMedia(
+        {
+          name: 'video.mp4',
+          path: ['cache', 'imports', 'batch-1', 'video.mp4'],
+          stat: { size: 1024, modifiedAt: 123 },
+        },
+        'project-1',
+      )
+
+      expect(indexedDbMocks.getCopiedMediaReadUrl).toHaveBeenCalledWith([
+        'cache',
+        'imports',
+        'batch-1',
+        'video.mp4',
+      ])
+      expect(mediaProcessorMocks.processMediaUrl).toHaveBeenCalledWith(
+        {
+          url: 'http://127.0.0.1:9999/media-token/video.mp4',
+          name: 'video.mp4',
+          size: 1024,
+          lastModified: 123,
+        },
+        'application/octet-stream',
+        { thumbnailTimestamp: 1, fastMetadata: true },
+      )
+      expect(indexedDbMocks.adoptCopiedMediaSource).toHaveBeenCalledWith(
+        ['cache', 'imports', 'batch-1', 'video.mp4'],
+        result.id,
+        'video.mp4',
+      )
+      expect(indexedDbMocks.writeMediaSource).not.toHaveBeenCalled()
+      expect(result).toMatchObject({
+        storageType: 'workspace',
+        fileName: 'video.mp4',
+        fileSize: 1024,
+        duration: 12,
+        width: 1920,
+        height: 1080,
+      })
     })
   })
 

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -917,10 +917,10 @@ class MediaLibraryService {
     }
 
     try {
-      const sourceUrl = await getCopiedMediaReadUrl(input.path)
+      const source = await getCopiedMediaReadUrl(input.path)
       const { metadata, thumbnail } = await mediaProcessorService.processMediaUrl(
         {
-          url: sourceUrl,
+          url: source.url,
           name: input.name,
           size: input.stat.size,
           lastModified: input.stat.modifiedAt,

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -60,6 +60,7 @@ import {
   getProjectsUsingMedia,
   getMediaForProject as getMediaForProjectDB,
   getCopiedMediaReadUrl,
+  getMediaSourceReadUrl,
   deleteTranscript,
   readAiOutput,
   saveCaptions,
@@ -548,27 +549,41 @@ class MediaLibraryService {
   }
 
   private schedulePostImportWork(
-    file: File,
+    source: File | (() => Promise<File>),
     mediaMetadata: MediaMetadata,
     options: {
       isVideo: boolean
       previewAudioCodec?: string
     },
   ): void {
+    let sourcePromise: Promise<File> | null = null
+    const getSourceFile = () => {
+      if (source instanceof File) return Promise.resolve(source)
+      sourcePromise ??= source()
+      return sourcePromise
+    }
+
     if (needsCustomAudioDecoder(options.previewAudioCodec)) {
-      enqueueBackgroundMediaWork(() => startPreviewAudioStartupWarm(mediaMetadata.id, file), {
-        priority: 'warm',
-        delayMs: IMPORT_BACKGROUND_WARM_DELAY_MS,
-      })
-      enqueueBackgroundMediaWork(() => startPreviewAudioConform(mediaMetadata.id, file), {
-        priority: 'heavy',
-        delayMs: IMPORT_BACKGROUND_HEAVY_DELAY_MS,
-      })
+      enqueueBackgroundMediaWork(
+        async () => startPreviewAudioStartupWarm(mediaMetadata.id, await getSourceFile()),
+        {
+          priority: 'warm',
+          delayMs: IMPORT_BACKGROUND_WARM_DELAY_MS,
+        },
+      )
+      enqueueBackgroundMediaWork(
+        async () => startPreviewAudioConform(mediaMetadata.id, await getSourceFile()),
+        {
+          priority: 'heavy',
+          delayMs: IMPORT_BACKGROUND_HEAVY_DELAY_MS,
+        },
+      )
     }
 
     if (mediaMetadata.mimeType === 'image/gif') {
       enqueueBackgroundMediaWork(
         async () => {
+          const file = await getSourceFile()
           const blobUrl = URL.createObjectURL(file)
           try {
             const { gifFrameCache } = await importGifFrameCache()
@@ -582,6 +597,21 @@ class MediaLibraryService {
           delayMs: IMPORT_BACKGROUND_WARM_DELAY_MS,
         },
       )
+    }
+  }
+
+  private workspaceMediaFileLoader(media: MediaMetadata): () => Promise<File> {
+    return async () => {
+      const source = await getMediaSourceReadUrl(media.id)
+      if (!source) throw new Error(`Workspace media source is missing: ${media.id}`)
+      const response = await fetch(source.url)
+      if (!response.ok) {
+        throw new Error(`Failed to read workspace media: ${response.status}`)
+      }
+      return new File([await response.blob()], media.fileName, {
+        type: media.mimeType,
+        lastModified: media.fileLastModified ?? media.updatedAt,
+      })
     }
   }
 
@@ -902,12 +932,28 @@ class MediaLibraryService {
     },
     projectId: string,
   ): Promise<MediaMetadata & { isDuplicate?: boolean; hasUnsupportedCodec?: boolean }> {
-    const existing = (await getMediaForProjectDB(projectId)).find(
-      (media) => media.fileName === input.name && media.fileSize === input.stat.size,
-    )
+    const [workspaceMedia, projectMedia] = await Promise.all([
+      getAllMediaMetadataDB(),
+      getMediaForProjectDB(projectId),
+    ])
+    const isSameCopiedFile = (media: MediaMetadata) =>
+      media.fileName === input.name &&
+      media.fileSize === input.stat.size &&
+      media.fileLastModified === input.stat.modifiedAt
+    const existing = workspaceMedia.find(isSameCopiedFile) ?? projectMedia.find(isSameCopiedFile)
     if (existing) {
+      const alreadyInThisProject = projectMedia.some((media) => media.id === existing.id)
+      if (!alreadyInThisProject) {
+        await associateMediaWithProject(projectId, existing.id)
+      }
+      this.schedulePostImportWork(this.workspaceMediaFileLoader(existing), existing, {
+        isVideo: existing.mimeType.startsWith('video/'),
+        previewAudioCodec: existing.mimeType.startsWith('audio/')
+          ? existing.codec
+          : existing.audioCodec,
+      })
       await removeWorkspaceCacheEntry([...input.path])
-      return { ...existing, isDuplicate: true }
+      return { ...existing, isDuplicate: alreadyInThisProject }
     }
 
     const mimeType = getMimeType(new File([], input.name))
@@ -974,6 +1020,12 @@ class MediaLibraryService {
         thumbnailBlob: thumbnail,
         thumbnailWidth: thumbnailDimensions?.width,
         thumbnailHeight: thumbnailDimensions?.height,
+      })
+      this.schedulePostImportWork(this.workspaceMediaFileLoader(persisted), persisted, {
+        isVideo: persisted.mimeType.startsWith('video/'),
+        previewAudioCodec: persisted.mimeType.startsWith('audio/')
+          ? persisted.codec
+          : persisted.audioCodec,
       })
       return { ...persisted, hasUnsupportedCodec: codecCheck.unsupported }
     } catch (error) {

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -940,7 +940,19 @@ class MediaLibraryService {
       media.fileName === input.name &&
       media.fileSize === input.stat.size &&
       media.fileLastModified === input.stat.modifiedAt
-    const existing = workspaceMedia.find(isSameCopiedFile) ?? projectMedia.find(isSameCopiedFile)
+    const duplicateCandidates = [
+      ...workspaceMedia.filter(isSameCopiedFile),
+      ...projectMedia.filter(isSameCopiedFile),
+    ]
+    let existing: MediaMetadata | undefined
+    for (const candidate of duplicateCandidates) {
+      if (candidate.storageType !== 'workspace') continue
+      const source = await getMediaSourceReadUrl(candidate.id).catch(() => null)
+      if (source) {
+        existing = candidate
+        break
+      }
+    }
     if (existing) {
       const alreadyInThisProject = projectMedia.some((media) => media.id === existing.id)
       if (!alreadyInThisProject) {

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -59,6 +59,7 @@ import {
   getProjectMediaIds,
   getProjectsUsingMedia,
   getMediaForProject as getMediaForProjectDB,
+  getCopiedMediaReadUrl,
   deleteTranscript,
   readAiOutput,
   saveCaptions,
@@ -66,6 +67,7 @@ import {
   deleteScenes,
   hasMediaSource,
   readMediaSource,
+  removeWorkspaceCacheEntry,
   writeMediaSource,
 } from '@/features/media-library/deps/storage'
 import {
@@ -80,6 +82,7 @@ import { enqueueBackgroundMediaWork } from './background-media-work'
 import {
   getGeneratedImageDimensions,
   getThumbnailDimensions,
+  persistAdoptedMediaAsset,
   persistGeneratedMediaAsset,
 } from './media-asset-helpers'
 import { validateMediaFileContent, getMimeType, isLottieMime } from '../utils/validation'
@@ -884,6 +887,99 @@ class MediaLibraryService {
   async getMedia(id: string): Promise<MediaMetadata | null> {
     const media = await getMediaDB(id)
     return media || null
+  }
+
+  /**
+   * Finalize a file already copied into the workspace by the Electron main
+   * process. Video/audio probing uses the bridge's Range URL, so source bytes
+   * never cross IPC or enter the renderer as one giant Blob.
+   */
+  async importCopiedWorkspaceMedia(
+    input: {
+      name: string
+      path: readonly string[]
+      stat: { size: number; modifiedAt: number }
+    },
+    projectId: string,
+  ): Promise<MediaMetadata & { isDuplicate?: boolean; hasUnsupportedCodec?: boolean }> {
+    const existing = (await getMediaForProjectDB(projectId)).find(
+      (media) => media.fileName === input.name && media.fileSize === input.stat.size,
+    )
+    if (existing) {
+      await removeWorkspaceCacheEntry([...input.path])
+      return { ...existing, isDuplicate: true }
+    }
+
+    const mimeType = getMimeType(new File([], input.name))
+    if (!mimeType) {
+      await removeWorkspaceCacheEntry([...input.path])
+      throw new Error(`Unsupported media type: ${input.name}`)
+    }
+
+    try {
+      const sourceUrl = await getCopiedMediaReadUrl(input.path)
+      const { metadata, thumbnail } = await mediaProcessorService.processMediaUrl(
+        {
+          url: sourceUrl,
+          name: input.name,
+          size: input.stat.size,
+          lastModified: input.stat.modifiedAt,
+        },
+        mimeType,
+        { thumbnailTimestamp: 1, fastMetadata: true },
+      )
+      const mediaId = crypto.randomUUID()
+      const createdAt = Date.now()
+      const codecCheck = mediaProcessorService.hasUnsupportedAudioCodec(metadata)
+      const thumbnailDimensions = thumbnail
+        ? metadata.type === 'audio'
+          ? { width: 320, height: 180 }
+          : getThumbnailDimensions(
+              Math.max(1, 'width' in metadata ? metadata.width || 1 : 1),
+              Math.max(1, 'height' in metadata ? metadata.height || 1 : 1),
+              320,
+            )
+        : undefined
+      const mediaMetadata: MediaMetadata = {
+        id: mediaId,
+        storageType: 'workspace',
+        fileName: input.name,
+        fileSize: input.stat.size,
+        fileLastModified: input.stat.modifiedAt,
+        mimeType,
+        duration: 'duration' in metadata ? metadata.duration : 0,
+        width: 'width' in metadata ? metadata.width : 0,
+        height: 'height' in metadata ? metadata.height : 0,
+        fps: metadata.type === 'video' ? metadata.fps : 0,
+        codec:
+          metadata.type === 'video'
+            ? metadata.codec
+            : metadata.type === 'audio'
+              ? metadata.codec || 'unknown'
+              : 'unknown',
+        bitrate: 'bitrate' in metadata ? (metadata.bitrate ?? 0) : 0,
+        audioCodec: metadata.type === 'video' ? metadata.audioCodec : undefined,
+        audioCodecSupported: metadata.type === 'video' ? metadata.audioCodecSupported : true,
+        videoCodecSupported: metadata.type === 'video' ? metadata.videoCodecSupported : true,
+        keyframeTimestamps: metadata.type === 'video' ? metadata.keyframeTimestamps : undefined,
+        gopInterval: metadata.type === 'video' ? metadata.gopInterval : undefined,
+        tags: [],
+        createdAt,
+        updatedAt: createdAt,
+      }
+      const persisted = await persistAdoptedMediaAsset({
+        stagedPath: input.path,
+        projectId,
+        mediaMetadata,
+        thumbnailBlob: thumbnail,
+        thumbnailWidth: thumbnailDimensions?.width,
+        thumbnailHeight: thumbnailDimensions?.height,
+      })
+      return { ...persisted, hasUnsupportedCodec: codecCheck.unsupported }
+    } catch (error) {
+      await removeWorkspaceCacheEntry([...input.path])
+      throw error
+    }
   }
 
   /**

--- a/src/features/media-library/services/media-processor-service.ts
+++ b/src/features/media-library/services/media-processor-service.ts
@@ -10,6 +10,7 @@ import { createManagedWorker, rejectAndDeletePendingRequests } from '@/shared/ut
 import type {
   ProcessMediaRequest,
   ProcessMediaResponse,
+  UrlMediaSource,
   VideoMetadata,
   AudioMetadata,
   ImageMetadata,
@@ -112,6 +113,34 @@ class MediaProcessorService {
       fastMetadata?: boolean
     },
   ): Promise<ProcessMediaResult> {
+    return this.processRequest({
+      file,
+      mimeType,
+      options,
+    })
+  }
+
+  async processMediaUrl(
+    source: UrlMediaSource,
+    mimeType: string,
+    options?: {
+      thumbnailMaxSize?: number
+      thumbnailQuality?: number
+      thumbnailTimestamp?: number
+      generateThumbnail?: boolean
+      fastMetadata?: boolean
+    },
+  ): Promise<ProcessMediaResult> {
+    return this.processRequest({
+      source,
+      mimeType,
+      options,
+    })
+  }
+
+  private async processRequest(
+    input: Pick<ProcessMediaRequest, 'file' | 'source' | 'mimeType' | 'options'>,
+  ): Promise<ProcessMediaResult> {
     const worker = this.ensureWorker()
     const requestId = `media-${++this.requestId}`
 
@@ -142,9 +171,7 @@ class MediaProcessorService {
       const request: ProcessMediaRequest = {
         type: 'process',
         requestId,
-        file,
-        mimeType,
-        options,
+        ...input,
       }
 
       worker.postMessage(request)

--- a/src/features/media-library/stores/media-import-actions.test.ts
+++ b/src/features/media-library/stores/media-import-actions.test.ts
@@ -5,10 +5,15 @@ import { createImportActions } from './media-import-actions'
 import { useMediaPreparationStore } from './media-preparation-store'
 
 const mediaLibraryServiceMocks = vi.hoisted(() => ({
+  importCopiedWorkspaceMedia: vi.fn(),
   importMediaWithHandle: vi.fn(),
   importMediaFromUrl: vi.fn(),
   waitForMediaPreparation: vi.fn(),
   getMediaFile: vi.fn(),
+}))
+
+const storageMocks = vi.hoisted(() => ({
+  getWorkspaceRoot: vi.fn(),
 }))
 
 const proxyServiceMocks = vi.hoisted(() => ({
@@ -47,6 +52,8 @@ vi.mock('./media-library-service-access', () => ({
 vi.mock('../services/proxy-service', () => ({
   proxyService: proxyServiceMocks,
 }))
+
+vi.mock('../deps/storage', () => storageMocks)
 
 vi.mock('../services/background-media-work', async () => {
   const { createBackgroundMediaWorkMocks } =
@@ -195,6 +202,7 @@ describe('createImportActions', () => {
     vi.clearAllMocks()
     useMediaPreparationStore.getState().clearAll()
     mediaLibraryServiceMocks.importMediaWithHandle.mockReset()
+    mediaLibraryServiceMocks.importCopiedWorkspaceMedia.mockReset()
     mediaLibraryServiceMocks.importMediaFromUrl.mockReset()
     mediaLibraryServiceMocks.waitForMediaPreparation.mockReset()
     mediaLibraryServiceMocks.waitForMediaPreparation.mockResolvedValue(undefined)
@@ -203,6 +211,7 @@ describe('createImportActions', () => {
       mimeType.startsWith('video/'),
     )
     proxyServiceMocks.hasProxy.mockReturnValue(false)
+    storageMocks.getWorkspaceRoot.mockReturnValue(null)
   })
 
   it('replaces optimistic placeholders with imported media', async () => {
@@ -546,6 +555,43 @@ describe('createImportActions', () => {
     } finally {
       vi.stubGlobal('window', originalWindow)
       vi.stubGlobal('navigator', originalNavigator)
+    }
+  })
+
+  it('limits concurrent Electron copied-file imports', async () => {
+    const originalWindow = globalThis.window
+    const copiedFiles = Array.from({ length: 5 }, (_, index) => ({
+      name: `clip-${index}.mp4`,
+      path: ['cache', 'imports', `clip-${index}.mp4`],
+      stat: { size: 1024, modifiedAt: index },
+    }))
+    storageMocks.getWorkspaceRoot.mockReturnValue({
+      kind: 'electron-directory',
+      selectAndCopyFiles: vi.fn().mockResolvedValue(copiedFiles),
+    })
+    vi.stubGlobal('window', {
+      electronLocalDirectory: { runtime: 'electron' },
+    } as Window & typeof globalThis)
+    let active = 0
+    let maxActive = 0
+    mediaLibraryServiceMocks.importCopiedWorkspaceMedia.mockImplementation(
+      async (file: { name: string }, _projectId: string) => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        active--
+        return makeMedia({ id: file.name, fileName: file.name })
+      },
+    )
+
+    try {
+      const result = await createImportActionsHarness().actions.importMedia()
+
+      expect(result).toHaveLength(5)
+      expect(mediaLibraryServiceMocks.importCopiedWorkspaceMedia).toHaveBeenCalledTimes(5)
+      expect(maxActive).toBeLessThanOrEqual(2)
+    } finally {
+      vi.stubGlobal('window', originalWindow)
     }
   })
 })

--- a/src/features/media-library/stores/media-import-actions.ts
+++ b/src/features/media-library/stores/media-import-actions.ts
@@ -7,6 +7,7 @@ import { getSharedProxyKey } from '../utils/proxy-key'
 import { hasMediaFilePickerSupport, showMediaFilePicker } from '../utils/media-file-picker'
 import { createLogger, createOperationId } from '@/shared/logging/logger'
 import { useMediaPreparationStore } from './media-preparation-store'
+import { getWorkspaceRoot } from '../deps/storage'
 
 const logger = createLogger('MediaImport')
 
@@ -448,6 +449,58 @@ export function createImportActions(
       event.set('projectId', currentProjectId)
 
       try {
+        const workspaceRoot = getWorkspaceRoot()
+        if (workspaceRoot?.kind === 'electron-directory') {
+          const batchId = crypto.randomUUID()
+          const copiedFiles = await workspaceRoot.selectAndCopyFiles(['cache', 'imports', batchId])
+          event.set('fileCount', copiedFiles.length)
+          const { mediaLibraryService } = await loadMediaLibraryService()
+          const settled = await Promise.allSettled(
+            copiedFiles.map((file) =>
+              mediaLibraryService.importCopiedWorkspaceMedia(file, currentProjectId),
+            ),
+          )
+          const results: MediaMetadata[] = []
+          const duplicateNames: string[] = []
+          const unsupportedCodecFiles: UnsupportedCodecFile[] = []
+          let failedCount = 0
+          for (const result of settled) {
+            if (result.status === 'rejected') {
+              failedCount += 1
+              logger.error('Failed to import Electron-copied media', result.reason)
+              continue
+            }
+            const metadata = result.value
+            if (metadata.isDuplicate) {
+              duplicateNames.push(metadata.fileName)
+              continue
+            }
+            prependImportedMedia(set, metadata)
+            setupImportedVideoProxy(metadata)
+            results.push(metadata)
+            if (metadata.hasUnsupportedCodec && metadata.audioCodec) {
+              unsupportedCodecFiles.push({
+                fileName: metadata.fileName,
+                audioCodec: metadata.audioCodec,
+              })
+            }
+          }
+          showImportNotifications(
+            results.length,
+            duplicateNames,
+            unsupportedCodecFiles,
+            failedCount,
+            get,
+          )
+          event.success({
+            imported: results.length,
+            duplicates: duplicateNames.length,
+            failed: failedCount,
+            unsupportedCodecs: unsupportedCodecFiles.length,
+          })
+          return results
+        }
+
         // Open file picker
         const handles = await showMediaFilePicker({ multiple: true })
 

--- a/src/features/media-library/stores/media-import-actions.ts
+++ b/src/features/media-library/stores/media-import-actions.ts
@@ -34,6 +34,28 @@ interface CompletedImportTask extends ImportTask {
 
 type ImportStorageMode = 'copy' | 'link'
 
+async function runSettledWithImportConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length)
+  let nextIndex = 0
+  const runNext = async (): Promise<void> => {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++
+      const task = tasks[index]
+      if (!task) continue
+      try {
+        results[index] = { status: 'fulfilled', value: await task() }
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason }
+      }
+    }
+  }
+  const workerCount = Math.min(IMPORT_PROCESSING_CONCURRENCY, tasks.length)
+  await Promise.all(Array.from({ length: workerCount }, runNext))
+  return results
+}
+
 function buildOptimisticMediaItem(
   handle: FileSystemFileHandle,
   file: File,
@@ -337,36 +359,16 @@ export function createImportActions(
     serviceModulePromise: ReturnType<typeof loadMediaLibraryService>,
     storageMode: ImportStorageMode,
   ): Promise<PromiseSettledResult<CompletedImportTask>[]> => {
-    const results: PromiseSettledResult<CompletedImportTask>[] = new Array(importTasks.length)
-    let nextIndex = 0
     const { mediaLibraryService } = await serviceModulePromise
-
-    const runNext = async (): Promise<void> => {
-      while (nextIndex < importTasks.length) {
-        const index = nextIndex++
-        const task = importTasks[index]
-        if (!task) {
-          continue
-        }
-
-        try {
-          markImportPreparationRunning(task.tempId)
-          const metadata = await mediaLibraryService.importMediaWithHandle(task.handle, projectId, {
-            storageMode,
-          })
-          results[index] = {
-            status: 'fulfilled',
-            value: { metadata, tempId: task.tempId, file: task.file, handle: task.handle },
-          }
-        } catch (reason) {
-          results[index] = { status: 'rejected', reason }
-        }
-      }
-    }
-
-    const workerCount = Math.min(IMPORT_PROCESSING_CONCURRENCY, importTasks.length)
-    await Promise.all(Array.from({ length: workerCount }, runNext))
-    return results
+    return runSettledWithImportConcurrency(
+      importTasks.map((task) => async () => {
+        markImportPreparationRunning(task.tempId)
+        const metadata = await mediaLibraryService.importMediaWithHandle(task.handle, projectId, {
+          storageMode,
+        })
+        return { metadata, tempId: task.tempId, file: task.file, handle: task.handle }
+      }),
+    )
   }
 
   const importHandlesInternal = async (
@@ -455,9 +457,10 @@ export function createImportActions(
           const copiedFiles = await workspaceRoot.selectAndCopyFiles(['cache', 'imports', batchId])
           event.set('fileCount', copiedFiles.length)
           const { mediaLibraryService } = await loadMediaLibraryService()
-          const settled = await Promise.allSettled(
-            copiedFiles.map((file) =>
-              mediaLibraryService.importCopiedWorkspaceMedia(file, currentProjectId),
+          const settled = await runSettledWithImportConcurrency(
+            copiedFiles.map(
+              (file) => () =>
+                mediaLibraryService.importCopiedWorkspaceMedia(file, currentProjectId),
             ),
           )
           const results: MediaMetadata[] = []

--- a/src/features/media-library/utils/media-file-picker.ts
+++ b/src/features/media-library/utils/media-file-picker.ts
@@ -24,7 +24,11 @@ export function getSupportedMediaFormatLabels(): string[] {
 }
 
 export function hasMediaFilePickerSupport(): boolean {
-  return typeof window !== 'undefined' && 'showOpenFilePicker' in window
+  return (
+    typeof window !== 'undefined' &&
+    (typeof window.showOpenFilePicker === 'function' ||
+      window.electronLocalDirectory?.runtime === 'electron')
+  )
 }
 
 export async function showMediaFilePicker(options?: {

--- a/src/features/media-library/utils/media-resolver.test.ts
+++ b/src/features/media-library/utils/media-resolver.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const mocks = vi.hoisted(() => ({
+  getMedia: vi.fn(),
+  getMediaSourceReadUrl: vi.fn(),
+  markMediaHealthy: vi.fn(),
+  registerUrl: vi.fn(),
+  registerKeyframeIndex: vi.fn(),
+}))
+
+vi.mock('@/features/media-library/services/media-library-service', () => ({
+  mediaLibraryService: { getMedia: mocks.getMedia, getMediaFile: vi.fn() },
+  FileAccessError: class FileAccessError extends Error {},
+}))
+
+vi.mock('@/features/media-library/stores/media-library-store', () => ({
+  useMediaLibraryStore: {
+    getState: () => ({
+      markMediaHealthy: mocks.markMediaHealthy,
+      markMediaBroken: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('@/infrastructure/browser/blob-url-manager', () => ({
+  blobUrlManager: {
+    get: vi.fn(() => null),
+    registerUrl: mocks.registerUrl,
+    acquire: vi.fn(),
+  },
+}))
+
+vi.mock('@/infrastructure/storage', () => ({
+  getMediaSourceReadUrl: mocks.getMediaSourceReadUrl,
+}))
+
+vi.mock('@/shared/utils/keyframe-index-registry', () => ({
+  registerKeyframeIndex: mocks.registerKeyframeIndex,
+}))
+
+vi.mock('@/features/media-library/services/proxy-service', () => ({
+  proxyService: {},
+}))
+
+vi.mock('@/features/media-library/utils/proxy-key', () => ({
+  getSharedProxyKey: vi.fn(),
+}))
+
+import { resolveMediaUrl } from './media-resolver'
+
+describe('resolveMediaUrl workspace source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers keyframe timestamps for a streamed workspace URL', async () => {
+    mocks.getMedia.mockResolvedValue({
+      id: 'media-1',
+      storageType: 'workspace',
+      fileName: 'clip.mp4',
+      keyframeTimestamps: [0, 2, 4],
+    })
+    mocks.getMediaSourceReadUrl.mockResolvedValue({
+      url: 'http://127.0.0.1/media-token',
+      expiresAt: 1234,
+    })
+    mocks.registerUrl.mockReturnValue('http://127.0.0.1/media-token')
+
+    await expect(resolveMediaUrl('media-1')).resolves.toBe('http://127.0.0.1/media-token')
+
+    expect(mocks.registerKeyframeIndex).toHaveBeenCalledWith(
+      'http://127.0.0.1/media-token',
+      [0, 2, 4],
+    )
+    expect(mocks.markMediaHealthy).toHaveBeenCalledWith('media-1')
+  })
+})

--- a/src/features/media-library/utils/media-resolver.ts
+++ b/src/features/media-library/utils/media-resolver.ts
@@ -5,6 +5,7 @@ import { blobUrlManager } from '@/infrastructure/browser/blob-url-manager'
 import { registerKeyframeIndex } from '@/shared/utils/keyframe-index-registry'
 import type { TimelineTrack } from '@/types/timeline'
 import { createLogger } from '@/shared/logging/logger'
+import { getMediaSourceReadUrl } from '@/infrastructure/storage'
 
 const logger = createLogger('MediaResolver')
 
@@ -44,6 +45,14 @@ export async function resolveMediaUrl(mediaId: string): Promise<string> {
       if (!media) {
         logger.warn(`Media not found: ${mediaId}`)
         return '' // Fallback: empty string (Composition will skip)
+      }
+
+      if (media.storageType === 'workspace') {
+        const streamedUrl = await getMediaSourceReadUrl(mediaId)
+        if (streamedUrl) {
+          useMediaLibraryStore.getState().markMediaHealthy(mediaId)
+          return blobUrlManager.registerUrl(mediaId, streamedUrl)
+        }
       }
 
       // Get the source blob without an extra validation pass; getMediaFile

--- a/src/features/media-library/utils/media-resolver.ts
+++ b/src/features/media-library/utils/media-resolver.ts
@@ -51,9 +51,13 @@ export async function resolveMediaUrl(mediaId: string): Promise<string> {
         const streamedSource = await getMediaSourceReadUrl(mediaId)
         if (streamedSource) {
           useMediaLibraryStore.getState().markMediaHealthy(mediaId)
-          return blobUrlManager.registerUrl(mediaId, streamedSource.url, {
+          const mediaUrl = blobUrlManager.registerUrl(mediaId, streamedSource.url, {
             expiresAt: streamedSource.expiresAt,
           })
+          if (media.keyframeTimestamps && media.keyframeTimestamps.length > 0) {
+            registerKeyframeIndex(mediaUrl, media.keyframeTimestamps)
+          }
+          return mediaUrl
         }
       }
 

--- a/src/features/media-library/utils/media-resolver.ts
+++ b/src/features/media-library/utils/media-resolver.ts
@@ -48,10 +48,12 @@ export async function resolveMediaUrl(mediaId: string): Promise<string> {
       }
 
       if (media.storageType === 'workspace') {
-        const streamedUrl = await getMediaSourceReadUrl(mediaId)
-        if (streamedUrl) {
+        const streamedSource = await getMediaSourceReadUrl(mediaId)
+        if (streamedSource) {
           useMediaLibraryStore.getState().markMediaHealthy(mediaId)
-          return blobUrlManager.registerUrl(mediaId, streamedUrl)
+          return blobUrlManager.registerUrl(mediaId, streamedSource.url, {
+            expiresAt: streamedSource.expiresAt,
+          })
         }
       }
 

--- a/src/features/media-library/workers/media-processor.worker.ts
+++ b/src/features/media-library/workers/media-processor.worker.ts
@@ -202,11 +202,19 @@ function mediaSourceName(source: MediaProcessSource): string {
   return source.name
 }
 
+const mediaSourceBlobCache = new WeakMap<UrlMediaSource, Promise<Blob>>()
+
 async function mediaSourceBlob(source: MediaProcessSource): Promise<Blob> {
   if (!isUrlMediaSource(source)) return source
-  const response = await fetch(source.url)
-  if (!response.ok) throw new Error(`Failed to read imported media: ${response.status}`)
-  return await response.blob()
+  let promise = mediaSourceBlobCache.get(source)
+  if (!promise) {
+    promise = fetch(source.url).then(async (response) => {
+      if (!response.ok) throw new Error(`Failed to read imported media: ${response.status}`)
+      return await response.blob()
+    })
+    mediaSourceBlobCache.set(source, promise)
+  }
+  return promise
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {

--- a/src/features/media-library/workers/media-processor.worker.ts
+++ b/src/features/media-library/workers/media-processor.worker.ts
@@ -87,6 +87,7 @@ interface MediabunnyModule {
   Input: new (config: { formats: unknown; source: unknown }) => MediabunnyInput
   ALL_FORMATS: unknown
   BlobSource: new (blob: Blob) => unknown
+  UrlSource: new (url: string) => unknown
   CanvasSink: new (
     track: MediabunnyVideoTrack,
     options: { width: number; height: number; fit: string },
@@ -98,7 +99,8 @@ interface MediabunnyModule {
 export interface ProcessMediaRequest {
   type: 'process'
   requestId: string
-  file: File
+  file?: File
+  source?: UrlMediaSource
   mimeType: string
   options?: {
     thumbnailMaxSize?: number
@@ -108,6 +110,15 @@ export interface ProcessMediaRequest {
     fastMetadata?: boolean
   }
 }
+
+export interface UrlMediaSource {
+  url: string
+  name: string
+  size: number
+  lastModified: number
+}
+
+type MediaProcessSource = File | UrlMediaSource
 
 export interface ProcessMediaResponse {
   type: 'complete' | 'error'
@@ -177,6 +188,25 @@ async function getMediabunny(): Promise<MediabunnyModule> {
     mediabunnyModule = mb as unknown as MediabunnyModule
   }
   return mediabunnyModule
+}
+
+function isUrlMediaSource(source: MediaProcessSource): source is UrlMediaSource {
+  return !(source instanceof File)
+}
+
+function createMediabunnySource(mb: MediabunnyModule, source: MediaProcessSource): unknown {
+  return isUrlMediaSource(source) ? new mb.UrlSource(source.url) : new mb.BlobSource(source)
+}
+
+function mediaSourceName(source: MediaProcessSource): string {
+  return source.name
+}
+
+async function mediaSourceBlob(source: MediaProcessSource): Promise<Blob> {
+  if (!isUrlMediaSource(source)) return source
+  const response = await fetch(source.url)
+  if (!response.ok) throw new Error(`Failed to read imported media: ${response.status}`)
+  return await response.blob()
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
@@ -409,14 +439,14 @@ async function extractKeyframeTimestamps(
  * Extract video metadata using mediabunny
  */
 async function extractVideoMetadata(
-  file: File,
+  source: MediaProcessSource,
   options: { fastMetadata?: boolean } = {},
 ): Promise<VideoMetadata> {
   const mb = await getMediabunny()
 
   const input = new mb.Input({
     formats: mb.ALL_FORMATS,
-    source: new mb.BlobSource(file),
+    source: createMediabunnySource(mb, source),
   })
 
   try {
@@ -487,12 +517,12 @@ async function extractVideoMetadata(
 /**
  * Extract audio metadata using mediabunny
  */
-async function extractAudioMetadata(file: File): Promise<AudioMetadata> {
+async function extractAudioMetadata(source: MediaProcessSource): Promise<AudioMetadata> {
   const mb = await getMediabunny()
 
   const input = new mb.Input({
     formats: mb.ALL_FORMATS,
-    source: new mb.BlobSource(file),
+    source: createMediabunnySource(mb, source),
   })
 
   try {
@@ -545,9 +575,13 @@ function parseSvgDimensions(svgText: string): { width: number; height: number } 
  * Falls back to SVG XML parsing for SVG files (createImageBitmap
  * doesn't support SVGs in web workers).
  */
-async function extractImageMetadata(file: File, mimeType: string): Promise<ImageMetadata> {
+async function extractImageMetadata(
+  source: MediaProcessSource,
+  mimeType: string,
+): Promise<ImageMetadata> {
+  const blob = await mediaSourceBlob(source)
   if (mimeType === 'image/svg+xml') {
-    const text = await file.text()
+    const text = await blob.text()
     const dims = parseSvgDimensions(text)
     return {
       type: 'image',
@@ -556,7 +590,7 @@ async function extractImageMetadata(file: File, mimeType: string): Promise<Image
     }
   }
 
-  const bitmap = await createImageBitmap(file)
+  const bitmap = await createImageBitmap(blob)
   const metadata: ImageMetadata = {
     type: 'image',
     width: bitmap.width,
@@ -570,7 +604,7 @@ async function extractImageMetadata(file: File, mimeType: string): Promise<Image
  * Generate video thumbnail using mediabunny
  */
 async function generateVideoThumbnail(
-  file: File,
+  source: MediaProcessSource,
   maxSize: number,
   quality: number,
   timestamp: number,
@@ -578,7 +612,7 @@ async function generateVideoThumbnail(
   const mb = await getMediabunny()
 
   const input = new mb.Input({
-    source: new mb.BlobSource(file),
+    source: createMediabunnySource(mb, source),
     formats: mb.ALL_FORMATS,
   })
   let sink: MediabunnyCanvasSink | null = null
@@ -624,7 +658,7 @@ async function generateVideoThumbnail(
  * Generate image thumbnail using OffscreenCanvas
  */
 async function generateImageThumbnail(
-  file: File,
+  source: MediaProcessSource,
   maxSize: number,
   quality: number,
   mimeType: string,
@@ -635,7 +669,7 @@ async function generateImageThumbnail(
     throw new Error('SVG thumbnail generation not supported in worker')
   }
 
-  const bitmap = await createImageBitmap(file)
+  const bitmap = await createImageBitmap(await mediaSourceBlob(source))
 
   // Calculate dimensions preserving aspect ratio
   const width =
@@ -659,7 +693,11 @@ async function generateImageThumbnail(
 /**
  * Generate audio thumbnail (waveform placeholder)
  */
-async function generateAudioThumbnail(file: File, maxSize: number, quality: number): Promise<Blob> {
+async function generateAudioThumbnail(
+  source: MediaProcessSource,
+  maxSize: number,
+  quality: number,
+): Promise<Blob> {
   const width = maxSize
   const height = Math.round(maxSize * (9 / 16))
 
@@ -697,7 +735,8 @@ async function generateAudioThumbnail(file: File, maxSize: number, quality: numb
   ctx.font = 'bold 14px sans-serif'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
-  const displayName = file.name.length > 30 ? file.name.substring(0, 27) + '...' : file.name
+  const name = mediaSourceName(source)
+  const displayName = name.length > 30 ? name.substring(0, 27) + '...' : name
   ctx.fillText(displayName, width / 2, height - 20)
 
   return canvas.convertToBlob({ type: 'image/webp', quality })
@@ -707,7 +746,7 @@ async function generateAudioThumbnail(file: File, maxSize: number, quality: numb
  * Process a media file - extract metadata and generate thumbnail
  */
 async function processMedia(
-  file: File,
+  source: MediaProcessSource,
   mimeType: string,
   options: ProcessMediaRequest['options'] = {},
 ): Promise<{ metadata: VideoMetadata | AudioMetadata | ImageMetadata; thumbnail?: Blob }> {
@@ -724,11 +763,11 @@ async function processMedia(
 
   if (mimeType.startsWith('video/')) {
     // Video: extract metadata and generate thumbnail in parallel after metadata
-    metadata = await extractVideoMetadata(file, { fastMetadata })
+    metadata = await extractVideoMetadata(source, { fastMetadata })
     if (generateThumbnail) {
       try {
         thumbnail = await withTimeout(
-          generateVideoThumbnail(file, thumbnailMaxSize, thumbnailQuality, thumbnailTimestamp),
+          generateVideoThumbnail(source, thumbnailMaxSize, thumbnailQuality, thumbnailTimestamp),
           THUMBNAIL_TIMEOUT_MS,
           'Video thumbnail generation',
         )
@@ -739,9 +778,9 @@ async function processMedia(
   } else if (mimeType.startsWith('audio/')) {
     // Audio: metadata and thumbnail are independent
     const [audioMeta, audioThumb] = await Promise.all([
-      extractAudioMetadata(file),
+      extractAudioMetadata(source),
       generateThumbnail
-        ? generateAudioThumbnail(file, thumbnailMaxSize, thumbnailQuality).catch(() => undefined)
+        ? generateAudioThumbnail(source, thumbnailMaxSize, thumbnailQuality).catch(() => undefined)
         : Promise.resolve(undefined),
     ])
     metadata = audioMeta
@@ -749,9 +788,9 @@ async function processMedia(
   } else if (mimeType.startsWith('image/')) {
     // Image: metadata and thumbnail can run in parallel
     const [imageMeta, imageThumb] = await Promise.all([
-      extractImageMetadata(file, mimeType),
+      extractImageMetadata(source, mimeType),
       generateThumbnail
-        ? generateImageThumbnail(file, thumbnailMaxSize, thumbnailQuality, mimeType).catch(
+        ? generateImageThumbnail(source, thumbnailMaxSize, thumbnailQuality, mimeType).catch(
             () => undefined,
           )
         : Promise.resolve(undefined),
@@ -771,7 +810,9 @@ self.onmessage = async (e: MessageEvent<ProcessMediaRequest>) => {
 
   if (msg.type === 'process') {
     try {
-      const result = await processMedia(msg.file, msg.mimeType, msg.options)
+      const source = msg.file ?? msg.source
+      if (!source) throw new Error('Media processor request is missing a source')
+      const result = await processMedia(source, msg.mimeType, msg.options)
 
       const response: ProcessMediaResponse = {
         type: 'complete',

--- a/src/features/preview/utils/media-resolver.test.ts
+++ b/src/features/preview/utils/media-resolver.test.ts
@@ -23,8 +23,10 @@ vi.mock('@/features/media-library/services/media-library-service', async () => {
 })
 
 const mockValidateMediaHandle = vi.fn()
+const mockGetMediaSourceReadUrl = vi.fn()
 vi.mock('@/infrastructure/storage', () => ({
   validateMediaHandle: (...args: unknown[]) => mockValidateMediaHandle(...args),
+  getMediaSourceReadUrl: (...args: unknown[]) => mockGetMediaSourceReadUrl(...args),
 }))
 
 vi.mock('@/features/media-library/services/proxy-service', () => ({
@@ -52,6 +54,7 @@ beforeEach(() => {
   blobUrlManager.releaseAll()
   cleanupBlobUrls()
   blobUrlCounter = 0
+  mockGetMediaSourceReadUrl.mockResolvedValue(null)
 
   vi.stubGlobal('URL', {
     ...URL,
@@ -242,6 +245,34 @@ describe('resolveMediaUrl', () => {
     const url2 = await resolveMediaUrl('media-1')
     expect(url2).toBe('blob:test-2') // new URL, not the cached one
     expect(mediaLibraryService.getMediaFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes an expired Electron media URL instead of returning the cached token', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    ;(mediaLibraryService.getMedia as Mock).mockResolvedValue({
+      id: 'media-1',
+      fileName: 'video.mp4',
+      storageType: 'workspace',
+    })
+    mockGetMediaSourceReadUrl
+      .mockResolvedValueOnce({
+        url: 'http://localhost/token-1',
+        expiresAt: 20_000,
+        stat: { kind: 'file', size: 1, modifiedAt: 1, etag: '1-1' },
+      })
+      .mockResolvedValueOnce({
+        url: 'http://localhost/token-2',
+        expiresAt: 40_000,
+        stat: { kind: 'file', size: 1, modifiedAt: 1, etag: '1-1' },
+      })
+
+    expect(await resolveMediaUrl('media-1')).toBe('http://localhost/token-1')
+
+    now.mockReturnValue(16_000)
+    expect(await resolveMediaUrl('media-1')).toBe('http://localhost/token-2')
+    expect(mockGetMediaSourceReadUrl).toHaveBeenCalledTimes(2)
+    expect(mediaLibraryService.getMediaFile).not.toHaveBeenCalled()
+    now.mockRestore()
   })
 
   it('deduplicates concurrent requests for same mediaId', async () => {

--- a/src/features/workspace-gate/workspace-gate.tsx
+++ b/src/features/workspace-gate/workspace-gate.tsx
@@ -187,33 +187,40 @@ export function WorkspaceGate({ children }: { children: React.ReactNode }) {
 
   const handleReconnect = useCallback(async () => {
     setError(null)
-    if (selectLocalDirectoryBackendKind(window) !== 'file-system-access') {
-      const bridge = getElectronLocalDirectoryBridge()
-      const grantId = localStorage.getItem(ELECTRON_GRANT_STORAGE_KEY)
-      if (!bridge || !grantId) {
+    const backendKind = selectLocalDirectoryBackendKind(window)
+    if (backendKind === 'file-system-access') {
+      const record = await getWorkspaceHandleRecord()
+      if (!record) {
         setStatus({ kind: 'pick' })
         return
       }
-      const grant = await bridge.restoreGrant(grantId)
-      if (!grant) {
-        setStatus({ kind: 'pick' })
+      const handle = record.handle as FileSystemDirectoryHandle
+      const permission = await requestHandlePermission(handle)
+      if (permission === 'granted') {
+        await activate(handle)
         return
       }
-      await activate(new ElectronDirectoryBackend(bridge, grant))
+      setError(t('projects.workspaceGate.reconnectPermissionDenied'))
       return
     }
-    const record = await getWorkspaceHandleRecord()
-    if (!record) {
+
+    if (backendKind !== 'electron-directory') {
+      setStatus({ kind: 'unavailable' })
+      return
+    }
+
+    const bridge = getElectronLocalDirectoryBridge()
+    const grantId = localStorage.getItem(ELECTRON_GRANT_STORAGE_KEY)
+    if (!bridge || !grantId) {
       setStatus({ kind: 'pick' })
       return
     }
-    const handle = record.handle as FileSystemDirectoryHandle
-    const permission = await requestHandlePermission(handle)
-    if (permission === 'granted') {
-      await activate(handle)
+    const grant = await bridge.restoreGrant(grantId)
+    if (!grant) {
+      setStatus({ kind: 'pick' })
       return
     }
-    setError(t('projects.workspaceGate.reconnectPermissionDenied'))
+    await activate(new ElectronDirectoryBackend(bridge, grant))
   }, [activate, t])
 
   // Routes that don't touch storage never wait on the gate — no splash, no

--- a/src/features/workspace-gate/workspace-gate.tsx
+++ b/src/features/workspace-gate/workspace-gate.tsx
@@ -24,12 +24,15 @@ import { useTranslation } from 'react-i18next'
 import {
   ensureKnownWorkspaceForCurrent,
   getWorkspaceHandleRecord,
-  isFileSystemAccessSupported,
   queryHandlePermission,
   requestHandlePermission,
   saveWorkspaceHandleRecord,
 } from '@/infrastructure/storage/handles-db'
 import { onPermissionLost, setWorkspaceRoot } from '@/infrastructure/storage/workspace-fs/root'
+import { ElectronDirectoryBackend } from '@/infrastructure/storage/local-directory/electron-directory-backend'
+import { getElectronLocalDirectoryBridge } from '@/infrastructure/storage/local-directory/electron-directory-backend'
+import type { LocalDirectoryBackend } from '@/infrastructure/storage/local-directory/types'
+import { selectLocalDirectoryBackendKind } from '@/infrastructure/storage/local-directory/select-backend'
 import { createLogger } from '@/shared/logging/logger'
 import { WorkspaceGateSplash } from './workspace-gate-splash'
 import { usePathname } from './use-pathname'
@@ -44,6 +47,7 @@ function isStorageProtectedPath(pathname: string): boolean {
 }
 
 const logger = createLogger('WorkspaceGate')
+const ELECTRON_GRANT_STORAGE_KEY = 'freecut:electron-directory-grant'
 
 type GateStatus =
   | { kind: 'initializing' }
@@ -59,11 +63,11 @@ export function WorkspaceGate({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const needsWorkspace = isStorageProtectedPath(pathname)
 
-  const activate = useCallback(async (handle: FileSystemDirectoryHandle) => {
-    setWorkspaceRoot(handle)
+  const activate = useCallback(async (root: FileSystemDirectoryHandle | LocalDirectoryBackend) => {
+    setWorkspaceRoot(root)
     try {
       const { bootstrapWorkspace } = await import('@/infrastructure/storage/workspace-fs/bootstrap')
-      await bootstrapWorkspace(handle)
+      await bootstrapWorkspace(root)
     } catch (error) {
       logger.warn('bootstrapWorkspace failed', error)
     }
@@ -83,27 +87,41 @@ export function WorkspaceGate({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     let cancelled = false
     ;(async () => {
-      if (!isFileSystemAccessSupported()) {
+      if (selectLocalDirectoryBackendKind(window) === 'file-system-access') {
+        // Promote any legacy `workspace:current` into a proper known-workspace
+        // record before we read it, so the indicator's list includes it.
+        await ensureKnownWorkspaceForCurrent()
+        const record = await getWorkspaceHandleRecord()
+        if (!record) {
+          if (!cancelled) setStatus({ kind: 'pick' })
+          return
+        }
+        const handle = record.handle as FileSystemDirectoryHandle
+        const permission = await queryHandlePermission(handle)
+        if (cancelled) return
+        if (permission === 'granted') {
+          await activate(handle)
+        } else {
+          setStatus({ kind: 'reconnect', handleName: record.name })
+        }
+        return
+      }
+
+      const bridge = getElectronLocalDirectoryBridge()
+      if (!bridge) {
         if (!cancelled) setStatus({ kind: 'unavailable' })
         return
       }
-      // Promote any legacy `workspace:current` into a proper known-workspace
-      // record before we read it, so the indicator's "known workspaces" list
-      // includes the one the user is about to use.
-      await ensureKnownWorkspaceForCurrent()
-      const record = await getWorkspaceHandleRecord()
-      if (!record) {
-        if (!cancelled) setStatus({ kind: 'pick' })
+      const savedGrantId = localStorage.getItem(ELECTRON_GRANT_STORAGE_KEY)
+      const restored = savedGrantId ? await bridge.restoreGrant(savedGrantId) : null
+      const grant = restored ?? (await bridge.listGrants())[0] ?? null
+      if (cancelled) return
+      if (!grant) {
+        setStatus({ kind: 'pick' })
         return
       }
-      const handle = record.handle as FileSystemDirectoryHandle
-      const permission = await queryHandlePermission(handle)
-      if (cancelled) return
-      if (permission === 'granted') {
-        await activate(handle)
-      } else {
-        setStatus({ kind: 'reconnect', handleName: record.name })
-      }
+      localStorage.setItem(ELECTRON_GRANT_STORAGE_KEY, grant.grantId)
+      await activate(new ElectronDirectoryBackend(bridge, grant))
     })().catch((error) => {
       logger.error('Gate initialization failed', error)
       if (!cancelled) setStatus({ kind: 'pick' })
@@ -129,21 +147,34 @@ export function WorkspaceGate({ children }: { children: React.ReactNode }) {
   const handlePick = useCallback(async () => {
     setError(null)
     try {
-      const handle = await window.showDirectoryPicker({
-        id: 'freecut-workspace',
-        mode: 'readwrite',
-        startIn: 'documents',
-      })
-      const queryState = await queryHandlePermission(handle)
-      const finalState =
-        queryState === 'granted' ? queryState : await requestHandlePermission(handle)
-      if (finalState !== 'granted') {
-        setError(t('projects.workspaceGate.folderPermissionDenied'))
-        setStatus({ kind: 'reconnect', handleName: handle.name })
+      if (selectLocalDirectoryBackendKind(window) === 'file-system-access') {
+        const handle = await window.showDirectoryPicker({
+          id: 'freecut-workspace',
+          mode: 'readwrite',
+          startIn: 'documents',
+        })
+        const queryState = await queryHandlePermission(handle)
+        const finalState =
+          queryState === 'granted' ? queryState : await requestHandlePermission(handle)
+        if (finalState !== 'granted') {
+          setError(t('projects.workspaceGate.folderPermissionDenied'))
+          setStatus({ kind: 'reconnect', handleName: handle.name })
+          return
+        }
+        await saveWorkspaceHandleRecord(handle)
+        await activate(handle)
         return
       }
-      await saveWorkspaceHandleRecord(handle)
-      await activate(handle)
+
+      const bridge = getElectronLocalDirectoryBridge()
+      if (!bridge) {
+        setStatus({ kind: 'unavailable' })
+        return
+      }
+      const grant = await bridge.pickDirectory({ mode: 'readwrite' })
+      if (!grant) return
+      localStorage.setItem(ELECTRON_GRANT_STORAGE_KEY, grant.grantId)
+      await activate(new ElectronDirectoryBackend(bridge, grant))
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         // User cancelled the picker; stay on splash.
@@ -156,6 +187,21 @@ export function WorkspaceGate({ children }: { children: React.ReactNode }) {
 
   const handleReconnect = useCallback(async () => {
     setError(null)
+    if (selectLocalDirectoryBackendKind(window) !== 'file-system-access') {
+      const bridge = getElectronLocalDirectoryBridge()
+      const grantId = localStorage.getItem(ELECTRON_GRANT_STORAGE_KEY)
+      if (!bridge || !grantId) {
+        setStatus({ kind: 'pick' })
+        return
+      }
+      const grant = await bridge.restoreGrant(grantId)
+      if (!grant) {
+        setStatus({ kind: 'pick' })
+        return
+      }
+      await activate(new ElectronDirectoryBackend(bridge, grant))
+      return
+    }
     const record = await getWorkspaceHandleRecord()
     if (!record) {
       setStatus({ kind: 'pick' })

--- a/src/infrastructure/browser/blob-url-manager.test.ts
+++ b/src/infrastructure/browser/blob-url-manager.test.ts
@@ -26,6 +26,21 @@ beforeEach(() => {
 })
 
 describe('BlobUrlManager', () => {
+  describe('registerUrl', () => {
+    it('drops an expired external URL so callers can register a fresh token', () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+      blobUrlManager.registerUrl('media-1', 'http://localhost/old', { expiresAt: 20_000 })
+
+      now.mockReturnValue(16_000)
+      expect(blobUrlManager.get('media-1')).toBeNull()
+
+      expect(
+        blobUrlManager.registerUrl('media-1', 'http://localhost/new', { expiresAt: 30_000 }),
+      ).toBe('http://localhost/new')
+      now.mockRestore()
+    })
+  })
+
   describe('acquire', () => {
     it('creates a new blob URL for a new mediaId', () => {
       const url = blobUrlManager.acquire('media-1', new Blob(['data']))

--- a/src/infrastructure/browser/blob-url-manager.ts
+++ b/src/infrastructure/browser/blob-url-manager.ts
@@ -16,7 +16,11 @@ interface BlobUrlEntry {
   metadata?: ObjectUrlSourceMetadata
   /** True when this entry points at an externally-hosted URL (e.g. HTTP), not an object URL. */
   external?: boolean
+  /** Absolute expiry for an external URL. Blob URLs do not expire. */
+  expiresAt?: number
 }
+
+const EXTERNAL_URL_EXPIRY_SAFETY_MS = 5_000
 
 /**
  * Centralized Blob URL manager with reference counting.
@@ -80,13 +84,19 @@ class BlobUrlManager {
    * the media is range-streamed over HTTP instead of held fully in memory.
    * Reference-counted like acquire(); never used by the in-app flows.
    */
-  registerUrl(mediaId: string, url: string): string {
+  registerUrl(mediaId: string, url: string, options?: { expiresAt?: number }): string {
     const existing = this.entries.get(mediaId)
-    if (existing) {
+    if (existing && !this.isExpired(existing)) {
       existing.refCount++
       return existing.url
     }
-    this.entries.set(mediaId, { url, refCount: 1, external: true })
+    if (existing) this.entries.delete(mediaId)
+    this.entries.set(mediaId, {
+      url,
+      refCount: 1,
+      external: true,
+      expiresAt: options?.expiresAt,
+    })
     this.notify()
     return url
   }
@@ -96,7 +106,14 @@ class BlobUrlManager {
    * Returns null if no URL exists for this mediaId.
    */
   get(mediaId: string): string | null {
-    return this.entries.get(mediaId)?.url ?? null
+    const entry = this.entries.get(mediaId)
+    if (!entry) return null
+    if (this.isExpired(entry)) {
+      this.entries.delete(mediaId)
+      this.notify()
+      return null
+    }
+    return entry.url
   }
 
   /**
@@ -134,6 +151,14 @@ class BlobUrlManager {
     if (entry.external) return
     unregisterObjectUrl(entry.url)
     URL.revokeObjectURL(entry.url)
+  }
+
+  private isExpired(entry: BlobUrlEntry): boolean {
+    return (
+      entry.external === true &&
+      entry.expiresAt !== undefined &&
+      entry.expiresAt <= Date.now() + EXTERNAL_URL_EXPIRY_SAFETY_MS
+    )
   }
 
   /**

--- a/src/infrastructure/storage/handles-db.ts
+++ b/src/infrastructure/storage/handles-db.ts
@@ -270,7 +270,3 @@ export async function requestHandlePermission(
     return 'denied'
   }
 }
-
-export function isFileSystemAccessSupported(): boolean {
-  return typeof window !== 'undefined' && typeof window.showDirectoryPicker === 'function'
-}

--- a/src/infrastructure/storage/index.ts
+++ b/src/infrastructure/storage/index.ts
@@ -7,6 +7,8 @@
  */
 
 // Projects
+export { getWorkspaceRoot } from '@/infrastructure/storage/workspace-fs/root'
+
 export {
   getAllProjects,
   getProject,
@@ -109,7 +111,10 @@ export {
 
 // Media source files
 export {
+  adoptCopiedMediaSource,
+  getCopiedMediaReadUrl,
   hasMediaSource,
+  getMediaSourceReadUrl,
   readMediaSource,
   writeMediaSource,
 } from '@/infrastructure/storage/workspace-fs/media-source'

--- a/src/infrastructure/storage/local-directory/electron-directory-backend.ts
+++ b/src/infrastructure/storage/local-directory/electron-directory-backend.ts
@@ -24,7 +24,7 @@ export class ElectronDirectoryBackend implements LocalDirectoryBackend {
 
   async readFile(path: LocalDirectoryPath): Promise<Blob | null> {
     const result = await this.#bridge.readFile({ grantId: this.grantId, path })
-    return result ? new Blob([result.data.slice().buffer as ArrayBuffer]) : null
+    return result ? new Blob([result.data as Uint8Array<ArrayBuffer>]) : null
   }
 
   getReadUrl(path: LocalDirectoryPath): Promise<LocalReadUrl> {

--- a/src/infrastructure/storage/local-directory/electron-directory-backend.ts
+++ b/src/infrastructure/storage/local-directory/electron-directory-backend.ts
@@ -1,0 +1,105 @@
+import type {
+  ElectronDirectoryGrant,
+  ElectronLocalDirectoryBridge,
+  LocalDirectoryBackend,
+  LocalDirectoryChangeEvent,
+  LocalDirectoryEntry,
+  LocalDirectoryPath,
+  ImportedLocalFile,
+  LocalFileStat,
+  LocalReadUrl,
+} from './types'
+
+export class ElectronDirectoryBackend implements LocalDirectoryBackend {
+  readonly kind = 'electron-directory' as const
+  readonly grantId: string
+  readonly name: string
+  readonly #bridge: ElectronLocalDirectoryBridge
+
+  constructor(bridge: ElectronLocalDirectoryBridge, grant: ElectronDirectoryGrant) {
+    this.#bridge = bridge
+    this.grantId = grant.grantId
+    this.name = grant.name
+  }
+
+  async readFile(path: LocalDirectoryPath): Promise<Blob | null> {
+    const result = await this.#bridge.readFile({ grantId: this.grantId, path })
+    return result ? new Blob([result.data.slice().buffer as ArrayBuffer]) : null
+  }
+
+  getReadUrl(path: LocalDirectoryPath): Promise<LocalReadUrl> {
+    return this.#bridge.createReadUrl({ grantId: this.grantId, path })
+  }
+
+  writeFile(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+  ): Promise<LocalFileStat> {
+    return this.writeFileAtomic(path, data)
+  }
+
+  async writeFileAtomic(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+    options: { expectedEtag?: string } = {},
+  ): Promise<LocalFileStat> {
+    const serialized =
+      typeof data === 'string'
+        ? data
+        : data instanceof Blob
+          ? new Uint8Array(await data.arrayBuffer())
+          : data instanceof Uint8Array
+            ? data
+            : new Uint8Array(data)
+    return this.#bridge.writeFileAtomic({
+      grantId: this.grantId,
+      path,
+      data: serialized,
+      ...(options.expectedEtag ? { expectedEtag: options.expectedEtag } : {}),
+    })
+  }
+
+  listDirectory(path: LocalDirectoryPath): Promise<LocalDirectoryEntry[]> {
+    return this.#bridge.listDirectory({ grantId: this.grantId, path })
+  }
+
+  createDirectory(path: LocalDirectoryPath): Promise<void> {
+    return this.#bridge.createDirectory({ grantId: this.grantId, path })
+  }
+
+  exists(path: LocalDirectoryPath): Promise<boolean> {
+    return this.#bridge.exists({ grantId: this.grantId, path })
+  }
+
+  stat(path: LocalDirectoryPath): Promise<LocalFileStat | null> {
+    return this.#bridge.stat({ grantId: this.grantId, path })
+  }
+
+  move(from: LocalDirectoryPath, to: LocalDirectoryPath): Promise<void> {
+    return this.#bridge.move({ grantId: this.grantId, from, to })
+  }
+
+  remove(path: LocalDirectoryPath, options: { recursive?: boolean } = {}): Promise<void> {
+    return this.#bridge.remove({
+      grantId: this.grantId,
+      path,
+      ...(options.recursive === undefined ? {} : { recursive: options.recursive }),
+    })
+  }
+
+  selectAndCopyFiles(destination: LocalDirectoryPath): Promise<ImportedLocalFile[]> {
+    return this.#bridge.selectAndCopyFiles({ grantId: this.grantId, destination })
+  }
+
+  subscribe(listener: (event: LocalDirectoryChangeEvent) => void): () => void {
+    return this.#bridge.onDidChange((event) => {
+      if (event.grantId === this.grantId) listener(event)
+    })
+  }
+}
+
+export function getElectronLocalDirectoryBridge(): ElectronLocalDirectoryBridge | null {
+  if (typeof window === 'undefined') return null
+  const bridge = window.electronLocalDirectory
+  return bridge?.runtime === 'electron' && bridge.version === 1 ? bridge : null
+}

--- a/src/infrastructure/storage/local-directory/file-system-access-backend.test.ts
+++ b/src/infrastructure/storage/local-directory/file-system-access-backend.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  asHandle,
+  createRoot,
+  readFileText,
+} from '@/infrastructure/storage/workspace-fs/__tests__/in-memory-handle'
+import { FileSystemAccessDirectoryBackend } from './file-system-access-backend'
+
+describe('FileSystemAccessDirectoryBackend', () => {
+  it('serializes the ETag check and replacement for the same path', async () => {
+    const root = createRoot()
+    const backend = new FileSystemAccessDirectoryBackend(asHandle(root))
+    const initial = await backend.writeFileAtomic(['project.json'], 'initial')
+
+    const results = await Promise.allSettled([
+      backend.writeFileAtomic(['project.json'], 'first', { expectedEtag: initial.etag }),
+      backend.writeFileAtomic(['project.json'], 'second', { expectedEtag: initial.etag }),
+    ])
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(await readFileText(root, 'project.json')).toBe('first')
+  })
+
+  it('does not overwrite or delete a pre-existing filename.tmp sibling', async () => {
+    const root = createRoot()
+    const backend = new FileSystemAccessDirectoryBackend(asHandle(root))
+    await backend.writeFile(['project.json.tmp'], 'user file')
+
+    await backend.writeFileAtomic(['project.json'], 'project')
+
+    expect(await readFileText(root, 'project.json')).toBe('project')
+    expect(await readFileText(root, 'project.json.tmp')).toBe('user file')
+  })
+
+  it('throws NotFoundError when a move source is missing', async () => {
+    const backend = new FileSystemAccessDirectoryBackend(asHandle(createRoot()))
+
+    await expect(backend.move(['missing'], ['target'])).rejects.toMatchObject({
+      name: 'NotFoundError',
+    })
+  })
+})

--- a/src/infrastructure/storage/local-directory/file-system-access-backend.ts
+++ b/src/infrastructure/storage/local-directory/file-system-access-backend.ts
@@ -89,9 +89,14 @@ export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
       }
     }
 
+    // The completed tmp file is the recovery journal for filesystems that
+    // cannot rename. Copy from those staged bytes and only remove the journal
+    // after the live target has closed successfully. If the page or browser
+    // dies mid-copy, bootstrap will replay the still-complete tmp file.
+    const staged = await tmpHandle.getFile()
     const target = await parent.getFileHandle(fileName, { create: true })
     const targetWritable = await target.createWritable()
-    await targetWritable.write(data as FileSystemWriteChunkType)
+    await targetWritable.write(staged)
     await targetWritable.close()
     await parent.removeEntry(tmpName).catch((error) => {
       if (!isNotFound(error)) throw error

--- a/src/infrastructure/storage/local-directory/file-system-access-backend.ts
+++ b/src/infrastructure/storage/local-directory/file-system-access-backend.ts
@@ -1,0 +1,243 @@
+import type {
+  LocalDirectoryBackend,
+  LocalDirectoryChangeEvent,
+  LocalDirectoryEntry,
+  LocalDirectoryPath,
+  ImportedLocalFile,
+  LocalFileStat,
+  LocalReadUrl,
+} from './types'
+
+type MovableHandle = FileSystemFileHandle & {
+  move?: (parent: FileSystemDirectoryHandle, newName: string) => Promise<void>
+}
+
+const rootsRejectingMove = new WeakSet<FileSystemDirectoryHandle>()
+
+export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
+  readonly kind = 'file-system-access' as const
+  readonly grantId: string
+  readonly name: string
+  readonly #root: FileSystemDirectoryHandle
+
+  constructor(root: FileSystemDirectoryHandle) {
+    this.#root = root
+    this.name = root.name
+    this.grantId = `fsa:${root.name}`
+  }
+
+  async readFile(path: LocalDirectoryPath): Promise<Blob | null> {
+    try {
+      const { parent, fileName } = await this.#resolveFileParent(path, false)
+      const handle = await parent.getFileHandle(fileName, { create: false })
+      return await handle.getFile()
+    } catch (error) {
+      if (isNotFound(error)) return null
+      throw error
+    }
+  }
+
+  async getReadUrl(path: LocalDirectoryPath): Promise<LocalReadUrl> {
+    const blob = await this.readFile(path)
+    if (!blob) throw new DOMException('File not found', 'NotFoundError')
+    return {
+      url: URL.createObjectURL(blob),
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      stat: fileStat(blob),
+    }
+  }
+
+  async writeFile(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+  ): Promise<LocalFileStat> {
+    const { parent, fileName } = await this.#resolveFileParent(path, true)
+    const handle = await parent.getFileHandle(fileName, { create: true })
+    const writable = await handle.createWritable()
+    await writable.write(data as FileSystemWriteChunkType)
+    await writable.close()
+    return fileStat(await handle.getFile())
+  }
+
+  async writeFileAtomic(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+    options: { expectedEtag?: string } = {},
+  ): Promise<LocalFileStat> {
+    const { parent, fileName } = await this.#resolveFileParent(path, true)
+    if (options.expectedEtag) {
+      const current = await this.stat(path)
+      if (!current || current.etag !== options.expectedEtag) {
+        throw new Error('LOCAL_DIRECTORY_ETAG_CONFLICT')
+      }
+    }
+    const tmpName = `${fileName}.tmp`
+    const tmpHandle = await parent.getFileHandle(tmpName, { create: true })
+    const writable = await tmpHandle.createWritable()
+    await writable.write(data as FileSystemWriteChunkType)
+    await writable.close()
+
+    const movable = tmpHandle as MovableHandle
+    if (!rootsRejectingMove.has(this.#root) && typeof movable.move === 'function') {
+      try {
+        await movable.move(parent, fileName)
+        const target = await parent.getFileHandle(fileName)
+        return fileStat(await target.getFile())
+      } catch (error) {
+        if (!isNotSupported(error)) throw error
+        rootsRejectingMove.add(this.#root)
+      }
+    }
+
+    const target = await parent.getFileHandle(fileName, { create: true })
+    const targetWritable = await target.createWritable()
+    await targetWritable.write(data as FileSystemWriteChunkType)
+    await targetWritable.close()
+    await parent.removeEntry(tmpName).catch((error) => {
+      if (!isNotFound(error)) throw error
+    })
+    return fileStat(await target.getFile())
+  }
+
+  async listDirectory(path: LocalDirectoryPath): Promise<LocalDirectoryEntry[]> {
+    try {
+      const directory = await this.#resolveDirectory(path, false)
+      const entries: LocalDirectoryEntry[] = []
+      for await (const entry of directory.values()) {
+        entries.push({ name: entry.name, kind: entry.kind })
+      }
+      return entries
+    } catch (error) {
+      if (isNotFound(error)) return []
+      throw error
+    }
+  }
+
+  async createDirectory(path: LocalDirectoryPath): Promise<void> {
+    await this.#resolveDirectory(path, true)
+  }
+
+  async exists(path: LocalDirectoryPath): Promise<boolean> {
+    if (path.length === 0) return true
+    try {
+      const { parent, fileName } = await this.#resolveFileParent(path, false)
+      try {
+        await parent.getFileHandle(fileName, { create: false })
+        return true
+      } catch (error) {
+        if (!isNotFound(error)) throw error
+      }
+      try {
+        await parent.getDirectoryHandle(fileName, { create: false })
+        return true
+      } catch (error) {
+        if (!isNotFound(error)) throw error
+      }
+      return false
+    } catch (error) {
+      if (isNotFound(error)) return false
+      throw error
+    }
+  }
+
+  async stat(path: LocalDirectoryPath): Promise<LocalFileStat | null> {
+    if (path.length === 0) {
+      return { kind: 'directory', size: 0, modifiedAt: 0, etag: 'directory-root' }
+    }
+    try {
+      const { parent, fileName } = await this.#resolveFileParent(path, false)
+      try {
+        const handle = await parent.getFileHandle(fileName, { create: false })
+        return fileStat(await handle.getFile())
+      } catch (error) {
+        if (!isNotFound(error)) throw error
+      }
+      try {
+        await parent.getDirectoryHandle(fileName, { create: false })
+        return { kind: 'directory', size: 0, modifiedAt: 0, etag: `directory:${path.join('/')}` }
+      } catch (error) {
+        if (!isNotFound(error)) throw error
+      }
+      return null
+    } catch (error) {
+      if (isNotFound(error)) return null
+      throw error
+    }
+  }
+
+  async move(from: LocalDirectoryPath, to: LocalDirectoryPath): Promise<void> {
+    const blob = await this.readFile(from)
+    if (!blob) return
+    await this.writeFileAtomic(to, blob)
+    await this.remove(from)
+  }
+
+  async remove(path: LocalDirectoryPath, options: { recursive?: boolean } = {}): Promise<void> {
+    if (path.length === 0) throw new Error('refusing to remove directory root')
+    try {
+      const { parent, fileName } = await this.#resolveFileParent(path, false)
+      await parent.removeEntry(fileName, { recursive: options.recursive ?? false })
+    } catch (error) {
+      if (!isNotFound(error)) throw error
+    }
+  }
+
+  async selectAndCopyFiles(destination: LocalDirectoryPath): Promise<ImportedLocalFile[]> {
+    const handles = await window.showOpenFilePicker({ multiple: true })
+    const imported: ImportedLocalFile[] = []
+    for (const handle of handles) {
+      const file = await handle.getFile()
+      const target = [...destination, file.name]
+      imported.push({
+        name: file.name,
+        path: target,
+        stat: await this.writeFileAtomic(target, file),
+      })
+    }
+    return imported
+  }
+
+  subscribe(_listener: (event: LocalDirectoryChangeEvent) => void): () => void {
+    return () => undefined
+  }
+
+  async #resolveDirectory(
+    path: LocalDirectoryPath,
+    create: boolean,
+  ): Promise<FileSystemDirectoryHandle> {
+    let directory = this.#root
+    for (const segment of path) {
+      directory = await directory.getDirectoryHandle(segment, { create })
+    }
+    return directory
+  }
+
+  async #resolveFileParent(
+    path: LocalDirectoryPath,
+    create: boolean,
+  ): Promise<{ parent: FileSystemDirectoryHandle; fileName: string }> {
+    if (path.length === 0) throw new Error('local directory file path is empty')
+    return {
+      parent: await this.#resolveDirectory(path.slice(0, -1), create),
+      fileName: path.at(-1)!,
+    }
+  }
+}
+
+function fileStat(file: File | Blob): LocalFileStat {
+  const modifiedAt = file instanceof File ? file.lastModified : 0
+  return {
+    kind: 'file',
+    size: file.size,
+    modifiedAt,
+    etag: `${file.size}-${Math.trunc(modifiedAt)}`,
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'NotFoundError'
+}
+
+function isNotSupported(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'NotSupportedError'
+}

--- a/src/infrastructure/storage/local-directory/file-system-access-backend.ts
+++ b/src/infrastructure/storage/local-directory/file-system-access-backend.ts
@@ -13,12 +13,14 @@ type MovableHandle = FileSystemFileHandle & {
 }
 
 const rootsRejectingMove = new WeakSet<FileSystemDirectoryHandle>()
+const ATOMIC_TEMP_TAG = '.freecut-'
 
 export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
   readonly kind = 'file-system-access' as const
   readonly grantId: string
   readonly name: string
   readonly #root: FileSystemDirectoryHandle
+  readonly #writeChains = new Map<string, Promise<unknown>>()
 
   constructor(root: FileSystemDirectoryHandle) {
     this.#root = root
@@ -51,12 +53,14 @@ export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
     path: LocalDirectoryPath,
     data: Blob | ArrayBuffer | Uint8Array | string,
   ): Promise<LocalFileStat> {
-    const { parent, fileName } = await this.#resolveFileParent(path, true)
-    const handle = await parent.getFileHandle(fileName, { create: true })
-    const writable = await handle.createWritable()
-    await writable.write(data as FileSystemWriteChunkType)
-    await writable.close()
-    return fileStat(await handle.getFile())
+    return this.#withWriteLock(path, async () => {
+      const { parent, fileName } = await this.#resolveFileParent(path, true)
+      const handle = await parent.getFileHandle(fileName, { create: true })
+      const writable = await handle.createWritable()
+      await writable.write(data as FileSystemWriteChunkType)
+      await writable.close()
+      return fileStat(await handle.getFile())
+    })
   }
 
   async writeFileAtomic(
@@ -64,24 +68,53 @@ export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
     data: Blob | ArrayBuffer | Uint8Array | string,
     options: { expectedEtag?: string } = {},
   ): Promise<LocalFileStat> {
-    const { parent, fileName } = await this.#resolveFileParent(path, true)
-    if (options.expectedEtag) {
-      const current = await this.stat(path)
-      if (!current || current.etag !== options.expectedEtag) {
-        throw new Error('LOCAL_DIRECTORY_ETAG_CONFLICT')
-      }
-    }
-    const tmpName = `${fileName}.tmp`
-    const tmpHandle = await parent.getFileHandle(tmpName, { create: true })
-    const writable = await tmpHandle.createWritable()
-    await writable.write(data as FileSystemWriteChunkType)
-    await writable.close()
+    return this.#withWriteLock(path, async () => {
+      const { parent, fileName } = await this.#resolveFileParent(path, true)
+      await this.#validateExpectedEtag(path, options.expectedEtag)
+      const { tmpName, tmpHandle } = await this.#createTemporaryFile(parent, fileName)
+      await this.#stageTemporaryFile(parent, tmpName, tmpHandle, data)
+      return this.#commitTemporaryFile(parent, fileName, tmpName, tmpHandle)
+    })
+  }
 
+  async #validateExpectedEtag(
+    path: LocalDirectoryPath,
+    expectedEtag: string | undefined,
+  ): Promise<void> {
+    if (!expectedEtag) return
+    const current = await this.stat(path)
+    if (!current || current.etag !== expectedEtag) {
+      throw new Error('LOCAL_DIRECTORY_ETAG_CONFLICT')
+    }
+  }
+
+  async #stageTemporaryFile(
+    parent: FileSystemDirectoryHandle,
+    tmpName: string,
+    tmpHandle: FileSystemFileHandle,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+  ): Promise<void> {
+    try {
+      const writable = await tmpHandle.createWritable()
+      await writable.write(data as FileSystemWriteChunkType)
+      await writable.close()
+    } catch (error) {
+      await parent.removeEntry(tmpName).catch(() => undefined)
+      throw error
+    }
+  }
+
+  async #commitTemporaryFile(
+    parent: FileSystemDirectoryHandle,
+    fileName: string,
+    tmpName: string,
+    tmpHandle: FileSystemFileHandle,
+  ): Promise<LocalFileStat> {
     const movable = tmpHandle as MovableHandle
     if (!rootsRejectingMove.has(this.#root) && typeof movable.move === 'function') {
       try {
         await movable.move(parent, fileName)
-        const target = await parent.getFileHandle(fileName)
+        const target = await parent.getFileHandle(fileName, { create: false })
         return fileStat(await target.getFile())
       } catch (error) {
         if (!isNotSupported(error)) throw error
@@ -172,7 +205,7 @@ export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
 
   async move(from: LocalDirectoryPath, to: LocalDirectoryPath): Promise<void> {
     const blob = await this.readFile(from)
-    if (!blob) return
+    if (!blob) throw new DOMException('File not found', 'NotFoundError')
     await this.writeFileAtomic(to, blob)
     await this.remove(from)
   }
@@ -227,6 +260,50 @@ export class FileSystemAccessDirectoryBackend implements LocalDirectoryBackend {
       fileName: path.at(-1)!,
     }
   }
+
+  async #createTemporaryFile(
+    parent: FileSystemDirectoryHandle,
+    fileName: string,
+  ): Promise<{ tmpName: string; tmpHandle: FileSystemFileHandle }> {
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const tmpName = `${fileName}${ATOMIC_TEMP_TAG}${crypto.randomUUID()}.tmp`
+      if (await entryExists(parent, tmpName)) continue
+      return {
+        tmpName,
+        tmpHandle: await parent.getFileHandle(tmpName, { create: true }),
+      }
+    }
+    throw new Error('Unable to allocate an atomic-write journal')
+  }
+
+  async #withWriteLock<T>(path: LocalDirectoryPath, operation: () => Promise<T>): Promise<T> {
+    const key = path.join('\0')
+    const previous = this.#writeChains.get(key) ?? Promise.resolve()
+    const result = previous.catch(() => undefined).then(operation)
+    const settled = result.catch(() => undefined)
+    this.#writeChains.set(key, settled)
+    try {
+      return await result
+    } finally {
+      if (this.#writeChains.get(key) === settled) this.#writeChains.delete(key)
+    }
+  }
+}
+
+async function entryExists(parent: FileSystemDirectoryHandle, name: string): Promise<boolean> {
+  try {
+    await parent.getFileHandle(name, { create: false })
+    return true
+  } catch (error) {
+    if (!isNotFound(error) && !isTypeMismatch(error)) throw error
+  }
+  try {
+    await parent.getDirectoryHandle(name, { create: false })
+    return true
+  } catch (error) {
+    if (!isNotFound(error) && !isTypeMismatch(error)) throw error
+  }
+  return false
 }
 
 function fileStat(file: File | Blob): LocalFileStat {
@@ -245,4 +322,8 @@ function isNotFound(error: unknown): boolean {
 
 function isNotSupported(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'NotSupportedError'
+}
+
+function isTypeMismatch(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'TypeMismatchError'
 }

--- a/src/infrastructure/storage/local-directory/select-backend.test.ts
+++ b/src/infrastructure/storage/local-directory/select-backend.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+import type { ElectronLocalDirectoryBridge } from './types'
+import { selectLocalDirectoryBackendKind } from './select-backend'
+
+function electronBridge(): ElectronLocalDirectoryBridge {
+  return {
+    runtime: 'electron',
+    version: 1,
+    pickDirectory: vi.fn(),
+    restoreGrant: vi.fn(),
+    listGrants: vi.fn(),
+    revokeGrant: vi.fn(),
+    readFile: vi.fn(),
+    createReadUrl: vi.fn(),
+    writeFileAtomic: vi.fn(),
+    listDirectory: vi.fn(),
+    createDirectory: vi.fn(),
+    exists: vi.fn(),
+    stat: vi.fn(),
+    move: vi.fn(),
+    remove: vi.fn(),
+    selectAndCopyFiles: vi.fn(),
+    onDidChange: vi.fn(),
+  }
+}
+
+describe('selectLocalDirectoryBackendKind', () => {
+  it('always prefers the standard File System Access API when both are present', () => {
+    expect(
+      selectLocalDirectoryBackendKind({
+        showDirectoryPicker: vi.fn(),
+        electronLocalDirectory: electronBridge(),
+      }),
+    ).toBe('file-system-access')
+  })
+
+  it('uses the controlled Electron bridge only when the standard picker is absent', () => {
+    expect(
+      selectLocalDirectoryBackendKind({
+        electronLocalDirectory: electronBridge(),
+      }),
+    ).toBe('electron-directory')
+  })
+
+  it('returns null without either supported backend', () => {
+    expect(selectLocalDirectoryBackendKind({})).toBeNull()
+  })
+})

--- a/src/infrastructure/storage/local-directory/select-backend.ts
+++ b/src/infrastructure/storage/local-directory/select-backend.ts
@@ -1,0 +1,21 @@
+import type { ElectronLocalDirectoryBridge, LocalDirectoryKind } from './types'
+
+type LocalDirectoryRuntime = {
+  showDirectoryPicker?: unknown
+  electronLocalDirectory?: ElectronLocalDirectoryBridge
+}
+
+export function selectLocalDirectoryBackendKind(
+  runtime: LocalDirectoryRuntime,
+): LocalDirectoryKind | null {
+  if (typeof runtime.showDirectoryPicker === 'function') {
+    return 'file-system-access'
+  }
+  if (
+    runtime.electronLocalDirectory?.runtime === 'electron' &&
+    runtime.electronLocalDirectory.version === 1
+  ) {
+    return 'electron-directory'
+  }
+  return null
+}

--- a/src/infrastructure/storage/local-directory/types.ts
+++ b/src/infrastructure/storage/local-directory/types.ts
@@ -1,0 +1,106 @@
+export type LocalDirectoryPath = readonly string[]
+export type LocalDirectoryKind = 'file-system-access' | 'electron-directory'
+
+export interface LocalDirectoryEntry {
+  name: string
+  kind: 'file' | 'directory'
+}
+
+export interface LocalFileStat {
+  kind: 'file' | 'directory'
+  size: number
+  modifiedAt: number
+  etag: string
+}
+
+export interface LocalReadUrl {
+  url: string
+  expiresAt: number
+  stat: LocalFileStat
+}
+
+export interface ImportedLocalFile {
+  name: string
+  path: LocalDirectoryPath
+  stat: LocalFileStat
+}
+
+export interface LocalDirectoryChangeEvent {
+  grantId: string
+  eventId: string
+  kind: 'created' | 'modified' | 'removed' | 'renamed'
+  paths: LocalDirectoryPath[]
+  timestamp: number
+  writerId?: string
+}
+
+export interface LocalDirectoryBackend {
+  readonly kind: LocalDirectoryKind
+  readonly grantId: string
+  readonly name: string
+
+  readFile(path: LocalDirectoryPath): Promise<Blob | null>
+  getReadUrl(path: LocalDirectoryPath): Promise<LocalReadUrl>
+  writeFile(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+  ): Promise<LocalFileStat>
+  writeFileAtomic(
+    path: LocalDirectoryPath,
+    data: Blob | ArrayBuffer | Uint8Array | string,
+    options?: { expectedEtag?: string },
+  ): Promise<LocalFileStat>
+  listDirectory(path: LocalDirectoryPath): Promise<LocalDirectoryEntry[]>
+  createDirectory(path: LocalDirectoryPath): Promise<void>
+  exists(path: LocalDirectoryPath): Promise<boolean>
+  stat(path: LocalDirectoryPath): Promise<LocalFileStat | null>
+  move(from: LocalDirectoryPath, to: LocalDirectoryPath): Promise<void>
+  remove(path: LocalDirectoryPath, options?: { recursive?: boolean }): Promise<void>
+  selectAndCopyFiles(destination: LocalDirectoryPath): Promise<ImportedLocalFile[]>
+  subscribe(listener: (event: LocalDirectoryChangeEvent) => void): () => void
+}
+
+export interface ElectronDirectoryGrant {
+  grantId: string
+  name: string
+  mode: 'read' | 'readwrite'
+  capabilities: {
+    atomicWrite: true
+    readUrl: true
+    watch: true
+  }
+}
+
+export interface ElectronLocalDirectoryBridge {
+  readonly runtime: 'electron'
+  readonly version: 1
+  pickDirectory(input?: { mode?: 'read' | 'readwrite' }): Promise<ElectronDirectoryGrant | null>
+  restoreGrant(grantId: string): Promise<ElectronDirectoryGrant | null>
+  listGrants(): Promise<Array<ElectronDirectoryGrant & { lastUsedAt: number }>>
+  revokeGrant(grantId: string): Promise<void>
+  readFile(input: {
+    grantId: string
+    path: LocalDirectoryPath
+  }): Promise<{ data: Uint8Array; stat: LocalFileStat } | null>
+  createReadUrl(input: { grantId: string; path: LocalDirectoryPath }): Promise<LocalReadUrl>
+  writeFileAtomic(input: {
+    grantId: string
+    path: LocalDirectoryPath
+    data: string | Uint8Array
+    expectedEtag?: string
+  }): Promise<LocalFileStat>
+  listDirectory(input: {
+    grantId: string
+    path: LocalDirectoryPath
+  }): Promise<LocalDirectoryEntry[]>
+  createDirectory(input: { grantId: string; path: LocalDirectoryPath }): Promise<void>
+  exists(input: { grantId: string; path: LocalDirectoryPath }): Promise<boolean>
+  stat(input: { grantId: string; path: LocalDirectoryPath }): Promise<LocalFileStat | null>
+  move(input: { grantId: string; from: LocalDirectoryPath; to: LocalDirectoryPath }): Promise<void>
+  remove(input: { grantId: string; path: LocalDirectoryPath; recursive?: boolean }): Promise<void>
+  selectAndCopyFiles(input: {
+    grantId: string
+    destination: LocalDirectoryPath
+  }): Promise<ImportedLocalFile[]>
+  onDidChange(listener: (event: LocalDirectoryChangeEvent) => void): () => void
+}

--- a/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
@@ -95,4 +95,14 @@ describe('bootstrapWorkspace atomic recovery', () => {
       ),
     ).toBeNull()
   })
+
+  it('preserves unrelated tmp files in owned directories', async () => {
+    const root = createRoot('workspace', 'NotSupportedError')
+    await writeRawText(root, ['media', 'render.tmp'], 'user-owned temporary file')
+
+    await bootstrapWorkspace(asHandle(root))
+
+    expect(await readFileText(root, 'media', 'render.tmp')).toBe('user-owned temporary file')
+    expect(await readFileText(root, 'media', 'render')).toBeNull()
+  })
 })

--- a/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
@@ -59,4 +59,40 @@ describe('bootstrapWorkspace atomic recovery', () => {
     )
     expect(await readFileText(root, 'projects', 'p1', 'project.json.tmp')).toBeNull()
   })
+
+  it('replays collision-resistant atomic journals', async () => {
+    const root = createRoot('workspace', 'NotSupportedError')
+    await writeRawText(
+      root,
+      ['.freecut-workspace.json.freecut-123e4567-e89b-12d3-a456-426614174000.tmp'],
+      JSON.stringify({ schemaVersion: '2.0', createdAt: 1 }),
+    )
+    await writeRawText(root, ['projects', 'p1', 'project.json'], '{partial')
+    await writeRawText(
+      root,
+      ['projects', 'p1', 'project.json.freecut-123e4567-e89b-12d3-a456-426614174001.tmp'],
+      JSON.stringify({ id: 'p1', name: 'Recovered random journal' }),
+    )
+
+    await bootstrapWorkspace(asHandle(root))
+
+    expect(await readFileText(root, '.freecut-workspace.json')).toContain('"schemaVersion":"2.0"')
+    expect(
+      await readFileText(
+        root,
+        '.freecut-workspace.json.freecut-123e4567-e89b-12d3-a456-426614174000.tmp',
+      ),
+    ).toBeNull()
+    expect(await readFileText(root, 'projects', 'p1', 'project.json')).toContain(
+      '"name":"Recovered random journal"',
+    )
+    expect(
+      await readFileText(
+        root,
+        'projects',
+        'p1',
+        'project.json.freecut-123e4567-e89b-12d3-a456-426614174001.tmp',
+      ),
+    ).toBeNull()
+  })
 })

--- a/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+vi.mock('@/shared/logging/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    event: vi.fn(),
+    startEvent: () => ({ set: vi.fn(), merge: vi.fn(), success: vi.fn(), failure: vi.fn() }),
+    child: vi.fn(),
+    setLevel: vi.fn(),
+  }),
+  createOperationId: () => 'op-test',
+}))
+
+import { bootstrapWorkspace } from './bootstrap'
+import { asHandle, createRoot, readFileText } from './__tests__/in-memory-handle'
+
+async function writeRawText(
+  root: ReturnType<typeof createRoot>,
+  segments: string[],
+  text: string,
+): Promise<void> {
+  let directory = root
+  for (const segment of segments.slice(0, -1)) {
+    directory = await directory.getDirectoryHandle(segment, { create: true })
+  }
+  const handle = await directory.getFileHandle(segments.at(-1)!, { create: true })
+  const writable = await handle.createWritable()
+  await writable.write(text)
+  await writable.close()
+}
+
+describe('bootstrapWorkspace atomic recovery', () => {
+  it('replays a complete tmp journal before reading workspace metadata', async () => {
+    const root = createRoot('workspace', 'NotSupportedError')
+    await writeRawText(root, ['.freecut-workspace.json'], '{broken')
+    await writeRawText(
+      root,
+      ['.freecut-workspace.json.tmp'],
+      JSON.stringify({ schemaVersion: '2.0', createdAt: 1 }),
+    )
+    await writeRawText(root, ['projects', 'p1', 'project.json'], '{partial')
+    await writeRawText(
+      root,
+      ['projects', 'p1', 'project.json.tmp'],
+      JSON.stringify({ id: 'p1', name: 'Recovered' }),
+    )
+
+    await bootstrapWorkspace(asHandle(root))
+
+    expect(await readFileText(root, '.freecut-workspace.json')).toContain('"schemaVersion":"2.0"')
+    expect(await readFileText(root, '.freecut-workspace.json.tmp')).toBeNull()
+    expect(await readFileText(root, 'projects', 'p1', 'project.json')).toContain(
+      '"name":"Recovered"',
+    )
+    expect(await readFileText(root, 'projects', 'p1', 'project.json.tmp')).toBeNull()
+  })
+})

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -23,6 +23,7 @@ import {
 } from './fs-primitives'
 import { migrateWorkspaceV2 } from './migrate-workspace-v2'
 import readmeTemplate from './README.template.md?raw'
+import type { LocalDirectoryBackend } from '@/infrastructure/storage/local-directory/types'
 
 const logger = createLogger('WorkspaceBootstrap')
 
@@ -45,22 +46,17 @@ export interface WorkspaceMarker {
  * Anything else in the workspace (user's own files) is left alone.
  */
 async function sweepStrandedTmpFiles(
-  root: FileSystemDirectoryHandle,
+  root: LocalDirectoryBackend | FileSystemDirectoryHandle,
   dirNames: string[],
 ): Promise<number> {
   let removed = 0
 
-  async function recurse(dir: FileSystemDirectoryHandle): Promise<void> {
-    // Collect entries first because we mutate the dir while iterating.
-    const entries: { name: string; kind: 'file' | 'directory' }[] = []
-    for await (const entry of dir.values()) {
-      entries.push({ name: entry.name, kind: entry.kind })
-    }
+  async function recurse(segments: string[]): Promise<void> {
+    const entries = await listDirectory(root, segments)
     for (const entry of entries) {
       if (entry.kind === 'directory') {
         try {
-          const sub = await dir.getDirectoryHandle(entry.name, { create: false })
-          await recurse(sub)
+          await recurse([...segments, entry.name])
         } catch (error) {
           logger.debug('sweepStrandedTmpFiles: subdir skipped', { name: entry.name, error })
         }
@@ -68,7 +64,7 @@ async function sweepStrandedTmpFiles(
       }
       if (entry.name.endsWith('.tmp')) {
         try {
-          await dir.removeEntry(entry.name)
+          await removeEntry(root, [...segments, entry.name])
           removed++
         } catch (error) {
           logger.debug('sweepStrandedTmpFiles: remove failed', { name: entry.name, error })
@@ -79,8 +75,7 @@ async function sweepStrandedTmpFiles(
 
   for (const name of dirNames) {
     try {
-      const sub = await root.getDirectoryHandle(name, { create: false })
-      await recurse(sub)
+      await recurse([name])
     } catch {
       // Directory missing (fresh workspace) — nothing to sweep.
     }
@@ -98,7 +93,9 @@ const PROXY_KEY_TAG_PATTERN = /^[hof]-/
  * expose a cross-browser rename. If both old and new names exist (e.g. a
  * partial prior run), the new name wins and the prefixed one is removed.
  */
-async function stripProxyKeyPrefixes(root: FileSystemDirectoryHandle): Promise<number> {
+async function stripProxyKeyPrefixes(
+  root: LocalDirectoryBackend | FileSystemDirectoryHandle,
+): Promise<number> {
   const entries = await listDirectory(root, proxiesRoot())
   let renamed = 0
   for (const entry of entries) {
@@ -170,7 +167,9 @@ async function stripProxyKeyPrefixes(root: FileSystemDirectoryHandle): Promise<n
   return renamed
 }
 
-export async function bootstrapWorkspace(root: FileSystemDirectoryHandle): Promise<void> {
+export async function bootstrapWorkspace(
+  root: LocalDirectoryBackend | FileSystemDirectoryHandle,
+): Promise<void> {
   // README: only write when missing — never overwrite user edits.
   if (!(await exists(root, [README_FILENAME]))) {
     try {

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -111,7 +111,7 @@ async function recoverStrandedTmpFiles(
         try {
           await recurse([...segments, entry.name])
         } catch (error) {
-          logger.debug('sweepStrandedTmpFiles: subdir skipped', { name: entry.name, error })
+          logger.debug('recoverStrandedTmpFiles: subdir skipped', { name: entry.name, error })
         }
         continue
       }

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -6,6 +6,7 @@
 import { createLogger } from '@/shared/logging/logger'
 import {
   CONTENT_DIR,
+  INDEX_FILENAME,
   MARKER_FILENAME,
   MEDIA_DIR,
   PROJECTS_DIR,
@@ -34,22 +35,32 @@ export interface WorkspaceMarker {
 }
 
 /**
- * Recursively remove stranded `*.tmp` files.
+ * Recover stranded `*.tmp` atomic-write journals.
  *
  * `writeJsonAtomic` creates `{name}.tmp` and then `.move()`s it (or writes
- * the target and removes the tmp). A crash between the tmp-write and the
- * move leaves the tmp-file behind. They're harmless — consumers only
- * read the non-tmp name — but they accumulate over time and clutter the
- * workspace when a user browses it externally.
+ * the target from the completed tmp bytes). A crash during the fallback copy
+ * can leave a partial target, while the tmp remains the complete intended
+ * replacement. Replaying the tmp before any workspace reads makes that
+ * fallback crash-recoverable.
  *
- * We only sweep the three directories we own (projects/media/content).
+ * We only inspect FreeCut's root metadata and owned directories.
  * Anything else in the workspace (user's own files) is left alone.
  */
-async function sweepStrandedTmpFiles(
+async function recoverStrandedTmpFiles(
   root: LocalDirectoryBackend | FileSystemDirectoryHandle,
   dirNames: string[],
 ): Promise<number> {
-  let removed = 0
+  let recovered = 0
+
+  async function recover(tmpPath: string[]): Promise<void> {
+    const staged = await readBlob(root, tmpPath)
+    if (!staged) return
+    const targetPath = [...tmpPath]
+    targetPath[targetPath.length - 1] = targetPath.at(-1)!.slice(0, -'.tmp'.length)
+    await writeBlob(root, targetPath, staged)
+    await removeEntry(root, tmpPath)
+    recovered++
+  }
 
   async function recurse(segments: string[]): Promise<void> {
     const entries = await listDirectory(root, segments)
@@ -64,12 +75,19 @@ async function sweepStrandedTmpFiles(
       }
       if (entry.name.endsWith('.tmp')) {
         try {
-          await removeEntry(root, [...segments, entry.name])
-          removed++
+          await recover([...segments, entry.name])
         } catch (error) {
-          logger.debug('sweepStrandedTmpFiles: remove failed', { name: entry.name, error })
+          logger.debug('recoverStrandedTmpFiles: recovery failed', { name: entry.name, error })
         }
       }
+    }
+  }
+
+  for (const name of [MARKER_FILENAME, INDEX_FILENAME]) {
+    try {
+      await recover([`${name}.tmp`])
+    } catch (error) {
+      logger.debug('recoverStrandedTmpFiles: root recovery failed', { name, error })
     }
   }
 
@@ -80,7 +98,7 @@ async function sweepStrandedTmpFiles(
       // Directory missing (fresh workspace) — nothing to sweep.
     }
   }
-  return removed
+  return recovered
 }
 
 const PROXY_KEY_TAG_PATTERN = /^[hof]-/
@@ -170,6 +188,17 @@ async function stripProxyKeyPrefixes(
 export async function bootstrapWorkspace(
   root: LocalDirectoryBackend | FileSystemDirectoryHandle,
 ): Promise<void> {
+  // Recover interrupted fallback commits before reading the marker, index, or
+  // project metadata. The tmp file is the complete intended replacement.
+  try {
+    const recovered = await recoverStrandedTmpFiles(root, [PROJECTS_DIR, MEDIA_DIR, CONTENT_DIR])
+    if (recovered > 0) {
+      logger.info(`Recovered ${recovered} stranded atomic write(s) from a prior crash`)
+    }
+  } catch (error) {
+    logger.warn('recoverStrandedTmpFiles failed', error)
+  }
+
   // README: only write when missing — never overwrite user edits.
   if (!(await exists(root, [README_FILENAME]))) {
     try {
@@ -227,15 +256,5 @@ export async function bootstrapWorkspace(
     }
   } catch (error) {
     logger.warn('stripProxyKeyPrefixes failed', error)
-  }
-
-  // Clean up any `.tmp` files stranded by a prior crash.
-  try {
-    const removed = await sweepStrandedTmpFiles(root, [PROJECTS_DIR, MEDIA_DIR, CONTENT_DIR])
-    if (removed > 0) {
-      logger.info(`Swept ${removed} stranded .tmp file(s) from prior crash`)
-    }
-  } catch (error) {
-    logger.warn('sweepStrandedTmpFiles failed', error)
   }
 }

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -35,11 +35,27 @@ export interface WorkspaceMarker {
 }
 
 const ATOMIC_TEMP_JOURNAL_PATTERN = /^(.*)\.freecut-[0-9a-f-]+\.tmp$/u
+const LEGACY_ATOMIC_JOURNAL_TARGET_PATTERNS = [
+  /^\.freecut-workspace\.json$/u,
+  /^index\.json$/u,
+  /^projects\/[^/]+\/(?:project|media-links|render-queue|animation-presets)\.json$/u,
+  /^projects\/[^/]+\/\.freecut-trashed\.json$/u,
+  /^media\/[^/]+\/metadata\.json$/u,
+  /^content\/.+\/(?:refs|meta)\.json$/u,
+]
 
-function atomicJournalTargetName(name: string): string | null {
+function atomicJournalTargetName(path: readonly string[]): string | null {
+  const name = path.at(-1)
+  if (!name) return null
   const randomJournal = ATOMIC_TEMP_JOURNAL_PATTERN.exec(name)
   if (randomJournal) return randomJournal[1] ?? null
-  return name.endsWith('.tmp') ? name.slice(0, -'.tmp'.length) : null
+  if (!name.endsWith('.tmp')) return null
+
+  const targetName = name.slice(0, -'.tmp'.length)
+  const targetPath = [...path.slice(0, -1), targetName].join('/')
+  return LEGACY_ATOMIC_JOURNAL_TARGET_PATTERNS.some((pattern) => pattern.test(targetPath))
+    ? targetName
+    : null
 }
 
 async function recoverRootAtomicJournals(
@@ -50,7 +66,7 @@ async function recoverRootAtomicJournals(
     const rootEntries = await listDirectory(root, [])
     for (const entry of rootEntries) {
       if (entry.kind !== 'file') continue
-      const targetName = atomicJournalTargetName(entry.name)
+      const targetName = atomicJournalTargetName([entry.name])
       if (targetName !== MARKER_FILENAME && targetName !== INDEX_FILENAME) continue
       await recover([entry.name])
     }
@@ -60,13 +76,12 @@ async function recoverRootAtomicJournals(
 }
 
 /**
- * Recover stranded `*.tmp` atomic-write journals.
+ * Recover stranded atomic-write journals.
  *
- * `writeJsonAtomic` creates `{name}.tmp` and then `.move()`s it (or writes
- * the target from the completed tmp bytes). A crash during the fallback copy
- * can leave a partial target, while the tmp remains the complete intended
- * replacement. Replaying the tmp before any workspace reads makes that
- * fallback crash-recoverable.
+ * Current writes use collision-resistant `{name}.freecut-{uuid}.tmp` names.
+ * A short allowlist also recognizes metadata journals produced by older
+ * versions that used `{name}.tmp`; unrelated user-owned `.tmp` files are
+ * deliberately preserved.
  *
  * We only inspect FreeCut's root metadata and owned directories.
  * Anything else in the workspace (user's own files) is left alone.
@@ -81,7 +96,7 @@ async function recoverStrandedTmpFiles(
     const staged = await readBlob(root, tmpPath)
     if (!staged) return
     const targetPath = [...tmpPath]
-    const targetName = atomicJournalTargetName(targetPath.at(-1)!)
+    const targetName = atomicJournalTargetName(targetPath)
     if (!targetName) return
     targetPath[targetPath.length - 1] = targetName
     await writeBlob(root, targetPath, staged)
@@ -100,9 +115,10 @@ async function recoverStrandedTmpFiles(
         }
         continue
       }
-      if (atomicJournalTargetName(entry.name)) {
+      const entryPath = [...segments, entry.name]
+      if (atomicJournalTargetName(entryPath)) {
         try {
-          await recover([...segments, entry.name])
+          await recover(entryPath)
         } catch (error) {
           logger.debug('recoverStrandedTmpFiles: recovery failed', { name: entry.name, error })
         }

--- a/src/infrastructure/storage/workspace-fs/bootstrap.ts
+++ b/src/infrastructure/storage/workspace-fs/bootstrap.ts
@@ -34,6 +34,31 @@ export interface WorkspaceMarker {
   migratedFromLegacyAt?: number
 }
 
+const ATOMIC_TEMP_JOURNAL_PATTERN = /^(.*)\.freecut-[0-9a-f-]+\.tmp$/u
+
+function atomicJournalTargetName(name: string): string | null {
+  const randomJournal = ATOMIC_TEMP_JOURNAL_PATTERN.exec(name)
+  if (randomJournal) return randomJournal[1] ?? null
+  return name.endsWith('.tmp') ? name.slice(0, -'.tmp'.length) : null
+}
+
+async function recoverRootAtomicJournals(
+  root: LocalDirectoryBackend | FileSystemDirectoryHandle,
+  recover: (path: string[]) => Promise<void>,
+): Promise<void> {
+  try {
+    const rootEntries = await listDirectory(root, [])
+    for (const entry of rootEntries) {
+      if (entry.kind !== 'file') continue
+      const targetName = atomicJournalTargetName(entry.name)
+      if (targetName !== MARKER_FILENAME && targetName !== INDEX_FILENAME) continue
+      await recover([entry.name])
+    }
+  } catch (error) {
+    logger.debug('recoverStrandedTmpFiles: root scan failed', error)
+  }
+}
+
 /**
  * Recover stranded `*.tmp` atomic-write journals.
  *
@@ -56,7 +81,9 @@ async function recoverStrandedTmpFiles(
     const staged = await readBlob(root, tmpPath)
     if (!staged) return
     const targetPath = [...tmpPath]
-    targetPath[targetPath.length - 1] = targetPath.at(-1)!.slice(0, -'.tmp'.length)
+    const targetName = atomicJournalTargetName(targetPath.at(-1)!)
+    if (!targetName) return
+    targetPath[targetPath.length - 1] = targetName
     await writeBlob(root, targetPath, staged)
     await removeEntry(root, tmpPath)
     recovered++
@@ -73,7 +100,7 @@ async function recoverStrandedTmpFiles(
         }
         continue
       }
-      if (entry.name.endsWith('.tmp')) {
+      if (atomicJournalTargetName(entry.name)) {
         try {
           await recover([...segments, entry.name])
         } catch (error) {
@@ -90,6 +117,8 @@ async function recoverStrandedTmpFiles(
       logger.debug('recoverStrandedTmpFiles: root recovery failed', { name, error })
     }
   }
+
+  await recoverRootAtomicJournals(root, recover)
 
   for (const name of dirNames) {
     try {

--- a/src/infrastructure/storage/workspace-fs/decoded-preview-audio.ts
+++ b/src/infrastructure/storage/workspace-fs/decoded-preview-audio.ts
@@ -19,7 +19,14 @@ import type {
 import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
-import { readArrayBuffer, readJson, removeEntry, writeBlob, writeJsonAtomic } from './fs-primitives'
+import {
+  readArrayBuffer,
+  readJson,
+  removeEntry,
+  writeBlob,
+  writeJsonAtomic,
+  type WorkspaceRootInput,
+} from './fs-primitives'
 import { decodedAudioBinPath, decodedAudioDir } from './paths'
 
 const logger = createLogger('WorkspaceFS:DecodedAudio')
@@ -54,7 +61,7 @@ function decodedAudioBinMetaPath(mediaId: string, binIndex: number): string[] {
 type StoredBinMeta = Omit<DecodedPreviewAudioBin, 'left' | 'right'>
 
 async function readMeta(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
 ): Promise<DecodedPreviewAudioMeta | undefined> {
   const meta = await readJson<DecodedPreviewAudioMeta>(root, decodedAudioMetaPath(mediaId))
@@ -62,7 +69,7 @@ async function readMeta(
 }
 
 async function readBin(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
   binIndex: number,
 ): Promise<DecodedPreviewAudioBin | undefined> {
@@ -96,7 +103,7 @@ export async function getDecodedPreviewAudio(id: string): Promise<DecodedPreview
  * was handed the workspace root (which has no module-global root of its own).
  */
 export async function writeDecodedPreviewAudioToRoot(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   data: DecodedPreviewAudio,
 ): Promise<void> {
   try {

--- a/src/infrastructure/storage/workspace-fs/exports.ts
+++ b/src/infrastructure/storage/workspace-fs/exports.ts
@@ -8,7 +8,14 @@
  */
 
 import { getWorkspaceRoot, requireWorkspaceRoot } from './root'
-import { exists, readBlob, readDirectoryFiles, removeEntry, writeBlob } from './fs-primitives'
+import {
+  exists,
+  readBlob,
+  readDirectoryFiles,
+  removeEntry,
+  writeBlob,
+  type WorkspaceRootInput,
+} from './fs-primitives'
 import {
   EXPORTS_DIR,
   PROJECTS_DIR,
@@ -44,7 +51,7 @@ function suffixFileName(fileName: string, n: number): string {
 }
 
 async function uniqueFileName(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   pathOf: (name: string) => string[],
   fileName: string,
 ): Promise<string> {

--- a/src/infrastructure/storage/workspace-fs/fs-primitives.test.ts
+++ b/src/infrastructure/storage/workspace-fs/fs-primitives.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, expect, it, vi } from 'vite-plus/test'
 
+const notifyPermissionLost = vi.hoisted(() => vi.fn())
+
 vi.mock('@/shared/logging/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -17,10 +19,10 @@ vi.mock('@/shared/logging/logger', () => ({
 }))
 
 vi.mock('./root', () => ({
-  notifyPermissionLost: vi.fn(),
+  notifyPermissionLost,
 }))
 
-import { readJson, writeJsonAtomic, WorkspaceFileCorruptError } from './fs-primitives'
+import { readBlob, readJson, writeJsonAtomic, WorkspaceFileCorruptError } from './fs-primitives'
 import {
   asHandle,
   createRoot,
@@ -71,6 +73,20 @@ describe('fs-primitives readJson', () => {
     await writeJsonAtomic(asHandle(root), ['valid.json'], { hello: 'world' })
     const result = await readJson<{ hello: string }>(asHandle(root), ['valid.json'])
     expect(result).toEqual({ hello: 'world' })
+  })
+})
+
+describe('fs-primitives permission loss', () => {
+  it('recognizes a revoked Electron grant serialized as a plain Error', async () => {
+    notifyPermissionLost.mockClear()
+    const error = new Error('Electron IPC failed: LOCAL_DIRECTORY_GRANT_REVOKED')
+    const backend = {
+      kind: 'electron-directory',
+      readFile: vi.fn().mockRejectedValue(error),
+    } as unknown as import('@/infrastructure/storage/local-directory/types').LocalDirectoryBackend
+
+    await expect(readBlob(backend, ['index.json'])).rejects.toBe(error)
+    expect(notifyPermissionLost).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/infrastructure/storage/workspace-fs/fs-primitives.ts
+++ b/src/infrastructure/storage/workspace-fs/fs-primitives.ts
@@ -51,12 +51,33 @@ function isLocalDirectoryBackend(root: WorkspaceRootInput): root is LocalDirecto
 
 function wrap<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   return fn().catch((error) => {
-    if (error instanceof DOMException && error.name === 'NotAllowedError') {
+    if (isPermissionLostError(error)) {
       notifyPermissionLost()
     }
     logger.warn(`${operation} failed`, error)
     throw error
   })
+}
+
+function isPermissionLostError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const value = error as { name?: unknown; code?: unknown; message?: unknown }
+  if (value.name === 'NotAllowedError' || value.name === 'SecurityError') return true
+  if (
+    value.code === 'EACCES' ||
+    value.code === 'EPERM' ||
+    value.code === 'ERR_ACCESS_DENIED' ||
+    value.code === 'LOCAL_DIRECTORY_GRANT_REVOKED' ||
+    value.code === 'LOCAL_DIRECTORY_PERMISSION_DENIED'
+  ) {
+    return true
+  }
+  return (
+    typeof value.message === 'string' &&
+    /(?:grant|permission).*(?:denied|revoked)|(?:denied|revoked).*(?:grant|permission)/i.test(
+      value.message,
+    )
+  )
 }
 
 export async function readJson<T>(root: WorkspaceRootInput, segments: string[]): Promise<T | null> {

--- a/src/infrastructure/storage/workspace-fs/fs-primitives.ts
+++ b/src/infrastructure/storage/workspace-fs/fs-primitives.ts
@@ -1,27 +1,21 @@
 /**
- * Filesystem primitives over FileSystemDirectoryHandle.
+ * Filesystem primitives over a LocalDirectoryBackend.
  *
- * Every higher-level storage module in workspace-fs calls these. They:
- *  - resolve path segments via nested getDirectoryHandle({ create: true })
- *  - read/write JSON and binary blobs
- *  - write JSON atomically (tmp-file + replace) so index.json / project.json
- *    don't tear on crash
- *  - convert NotFoundError to typed null returns so callers don't have to
- *    do try/catch everywhere
- *  - detect NotAllowedError (permission revoked) and emit a signal so UI
- *    can prompt re-grant
- *
- * Path inputs are arrays of segments — consistent with paths.ts.
+ * Higher-level FreeCut storage modules remain unaware of whether the directory
+ * came from showDirectoryPicker() or Electron's local-directory bridge.
  */
 
 import { createLogger } from '@/shared/logging/logger'
+import { FileSystemAccessDirectoryBackend } from '@/infrastructure/storage/local-directory/file-system-access-backend'
+import type {
+  LocalDirectoryBackend,
+  LocalDirectoryEntry,
+} from '@/infrastructure/storage/local-directory/types'
 import { notifyPermissionLost } from './root'
-import { describeStorageEnvironment } from './storage-environment'
 import { withKeyLock } from './with-key-lock'
 
 const logger = createLogger('WorkspaceFS')
 
-/** A file exists but its content is not valid JSON. */
 export class WorkspaceFileCorruptError extends Error {
   constructor(
     public readonly path: string,
@@ -33,21 +27,31 @@ export class WorkspaceFileCorruptError extends Error {
   }
 }
 
-function isNotFound(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'NotFoundError'
+export type WorkspaceRootInput = LocalDirectoryBackend | FileSystemDirectoryHandle
+export type DirectoryEntry = LocalDirectoryEntry
+
+const backendByHandle = new WeakMap<FileSystemDirectoryHandle, FileSystemAccessDirectoryBackend>()
+
+function backendOf(root: WorkspaceRootInput): LocalDirectoryBackend {
+  if (isLocalDirectoryBackend(root)) {
+    return root
+  }
+  let backend = backendByHandle.get(root)
+  if (!backend) {
+    backend = new FileSystemAccessDirectoryBackend(root)
+    backendByHandle.set(root, backend)
+  }
+  return backend
 }
 
-function isNotAllowed(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'NotAllowedError'
-}
-
-function isNotSupported(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'NotSupportedError'
+function isLocalDirectoryBackend(root: WorkspaceRootInput): root is LocalDirectoryBackend {
+  const kind = (root as { kind?: unknown }).kind
+  return kind === 'file-system-access' || kind === 'electron-directory'
 }
 
 function wrap<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   return fn().catch((error) => {
-    if (isNotAllowed(error)) {
+    if (error instanceof DOMException && error.name === 'NotAllowedError') {
       notifyPermissionLost()
     }
     logger.warn(`${operation} failed`, error)
@@ -55,345 +59,95 @@ function wrap<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   })
 }
 
-/**
- * Walk a path of directory segments, creating each if missing.
- * Last segment is returned as the directory handle.
- */
-async function resolveDir(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-  create: boolean,
-): Promise<FileSystemDirectoryHandle> {
-  let dir = root
-  for (const segment of segments) {
-    dir = await dir.getDirectoryHandle(segment, { create })
-  }
-  return dir
-}
-
-/**
- * Resolve segments to (parent dir, file name). Segments must have length >= 1.
- */
-async function resolveFileParent(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-  create: boolean,
-): Promise<{ parent: FileSystemDirectoryHandle; fileName: string }> {
-  if (segments.length === 0) {
-    throw new Error('fs-primitives: empty path segments')
-  }
-  const parentSegments = segments.slice(0, -1)
-  const fileName = segments[segments.length - 1]!
-  const parent = await resolveDir(root, parentSegments, create)
-  return { parent, fileName }
-}
-
-/* ────────────────────────────── Read helpers ─────────────────────────── */
-
-export async function readJson<T>(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-): Promise<T | null> {
+export async function readJson<T>(root: WorkspaceRootInput, segments: string[]): Promise<T | null> {
   return wrap('readJson', async () => {
+    const blob = await backendOf(root).readFile(segments)
+    if (!blob) return null
+    const text = await blob.text()
+    if (text.length === 0) return null
     try {
-      const { parent, fileName } = await resolveFileParent(root, segments, false)
-      const file = await parent.getFileHandle(fileName, { create: false })
-      const blob = await file.getFile()
-      const text = await blob.text()
-      if (text.length === 0) return null
-      try {
-        return JSON.parse(text) as T
-      } catch (error) {
-        throw new WorkspaceFileCorruptError(segments.join('/'), error)
-      }
+      return JSON.parse(text) as T
     } catch (error) {
-      if (isNotFound(error)) return null
-      throw error
+      throw new WorkspaceFileCorruptError(segments.join('/'), error)
     }
   })
 }
 
-export async function readBlob(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-): Promise<Blob | null> {
-  return wrap('readBlob', async () => {
-    try {
-      const { parent, fileName } = await resolveFileParent(root, segments, false)
-      const file = await parent.getFileHandle(fileName, { create: false })
-      return await file.getFile()
-    } catch (error) {
-      if (isNotFound(error)) return null
-      throw error
-    }
-  })
+export function readBlob(root: WorkspaceRootInput, segments: string[]): Promise<Blob | null> {
+  return wrap('readBlob', () => backendOf(root).readFile(segments))
 }
 
 export async function readArrayBuffer(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   segments: string[],
 ): Promise<ArrayBuffer | null> {
   const blob = await readBlob(root, segments)
-  if (!blob) return null
-  return blob.arrayBuffer()
+  return blob ? blob.arrayBuffer() : null
 }
 
-/* ────────────────────────────── Write helpers ────────────────────────── */
-
-/**
- * Atomic JSON write: writes to `{name}.tmp`, then replaces the target.
- * Protects against torn writes on crash. Uses FileSystemFileHandle.move
- * (Chromium) when available, falls back to write-then-remove-tmp.
- *
- * Serialized per-path by an in-memory lock. Without this, two concurrent
- * callers racing on the same path can deadlock each other's move():
- *   - A: open tmp writable, write, close → begin .move()
- *   - B: open tmp writable (A has closed, so B succeeds) → write
- *   - A: .move() throws NoModificationAllowedError — "cannot move while
- *     the handle is locked" (B's writable is open on the same tmp)
- * The lock scope is one tab; cross-tab races on the same path are still
- * last-write-wins but can't produce the locked-handle error because each
- * tab has its own tmp writable lifecycle.
- */
-function writeJsonAtomicLockKey(segments: string[]): string {
-  return `writeJsonAtomic:${segments.join('/')}`
-}
-
-type MovableHandle = FileSystemFileHandle & {
-  move?: (parent: FileSystemDirectoryHandle, newName: string) => Promise<void>
-}
-
-/**
- * Workspace roots whose `FileSystemFileHandle.move()` rejected as unsupported.
- *
- * `move` is always present on the prototype in Chromium, yet calling it can
- * still reject with NotSupportedError. This is not a blanket "not implemented":
- * Chromium has shipped move() for local files since M111. The spec permits
- * rejection when the file "does not correspond to a file on the underlying file
- * system", which covers cloud-synced and network folders, and pre-M111 engines
- * reject every non-OPFS move. Our root always comes from showDirectoryPicker(),
- * so we are never on the guaranteed-OPFS path.
- *
- * Presence is therefore NOT support; the only way to find out is to call it. We
- * remember the answer so at most one doomed move() happens per workspace rather
- * than one per write.
- *
- * Keyed on the root handle, NOT module-global: `setWorkspaceRoot` can swap the
- * active root mid-session (reconnect, or "choose a different folder" after this
- * very failure). A session-global flag would strand a freshly picked local
- * folder — where move() works fine — on the non-atomic fallback for the rest of
- * the page. A WeakSet also lets a discarded root be collected.
- *
- * Never un-set for a given root: a handle that rejects move() once will keep
- * rejecting it, since the answer is a property of the underlying filesystem.
- */
-const rootsRejectingMove = new WeakSet<FileSystemDirectoryHandle>()
-
-/**
- * Replace `fileName` with the already-written `tmpName` in `parent`.
- * Prefers rename (truly atomic), degrades to copy + delete.
- */
-async function commitTmpFile(
-  root: FileSystemDirectoryHandle,
-  parent: FileSystemDirectoryHandle,
-  tmpHandle: FileSystemFileHandle,
-  tmpName: string,
-  fileName: string,
-  json: string,
-): Promise<void> {
-  const movable = tmpHandle as MovableHandle
-  if (!rootsRejectingMove.has(root) && typeof movable.move === 'function') {
-    try {
-      await movable.move(parent, fileName)
-      return
-    } catch (error) {
-      if (!isNotSupported(error)) throw error
-      rootsRejectingMove.add(root)
-      // Logged once per workspace (the set short-circuits later writes). Carries
-      // the environment because the error alone cannot say *why* it rejected.
-      logger.warn(
-        'writeJsonAtomic: FileSystemFileHandle.move() rejected as unsupported — ' +
-          'falling back to a non-atomic copy+delete for this workspace',
-        { environment: describeStorageEnvironment() },
-        error,
-      )
-    }
-  }
-
-  // Fallback: copy tmp → target, then remove tmp. Not atomic — a crash between
-  // the two closes leaves a torn target — but it is the only option available.
-  const targetHandle = await parent.getFileHandle(fileName, { create: true })
-  const targetWritable = await targetHandle.createWritable()
-  await targetWritable.write(json)
-  await targetWritable.close()
-  try {
-    await parent.removeEntry(tmpName)
-  } catch (error) {
-    if (!isNotFound(error)) throw error
-  }
-}
-
-export async function writeJsonAtomic(
-  root: FileSystemDirectoryHandle,
+export function writeJsonAtomic(
+  root: WorkspaceRootInput,
   segments: string[],
   data: unknown,
 ): Promise<number> {
   return wrap('writeJsonAtomic', () =>
-    withKeyLock(writeJsonAtomicLockKey(segments), async () => {
-      const { parent, fileName } = await resolveFileParent(root, segments, true)
-      const tmpName = `${fileName}.tmp`
+    withKeyLock(`writeJsonAtomic:${segments.join('/')}`, async () => {
       const json = JSON.stringify(data, null, 2)
-
-      const tmpHandle = await parent.getFileHandle(tmpName, { create: true })
-      const writable = await tmpHandle.createWritable()
-      await writable.write(json)
-      await writable.close()
-
-      await commitTmpFile(root, parent, tmpHandle, tmpName, fileName, json)
-
+      await backendOf(root).writeFileAtomic(segments, json)
       return json.length
     }),
   )
 }
 
-export async function writeBlob(
-  root: FileSystemDirectoryHandle,
+export function writeBlob(
+  root: WorkspaceRootInput,
   segments: string[],
   data: Blob | ArrayBuffer | Uint8Array | string,
 ): Promise<void> {
-  // Serialized per-path for the same reason as writeJsonAtomic: two
-  // concurrent writers on the same file race on the writable lock. In
-  // writeBlob's case the loser fails at createWritable with
-  // NoModificationAllowedError rather than at move(), but the fix is
-  // identical. Different paths use different lock keys, so this does
-  // not constrain parallelism of unrelated writes.
   return wrap('writeBlob', () =>
     withKeyLock(`writeBlob:${segments.join('/')}`, async () => {
-      const { parent, fileName } = await resolveFileParent(root, segments, true)
-      const fh = await parent.getFileHandle(fileName, { create: true })
-      const writable = await fh.createWritable()
-      await writable.write(data as FileSystemWriteChunkType)
-      await writable.close()
+      await backendOf(root).writeFile(segments, data)
     }),
   )
 }
 
-/* ────────────────────────────── Delete helpers ───────────────────────── */
-
-/**
- * Remove a file or a whole subtree. No-op when missing.
- */
-export async function removeEntry(
-  root: FileSystemDirectoryHandle,
+export function removeEntry(
+  root: WorkspaceRootInput,
   segments: string[],
   options: { recursive?: boolean } = {},
 ): Promise<void> {
   if (segments.length === 0) {
     throw new Error('fs-primitives: refusing to remove empty path')
   }
-  return wrap('removeEntry', async () => {
-    try {
-      const { parent, fileName } = await resolveFileParent(root, segments, false)
-      await parent.removeEntry(fileName, { recursive: options.recursive ?? false })
-    } catch (error) {
-      if (isNotFound(error)) return
-      throw error
-    }
-  })
+  return wrap('removeEntry', () => backendOf(root).remove(segments, options))
 }
 
-/* ────────────────────────────── Enumeration ──────────────────────────── */
-
-export interface DirectoryEntry {
-  name: string
-  kind: 'file' | 'directory'
-}
-
-export async function listDirectory(
-  root: FileSystemDirectoryHandle,
+export function listDirectory(
+  root: WorkspaceRootInput,
   segments: string[],
 ): Promise<DirectoryEntry[]> {
-  return wrap('listDirectory', async () => {
-    try {
-      const dir = await resolveDir(root, segments, false)
-      const entries: DirectoryEntry[] = []
-      for await (const entry of dir.values()) {
-        entries.push({ name: entry.name, kind: entry.kind })
-      }
-      return entries
-    } catch (error) {
-      if (isNotFound(error)) return []
-      throw error
-    }
-  })
+  return wrap('listDirectory', () => backendOf(root).listDirectory(segments))
 }
 
-/**
- * List a directory and read all matching files in a single resolved-dir pass.
- *
- * Calling readBlob() per file forces resolveDir() to re-walk the segments
- * (4 getDirectoryHandle calls for typical media paths) on every read. For
- * directories with many files this dominates wall time. This helper resolves
- * the parent dir once and reuses its file-handle iterator, then reads all
- * files concurrently.
- */
 export async function readDirectoryFiles(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   segments: string[],
   filter?: (entry: DirectoryEntry) => boolean,
 ): Promise<Array<{ name: string; blob: Blob }>> {
   return wrap('readDirectoryFiles', async () => {
-    try {
-      const dir = await resolveDir(root, segments, false)
-      const fileHandles: Array<{ name: string; handle: FileSystemFileHandle }> = []
-      for await (const entry of dir.values()) {
-        if (entry.kind !== 'file') continue
-        if (filter && !filter({ name: entry.name, kind: entry.kind })) continue
-        fileHandles.push({ name: entry.name, handle: entry as FileSystemFileHandle })
-      }
-      const results = await Promise.all(
-        fileHandles.map(async ({ name, handle }) => {
-          try {
-            const file = await handle.getFile()
-            return { name, blob: file as Blob }
-          } catch (error) {
-            // A file can disappear between iterating dir.values() and calling
-            // getFile() (e.g. concurrent delete). Skip it instead of failing
-            // the whole batch.
-            if (isNotFound(error)) return null
-            throw error
-          }
-        }),
-      )
-      return results.filter((r): r is { name: string; blob: Blob } => r !== null)
-    } catch (error) {
-      if (isNotFound(error)) return []
-      throw error
-    }
+    const backend = backendOf(root)
+    const entries = await backend.listDirectory(segments)
+    const files = entries.filter((entry) => entry.kind === 'file' && (!filter || filter(entry)))
+    const results = await Promise.all(
+      files.map(async (entry) => {
+        const blob = await backend.readFile([...segments, entry.name])
+        return blob ? { name: entry.name, blob } : null
+      }),
+    )
+    return results.filter((result): result is { name: string; blob: Blob } => result !== null)
   })
 }
 
-export async function exists(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-): Promise<boolean> {
-  try {
-    const { parent, fileName } = await resolveFileParent(root, segments, false)
-    try {
-      await parent.getFileHandle(fileName, { create: false })
-      return true
-    } catch (error) {
-      if (!isNotFound(error)) throw error
-    }
-    try {
-      await parent.getDirectoryHandle(fileName, { create: false })
-      return true
-    } catch (error) {
-      if (!isNotFound(error)) throw error
-    }
-    return false
-  } catch (error) {
-    if (isNotFound(error)) return false
-    throw error
-  }
+export function exists(root: WorkspaceRootInput, segments: string[]): Promise<boolean> {
+  return wrap('exists', () => backendOf(root).exists(segments))
 }

--- a/src/infrastructure/storage/workspace-fs/media-source.ts
+++ b/src/infrastructure/storage/workspace-fs/media-source.ts
@@ -17,7 +17,7 @@
 import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
-import { listDirectory, readBlob, writeBlob } from './fs-primitives'
+import { listDirectory, readBlob, writeBlob, type WorkspaceRootInput } from './fs-primitives'
 import { mediaDir, mediaSourceByFileName } from './paths'
 
 const logger = createLogger('WorkspaceFS:MediaSource')
@@ -38,7 +38,7 @@ const NON_SOURCE_NAMES = new Set([
  * the new real-filename layout and the legacy `source.{ext}` layout.
  */
 async function findSourceSegments(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
 ): Promise<string[] | null> {
   const entries = await listDirectory(root, mediaDir(mediaId))
@@ -71,6 +71,37 @@ export async function hasMediaSource(mediaId: string): Promise<boolean> {
   const root = requireWorkspaceRoot()
   const segments = await findSourceSegments(root, mediaId)
   return segments !== null
+}
+
+/**
+ * Return a range-capable URL for Electron-backed workspace media.
+ * Standard File System Access callers keep using lazy File blobs.
+ */
+export async function getMediaSourceReadUrl(mediaId: string): Promise<string | null> {
+  const root = requireWorkspaceRoot()
+  if (root.kind !== 'electron-directory') return null
+  const segments = await findSourceSegments(root, mediaId)
+  if (!segments) return null
+  return (await root.getReadUrl(segments)).url
+}
+
+export async function getCopiedMediaReadUrl(stagedPath: readonly string[]): Promise<string> {
+  return (await requireWorkspaceRoot().getReadUrl(stagedPath)).url
+}
+
+/**
+ * Move a file that the Electron bridge already copied into this workspace
+ * into its final media directory. The bytes never cross the renderer process.
+ */
+export async function adoptCopiedMediaSource(
+  stagedPath: readonly string[],
+  mediaId: string,
+  fileName: string,
+): Promise<void> {
+  const root = requireWorkspaceRoot()
+  const targetPath = mediaSourceByFileName(mediaId, fileName)
+  await root.createDirectory(mediaDir(mediaId))
+  await root.move(stagedPath, targetPath)
 }
 
 /**

--- a/src/infrastructure/storage/workspace-fs/media-source.ts
+++ b/src/infrastructure/storage/workspace-fs/media-source.ts
@@ -15,6 +15,7 @@
  */
 
 import { createLogger } from '@/shared/logging/logger'
+import type { LocalReadUrl } from '@/infrastructure/storage/local-directory/types'
 
 import { requireWorkspaceRoot } from './root'
 import { listDirectory, readBlob, writeBlob, type WorkspaceRootInput } from './fs-primitives'
@@ -77,16 +78,16 @@ export async function hasMediaSource(mediaId: string): Promise<boolean> {
  * Return a range-capable URL for Electron-backed workspace media.
  * Standard File System Access callers keep using lazy File blobs.
  */
-export async function getMediaSourceReadUrl(mediaId: string): Promise<string | null> {
+export async function getMediaSourceReadUrl(mediaId: string): Promise<LocalReadUrl | null> {
   const root = requireWorkspaceRoot()
   if (root.kind !== 'electron-directory') return null
   const segments = await findSourceSegments(root, mediaId)
   if (!segments) return null
-  return (await root.getReadUrl(segments)).url
+  return root.getReadUrl(segments)
 }
 
-export async function getCopiedMediaReadUrl(stagedPath: readonly string[]): Promise<string> {
-  return (await requireWorkspaceRoot().getReadUrl(stagedPath)).url
+export async function getCopiedMediaReadUrl(stagedPath: readonly string[]): Promise<LocalReadUrl> {
+  return requireWorkspaceRoot().getReadUrl(stagedPath)
 }
 
 /**

--- a/src/infrastructure/storage/workspace-fs/media.ts
+++ b/src/infrastructure/storage/workspace-fs/media.ts
@@ -19,6 +19,7 @@ import {
   removeEntry,
   writeJsonAtomic,
   WorkspaceFileCorruptError,
+  type WorkspaceRootInput,
 } from './fs-primitives'
 import { MEDIA_DIR, mediaDir, mediaMetadataPath } from './paths'
 
@@ -132,7 +133,7 @@ type MediaReadResult =
   | { kind: 'error'; error: unknown }
 
 async function readAllSerializedMedia(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   context: string,
 ): Promise<SerializedMedia[]> {
   const dirs = await listDirectory(root, [MEDIA_DIR])

--- a/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
+++ b/src/infrastructure/storage/workspace-fs/migrate-workspace-v2.ts
@@ -44,6 +44,7 @@ import {
   removeEntry,
   writeBlob,
   writeJsonAtomic,
+  type WorkspaceRootInput,
 } from './fs-primitives'
 import { withKeyLock } from './with-key-lock'
 import type { WorkspaceMarker } from './bootstrap'
@@ -76,9 +77,7 @@ export interface MigrationReport {
  * marker already claims v2 or is missing (fresh workspace will get a v2
  * marker written by bootstrap).
  */
-export async function migrateWorkspaceV2(
-  root: FileSystemDirectoryHandle,
-): Promise<MigrationReport> {
+export async function migrateWorkspaceV2(root: WorkspaceRootInput): Promise<MigrationReport> {
   const start = performance.now()
   const report: MigrationReport = {
     ran: false,
@@ -164,7 +163,7 @@ export async function migrateWorkspaceV2(
   return report
 }
 
-async function collectProjectIds(root: FileSystemDirectoryHandle): Promise<Set<string>> {
+async function collectProjectIds(root: WorkspaceRootInput): Promise<Set<string>> {
   const entries = await listDirectory(root, [PROJECTS_DIR])
   const ids = new Set<string>()
   for (const entry of entries) {
@@ -175,10 +174,7 @@ async function collectProjectIds(root: FileSystemDirectoryHandle): Promise<Set<s
 
 /* ──────────────────────────── filmstrips ─────────────────────────────── */
 
-async function migrateFilmstrips(
-  root: FileSystemDirectoryHandle,
-  errors: string[],
-): Promise<number> {
+async function migrateFilmstrips(root: WorkspaceRootInput, errors: string[]): Promise<number> {
   const entries = await listDirectory(root, [LEGACY_FILMSTRIPS_DIR])
   let migrated = 0
   for (const entry of entries) {
@@ -208,10 +204,7 @@ async function migrateFilmstrips(
 
 /* ──────────────────────────── waveform-bin ───────────────────────────── */
 
-async function migrateWaveformBins(
-  root: FileSystemDirectoryHandle,
-  errors: string[],
-): Promise<number> {
+async function migrateWaveformBins(root: WorkspaceRootInput, errors: string[]): Promise<number> {
   const entries = await listDirectory(root, [LEGACY_WAVEFORM_BIN_DIR])
   let migrated = 0
   for (const entry of entries) {
@@ -241,10 +234,7 @@ async function migrateWaveformBins(
  * Legacy layout is two-level sharded: `preview-audio/<hex2>/<hex2>/<mediaId>.wav`.
  * Walk the shards and pull every `.wav` up to `media/<id>/cache/preview-audio.wav`.
  */
-async function migratePreviewAudio(
-  root: FileSystemDirectoryHandle,
-  errors: string[],
-): Promise<number> {
+async function migratePreviewAudio(root: WorkspaceRootInput, errors: string[]): Promise<number> {
   const shard1Entries = await listDirectory(root, [LEGACY_PREVIEW_AUDIO_DIR])
   let migrated = 0
   for (const shard1 of shard1Entries) {
@@ -285,7 +275,7 @@ async function migratePreviewAudio(
 
 /* ──────────────────────────── proxies ────────────────────────────────── */
 
-async function migrateProxies(root: FileSystemDirectoryHandle, errors: string[]): Promise<number> {
+async function migrateProxies(root: WorkspaceRootInput, errors: string[]): Promise<number> {
   const entries = await listDirectory(root, [LEGACY_PROXIES_DIR])
   let migrated = 0
   for (const entry of entries) {
@@ -316,7 +306,7 @@ async function migrateProxies(root: FileSystemDirectoryHandle, errors: string[])
 /* ──────────────────────────── thumbnail.meta sidecars ────────────────── */
 
 async function dropThumbnailMetaSidecars(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   errors: string[],
 ): Promise<number> {
   const entries = await listDirectory(root, [MEDIA_DIR])
@@ -348,7 +338,7 @@ async function dropThumbnailMetaSidecars(
  * with a project id.
  */
 async function fixProjectThumbnailContamination(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   knownProjectIds: Set<string>,
   errors: string[],
 ): Promise<number> {
@@ -397,17 +387,11 @@ async function fixProjectThumbnailContamination(
 
 /* ──────────────────────────── helpers ────────────────────────────────── */
 
-async function removeTopLevelDirIfEmpty(
-  root: FileSystemDirectoryHandle,
-  dir: string,
-): Promise<void> {
+async function removeTopLevelDirIfEmpty(root: WorkspaceRootInput, dir: string): Promise<void> {
   await removeDirIfEmpty(root, [dir])
 }
 
-async function removeDirIfEmpty(
-  root: FileSystemDirectoryHandle,
-  segments: string[],
-): Promise<void> {
+async function removeDirIfEmpty(root: WorkspaceRootInput, segments: string[]): Promise<void> {
   const entries = await listDirectory(root, segments)
   if (entries.length > 0) return
   try {

--- a/src/infrastructure/storage/workspace-fs/orphan-sweep.ts
+++ b/src/infrastructure/storage/workspace-fs/orphan-sweep.ts
@@ -24,7 +24,7 @@
 
 import { createLogger } from '@/shared/logging/logger'
 import { requireWorkspaceRoot } from './root'
-import { listDirectory } from './fs-primitives'
+import { listDirectory, type WorkspaceRootInput } from './fs-primitives'
 import { MEDIA_DIR } from './paths'
 
 const logger = createLogger('WorkspaceFS:OrphanSweep')
@@ -42,7 +42,7 @@ export interface OrphanSweepOptions {
   dryRun?: boolean
 }
 
-async function countLiveMedia(root: FileSystemDirectoryHandle): Promise<number> {
+async function countLiveMedia(root: WorkspaceRootInput): Promise<number> {
   const entries = await listDirectory(root, [MEDIA_DIR])
   return entries.filter((e) => e.kind === 'directory').length
 }

--- a/src/infrastructure/storage/workspace-fs/paths.ts
+++ b/src/infrastructure/storage/workspace-fs/paths.ts
@@ -89,7 +89,7 @@ const PROJECT_ANIMATION_PRESETS_FILENAME = 'animation-presets.json'
 const PROJECT_TRASHED_MARKER_FILENAME = '.freecut-trashed.json'
 
 const MEDIA_METADATA_FILENAME = 'metadata.json'
-export const MEDIA_THUMBNAIL_FILENAME = 'thumbnail.jpg'
+const MEDIA_THUMBNAIL_FILENAME = 'thumbnail.jpg'
 const MEDIA_CACHE_DIR = 'cache'
 
 const CACHE_WAVEFORM_DIR = 'waveform'

--- a/src/infrastructure/storage/workspace-fs/project-media.ts
+++ b/src/infrastructure/storage/workspace-fs/project-media.ts
@@ -18,7 +18,7 @@ import type { MediaMetadata } from '@/types/storage'
 import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
-import { readJson, writeJsonAtomic } from './fs-primitives'
+import { readJson, writeJsonAtomic, type WorkspaceRootInput } from './fs-primitives'
 import { projectMediaLinksPath, PROJECTS_DIR } from './paths'
 import { listDirectory } from './fs-primitives'
 import { getProject } from './projects'
@@ -65,17 +65,14 @@ interface ProjectMediaLinks {
   mediaIds: LinkEntry[]
 }
 
-async function readLinks(
-  root: FileSystemDirectoryHandle,
-  projectId: string,
-): Promise<ProjectMediaLinks> {
+async function readLinks(root: WorkspaceRootInput, projectId: string): Promise<ProjectMediaLinks> {
   const existing = await readJson<ProjectMediaLinks>(root, projectMediaLinksPath(projectId))
   if (existing && Array.isArray(existing.mediaIds)) return existing
   return { version: LINKS_VERSION, mediaIds: [] }
 }
 
 async function writeLinks(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   projectId: string,
   links: ProjectMediaLinks,
 ): Promise<void> {

--- a/src/infrastructure/storage/workspace-fs/projects.ts
+++ b/src/infrastructure/storage/workspace-fs/projects.ts
@@ -22,6 +22,7 @@ import {
   removeEntry,
   writeJsonAtomic,
   WorkspaceFileCorruptError,
+  type WorkspaceRootInput,
 } from './fs-primitives'
 import { PROJECTS_DIR, projectDir, projectJsonPath, projectTrashedMarkerPath } from './paths'
 import { describeStorageEnvironment } from './storage-environment'
@@ -81,11 +82,11 @@ async function restoreRootFolderHandle(serialized: SerializedProject): Promise<P
   return serialized as Project
 }
 
-async function isTrashed(root: FileSystemDirectoryHandle, id: string): Promise<boolean> {
+async function isTrashed(root: WorkspaceRootInput, id: string): Promise<boolean> {
   return exists(root, projectTrashedMarkerPath(id))
 }
 
-async function rebuildIndex(root: FileSystemDirectoryHandle): Promise<WorkspaceIndexEntry[]> {
+async function rebuildIndex(root: WorkspaceRootInput): Promise<WorkspaceIndexEntry[]> {
   const entries = await listDirectory(root, [PROJECTS_DIR])
   const indexEntries: WorkspaceIndexEntry[] = []
   for (const entry of entries) {
@@ -125,7 +126,7 @@ async function rebuildIndex(root: FileSystemDirectoryHandle): Promise<WorkspaceI
  *    instead of failing the whole load.
  */
 async function refreshIndex(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   persist: 'required' | 'best-effort' = 'required',
 ): Promise<WorkspaceIndexEntry[]> {
   return withKeyLock(INDEX_LOCK_KEY, async () => {
@@ -158,7 +159,7 @@ async function refreshIndex(
  * entries. On the common warm path the index is non-empty and this stays O(1).
  */
 async function upsertIndexEntry(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   entry: WorkspaceIndexEntry,
 ): Promise<void> {
   await withKeyLock(INDEX_LOCK_KEY, async () => {

--- a/src/infrastructure/storage/workspace-fs/root.ts
+++ b/src/infrastructure/storage/workspace-fs/root.ts
@@ -1,34 +1,37 @@
 /**
  * Active workspace root owner.
  *
- * Holds the single FileSystemDirectoryHandle the entire app writes to.
- * `setWorkspaceRoot` is called once by WorkspaceGate after the user picks
- * (or re-grants) their workspace folder. Every storage module calls
- * `requireWorkspaceRoot()` to get the handle.
+ * Holds the active local-directory backend the app writes to.
+ * The backend is either the standard File System Access API or the generic
+ * Electron local-directory bridge.
  *
  * Kept deliberately minimal — no React, no Zustand. This is the lowest
  * layer: pure getter/setter + permission-lost signaling.
  */
 
 import { createLogger } from '@/shared/logging/logger'
+import { FileSystemAccessDirectoryBackend } from '@/infrastructure/storage/local-directory/file-system-access-backend'
+import type { LocalDirectoryBackend } from '@/infrastructure/storage/local-directory/types'
 
 const logger = createLogger('WorkspaceRoot')
 
-let activeRoot: FileSystemDirectoryHandle | null = null
+let activeRoot: LocalDirectoryBackend | null = null
 
 type PermissionLostListener = () => void
 const permissionLostListeners = new Set<PermissionLostListener>()
 
-export function setWorkspaceRoot(handle: FileSystemDirectoryHandle | null): void {
-  activeRoot = handle
-  if (handle) {
-    logger.info(`Workspace root set: ${handle.name}`)
+export function setWorkspaceRoot(
+  root: FileSystemDirectoryHandle | LocalDirectoryBackend | null,
+): void {
+  activeRoot = root ? toBackend(root) : null
+  if (activeRoot) {
+    logger.info(`Workspace root set: ${activeRoot.name}`, { backend: activeRoot.kind })
   } else {
     logger.info('Workspace root cleared')
   }
 }
 
-export function getWorkspaceRoot(): FileSystemDirectoryHandle | null {
+export function getWorkspaceRoot(): LocalDirectoryBackend | null {
   return activeRoot
 }
 
@@ -37,13 +40,27 @@ export function getWorkspaceRoot(): FileSystemDirectoryHandle | null {
  * Throwing is correct: if WorkspaceGate did its job, a storage op can
  * never run without an active root.
  */
-export function requireWorkspaceRoot(): FileSystemDirectoryHandle {
+export function requireWorkspaceRoot(): LocalDirectoryBackend {
   if (!activeRoot) {
     throw new Error(
       'Workspace root is not set. The app must render <WorkspaceGate> before any storage operation runs.',
     )
   }
   return activeRoot
+}
+
+function toBackend(root: FileSystemDirectoryHandle | LocalDirectoryBackend): LocalDirectoryBackend {
+  if (isLocalDirectoryBackend(root)) {
+    return root
+  }
+  return new FileSystemAccessDirectoryBackend(root)
+}
+
+function isLocalDirectoryBackend(
+  root: FileSystemDirectoryHandle | LocalDirectoryBackend,
+): root is LocalDirectoryBackend {
+  const kind = (root as { kind?: unknown }).kind
+  return kind === 'file-system-access' || kind === 'electron-directory'
 }
 
 /**

--- a/src/infrastructure/storage/workspace-fs/thumbnails.ts
+++ b/src/infrastructure/storage/workspace-fs/thumbnails.ts
@@ -23,12 +23,7 @@ import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
 import { readBlob, removeEntry, writeBlob } from './fs-primitives'
-import {
-  MEDIA_DIR,
-  MEDIA_THUMBNAIL_FILENAME,
-  mediaThumbnailPath,
-  projectThumbnailPath,
-} from './paths'
+import { mediaThumbnailPath, projectThumbnailPath } from './paths'
 import { blobToArrayBuffer } from './blob-utils'
 import { mapWithConcurrency } from '@/shared/utils/async-utils'
 
@@ -91,25 +86,13 @@ export async function getThumbnailsByMediaIds(mediaIds: string[]): Promise<Map<s
   const result = new Map<string, Blob>()
   if (mediaIds.length === 0) return result
 
-  const root = requireWorkspaceRoot()
-  let mediaDirHandle: FileSystemDirectoryHandle
-  try {
-    mediaDirHandle = await root.getDirectoryHandle(MEDIA_DIR, { create: false })
-  } catch (error) {
-    // No media/ directory yet — nothing to prefetch.
-    if (error instanceof DOMException && error.name === 'NotFoundError') return result
-    logger.warn('getThumbnailsByMediaIds: failed to open media directory', error)
-    return result
-  }
-
   const reads = await mapWithConcurrency(
     mediaIds,
     THUMBNAIL_READ_CONCURRENCY,
     async (mediaId): Promise<{ mediaId: string; blob: Blob } | null> => {
       try {
-        const dir = await mediaDirHandle.getDirectoryHandle(mediaId, { create: false })
-        const fileHandle = await dir.getFileHandle(MEDIA_THUMBNAIL_FILENAME, { create: false })
-        return { mediaId, blob: await fileHandle.getFile() }
+        const blob = await readBlob(requireWorkspaceRoot(), mediaThumbnailPath(mediaId))
+        return blob ? { mediaId, blob } : null
       } catch (error) {
         // A media dir without a thumbnail (or removed mid-read) is expected — skip.
         if (error instanceof DOMException && error.name === 'NotFoundError') return null

--- a/src/infrastructure/storage/workspace-fs/trash.ts
+++ b/src/infrastructure/storage/workspace-fs/trash.ts
@@ -34,6 +34,7 @@ import {
   readJson,
   writeJsonAtomic,
   WorkspaceFileCorruptError,
+  type WorkspaceRootInput,
 } from './fs-primitives'
 import { PROJECTS_DIR, projectJsonPath, projectTrashedMarkerPath } from './paths'
 import { writeWorkspaceIndex, type WorkspaceIndexEntry } from './workspace-index'
@@ -64,14 +65,11 @@ export interface TrashedProjectEntry {
 
 /* ────────────────────────────── Helpers ────────────────────────────── */
 
-async function readMarker(
-  root: FileSystemDirectoryHandle,
-  id: string,
-): Promise<TrashMarker | null> {
+async function readMarker(root: WorkspaceRootInput, id: string): Promise<TrashMarker | null> {
   return readJson<TrashMarker>(root, projectTrashedMarkerPath(id))
 }
 
-async function markerExists(root: FileSystemDirectoryHandle, id: string): Promise<boolean> {
+async function markerExists(root: WorkspaceRootInput, id: string): Promise<boolean> {
   return exists(root, projectTrashedMarkerPath(id))
 }
 
@@ -80,7 +78,7 @@ async function markerExists(root: FileSystemDirectoryHandle, id: string): Promis
  * Used by soft-delete and restore to keep the index in sync without
  * touching live-project code paths.
  */
-async function rebuildAndWriteIndex(root: FileSystemDirectoryHandle): Promise<void> {
+async function rebuildAndWriteIndex(root: WorkspaceRootInput): Promise<void> {
   const entries = await listDirectory(root, [PROJECTS_DIR])
   const indexEntries: WorkspaceIndexEntry[] = []
   for (const entry of entries) {

--- a/src/infrastructure/storage/workspace-fs/waveforms.ts
+++ b/src/infrastructure/storage/workspace-fs/waveforms.ts
@@ -19,7 +19,14 @@ import type { WaveformBin, WaveformData, WaveformMeta, WaveformRecord } from '@/
 import { createLogger } from '@/shared/logging/logger'
 
 import { requireWorkspaceRoot } from './root'
-import { readArrayBuffer, readJson, removeEntry, writeBlob, writeJsonAtomic } from './fs-primitives'
+import {
+  readArrayBuffer,
+  readJson,
+  removeEntry,
+  writeBlob,
+  writeJsonAtomic,
+  type WorkspaceRootInput,
+} from './fs-primitives'
 import { waveformDir, waveformBinPath } from './paths'
 
 const logger = createLogger('WorkspaceFS:Waveforms')
@@ -61,7 +68,7 @@ type StoredMeta = WaveformMeta
 type StoredBinMeta = Omit<WaveformBin, 'peaks'>
 
 async function readLegacy(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
 ): Promise<WaveformData | undefined> {
   const meta = await readJson<StoredLegacy>(root, waveformLegacyPath(mediaId))
@@ -72,7 +79,7 @@ async function readLegacy(
 }
 
 async function readMeta(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
 ): Promise<WaveformMeta | undefined> {
   const meta = await readJson<StoredMeta>(root, waveformMetaPath(mediaId))
@@ -80,7 +87,7 @@ async function readMeta(
 }
 
 async function readBin(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   mediaId: string,
   binIndex: number,
 ): Promise<WaveformBin | undefined> {

--- a/src/infrastructure/storage/workspace-fs/workspace-index.ts
+++ b/src/infrastructure/storage/workspace-fs/workspace-index.ts
@@ -8,7 +8,12 @@
 
 import { createLogger } from '@/shared/logging/logger'
 import { INDEX_FILENAME } from './paths'
-import { readJson, writeJsonAtomic, WorkspaceFileCorruptError } from './fs-primitives'
+import {
+  readJson,
+  writeJsonAtomic,
+  WorkspaceFileCorruptError,
+  type WorkspaceRootInput,
+} from './fs-primitives'
 
 const INDEX_VERSION = '1.0'
 
@@ -26,7 +31,7 @@ export interface WorkspaceIndex {
   projects: WorkspaceIndexEntry[]
 }
 
-export async function readWorkspaceIndex(root: FileSystemDirectoryHandle): Promise<WorkspaceIndex> {
+export async function readWorkspaceIndex(root: WorkspaceRootInput): Promise<WorkspaceIndex> {
   let existing: WorkspaceIndex | null = null
   try {
     existing = await readJson<WorkspaceIndex>(root, [INDEX_FILENAME])
@@ -48,7 +53,7 @@ export function sortIndexEntries(entries: WorkspaceIndexEntry[]): WorkspaceIndex
 }
 
 export async function writeWorkspaceIndex(
-  root: FileSystemDirectoryHandle,
+  root: WorkspaceRootInput,
   entries: WorkspaceIndexEntry[],
 ): Promise<void> {
   const index: WorkspaceIndex = {

--- a/src/types/file-system-access.d.ts
+++ b/src/types/file-system-access.d.ts
@@ -121,6 +121,10 @@ interface FileSystemDirectoryHandle {
   [Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]>
 }
 
+interface Window {
+  electronLocalDirectory?: import('@/infrastructure/storage/local-directory/types').ElectronLocalDirectoryBridge
+}
+
 /**
  * Extends DataTransferItem to support getAsFileSystemHandle()
  * Only supported in Chrome/Edge 86+


### PR DESCRIPTION
## 变更内容

- 抽象统一的 `LocalDirectoryBackend`，保留标准 File System Access API 路径。
- 增加受控的 Electron 本地目录 Bridge，支持授权恢复、原子写入、目录操作和媒体选择复制。
- 让工作区存储、迁移、缩略图、波形和媒体源读写同时适配浏览器与 Electron 内置浏览器。
- 支持 Electron 主进程已复制媒体通过可读取 URL 进行探测和导入，避免大文件整体穿过 IPC。

## 目的

让 FreeCut 可在 Codex 等 Electron 生态的内置浏览器中打开本地目录工作区，同时保持普通 Chromium 浏览器行为不变。本 PR 不包含项目实时同步编辑器逻辑。

## 验证

- `npm run check`：0 errors，1 个既有 Fast Refresh warning。
- 本地目录选择与媒体服务定向测试：50 tests passed。
- `npm run build` 通过。
- feature boundaries、deps contracts、legacy imports、wrapper health、unused exports、unused class members 均通过。

## 已知门禁

- `changed-health` 会把通过接口动态调用的后端类方法计为新增未使用，并报告部分复杂度/重复片段；项目专用 unused-class-members 门禁已通过。
- `origin/develop` 当前 editor → timeline 实际导入数为 74，但预算仍为 73；该差异并非本 PR 引入，因此未在此 PR 混入无关预算调整。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Electron/local “copied into workspace” media import with de-duplication and staged-asset adoption.
  * Media processing now supports URL-based inputs (metadata + thumbnails).
  * Enhanced local directory backend selection, including Electron directory activation/pick/reconnect and improved file picker support detection.
* **Bug Fixes**
  * Improved recovery for interrupted atomic workspace writes and temp journal handling.
  * External media URLs with expiry are now automatically evicted/renewed.
  * Better handling for duplicates, missing staged sources, unsupported codecs, and thumbnail loading/rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->