### PR TITLE
Fix timeline navigator live zoom synchronization

### DIFF
--- a/src/features/timeline/components/timeline-header.test.tsx
+++ b/src/features/timeline/components/timeline-header.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { ZOOM_MAX, ZOOM_MIN } from '../constants'
+import { useZoomStore } from '../stores/zoom-store'
+import { TimelineHeader } from './timeline-header'
+
+const { micRenderSpy } = vi.hoisted(() => ({ micRenderSpy: vi.fn() }))
+
+vi.mock('@/components/ui/slider', async () => {
+  const { forwardRef } = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    Slider: forwardRef<
+      HTMLSpanElement,
+      {
+        value?: number[]
+        onValueChange?: (value: number[]) => void
+        onValueCommit?: (value: number[]) => void
+      }
+    >(function MockSlider({ value, onValueChange, onValueCommit }, ref) {
+      return (
+        <span ref={ref} data-testid="zoom-slider" data-value={value?.[0]}>
+          <span>
+            <span data-testid="zoom-slider-range" />
+          </span>
+          <span data-testid="zoom-slider-thumb-positioner">
+            <button
+              type="button"
+              role="slider"
+              aria-valuenow={value?.[0]}
+              onMouseDown={() => onValueChange?.([0.75])}
+              onMouseUp={() => onValueCommit?.([0.75])}
+            />
+          </span>
+        </span>
+      )
+    }),
+  }
+})
+
+vi.mock('./mic-record-control', () => ({
+  MicRecordControl: () => {
+    micRenderSpy()
+    return null
+  },
+}))
+
+describe('TimelineHeader zoom slider', () => {
+  beforeEach(() => {
+    micRenderSpy.mockClear()
+    useZoomStore.getState().setZoomLevelSynchronized(1)
+  })
+
+  it('previews pointer input immediately and commits without slider-only momentum', () => {
+    const animationFrameSpy = vi.spyOn(window, 'requestAnimationFrame')
+    const onZoomChange = vi.fn()
+    const targetZoom = ZOOM_MIN * Math.pow(ZOOM_MAX / ZOOM_MIN, 0.75)
+
+    render(<TimelineHeader onZoomChange={onZoomChange} />)
+    expect(micRenderSpy).toHaveBeenCalledTimes(1)
+
+    const slider = screen.getByTestId('zoom-slider')
+    fireEvent.mouseDown(screen.getByRole('slider'))
+
+    expect(screen.getByTestId('zoom-slider-thumb-positioner').style.left).toBe('calc(75% - 4px)')
+    expect(screen.getByTestId('zoom-slider-range').style.right).toBe('25%')
+    expect(onZoomChange).toHaveBeenLastCalledWith(targetZoom)
+    expect(animationFrameSpy).not.toHaveBeenCalled()
+    expect(micRenderSpy).toHaveBeenCalledTimes(1)
+    expect(useZoomStore.getState().level).toBe(1)
+
+    fireEvent.mouseUp(screen.getByRole('slider'))
+
+    expect(onZoomChange).toHaveBeenCalledTimes(1)
+    expect(onZoomChange).toHaveBeenLastCalledWith(targetZoom)
+    expect(animationFrameSpy).not.toHaveBeenCalled()
+
+    act(() => useZoomStore.getState().setZoomLevelImmediate(targetZoom))
+    expect(Number(slider.dataset.value)).toBeCloseTo(0.75)
+    expect(micRenderSpy).toHaveBeenCalledTimes(1)
+
+    animationFrameSpy.mockRestore()
+  })
+})

--- a/src/features/timeline/components/timeline-header.tsx
+++ b/src/features/timeline/components/timeline-header.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, memo } from 'react'
+import { useEffect, useCallback, memo, useLayoutEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import {
@@ -36,13 +36,7 @@ import { useTimelineCommandStore } from '../stores/timeline-command-store'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { useEditorStore } from '@/shared/state/editor'
 import { useSelectionStore } from '@/shared/state/selection'
-import {
-  ZOOM_FRICTION,
-  ZOOM_MIN_VELOCITY,
-  ZOOM_MIN,
-  ZOOM_MAX,
-  SLIP_SLIDE_TOOLS_ENABLED,
-} from '../constants'
+import { ZOOM_MIN, ZOOM_MAX, SLIP_SLIDE_TOOLS_ENABLED } from '../constants'
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/config/editor-layout'
 import { useResolvedHotkeys } from '@/features/timeline/deps/settings'
 import { MicRecordControl } from './mic-record-control'
@@ -64,6 +58,202 @@ function TrimEditIcon({ className }: { className?: string }) {
   )
 }
 
+function isDifferentSliderValue(previousValue: number | null, nextValue: number): boolean {
+  return previousValue === null || Math.abs(previousValue - nextValue) > 0.000001
+}
+
+function blurActiveElement(): void {
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur()
+  }
+}
+
+const TimelineZoomControls = memo(function TimelineZoomControls({
+  onZoomChange,
+  onZoomIn,
+  onZoomOut,
+  onZoomToFit,
+}: TimelineHeaderProps) {
+  const { t } = useTranslation()
+  const { zoomLevel, zoomIn, zoomOut, setZoomImmediate } = useTimelineZoom()
+  const sliderRef = useRef<HTMLSpanElement>(null)
+  const sliderRafRef = useRef<number | null>(null)
+  const pendingSliderValueRef = useRef<number | null>(null)
+  const latestSliderValueRef = useRef<number | null>(null)
+  const btnSize = {
+    width: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
+    height: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
+  } as const
+
+  const applyZoom = useCallback(
+    (newZoom: number) => {
+      const clampedZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, newZoom))
+      if (onZoomChange) {
+        onZoomChange(clampedZoom)
+      } else {
+        setZoomImmediate(clampedZoom)
+      }
+    },
+    [onZoomChange, setZoomImmediate],
+  )
+
+  const sliderToZoom = useCallback(
+    (sliderValue: number) => ZOOM_MIN * Math.pow(ZOOM_MAX / ZOOM_MIN, sliderValue),
+    [],
+  )
+
+  const zoomToSlider = useCallback(
+    (zoom: number) => Math.log(zoom / ZOOM_MIN) / Math.log(ZOOM_MAX / ZOOM_MIN),
+    [],
+  )
+
+  const renderSliderPreview = useCallback((sliderValue: number) => {
+    const root = sliderRef.current
+    const thumb = root?.querySelector<HTMLElement>('[role="slider"]')
+    const thumbPositioner = thumb?.parentElement
+    const track = root?.firstElementChild as HTMLElement | null
+    const range = track?.firstElementChild as HTMLElement | null
+    if (!thumb || !thumbPositioner || !range) return
+
+    const value = Math.max(0, Math.min(1, sliderValue))
+    const percentage = value * 100
+    const thumbOffset = 8 - value * 16
+    thumbPositioner.style.left = `calc(${percentage}% + ${thumbOffset}px)`
+    range.style.left = '0%'
+    range.style.right = `${100 - percentage}%`
+    thumb.setAttribute('aria-valuenow', String(value))
+  }, [])
+
+  const flushSliderChange = useCallback(() => {
+    sliderRafRef.current = null
+    const sliderValue = pendingSliderValueRef.current
+    pendingSliderValueRef.current = null
+    if (sliderValue === null) return
+    applyZoom(sliderToZoom(sliderValue))
+  }, [applyZoom, sliderToZoom])
+
+  useLayoutEffect(() => {
+    const sliderPreviewValue = latestSliderValueRef.current
+    if (sliderPreviewValue === null) return
+    const previewZoom = sliderToZoom(sliderPreviewValue)
+    const tolerance = Math.max(0.000001, previewZoom * 0.0001)
+    if (Math.abs(zoomLevel - previewZoom) <= tolerance) {
+      latestSliderValueRef.current = null
+    }
+  }, [sliderToZoom, zoomLevel])
+
+  useEffect(() => {
+    return () => {
+      if (sliderRafRef.current !== null) {
+        cancelAnimationFrame(sliderRafRef.current)
+      }
+    }
+  }, [])
+
+  const handleSliderChange = useCallback(
+    (values: number[]) => {
+      const sliderValue = values[0] ?? 0.5
+      latestSliderValueRef.current = sliderValue
+      renderSliderPreview(sliderValue)
+      if (onZoomChange) {
+        applyZoom(sliderToZoom(sliderValue))
+        return
+      }
+
+      pendingSliderValueRef.current = sliderValue
+      if (sliderRafRef.current === null) {
+        sliderRafRef.current = requestAnimationFrame(flushSliderChange)
+      }
+    },
+    [applyZoom, flushSliderChange, onZoomChange, renderSliderPreview, sliderToZoom],
+  )
+
+  const commitSliderZoom = useCallback(
+    (sliderValue: number, previousSliderValue: number | null) => {
+      if (onZoomChange) {
+        if (isDifferentSliderValue(previousSliderValue, sliderValue)) {
+          applyZoom(sliderToZoom(sliderValue))
+        }
+        return
+      }
+
+      if (
+        pendingSliderValueRef.current === null &&
+        isDifferentSliderValue(previousSliderValue, sliderValue)
+      ) {
+        pendingSliderValueRef.current = sliderValue
+      }
+      if (sliderRafRef.current !== null) {
+        cancelAnimationFrame(sliderRafRef.current)
+        sliderRafRef.current = null
+      }
+      flushSliderChange()
+    },
+    [applyZoom, flushSliderChange, onZoomChange, sliderToZoom],
+  )
+
+  const handleSliderCommit = useCallback(
+    (values: number[]) => {
+      const sliderValue = values[0] ?? 0.5
+      const latestSliderValue = latestSliderValueRef.current
+      latestSliderValueRef.current = sliderValue
+      renderSliderPreview(sliderValue)
+      commitSliderZoom(sliderValue, latestSliderValue)
+      blurActiveElement()
+    },
+    [commitSliderZoom, renderSliderPreview],
+  )
+
+  return (
+    <div className="flex items-center justify-end gap-1.5">
+      <Button
+        variant="ghost"
+        size="icon"
+        style={btnSize}
+        onClick={onZoomOut ?? zoomOut}
+        aria-label={t('timeline.header.zoomOut')}
+        data-tooltip={t('timeline.header.zoomOutTooltip')}
+      >
+        <ZoomOut className="w-3.5 h-3.5" />
+      </Button>
+
+      <Slider
+        ref={sliderRef}
+        value={[latestSliderValueRef.current ?? zoomToSlider(zoomLevel)]}
+        onValueChange={handleSliderChange}
+        onValueCommit={handleSliderCommit}
+        min={0}
+        max={1}
+        step={0.005}
+        className="w-24"
+        aria-label={t('timeline.header.zoomSlider')}
+      />
+
+      <Button
+        variant="ghost"
+        size="icon"
+        style={btnSize}
+        onClick={onZoomIn ?? zoomIn}
+        aria-label={t('timeline.header.zoomIn')}
+        data-tooltip={t('timeline.header.zoomInTooltip')}
+      >
+        <ZoomIn className="w-3.5 h-3.5" />
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        style={btnSize}
+        onClick={onZoomToFit}
+        aria-label={t('timeline.header.zoomToFit')}
+        data-tooltip={t('timeline.header.zoomToFitTooltip')}
+      >
+        <Maximize2 className="w-3.5 h-3.5" />
+      </Button>
+    </div>
+  )
+})
+
 /**
  * Timeline Toolbar Component
  *
@@ -81,7 +271,6 @@ export const TimelineHeader = memo(function TimelineHeader({
 }: TimelineHeaderProps) {
   const { t } = useTranslation()
   const hotkeys = useResolvedHotkeys()
-  const { zoomLevel, zoomIn, zoomOut, setZoomImmediate } = useTimelineZoom()
   const snapEnabled = useTimelineStore((s) => s.snapEnabled)
   const toggleSnap = useTimelineStore((s) => s.toggleSnap)
   const audioSkimmingEnabled = useTimelineStore((s) => s.audioSkimmingEnabled)
@@ -115,121 +304,6 @@ export const TimelineHeader = memo(function TimelineHeader({
     width: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
     height: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
   } as const
-
-  // Momentum state for zoom slider
-  const zoomVelocityRef = useRef(0)
-  const lastZoomValueRef = useRef(zoomLevel)
-  const lastZoomTimeRef = useRef(0)
-  const momentumIdRef = useRef<number | null>(null)
-  const isDraggingRef = useRef(false)
-  const zoomLevelRef = useRef(zoomLevel)
-  zoomLevelRef.current = zoomLevel
-
-  // Apply zoom with bounds checking
-  const applyZoom = useCallback(
-    (newZoom: number) => {
-      const clampedZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, newZoom))
-      if (onZoomChange) {
-        onZoomChange(clampedZoom)
-      } else {
-        // Fallback when timeline-content's anchored RAF path isn't wired up
-        // (mainly tests). Use immediate so slider drag doesn't sit behind the
-        // 120ms throttle that setZoom imposes.
-        setZoomImmediate(clampedZoom)
-      }
-      return clampedZoom
-    },
-    [onZoomChange, setZoomImmediate],
-  )
-
-  // Momentum loop for zoom slider
-  const startZoomMomentum = useCallback(() => {
-    if (momentumIdRef.current !== null) {
-      cancelAnimationFrame(momentumIdRef.current)
-    }
-
-    const momentumLoop = () => {
-      if (Math.abs(zoomVelocityRef.current) > ZOOM_MIN_VELOCITY) {
-        const newZoom = zoomLevelRef.current + zoomVelocityRef.current
-        const clampedZoom = applyZoom(newZoom)
-
-        // Stop momentum if we hit bounds
-        if (clampedZoom <= ZOOM_MIN || clampedZoom >= ZOOM_MAX) {
-          zoomVelocityRef.current = 0
-          momentumIdRef.current = null
-          return
-        }
-
-        zoomVelocityRef.current *= ZOOM_FRICTION
-        momentumIdRef.current = requestAnimationFrame(momentumLoop)
-      } else {
-        zoomVelocityRef.current = 0
-        momentumIdRef.current = null
-      }
-    }
-
-    momentumIdRef.current = requestAnimationFrame(momentumLoop)
-  }, [applyZoom])
-
-  // Convert between linear slider position (0-1) and logarithmic zoom level
-  // This gives finer control at low zoom levels
-  const sliderToZoom = useCallback((sliderValue: number) => {
-    // Map 0-1 to log scale: ZOOM_MIN to ZOOM_MAX
-    // Using exponential: zoom = min * (max/min)^slider
-    return ZOOM_MIN * Math.pow(ZOOM_MAX / ZOOM_MIN, sliderValue)
-  }, [])
-
-  const zoomToSlider = useCallback((zoom: number) => {
-    // Inverse of sliderToZoom: slider = log(zoom/min) / log(max/min)
-    return Math.log(zoom / ZOOM_MIN) / Math.log(ZOOM_MAX / ZOOM_MIN)
-  }, [])
-
-  // Handle slider value change (while dragging)
-  const handleSliderChange = useCallback(
-    (values: number[]) => {
-      const sliderValue = values[0] ?? 0.5
-      const newZoom = sliderToZoom(sliderValue)
-      const now = performance.now()
-      const timeDelta = now - lastZoomTimeRef.current
-
-      // Calculate velocity based on change over time (in zoom space, not slider space)
-      if (timeDelta > 0 && timeDelta < 100) {
-        const valueDelta = newZoom - lastZoomValueRef.current
-        zoomVelocityRef.current = (valueDelta / timeDelta) * 16 // Normalize to ~60fps
-      }
-
-      lastZoomValueRef.current = newZoom
-      lastZoomTimeRef.current = now
-      isDraggingRef.current = true
-      // Downstream scheduleZoomApply (timeline-content) already RAF-coalesces
-      // writes to the zoom store, so a second RAF here would only add a frame
-      // of input latency without preventing extra work.
-      applyZoom(newZoom)
-    },
-    [applyZoom, sliderToZoom],
-  )
-
-  // Handle slider release - start momentum
-  const handleSliderCommit = useCallback(() => {
-    isDraggingRef.current = false
-    // Only start momentum if there's meaningful velocity
-    if (Math.abs(zoomVelocityRef.current) > ZOOM_MIN_VELOCITY) {
-      startZoomMomentum()
-    }
-    // Blur slider to release focus for keyboard shortcuts (play/pause)
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
-  }, [startZoomMomentum])
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (momentumIdRef.current !== null) {
-        cancelAnimationFrame(momentumIdRef.current)
-      }
-    }
-  }, [])
 
   const handleUndo = () => {
     useTimelineStore.temporal.getState().undo()
@@ -581,64 +655,12 @@ export const TimelineHeader = memo(function TimelineHeader({
         </div>
       </div>
 
-      {/* Right: Zoom Controls */}
-      <div className="flex items-center justify-end gap-1.5">
-        <Button
-          variant="ghost"
-          size="icon"
-          style={btnSize}
-          onClick={() => {
-            if (onZoomOut) {
-              onZoomOut()
-            } else {
-              zoomOut()
-            }
-          }}
-          aria-label={t('timeline.header.zoomOut')}
-          data-tooltip={t('timeline.header.zoomOutTooltip')}
-        >
-          <ZoomOut className="w-3.5 h-3.5" />
-        </Button>
-
-        <Slider
-          value={[zoomToSlider(zoomLevel)]}
-          onValueChange={handleSliderChange}
-          onValueCommit={handleSliderCommit}
-          min={0}
-          max={1}
-          step={0.005}
-          className="w-24"
-          aria-label={t('timeline.header.zoomSlider')}
-        />
-
-        <Button
-          variant="ghost"
-          size="icon"
-          style={btnSize}
-          onClick={() => {
-            if (onZoomIn) {
-              onZoomIn()
-            } else {
-              zoomIn()
-            }
-          }}
-          aria-label={t('timeline.header.zoomIn')}
-          data-tooltip={t('timeline.header.zoomInTooltip')}
-        >
-          <ZoomIn className="w-3.5 h-3.5" />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          style={btnSize}
-          onClick={onZoomToFit}
-          aria-label={t('timeline.header.zoomToFit')}
-          data-tooltip={t('timeline.header.zoomToFitTooltip')}
-        >
-          <Maximize2 className="w-3.5 h-3.5" />
-        </Button>
-      </div>
+      <TimelineZoomControls
+        onZoomChange={onZoomChange}
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
+        onZoomToFit={onZoomToFit}
+      />
     </div>
   )
 })

--- a/src/features/timeline/components/timeline-navigator.test.tsx
+++ b/src/features/timeline/components/timeline-navigator.test.tsx
@@ -156,4 +156,82 @@ describe('timeline navigator interaction', () => {
     clientWidthSpy.mockRestore()
     animationFrameSpy.mockRestore()
   })
+
+  it('rebases an active handle drag when the navigator track resizes', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const animationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    let currentTrackWidth = 400
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockImplementation(() => currentTrackWidth)
+    const scrollContainer = document.createElement('div')
+    scrollContainer.scrollLeft = 120
+
+    const { getByTestId } = render(
+      <TimelineNavigator
+        actualDuration={10}
+        timelineWidth={1240}
+        scrollContainerRef={{ current: scrollContainer }}
+      />,
+    )
+
+    const initialMetrics = getNavigatorThumbMetrics({
+      timelineWidth: 1240,
+      viewportWidth: 300,
+      trackWidth: 400,
+      scrollLeft: 120,
+    })
+    fireEvent.mouseDown(getByTestId('timeline-navigator-right-handle'), { clientX: 200 })
+    fireEvent.mouseMove(window, { clientX: 240 })
+
+    const firstDrag = getNavigatorResizeDragResult({
+      dragTarget: 'right',
+      deltaX: 40,
+      dragStartThumbLeft: initialMetrics.thumbLeft,
+      dragStartThumbWidth: initialMetrics.thumbWidth,
+      trackWidth: 400,
+      viewportWidth: 300,
+      contentDuration: 10,
+    })
+    const rebasedMetrics = getNavigatorThumbMetrics({
+      timelineWidth: firstDrag.nextTimelineWidth,
+      viewportWidth: 300,
+      trackWidth: 800,
+      scrollLeft: firstDrag.nextScrollLeft,
+    })
+
+    currentTrackWidth = 800
+    fireEvent.mouseMove(window, { clientX: 250 })
+
+    const finalDrag = getNavigatorResizeDragResult({
+      dragTarget: 'right',
+      deltaX: 10,
+      dragStartThumbLeft: rebasedMetrics.thumbLeft,
+      dragStartThumbWidth: rebasedMetrics.thumbWidth,
+      trackWidth: 800,
+      viewportWidth: 300,
+      contentDuration: 10,
+    })
+    const finalMetrics = getNavigatorThumbMetrics({
+      timelineWidth: finalDrag.nextTimelineWidth,
+      viewportWidth: 300,
+      trackWidth: 800,
+      scrollLeft: finalDrag.nextScrollLeft,
+    })
+    const thumb = getByTestId('timeline-navigator-thumb')
+    expect(Number.parseFloat(thumb.style.width)).toBeCloseTo(finalMetrics.thumbWidth)
+    expect(Number.parseFloat(thumb.style.left)).toBeCloseTo(finalMetrics.thumbLeft)
+
+    fireEvent.mouseUp(window)
+
+    expect(useZoomStore.getState().level).toBeCloseTo(finalDrag.nextZoom)
+
+    clientWidthSpy.mockRestore()
+    animationFrameSpy.mockRestore()
+  })
 })

--- a/src/features/timeline/components/timeline-navigator.test.tsx
+++ b/src/features/timeline/components/timeline-navigator.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vite-plus/test'
 
 import { TimelineNavigator } from './timeline-navigator'
-import { getNavigatorResizeDragResult } from './timeline-navigator-utils'
+import { getNavigatorResizeDragResult, getNavigatorThumbMetrics } from './timeline-navigator-utils'
 import { useTimelineViewportStore } from '../stores/timeline-viewport-store'
 import { useTimelineSettingsStore } from '../stores/timeline-settings-store'
 import { useItemsStore } from '../stores/items-store'
@@ -69,5 +69,91 @@ describe('timeline navigator interaction', () => {
     fireEvent.click(getByTestId('timeline-navigator-thumb'))
 
     expect(scrollContainer.scrollLeft).toBe(120)
+  })
+
+  it('keeps live wheel zoom and anchor scrolling synchronized before content settles', async () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    const scrollContainer = document.createElement('div')
+
+    const { getByTestId } = render(
+      <TimelineNavigator
+        actualDuration={10}
+        timelineWidth={1240}
+        scrollContainerRef={{ current: scrollContainer }}
+      />,
+    )
+
+    const thumb = getByTestId('timeline-navigator-thumb')
+    const initialWidth = thumb.style.width
+
+    await act(async () => {
+      useZoomStore.getState().setZoomLevelImmediate(0.5)
+      scrollContainer.scrollLeft = 200
+      await Promise.resolve()
+    })
+
+    const expected = getNavigatorThumbMetrics({
+      timelineWidth: 740,
+      viewportWidth: 300,
+      trackWidth: 400,
+      scrollLeft: 200,
+    })
+    expect(thumb.style.width).not.toBe(initialWidth)
+    expect(Number.parseFloat(thumb.style.width)).toBeCloseTo(expected.thumbWidth)
+    expect(Number.parseFloat(thumb.style.left)).toBeCloseTo(expected.thumbLeft)
+
+    clientWidthSpy.mockRestore()
+  })
+
+  it('previews handle resizing immediately and flushes the final drag on release', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const animationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(400)
+    const scrollContainer = document.createElement('div')
+    scrollContainer.scrollLeft = 120
+    const scrollContainerRef = { current: scrollContainer }
+
+    const { getByTestId, rerender } = render(
+      <TimelineNavigator
+        actualDuration={10}
+        timelineWidth={1000}
+        scrollContainerRef={scrollContainerRef}
+      />,
+    )
+
+    const thumb = getByTestId('timeline-navigator-thumb')
+    const initialWidth = thumb.style.width
+    fireEvent.mouseDown(getByTestId('timeline-navigator-right-handle'), { clientX: 200 })
+    fireEvent.mouseMove(window, { clientX: 240 })
+
+    const previewWidth = thumb.style.width
+    expect(previewWidth).not.toBe(initialWidth)
+    expect(frameCallbacks).toHaveLength(1)
+
+    rerender(
+      <TimelineNavigator
+        actualDuration={10}
+        timelineWidth={1000}
+        scrollContainerRef={scrollContainerRef}
+      />,
+    )
+    expect(thumb.style.width).toBe(previewWidth)
+
+    fireEvent.mouseUp(window)
+
+    expect(useZoomStore.getState().level).not.toBe(1)
+    expect(thumb.style.width).toBe(previewWidth)
+
+    clientWidthSpy.mockRestore()
+    animationFrameSpy.mockRestore()
   })
 })

--- a/src/features/timeline/components/timeline-navigator.tsx
+++ b/src/features/timeline/components/timeline-navigator.tsx
@@ -18,6 +18,7 @@ type DragTarget = 'thumb' | 'left' | 'right' | null
 
 interface NavigatorDragSnapshot {
   startX: number
+  lastX: number
   thumbLeft: number
   thumbWidth: number
   trackWidth: number
@@ -40,6 +41,80 @@ interface NavigatorViewHandoff {
   to: Pick<NavigatorDragPreview, 'timelineWidth' | 'scrollLeft'>
   thumbLeft: number
   thumbWidth: number
+}
+
+interface NavigatorDragPreviewInput {
+  dragTarget: Exclude<DragTarget, null>
+  snapshot: NavigatorDragSnapshot
+  deltaX: number
+  viewportWidth: number
+  contentDuration: number
+}
+
+function shouldRebaseDrag(snapshot: NavigatorDragSnapshot, nextTrackWidth: number): boolean {
+  return nextTrackWidth > 0 && Math.abs(nextTrackWidth - snapshot.trackWidth) >= 0.5
+}
+
+function getDragView(
+  snapshot: NavigatorDragSnapshot,
+  preview: NavigatorDragPreview | null,
+): Pick<NavigatorDragPreview, 'timelineWidth' | 'scrollLeft'> {
+  if (preview) {
+    return { timelineWidth: preview.timelineWidth, scrollLeft: preview.scrollLeft }
+  }
+  return { timelineWidth: snapshot.timelineWidth, scrollLeft: snapshot.scrollLeft }
+}
+
+function updateNavigatorThumb(
+  thumb: HTMLDivElement | null,
+  metrics: Pick<NavigatorDragPreview, 'thumbLeft' | 'thumbWidth'>,
+): void {
+  if (!thumb) return
+  thumb.style.left = `${metrics.thumbLeft}px`
+  thumb.style.width = `${metrics.thumbWidth}px`
+}
+
+function getNavigatorDragPreview({
+  dragTarget,
+  snapshot,
+  deltaX,
+  viewportWidth,
+  contentDuration,
+}: NavigatorDragPreviewInput): NavigatorDragPreview | null {
+  if (dragTarget === 'thumb') {
+    if (snapshot.thumbTravel <= 0 || snapshot.maxScrollLeft <= 0) return null
+    const nextThumbLeft = Math.max(0, Math.min(snapshot.thumbTravel, snapshot.thumbLeft + deltaX))
+    return {
+      timelineWidth: snapshot.timelineWidth,
+      scrollLeft: (nextThumbLeft / snapshot.thumbTravel) * snapshot.maxScrollLeft,
+      thumbLeft: nextThumbLeft,
+      thumbWidth: snapshot.thumbWidth,
+    }
+  }
+
+  if (contentDuration <= 0) return null
+  const result = getNavigatorResizeDragResult({
+    dragTarget,
+    deltaX,
+    dragStartThumbLeft: snapshot.thumbLeft,
+    dragStartThumbWidth: snapshot.thumbWidth,
+    trackWidth: snapshot.trackWidth,
+    viewportWidth,
+    contentDuration,
+  })
+  const previewMetrics = getNavigatorThumbMetrics({
+    timelineWidth: result.nextTimelineWidth,
+    viewportWidth,
+    trackWidth: snapshot.trackWidth,
+    scrollLeft: result.nextScrollLeft,
+  })
+  return {
+    timelineWidth: result.nextTimelineWidth,
+    scrollLeft: result.nextScrollLeft,
+    thumbLeft: previewMetrics.thumbLeft,
+    thumbWidth: previewMetrics.thumbWidth,
+    zoom: result.nextZoom,
+  }
 }
 
 function isSameNavigatorView(
@@ -165,9 +240,51 @@ export function TimelineNavigator({
   const syncThumbToLiveGeometry = useCallback(() => {
     if (dragSnapshotRef.current || !thumbRef.current) return
     const live = getLiveNavigatorMetrics()
-    thumbRef.current.style.left = `${live.metrics.thumbLeft}px`
-    thumbRef.current.style.width = `${live.metrics.thumbWidth}px`
+    updateNavigatorThumb(thumbRef.current, live.metrics)
   }, [getLiveNavigatorMetrics])
+
+  const rebaseActiveDragToTrackWidth = useCallback(
+    (nextTrackWidth: number) => {
+      const snapshot = dragSnapshotRef.current
+      if (!snapshot) return
+      if (!shouldRebaseDrag(snapshot, nextTrackWidth)) return
+
+      const preview = latestPreviewRef.current
+      const { timelineWidth: nextTimelineWidth, scrollLeft: nextScrollLeft } = getDragView(
+        snapshot,
+        preview,
+      )
+      const nextMetrics = getNavigatorThumbMetrics({
+        timelineWidth: nextTimelineWidth,
+        viewportWidth,
+        trackWidth: nextTrackWidth,
+        scrollLeft: nextScrollLeft,
+      })
+
+      dragSnapshotRef.current = {
+        ...snapshot,
+        startX: snapshot.lastX,
+        thumbLeft: nextMetrics.thumbLeft,
+        thumbWidth: nextMetrics.thumbWidth,
+        trackWidth: nextTrackWidth,
+        timelineWidth: nextTimelineWidth,
+        scrollLeft: nextScrollLeft,
+        maxScrollLeft: nextMetrics.maxScrollLeft,
+        thumbTravel: nextMetrics.thumbTravel,
+      }
+
+      if (!preview) return
+      const rebasedPreview = {
+        ...preview,
+        thumbLeft: nextMetrics.thumbLeft,
+        thumbWidth: nextMetrics.thumbWidth,
+      }
+      latestPreviewRef.current = rebasedPreview
+      if (pendingPreviewRef.current) pendingPreviewRef.current = rebasedPreview
+      updateNavigatorThumb(thumbRef.current, nextMetrics)
+    },
+    [viewportWidth],
+  )
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent, target: Exclude<DragTarget, null>) => {
@@ -176,6 +293,7 @@ export function TimelineNavigator({
       const live = getLiveNavigatorMetrics()
       dragSnapshotRef.current = {
         startX: event.clientX,
+        lastX: event.clientX,
         thumbLeft: live.metrics.thumbLeft,
         thumbWidth: live.metrics.thumbWidth,
         trackWidth: trackRef.current?.clientWidth ?? trackWidth,
@@ -230,7 +348,9 @@ export function TimelineNavigator({
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
       if (entry) {
-        setTrackWidth(entry.contentRect.width)
+        const nextTrackWidth = entry.contentRect.width
+        rebaseActiveDragToTrackWidth(nextTrackWidth)
+        setTrackWidth(nextTrackWidth)
       }
     })
 
@@ -239,7 +359,7 @@ export function TimelineNavigator({
     return () => {
       observer.disconnect()
     }
-  }, [])
+  }, [rebaseActiveDragToTrackWidth])
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current
@@ -298,7 +418,8 @@ export function TimelineNavigator({
   }, [])
 
   useEffect(() => {
-    if (!dragTarget) return
+    const activeDragTarget = dragTarget
+    if (!activeDragTarget) return
 
     const flush = () => {
       dragRafRef.current = null
@@ -310,61 +431,36 @@ export function TimelineNavigator({
     }
 
     const handleMouseMove = (event: MouseEvent) => {
+      const measuredTrackWidth = trackRef.current?.clientWidth
+      if (measuredTrackWidth !== undefined) {
+        rebaseActiveDragToTrackWidth(measuredTrackWidth)
+      }
       const snapshot = dragSnapshotRef.current
       if (!snapshot || snapshot.trackWidth <= 0) return
 
       const deltaX = event.clientX - snapshot.startX
-      let preview: NavigatorDragPreview
-
-      if (dragTarget === 'thumb') {
-        if (snapshot.thumbTravel <= 0 || snapshot.maxScrollLeft <= 0) return
-        const nextThumbLeft = Math.max(
-          0,
-          Math.min(snapshot.thumbTravel, snapshot.thumbLeft + deltaX),
-        )
-        preview = {
-          timelineWidth: snapshot.timelineWidth,
-          scrollLeft: (nextThumbLeft / snapshot.thumbTravel) * snapshot.maxScrollLeft,
-          thumbLeft: nextThumbLeft,
-          thumbWidth: snapshot.thumbWidth,
-        }
-      } else {
-        if (contentDuration <= 0) return
-        const result = getNavigatorResizeDragResult({
-          dragTarget,
-          deltaX,
-          dragStartThumbLeft: snapshot.thumbLeft,
-          dragStartThumbWidth: snapshot.thumbWidth,
-          trackWidth: snapshot.trackWidth,
-          viewportWidth,
-          contentDuration,
-        })
-        const previewMetrics = getNavigatorThumbMetrics({
-          timelineWidth: result.nextTimelineWidth,
-          viewportWidth,
-          trackWidth: snapshot.trackWidth,
-          scrollLeft: result.nextScrollLeft,
-        })
-        preview = {
-          timelineWidth: result.nextTimelineWidth,
-          scrollLeft: result.nextScrollLeft,
-          thumbLeft: previewMetrics.thumbLeft,
-          thumbWidth: previewMetrics.thumbWidth,
-          zoom: result.nextZoom,
-        }
-      }
+      const preview = getNavigatorDragPreview({
+        dragTarget: activeDragTarget,
+        snapshot,
+        deltaX,
+        viewportWidth,
+        contentDuration,
+      })
+      if (!preview) return
 
       latestPreviewRef.current = preview
       pendingPreviewRef.current = preview
-      if (thumbRef.current) {
-        thumbRef.current.style.left = `${preview.thumbLeft}px`
-        thumbRef.current.style.width = `${preview.thumbWidth}px`
-      }
+      dragSnapshotRef.current = { ...snapshot, lastX: event.clientX }
+      updateNavigatorThumb(thumbRef.current, preview)
       if (dragRafRef.current !== null) return
       dragRafRef.current = requestAnimationFrame(flush)
     }
 
     const handleMouseUp = () => {
+      const measuredTrackWidth = trackRef.current?.clientWidth
+      if (measuredTrackWidth !== undefined) {
+        rebaseActiveDragToTrackWidth(measuredTrackWidth)
+      }
       if (dragRafRef.current !== null) {
         cancelAnimationFrame(dragRafRef.current)
         dragRafRef.current = null
@@ -404,7 +500,14 @@ export function TimelineNavigator({
       }
       pendingPreviewRef.current = null
     }
-  }, [contentDuration, dragTarget, setZoomImmediate, setScrollLeftOnContainer, viewportWidth])
+  }, [
+    contentDuration,
+    dragTarget,
+    rebaseActiveDragToTrackWidth,
+    setZoomImmediate,
+    setScrollLeftOnContainer,
+    viewportWidth,
+  ])
 
   return (
     <div className="h-5 border-t border-border bg-background/80 px-2 py-1">

--- a/src/features/timeline/components/timeline-navigator.tsx
+++ b/src/features/timeline/components/timeline-navigator.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { useTimelineViewportStore } from '../stores/timeline-viewport-store'
 import { useTimelineStore } from '../stores/timeline-store'
 import { useItemsStore } from '../stores/items-store'
 import { useZoomStore } from '../stores/zoom-store'
+import { getTimelineWidth } from '../utils/timeline-layout'
 import { cn } from '@/shared/ui/cn'
 import { getNavigatorResizeDragResult, getNavigatorThumbMetrics } from './timeline-navigator-utils'
 
@@ -15,24 +16,78 @@ interface TimelineNavigatorProps {
 
 type DragTarget = 'thumb' | 'left' | 'right' | null
 
+interface NavigatorDragSnapshot {
+  startX: number
+  thumbLeft: number
+  thumbWidth: number
+  trackWidth: number
+  timelineWidth: number
+  scrollLeft: number
+  maxScrollLeft: number
+  thumbTravel: number
+}
+
+interface NavigatorDragPreview {
+  timelineWidth: number
+  scrollLeft: number
+  thumbLeft: number
+  thumbWidth: number
+  zoom?: number
+}
+
+interface NavigatorViewHandoff {
+  from: Pick<NavigatorDragPreview, 'timelineWidth' | 'scrollLeft'>
+  to: Pick<NavigatorDragPreview, 'timelineWidth' | 'scrollLeft'>
+  thumbLeft: number
+  thumbWidth: number
+}
+
+function isSameNavigatorView(
+  timelineWidth: number,
+  scrollLeft: number,
+  view: Pick<NavigatorDragPreview, 'timelineWidth' | 'scrollLeft'>,
+): boolean {
+  return (
+    Math.abs(timelineWidth - view.timelineWidth) < 0.5 &&
+    Math.abs(scrollLeft - view.scrollLeft) < 0.5
+  )
+}
+
+function isNavigatorViewHandoffState(
+  timelineWidth: number,
+  scrollLeft: number,
+  handoff: NavigatorViewHandoff,
+): boolean {
+  const timelineWidthIsExpected =
+    Math.abs(timelineWidth - handoff.from.timelineWidth) < 0.5 ||
+    Math.abs(timelineWidth - handoff.to.timelineWidth) < 0.5
+  const scrollLeftIsExpected =
+    Math.abs(scrollLeft - handoff.from.scrollLeft) < 0.5 ||
+    Math.abs(scrollLeft - handoff.to.scrollLeft) < 0.5
+  return timelineWidthIsExpected && scrollLeftIsExpected
+}
+
 export function TimelineNavigator({
   actualDuration,
   timelineWidth,
   scrollContainerRef,
 }: TimelineNavigatorProps) {
   const trackRef = useRef<HTMLDivElement>(null)
+  const thumbRef = useRef<HTMLDivElement>(null)
   const dragRafRef = useRef<number | null>(null)
-  const latestDeltaXRef = useRef(0)
+  const dragSnapshotRef = useRef<NavigatorDragSnapshot | null>(null)
+  const pendingPreviewRef = useRef<NavigatorDragPreview | null>(null)
+  const latestPreviewRef = useRef<NavigatorDragPreview | null>(null)
+  const viewHandoffRef = useRef<NavigatorViewHandoff | null>(null)
   const fps = useTimelineStore((s) => s.fps)
   const setZoomImmediate = useZoomStore((s) => s.setZoomLevelImmediate)
   const scrollLeft = useTimelineViewportStore((s) => s.scrollLeft)
   const viewportWidth = useTimelineViewportStore((s) => s.viewportWidth)
+  const livePixelsPerSecondRef = useRef(useZoomStore.getState().pixelsPerSecond)
+  const liveScrollLeftRef = useRef(scrollLeft)
 
   const [trackWidth, setTrackWidth] = useState(0)
   const [dragTarget, setDragTarget] = useState<DragTarget>(null)
-  const [dragStartX, setDragStartX] = useState(0)
-  const [dragStartThumbLeft, setDragStartThumbLeft] = useState(0)
-  const [dragStartThumbWidth, setDragStartThumbWidth] = useState(0)
 
   const maxFrame = useItemsStore((s) => s.maxItemEndFrame)
 
@@ -41,47 +96,125 @@ export function TimelineNavigator({
     return Math.max(actualDuration, furthestEndSeconds, 10)
   }, [actualDuration, fps, maxFrame])
 
-  const { maxScrollLeft, thumbWidth, thumbTravel, thumbLeft } = getNavigatorThumbMetrics({
-    timelineWidth,
+  // The timeline content deliberately defers its expensive settled geometry
+  // while wheel zoom is active. The navigator is lightweight and should mirror
+  // the live geometry so its thumb does not jump only after input settles.
+  const navigatorTimelineWidth =
+    viewportWidth > 0
+      ? getTimelineWidth({
+          contentWidth: contentDuration * livePixelsPerSecondRef.current,
+          viewportWidth,
+        })
+      : timelineWidth
+  const navigatorScrollLeft = liveScrollLeftRef.current
+
+  const currentMetrics = getNavigatorThumbMetrics({
+    timelineWidth: navigatorTimelineWidth,
     viewportWidth,
     trackWidth,
-    scrollLeft,
+    scrollLeft: navigatorScrollLeft,
   })
+  const handoff = viewHandoffRef.current
+  const renderedMetrics = latestPreviewRef.current
+    ? {
+        ...currentMetrics,
+        thumbLeft: latestPreviewRef.current.thumbLeft,
+        thumbWidth: latestPreviewRef.current.thumbWidth,
+      }
+    : handoff && isNavigatorViewHandoffState(navigatorTimelineWidth, navigatorScrollLeft, handoff)
+      ? { ...currentMetrics, thumbLeft: handoff.thumbLeft, thumbWidth: handoff.thumbWidth }
+      : currentMetrics
+  const { thumbWidth, thumbLeft } = renderedMetrics
 
   const setScrollLeftOnContainer = useCallback(
     (nextScrollLeft: number) => {
       const node = scrollContainerRef.current
       if (!node) return
       node.scrollLeft = nextScrollLeft
+      liveScrollLeftRef.current = node.scrollLeft
     },
     [scrollContainerRef],
   )
+
+  const getLiveNavigatorMetrics = useCallback(() => {
+    const nextTrackWidth = trackRef.current?.clientWidth ?? trackWidth
+    const nextPixelsPerSecond = useZoomStore.getState().pixelsPerSecond
+    const nextScrollLeft = scrollContainerRef.current?.scrollLeft ?? liveScrollLeftRef.current
+    const nextTimelineWidth =
+      viewportWidth > 0
+        ? getTimelineWidth({
+            contentWidth: contentDuration * nextPixelsPerSecond,
+            viewportWidth,
+          })
+        : timelineWidth
+
+    livePixelsPerSecondRef.current = nextPixelsPerSecond
+    liveScrollLeftRef.current = nextScrollLeft
+    return {
+      timelineWidth: nextTimelineWidth,
+      scrollLeft: nextScrollLeft,
+      metrics: getNavigatorThumbMetrics({
+        timelineWidth: nextTimelineWidth,
+        viewportWidth,
+        trackWidth: nextTrackWidth,
+        scrollLeft: nextScrollLeft,
+      }),
+    }
+  }, [contentDuration, scrollContainerRef, timelineWidth, trackWidth, viewportWidth])
+
+  const syncThumbToLiveGeometry = useCallback(() => {
+    if (dragSnapshotRef.current || !thumbRef.current) return
+    const live = getLiveNavigatorMetrics()
+    thumbRef.current.style.left = `${live.metrics.thumbLeft}px`
+    thumbRef.current.style.width = `${live.metrics.thumbWidth}px`
+  }, [getLiveNavigatorMetrics])
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent, target: Exclude<DragTarget, null>) => {
       event.preventDefault()
       event.stopPropagation()
+      const live = getLiveNavigatorMetrics()
+      dragSnapshotRef.current = {
+        startX: event.clientX,
+        thumbLeft: live.metrics.thumbLeft,
+        thumbWidth: live.metrics.thumbWidth,
+        trackWidth: trackRef.current?.clientWidth ?? trackWidth,
+        timelineWidth: live.timelineWidth,
+        scrollLeft: live.scrollLeft,
+        maxScrollLeft: live.metrics.maxScrollLeft,
+        thumbTravel: live.metrics.thumbTravel,
+      }
+      latestPreviewRef.current = null
+      pendingPreviewRef.current = null
+      viewHandoffRef.current = null
       setDragTarget(target)
-      setDragStartX(event.clientX)
-      setDragStartThumbLeft(thumbLeft)
-      setDragStartThumbWidth(thumbWidth)
     },
-    [thumbLeft, thumbWidth],
+    [getLiveNavigatorMetrics, trackWidth],
   )
 
   const handleTrackClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!trackRef.current || dragTarget || maxScrollLeft <= 0 || thumbTravel <= 0) {
+      const live = getLiveNavigatorMetrics()
+      if (
+        !trackRef.current ||
+        dragTarget ||
+        live.metrics.maxScrollLeft <= 0 ||
+        live.metrics.thumbTravel <= 0
+      ) {
         return
       }
 
       const rect = trackRef.current.getBoundingClientRect()
       const clickX = event.clientX - rect.left
-      const desiredThumbLeft = Math.max(0, Math.min(thumbTravel, clickX - thumbWidth / 2))
-      const nextScrollLeft = (desiredThumbLeft / thumbTravel) * maxScrollLeft
+      const desiredThumbLeft = Math.max(
+        0,
+        Math.min(live.metrics.thumbTravel, clickX - live.metrics.thumbWidth / 2),
+      )
+      const nextScrollLeft =
+        (desiredThumbLeft / live.metrics.thumbTravel) * live.metrics.maxScrollLeft
       setScrollLeftOnContainer(nextScrollLeft)
     },
-    [dragTarget, maxScrollLeft, setScrollLeftOnContainer, thumbTravel, thumbWidth],
+    [dragTarget, getLiveNavigatorMetrics, setScrollLeftOnContainer],
   )
 
   useEffect(() => {
@@ -109,6 +242,54 @@ export function TimelineNavigator({
   }, [])
 
   useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    let microtaskQueued = false
+    let disposed = false
+    const scheduleSynchronizedUpdate = () => {
+      if (microtaskQueued) return
+      microtaskQueued = true
+      queueMicrotask(() => {
+        microtaskQueued = false
+        if (!disposed) syncThumbToLiveGeometry()
+      })
+    }
+    const handleScroll = () => syncThumbToLiveGeometry()
+    const unsubscribeZoom = useZoomStore.subscribe((state, previousState) => {
+      if (state.pixelsPerSecond !== previousState.pixelsPerSecond) {
+        scheduleSynchronizedUpdate()
+      }
+    })
+
+    scrollContainer?.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      disposed = true
+      unsubscribeZoom()
+      scrollContainer?.removeEventListener('scroll', handleScroll)
+    }
+  }, [scrollContainerRef, syncThumbToLiveGeometry])
+
+  useLayoutEffect(() => {
+    const nextHandoff = viewHandoffRef.current
+    if (
+      nextHandoff &&
+      (isSameNavigatorView(navigatorTimelineWidth, navigatorScrollLeft, nextHandoff.to) ||
+        !isNavigatorViewHandoffState(navigatorTimelineWidth, navigatorScrollLeft, nextHandoff))
+    ) {
+      viewHandoffRef.current = null
+    }
+    if (dragTarget || !thumbRef.current) return
+    thumbRef.current.style.left = `${renderedMetrics.thumbLeft}px`
+    thumbRef.current.style.width = `${renderedMetrics.thumbWidth}px`
+  }, [
+    dragTarget,
+    navigatorScrollLeft,
+    navigatorTimelineWidth,
+    renderedMetrics.thumbLeft,
+    renderedMetrics.thumbWidth,
+    scrollLeft,
+  ])
+
+  useEffect(() => {
     return () => {
       if (dragRafRef.current !== null) {
         cancelAnimationFrame(dragRafRef.current)
@@ -119,50 +300,95 @@ export function TimelineNavigator({
   useEffect(() => {
     if (!dragTarget) return
 
-    // Coalesce mousemoves into one RAF: high-refresh displays fire mousemove
-    // > 60Hz, and each setZoomImmediate triggers a full timeline re-render
-    // (level/pixelsPerSecond subscribers in timeline-content cascade down to
-    // tracks and items). One zoom-store write per frame is plenty.
     const flush = () => {
       dragRafRef.current = null
-      const track = trackRef.current
-      if (!track) return
-      const nextTrackWidth = track.clientWidth
-      if (nextTrackWidth <= 0) return
-
-      const deltaX = latestDeltaXRef.current
-
-      if (dragTarget === 'thumb') {
-        if (thumbTravel <= 0 || maxScrollLeft <= 0) return
-        const nextThumbLeft = Math.max(0, Math.min(thumbTravel, dragStartThumbLeft + deltaX))
-        const nextScrollLeft = (nextThumbLeft / thumbTravel) * maxScrollLeft
-        setScrollLeftOnContainer(nextScrollLeft)
-        return
-      }
-
-      if (contentDuration <= 0) return
-
-      const { nextZoom, nextScrollLeft } = getNavigatorResizeDragResult({
-        dragTarget,
-        deltaX,
-        dragStartThumbLeft,
-        dragStartThumbWidth,
-        trackWidth: nextTrackWidth,
-        viewportWidth,
-        contentDuration,
-      })
-
-      setZoomImmediate(nextZoom)
-      setScrollLeftOnContainer(nextScrollLeft)
+      const preview = pendingPreviewRef.current
+      pendingPreviewRef.current = null
+      if (!preview) return
+      if (preview.zoom !== undefined) setZoomImmediate(preview.zoom)
+      setScrollLeftOnContainer(preview.scrollLeft)
     }
 
     const handleMouseMove = (event: MouseEvent) => {
-      latestDeltaXRef.current = event.clientX - dragStartX
+      const snapshot = dragSnapshotRef.current
+      if (!snapshot || snapshot.trackWidth <= 0) return
+
+      const deltaX = event.clientX - snapshot.startX
+      let preview: NavigatorDragPreview
+
+      if (dragTarget === 'thumb') {
+        if (snapshot.thumbTravel <= 0 || snapshot.maxScrollLeft <= 0) return
+        const nextThumbLeft = Math.max(
+          0,
+          Math.min(snapshot.thumbTravel, snapshot.thumbLeft + deltaX),
+        )
+        preview = {
+          timelineWidth: snapshot.timelineWidth,
+          scrollLeft: (nextThumbLeft / snapshot.thumbTravel) * snapshot.maxScrollLeft,
+          thumbLeft: nextThumbLeft,
+          thumbWidth: snapshot.thumbWidth,
+        }
+      } else {
+        if (contentDuration <= 0) return
+        const result = getNavigatorResizeDragResult({
+          dragTarget,
+          deltaX,
+          dragStartThumbLeft: snapshot.thumbLeft,
+          dragStartThumbWidth: snapshot.thumbWidth,
+          trackWidth: snapshot.trackWidth,
+          viewportWidth,
+          contentDuration,
+        })
+        const previewMetrics = getNavigatorThumbMetrics({
+          timelineWidth: result.nextTimelineWidth,
+          viewportWidth,
+          trackWidth: snapshot.trackWidth,
+          scrollLeft: result.nextScrollLeft,
+        })
+        preview = {
+          timelineWidth: result.nextTimelineWidth,
+          scrollLeft: result.nextScrollLeft,
+          thumbLeft: previewMetrics.thumbLeft,
+          thumbWidth: previewMetrics.thumbWidth,
+          zoom: result.nextZoom,
+        }
+      }
+
+      latestPreviewRef.current = preview
+      pendingPreviewRef.current = preview
+      if (thumbRef.current) {
+        thumbRef.current.style.left = `${preview.thumbLeft}px`
+        thumbRef.current.style.width = `${preview.thumbWidth}px`
+      }
       if (dragRafRef.current !== null) return
       dragRafRef.current = requestAnimationFrame(flush)
     }
 
     const handleMouseUp = () => {
+      if (dragRafRef.current !== null) {
+        cancelAnimationFrame(dragRafRef.current)
+        dragRafRef.current = null
+      }
+      flush()
+      const snapshot = dragSnapshotRef.current
+      const finalPreview = latestPreviewRef.current
+      viewHandoffRef.current =
+        snapshot && finalPreview
+          ? {
+              from: {
+                timelineWidth: snapshot.timelineWidth,
+                scrollLeft: snapshot.scrollLeft,
+              },
+              to: {
+                timelineWidth: finalPreview.timelineWidth,
+                scrollLeft: finalPreview.scrollLeft,
+              },
+              thumbLeft: finalPreview.thumbLeft,
+              thumbWidth: finalPreview.thumbWidth,
+            }
+          : null
+      latestPreviewRef.current = null
+      dragSnapshotRef.current = null
       setDragTarget(null)
     }
 
@@ -176,19 +402,9 @@ export function TimelineNavigator({
         cancelAnimationFrame(dragRafRef.current)
         dragRafRef.current = null
       }
+      pendingPreviewRef.current = null
     }
-  }, [
-    contentDuration,
-    dragStartThumbLeft,
-    dragStartThumbWidth,
-    dragStartX,
-    dragTarget,
-    maxScrollLeft,
-    setZoomImmediate,
-    setScrollLeftOnContainer,
-    thumbTravel,
-    viewportWidth,
-  ])
+  }, [contentDuration, dragTarget, setZoomImmediate, setScrollLeftOnContainer, viewportWidth])
 
   return (
     <div className="h-5 border-t border-border bg-background/80 px-2 py-1">
@@ -198,6 +414,7 @@ export function TimelineNavigator({
         onClick={handleTrackClick}
       >
         <div
+          ref={thumbRef}
           className={cn(
             'absolute top-0 flex h-full items-center justify-between rounded-sm bg-muted-foreground/55 transition-colors',
             dragTarget
@@ -213,6 +430,7 @@ export function TimelineNavigator({
           data-testid="timeline-navigator-thumb"
         >
           <div
+            data-testid="timeline-navigator-left-handle"
             className="flex h-full w-3 items-center justify-center cursor-ew-resize"
             onMouseDown={(event) => handleMouseDown(event, 'left')}
           >
@@ -220,6 +438,7 @@ export function TimelineNavigator({
           </div>
           <div className="h-2 w-8 rounded-full bg-background/20" />
           <div
+            data-testid="timeline-navigator-right-handle"
             className="flex h-full w-3 items-center justify-center cursor-ew-resize"
             onMouseDown={(event) => handleMouseDown(event, 'right')}
           >


### PR DESCRIPTION
## Summary

- make the Edit workspace navigator follow handle drags immediately
- keep navigator thumb width and cursor-anchored scroll position synchronized during mouse-wheel zoom
- preserve the final drag geometry while deferred timeline state catches up
- add regression coverage for live resize, release-between-frames, and wheel-zoom synchronization

## Root cause

The Edit navigator mixed live zoom geometry with throttled scroll state. During wheel zoom it could render the new width against the previous cursor-anchored scroll position, causing the thumb to jump or flicker. Handle updates could also be lost when release occurred between animation frames.

## Impact

Navigator resizing and wheel zoom now track smoothly using synchronized live geometry while expensive timeline content remains deferred.

## Validation

- 9 relevant navigator tests passed
- all 7 pre-push checks passed
- edge budgets passed
- full check completed with 0 errors and one existing non-blocking Fast Refresh warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline header zoom controls have been reworked for smoother slider preview and reliable zoom-to-fit behavior.
* **Bug Fixes**
  * Improved timeline navigator live zooming/scroll synchronization to keep the thumb aligned.
  * Thumb resizing and drag previews now update immediately and settle correctly on release.
  * Track resize during an active drag no longer causes incorrect thumb metrics or final positioning.
* **Tests**
  * Added/extended automated coverage for timeline navigator and header zoom slider interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->