### PR TITLE
fix: stabilize linked timeline scrubbing

### DIFF
--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
@@ -15,6 +15,7 @@ import {
 import {
   TIMELINE_LIVE_SCROLL_EVENT,
   TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
+  getTimelineScrubViewportX,
   type TimelineScrubVisualFrameDetail,
 } from '@/shared/timeline/live-scroll-sync'
 
@@ -226,10 +227,10 @@ export function DopesheetPlayheadLine({
       update()
     }
     const updateFromScrubVisualFrame = (event: Event) => {
-      const { frame } = (event as CustomEvent<TimelineScrubVisualFrameDetail>).detail
+      const { viewportProgress } = (event as CustomEvent<TimelineScrubVisualFrameDetail>).detail
       if (!ref.current) return
-      const relativeFrame = clampRelativeFrame(frame - posRef.current.itemFrom, posRef.current)
-      ref.current.style.transform = `translate3d(${clampLeft(relativeFrame)}px, 0, 0)`
+      const viewportX = getTimelineScrubViewportX(viewportProgress, posRef.current.maxLeft)
+      ref.current.style.transform = `translate3d(${viewportX}px, 0, 0)`
     }
     const unsubscribe = usePlaybackStore.subscribe(update)
     const target = positionSyncTargetRef?.current

--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
@@ -198,6 +198,10 @@ export function DopesheetPlayheadLine({
 
   useLayoutEffect(() => {
     if (!ref.current) return
+    // The local ruler drag owns the visual position until its queued scrub
+    // frame catches up with a live edge-scroll. Reapplying settled props here
+    // would briefly map the previous frame against the new scroll position.
+    if (localScrubActiveRef?.current === true) return
     const liveRelativeFrame = livePlaybackRelFrame()
     const x = clampLeft(liveRelativeFrame ?? posRef.current.relativeFrame)
     ref.current.style.transform = `translate3d(${x}px, 0, 0)`
@@ -211,14 +215,20 @@ export function DopesheetPlayheadLine({
         ref.current.style.transform = `translate3d(${clampLeft(relativeFrame)}px, 0, 0)`
       }
     }
+    const updateFromScroll = () => {
+      // Edge scrolling broadcasts scrollLeft before the coalesced scrub frame.
+      // Preserve the cursor-locked visual until the playback-store update.
+      if (localScrubActiveRef?.current === true) return
+      update()
+    }
     const unsubscribe = usePlaybackStore.subscribe(update)
     const target = positionSyncTargetRef?.current
-    target?.addEventListener('scroll', update, { passive: true })
-    target?.addEventListener(TIMELINE_LIVE_SCROLL_EVENT, update)
+    target?.addEventListener('scroll', updateFromScroll, { passive: true })
+    target?.addEventListener(TIMELINE_LIVE_SCROLL_EVENT, updateFromScroll)
     return () => {
       unsubscribe()
-      target?.removeEventListener('scroll', update)
-      target?.removeEventListener(TIMELINE_LIVE_SCROLL_EVENT, update)
+      target?.removeEventListener('scroll', updateFromScroll)
+      target?.removeEventListener(TIMELINE_LIVE_SCROLL_EVENT, updateFromScroll)
     }
     // Positioning inputs are read from posRef so this subscription stays stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/dopesheet-playhead-line.tsx
@@ -12,7 +12,11 @@ import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
 } from '@/shared/timeline/main-timeline-scrub'
-import { TIMELINE_LIVE_SCROLL_EVENT } from '@/shared/timeline/live-scroll-sync'
+import {
+  TIMELINE_LIVE_SCROLL_EVENT,
+  TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
+  type TimelineScrubVisualFrameDetail,
+} from '@/shared/timeline/live-scroll-sync'
 
 interface DopesheetPlayheadLineProps {
   /** Clip-relative playhead frame for paused seek and zoom updates. */
@@ -201,7 +205,7 @@ export function DopesheetPlayheadLine({
     // The local ruler drag owns the visual position until its queued scrub
     // frame catches up with a live edge-scroll. Reapplying settled props here
     // would briefly map the previous frame against the new scroll position.
-    if (localScrubActiveRef?.current === true) return
+    if (localScrubActiveRef?.current === true || mainTimelineScrubActiveRef.current) return
     const liveRelativeFrame = livePlaybackRelFrame()
     const x = clampLeft(liveRelativeFrame ?? posRef.current.relativeFrame)
     ref.current.style.transform = `translate3d(${x}px, 0, 0)`
@@ -218,17 +222,25 @@ export function DopesheetPlayheadLine({
     const updateFromScroll = () => {
       // Edge scrolling broadcasts scrollLeft before the coalesced scrub frame.
       // Preserve the cursor-locked visual until the playback-store update.
-      if (localScrubActiveRef?.current === true) return
+      if (localScrubActiveRef?.current === true || mainTimelineScrubActiveRef.current) return
       update()
+    }
+    const updateFromScrubVisualFrame = (event: Event) => {
+      const { frame } = (event as CustomEvent<TimelineScrubVisualFrameDetail>).detail
+      if (!ref.current) return
+      const relativeFrame = clampRelativeFrame(frame - posRef.current.itemFrom, posRef.current)
+      ref.current.style.transform = `translate3d(${clampLeft(relativeFrame)}px, 0, 0)`
     }
     const unsubscribe = usePlaybackStore.subscribe(update)
     const target = positionSyncTargetRef?.current
     target?.addEventListener('scroll', updateFromScroll, { passive: true })
     target?.addEventListener(TIMELINE_LIVE_SCROLL_EVENT, updateFromScroll)
+    target?.addEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, updateFromScrubVisualFrame)
     return () => {
       unsubscribe()
       target?.removeEventListener('scroll', updateFromScroll)
       target?.removeEventListener(TIMELINE_LIVE_SCROLL_EVENT, updateFromScroll)
+      target?.removeEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, updateFromScrubVisualFrame)
     }
     // Positioning inputs are read from posRef so this subscription stays stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -73,7 +73,10 @@ import { DopesheetHeaderFrameInputs } from './dopesheet-header-frame-inputs'
 import { DopesheetRulerHeader } from './dopesheet-ruler-header'
 import { TimelinePreviewScrubberVisual } from '@/shared/ui/timeline-preview-scrubber-visual'
 import { perfMarkRender } from '@/shared/logging/perf-marks'
-import { TIMELINE_LIVE_SCROLL_EVENT } from '@/shared/timeline/live-scroll-sync'
+import {
+  TIMELINE_LIVE_SCROLL_EVENT,
+  notifyTimelineScrubVisualFrame,
+} from '@/shared/timeline/live-scroll-sync'
 import { DopesheetSheetBody } from './dopesheet-sheet-body'
 import { DopesheetInterpolationButtons } from './dopesheet-interpolation-buttons'
 import { DopesheetParameterMenu } from './dopesheet-parameter-menu'
@@ -2770,6 +2773,14 @@ export const DopesheetEditor = memo(function DopesheetEditor({
   const rulerEdgeScrollRafRef = useRef<number | null>(null)
   const rulerEdgeScrollTimestampRef = useRef<number | null>(null)
   const rulerEdgeScrollLoopRef = useRef<(timestamp: number) => void>(() => {})
+  const notifyLinkedTimelineScrubFrame = useCallback(
+    (frame: number) =>
+      notifyTimelineScrubVisualFrame(timelineScrollContainerRef?.current, {
+        frame: itemFrom + frame,
+        source: 'keyframe',
+      }),
+    [itemFrom, timelineScrollContainerRef],
+  )
   if (scrubPointerIdRef.current === null) rulerScrubViewportRef.current = viewport
   const {
     startScrub: startRulerScrub,
@@ -2826,6 +2837,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
         }
         const frame = getRulerScrubFrameFromClientX(clientX)
         lastScrubbedFrameRef.current = frame
+        notifyLinkedTimelineScrubFrame(frame)
         queueRulerScrub({
           frame,
           pointerX: getTimelineXFromClientX(clientX),

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -75,8 +75,10 @@ import { TimelinePreviewScrubberVisual } from '@/shared/ui/timeline-preview-scru
 import { perfMarkRender } from '@/shared/logging/perf-marks'
 import {
   TIMELINE_LIVE_SCROLL_EVENT,
+  getTimelineScrubViewportProgress,
   notifyTimelineScrubVisualFrame,
 } from '@/shared/timeline/live-scroll-sync'
+import { timelineSkimmerScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
 import { DopesheetSheetBody } from './dopesheet-sheet-body'
 import { DopesheetInterpolationButtons } from './dopesheet-interpolation-buttons'
 import { DopesheetParameterMenu } from './dopesheet-parameter-menu'
@@ -664,6 +666,36 @@ function getDopesheetDragPixelsPerFrame(
       ? livePixelsPerSecond
       : fallbackPixelsPerSecond
   return pixelsPerSecond / Math.max(fps, 1)
+}
+
+function getLiveRulerFrame({
+  viewportX,
+  fallbackFrame,
+  scrollContainer,
+  livePixelsPerSecond,
+  fps,
+  itemFrom,
+}: {
+  viewportX: number
+  fallbackFrame: number
+  scrollContainer: HTMLDivElement | null | undefined
+  livePixelsPerSecond: number | undefined
+  fps: number
+  itemFrom: number
+}): number {
+  if (!scrollContainer || !livePixelsPerSecond || livePixelsPerSecond <= 0) return fallbackFrame
+  return Math.round(
+    ((scrollContainer.scrollLeft + viewportX) / livePixelsPerSecond) * fps - itemFrom,
+  )
+}
+
+function getDopesheetTimelineClientBounds(
+  node: HTMLDivElement,
+  borderWidth: number,
+  timelineWidth: number,
+): { left: number; right: number } {
+  const left = node.getBoundingClientRect().left + borderWidth
+  return { left, right: left + timelineWidth }
 }
 
 const TimelineViewportCuller = memo(function TimelineViewportCuller({
@@ -1724,7 +1756,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       const rect = node.getBoundingClientRect()
       return Math.max(
         0,
-        Math.min(effectiveTimelineWidth, clientX - rect.left - timelineCellBorderWidth),
+        Math.min(effectiveTimelineWidth - 1, clientX - rect.left - timelineCellBorderWidth),
       )
     },
     [effectiveTimelineWidth, timelineCellBorderWidth],
@@ -2773,13 +2805,49 @@ export const DopesheetEditor = memo(function DopesheetEditor({
   const rulerEdgeScrollRafRef = useRef<number | null>(null)
   const rulerEdgeScrollTimestampRef = useRef<number | null>(null)
   const rulerEdgeScrollLoopRef = useRef<(timestamp: number) => void>(() => {})
+  const getRulerFrameViewportX = useCallback(
+    (frame: number) => {
+      const mappedX = globalFrameToPixels ? globalFrameToPixels(itemFrom + frame) : frameToX(frame)
+      return Math.max(0, Math.min(effectiveTimelineWidth - 1, mappedX))
+    },
+    [effectiveTimelineWidth, frameToX, globalFrameToPixels, itemFrom],
+  )
+  const getRulerScrubVisualX = useCallback(
+    (clientX: number) => {
+      const pointerX = getTimelineXFromClientX(clientX)
+      if (scrubClampToItemBounds) {
+        return Math.max(
+          getRulerFrameViewportX(0),
+          Math.min(getRulerFrameViewportX(Math.max(0, totalFrames - 1)), pointerX),
+        )
+      }
+      if (scrubFrameBounds) {
+        return Math.max(
+          getRulerFrameViewportX(scrubFrameBounds.minFrame),
+          Math.min(getRulerFrameViewportX(scrubFrameBounds.maxFrame), pointerX),
+        )
+      }
+      return pointerX
+    },
+    [
+      getRulerFrameViewportX,
+      getTimelineXFromClientX,
+      scrubClampToItemBounds,
+      scrubFrameBounds,
+      totalFrames,
+    ],
+  )
   const notifyLinkedTimelineScrubFrame = useCallback(
-    (frame: number) =>
+    (frame: number, clientX: number) =>
       notifyTimelineScrubVisualFrame(timelineScrollContainerRef?.current, {
         frame: itemFrom + frame,
         source: 'keyframe',
+        viewportProgress: getTimelineScrubViewportProgress(
+          getRulerScrubVisualX(clientX),
+          effectiveTimelineWidth - 1,
+        ),
       }),
-    [itemFrom, timelineScrollContainerRef],
+    [effectiveTimelineWidth, getRulerScrubVisualX, itemFrom, timelineScrollContainerRef],
   )
   if (scrubPointerIdRef.current === null) rulerScrubViewportRef.current = viewport
   const {
@@ -2789,26 +2857,35 @@ export const DopesheetEditor = memo(function DopesheetEditor({
   } = useCoalescedScrub(onScrub)
   const getRulerScrubFrameFromClientX = useCallback(
     (clientX: number) => {
-      const node = timelineRef.current
-      if (!node) return currentFrame
-      const rect = node.getBoundingClientRect()
-      const frame = getFrameFromAxisX(
-        clientX - rect.left - timelineCellBorderWidth,
+      const viewportX = getTimelineXFromClientX(clientX)
+      const fallbackFrame = getFrameFromAxisX(
+        viewportX,
         rulerScrubViewportRef.current,
         effectiveTimelineWidth,
         timelineEdgeInset,
       )
+      const frame = getLiveRulerFrame({
+        viewportX,
+        fallbackFrame,
+        scrollContainer: timelineScrollContainerRef?.current,
+        livePixelsPerSecond: getTimelineLivePixelsPerSecond?.(),
+        fps,
+        itemFrom,
+      })
       if (scrubClampToItemBounds) return clampFrame(frame, totalFrames)
       if (!scrubFrameBounds) return frame
       return Math.max(scrubFrameBounds.minFrame, Math.min(scrubFrameBounds.maxFrame, frame))
     },
     [
-      currentFrame,
       effectiveTimelineWidth,
+      fps,
+      getTimelineLivePixelsPerSecond,
+      getTimelineXFromClientX,
+      itemFrom,
       scrubClampToItemBounds,
       scrubFrameBounds,
-      timelineCellBorderWidth,
       timelineEdgeInset,
+      timelineScrollContainerRef,
       totalFrames,
     ],
   )
@@ -2820,7 +2897,11 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       return
     }
 
-    const bounds = node.getBoundingClientRect()
+    const bounds = getDopesheetTimelineClientBounds(
+      node,
+      timelineCellBorderWidth,
+      effectiveTimelineWidth,
+    )
     const velocity = getPlayheadEdgeScrollVelocity(clientX, bounds)
     if (velocity !== 0) {
       const previousTimestamp = rulerEdgeScrollTimestampRef.current ?? timestamp - 1000 / 60
@@ -2829,15 +2910,14 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       )
       if (appliedPixels !== 0 && effectiveTimelineWidth > 0) {
         const liveViewport = rulerScrubViewportRef.current
-        const visibleFrames = liveViewport.endFrame - liveViewport.startFrame
-        const frameDelta = (appliedPixels / effectiveTimelineWidth) * visibleFrames
+        const frameDelta = appliedPixels / getLiveDragPixelsPerFrame()
         rulerScrubViewportRef.current = {
           startFrame: liveViewport.startFrame + frameDelta,
           endFrame: liveViewport.endFrame + frameDelta,
         }
         const frame = getRulerScrubFrameFromClientX(clientX)
         lastScrubbedFrameRef.current = frame
-        notifyLinkedTimelineScrubFrame(frame)
+        notifyLinkedTimelineScrubFrame(frame, clientX)
         queueRulerScrub({
           frame,
           pointerX: getTimelineXFromClientX(clientX),
@@ -2858,6 +2938,10 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       if (rulerEdgeScrollRafRef.current !== null) {
         cancelAnimationFrame(rulerEdgeScrollRafRef.current)
       }
+      if (scrubPointerIdRef.current !== null) {
+        rulerScrubActiveRef.current = false
+        timelineSkimmerScrubActiveRef.current = false
+      }
     }
   }, [])
   const handleRulerPointerDown = useCallback(
@@ -2866,14 +2950,16 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       event.preventDefault()
       rulerScrubHandoffFrameRef.current = null
       rulerScrubActiveRef.current = true
+      timelineSkimmerScrubActiveRef.current = true
       setIsRulerScrubbing(true)
       scrubPointerIdRef.current = event.pointerId
       rulerScrubClientXRef.current = event.clientX
       rulerScrubViewportRef.current = viewport
       rulerEdgeScrollTimestampRef.current = null
       setPointerCaptureSafely(event.currentTarget, event.pointerId)
-      const frame = getFrameFromClientX(event.clientX)
+      const frame = getRulerScrubFrameFromClientX(event.clientX)
       lastScrubbedFrameRef.current = frame
+      notifyLinkedTimelineScrubFrame(frame, event.clientX)
       onScrubStart?.()
       startRulerScrub({
         frame,
@@ -2888,8 +2974,9 @@ export const DopesheetEditor = memo(function DopesheetEditor({
     },
     [
       disabled,
-      getFrameFromClientX,
+      getRulerScrubFrameFromClientX,
       getTimelineXFromClientX,
+      notifyLinkedTimelineScrubFrame,
       onRulerEdgeScroll,
       onScrubStart,
       startRulerScrub,
@@ -2906,6 +2993,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       if (scrubPointerIdRef.current !== event.pointerId) return
       rulerScrubClientXRef.current = event.clientX
       const scrubFrame = getRulerScrubFrameFromClientX(event.clientX)
+      notifyLinkedTimelineScrubFrame(scrubFrame, event.clientX)
       if (scrubFrame === lastScrubbedFrameRef.current) return
       lastScrubbedFrameRef.current = scrubFrame
       queueRulerScrub({
@@ -2919,6 +3007,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       getFrameFromClientX,
       getRulerScrubFrameFromClientX,
       getTimelineXFromClientX,
+      notifyLinkedTimelineScrubFrame,
       onSkim,
       queueRulerScrub,
       timelinePixelsPerSecond,
@@ -2939,6 +3028,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       }
       const finalFrame = getRulerScrubFrameFromClientX(event.clientX)
       rulerScrubHandoffFrameRef.current = finalFrame
+      notifyLinkedTimelineScrubFrame(finalFrame, event.clientX)
       if (finalFrame !== lastScrubbedFrameRef.current) {
         queueRulerScrub({
           frame: finalFrame,
@@ -2958,11 +3048,13 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       flushPendingRulerScrub(true)
       rulerScrubActiveRef.current = false
       onScrubEnd?.()
+      timelineSkimmerScrubActiveRef.current = false
     },
     [
       flushPendingRulerScrub,
       getRulerScrubFrameFromClientX,
       getTimelineXFromClientX,
+      notifyLinkedTimelineScrubFrame,
       onScrubEnd,
       queueRulerScrub,
       timelinePixelsPerSecond,
@@ -4544,6 +4636,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
         rulerOffset={0}
         showTooltip={false}
         suppressed={isRulerScrubbing}
+        suppressRefs={[rulerScrubActiveRef, timelineSkimmerScrubActiveRef]}
         positionSyncTargetRef={timelineScrollContainerRef}
       />
     </div>

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -78,7 +78,11 @@ import {
   getTimelineScrubViewportProgress,
   notifyTimelineScrubVisualFrame,
 } from '@/shared/timeline/live-scroll-sync'
-import { timelineSkimmerScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
+import {
+  beginTimelineSkimmerScrub,
+  endTimelineSkimmerScrub,
+  timelineSkimmerScrubSignal,
+} from '@/shared/timeline/main-timeline-scrub'
 import { DopesheetSheetBody } from './dopesheet-sheet-body'
 import { DopesheetInterpolationButtons } from './dopesheet-interpolation-buttons'
 import { DopesheetParameterMenu } from './dopesheet-parameter-menu'
@@ -2805,6 +2809,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
   const rulerEdgeScrollRafRef = useRef<number | null>(null)
   const rulerEdgeScrollTimestampRef = useRef<number | null>(null)
   const rulerEdgeScrollLoopRef = useRef<(timestamp: number) => void>(() => {})
+  const skimmerScrubOwnerRef = useRef({})
   const getRulerFrameViewportX = useCallback(
     (frame: number) => {
       const mappedX = globalFrameToPixels ? globalFrameToPixels(itemFrom + frame) : frameToX(frame)
@@ -2934,14 +2939,15 @@ export const DopesheetEditor = memo(function DopesheetEditor({
     )
   }
   useEffect(() => {
+    const skimmerScrubOwner = skimmerScrubOwnerRef.current
     return () => {
       if (rulerEdgeScrollRafRef.current !== null) {
         cancelAnimationFrame(rulerEdgeScrollRafRef.current)
       }
       if (scrubPointerIdRef.current !== null) {
         rulerScrubActiveRef.current = false
-        timelineSkimmerScrubActiveRef.current = false
       }
+      endTimelineSkimmerScrub(skimmerScrubOwner)
     }
   }, [])
   const handleRulerPointerDown = useCallback(
@@ -2950,7 +2956,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       event.preventDefault()
       rulerScrubHandoffFrameRef.current = null
       rulerScrubActiveRef.current = true
-      timelineSkimmerScrubActiveRef.current = true
+      beginTimelineSkimmerScrub(skimmerScrubOwnerRef.current)
       setIsRulerScrubbing(true)
       scrubPointerIdRef.current = event.pointerId
       rulerScrubClientXRef.current = event.clientX
@@ -3048,7 +3054,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       flushPendingRulerScrub(true)
       rulerScrubActiveRef.current = false
       onScrubEnd?.()
-      timelineSkimmerScrubActiveRef.current = false
+      endTimelineSkimmerScrub(skimmerScrubOwnerRef.current)
     },
     [
       flushPendingRulerScrub,
@@ -4636,7 +4642,8 @@ export const DopesheetEditor = memo(function DopesheetEditor({
         rulerOffset={0}
         showTooltip={false}
         suppressed={isRulerScrubbing}
-        suppressRefs={[rulerScrubActiveRef, timelineSkimmerScrubActiveRef]}
+        suppressRefs={[rulerScrubActiveRef]}
+        suppressSignal={timelineSkimmerScrubSignal}
         positionSyncTargetRef={timelineScrollContainerRef}
       />
     </div>

--- a/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
@@ -5,9 +5,11 @@ import { DopesheetEditor } from './index'
 import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
+  timelineSkimmerScrubActiveRef,
 } from '@/shared/timeline/main-timeline-scrub'
 import {
   TIMELINE_LIVE_SCROLL_EVENT,
+  TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
   notifyTimelineScrubVisualFrame,
 } from '@/shared/timeline/live-scroll-sync'
 
@@ -23,9 +25,14 @@ describe('DopesheetEditor playhead overlay', () => {
   })
 
   beforeEach(() => {
-    usePlaybackStore.setState({ currentFrame: 0, previewFrame: null, isPlaying: false })
+    usePlaybackStore.setState({
+      currentFrame: 0,
+      previewFrame: null,
+      isPlaying: false,
+    })
     mainTimelineScrubActiveRef.current = false
     mainTimelineScrubHandoffFrameRef.current = null
+    timelineSkimmerScrubActiveRef.current = false
   })
 
   it('clamps the playhead to the left edge when the current frame is before the viewport', () => {
@@ -112,13 +119,17 @@ describe('DopesheetEditor playhead overlay', () => {
       />,
     )
 
-    expect(screen.getByTestId('dopesheet-scroll-area')).toHaveStyle({ right: '12px' })
+    expect(screen.getByTestId('dopesheet-scroll-area')).toHaveStyle({
+      right: '12px',
+    })
     expect(screen.getByTestId('dopesheet-scrollbar')).toHaveClass(
       'right-0',
       'w-3',
       'bg-background/80',
     )
-    expect(screen.getByTestId('dopesheet-ruler-scrollbar-gutter')).toHaveStyle({ width: '12px' })
+    expect(screen.getByTestId('dopesheet-ruler-scrollbar-gutter')).toHaveStyle({
+      width: '12px',
+    })
     expect(screen.getByTestId('dopesheet-playhead-line')).toHaveStyle({
       transform: 'translate3d(378px, 0, 0)',
     })
@@ -394,7 +405,10 @@ describe('DopesheetEditor playhead overlay', () => {
 
     const ruler = screen.getByTestId('dopesheet-ruler')
     fireEvent.wheel(ruler, { deltaY: 120 })
-    expect(onFrameViewportChange).toHaveBeenLastCalledWith({ startFrame: 31, endFrame: 131 })
+    expect(onFrameViewportChange).toHaveBeenLastCalledWith({
+      startFrame: 31,
+      endFrame: 131,
+    })
 
     onFrameViewportChange.mockClear()
     fireEvent.wheel(ruler, { deltaY: 120, shiftKey: true })
@@ -441,7 +455,11 @@ describe('DopesheetEditor playhead overlay', () => {
     act(() => ruler.dispatchEvent(panEvent))
     expect(panEvent.defaultPrevented).toBe(true)
     expect(forwardedEvents).toHaveLength(1)
-    expect(forwardedEvents[0]).toMatchObject({ clientX: 320, deltaY: 120, ctrlKey: false })
+    expect(forwardedEvents[0]).toMatchObject({
+      clientX: 320,
+      deltaY: 120,
+      ctrlKey: false,
+    })
 
     const zoomEvent = new WheelEvent('wheel', {
       bubbles: true,
@@ -452,7 +470,11 @@ describe('DopesheetEditor playhead overlay', () => {
     })
     act(() => ruler.dispatchEvent(zoomEvent))
     expect(forwardedEvents).toHaveLength(2)
-    expect(forwardedEvents[1]).toMatchObject({ clientX: 400, deltaY: -120, ctrlKey: true })
+    expect(forwardedEvents[1]).toMatchObject({
+      clientX: 400,
+      deltaY: -120,
+      ctrlKey: true,
+    })
 
     fireEvent.wheel(ruler, { deltaY: 120, shiftKey: true })
     expect(forwardedEvents).toHaveLength(2)
@@ -598,9 +620,89 @@ describe('DopesheetEditor playhead overlay', () => {
 
     expect(playhead.style.transform).toBe(cursorLockedTransform)
 
-    notifyTimelineScrubVisualFrame(scrollContainer, { frame: 190, source: 'main' })
+    notifyTimelineScrubVisualFrame(scrollContainer, {
+      frame: 190,
+      source: 'main',
+      viewportProgress: 130 / 391,
+    })
     expect(playhead.style.transform).toBe(cursorLockedTransform)
+
+    notifyTimelineScrubVisualFrame(scrollContainer, {
+      frame: 300,
+      source: 'main',
+      viewportProgress: 1,
+    })
+    expect(playhead).toHaveStyle({ transform: 'translate3d(391px, 0, 0)' })
     mainTimelineScrubActiveRef.current = false
+  })
+
+  it('derives linked edge-scroll frames from the live main-timeline scale', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const animationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const scrollContainer = document.createElement('div')
+    const timelineScrollContainerRef = { current: scrollContainer }
+    const onScrub = vi.fn()
+    const onVisualFrame = vi.fn()
+    scrollContainer.addEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, (event) => {
+      onVisualFrame((event as CustomEvent).detail)
+    })
+    const onRulerEdgeScroll = vi.fn(() => {
+      scrollContainer.scrollLeft += 12
+      scrollContainer.dispatchEvent(new Event(TIMELINE_LIVE_SCROLL_EVENT))
+      return 12
+    })
+
+    render(
+      <DopesheetEditor
+        itemId="item-1"
+        keyframesByProperty={{ x: [] }}
+        currentFrame={0}
+        totalFrames={300}
+        frameViewport={{ startFrame: 0, endFrame: 100 }}
+        clampViewportToContent={false}
+        scrubClampToItemBounds={false}
+        presentation="classic"
+        width={640}
+        height={240}
+        fps={30}
+        onScrub={onScrub}
+        onRulerEdgeScroll={onRulerEdgeScroll}
+        timelineScrollContainerRef={timelineScrollContainerRef}
+        getTimelineLivePixelsPerSecond={() => 240}
+      />,
+    )
+
+    const ruler = screen.getByTestId('dopesheet-ruler')
+    vi.spyOn(ruler, 'getBoundingClientRect').mockReturnValue({
+      x: 248,
+      y: 0,
+      left: 248,
+      top: 0,
+      right: 640,
+      bottom: 22,
+      width: 392,
+      height: 22,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    fireEvent.pointerDown(ruler, { button: 0, pointerId: 92, clientX: 640 })
+    expect(onScrub).toHaveBeenLastCalledWith(49)
+    expect(timelineSkimmerScrubActiveRef.current).toBe(true)
+
+    act(() => frameCallbacks.shift()?.(16))
+
+    expect(onVisualFrame).toHaveBeenLastCalledWith(
+      expect.objectContaining({ frame: 50, source: 'keyframe' }),
+    )
+
+    fireEvent.pointerUp(ruler, { pointerId: 92, clientX: 640 })
+    expect(timelineSkimmerScrubActiveRef.current).toBe(false)
+    animationFrameSpy.mockRestore()
   })
 
   it('compositor-pans keyframe geometry between settled React viewport updates', () => {

--- a/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
@@ -1,11 +1,13 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { usePlaybackStore } from '@/shared/state/playback'
+import { TimelinePreviewScrubberVisual } from '@/shared/ui/timeline-preview-scrubber-visual'
 import { DopesheetEditor } from './index'
 import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
-  timelineSkimmerScrubActiveRef,
+  resetTimelineSkimmerScrubForTest,
+  timelineSkimmerScrubSignal,
 } from '@/shared/timeline/main-timeline-scrub'
 import {
   TIMELINE_LIVE_SCROLL_EVENT,
@@ -32,7 +34,7 @@ describe('DopesheetEditor playhead overlay', () => {
     })
     mainTimelineScrubActiveRef.current = false
     mainTimelineScrubHandoffFrameRef.current = null
-    timelineSkimmerScrubActiveRef.current = false
+    resetTimelineSkimmerScrubForTest()
   })
 
   it('clamps the playhead to the left edge when the current frame is before the viewport', () => {
@@ -646,7 +648,9 @@ describe('DopesheetEditor playhead overlay', () => {
       })
     const scrollContainer = document.createElement('div')
     const timelineScrollContainerRef = { current: scrollContainer }
-    const onScrub = vi.fn()
+    const onScrub = vi.fn((frame: number) => {
+      usePlaybackStore.getState().setScrubFrame(frame)
+    })
     const onVisualFrame = vi.fn()
     scrollContainer.addEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, (event) => {
       onVisualFrame((event as CustomEvent).detail)
@@ -658,26 +662,35 @@ describe('DopesheetEditor playhead overlay', () => {
     })
 
     render(
-      <DopesheetEditor
-        itemId="item-1"
-        keyframesByProperty={{ x: [] }}
-        currentFrame={0}
-        totalFrames={300}
-        frameViewport={{ startFrame: 0, endFrame: 100 }}
-        clampViewportToContent={false}
-        scrubClampToItemBounds={false}
-        presentation="classic"
-        width={640}
-        height={240}
-        fps={30}
-        onScrub={onScrub}
-        onRulerEdgeScroll={onRulerEdgeScroll}
-        timelineScrollContainerRef={timelineScrollContainerRef}
-        getTimelineLivePixelsPerSecond={() => 240}
-      />,
+      <>
+        <TimelinePreviewScrubberVisual
+          frameToPixels={(frame) => frame}
+          fps={30}
+          suppressSignal={timelineSkimmerScrubSignal}
+        />
+        <DopesheetEditor
+          itemId="item-1"
+          keyframesByProperty={{ x: [] }}
+          currentFrame={0}
+          totalFrames={300}
+          frameViewport={{ startFrame: 0, endFrame: 100 }}
+          clampViewportToContent={false}
+          scrubClampToItemBounds={false}
+          presentation="classic"
+          width={640}
+          height={240}
+          fps={30}
+          onScrub={onScrub}
+          onScrubEnd={() => usePlaybackStore.getState().setPreviewFrame(null)}
+          onRulerEdgeScroll={onRulerEdgeScroll}
+          timelineScrollContainerRef={timelineScrollContainerRef}
+          getTimelineLivePixelsPerSecond={() => 240}
+        />
+      </>,
     )
 
     const ruler = screen.getByTestId('dopesheet-ruler')
+    const mainSkimmer = screen.getByTestId('timeline-preview-scrubber')
     vi.spyOn(ruler, 'getBoundingClientRect').mockReturnValue({
       x: 248,
       y: 0,
@@ -690,18 +703,23 @@ describe('DopesheetEditor playhead overlay', () => {
       toJSON: () => ({}),
     } as DOMRect)
 
+    act(() => usePlaybackStore.getState().setPreviewFrame(20))
+    expect(mainSkimmer).not.toHaveStyle({ display: 'none' })
+
     fireEvent.pointerDown(ruler, { button: 0, pointerId: 92, clientX: 640 })
     expect(onScrub).toHaveBeenLastCalledWith(49)
-    expect(timelineSkimmerScrubActiveRef.current).toBe(true)
+    expect(timelineSkimmerScrubSignal.current).toBe(true)
+    expect(mainSkimmer).toHaveStyle({ display: 'none' })
 
     act(() => frameCallbacks.shift()?.(16))
 
     expect(onVisualFrame).toHaveBeenLastCalledWith(
       expect.objectContaining({ frame: 50, source: 'keyframe' }),
     )
+    expect(mainSkimmer).toHaveStyle({ display: 'none' })
 
     fireEvent.pointerUp(ruler, { pointerId: 92, clientX: 640 })
-    expect(timelineSkimmerScrubActiveRef.current).toBe(false)
+    expect(timelineSkimmerScrubSignal.current).toBe(false)
     animationFrameSpy.mockRestore()
   })
 

--- a/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
@@ -6,7 +6,10 @@ import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
 } from '@/shared/timeline/main-timeline-scrub'
-import { TIMELINE_LIVE_SCROLL_EVENT } from '@/shared/timeline/live-scroll-sync'
+import {
+  TIMELINE_LIVE_SCROLL_EVENT,
+  notifyTimelineScrubVisualFrame,
+} from '@/shared/timeline/live-scroll-sync'
 
 describe('DopesheetEditor playhead overlay', () => {
   beforeAll(() => {
@@ -560,6 +563,44 @@ describe('DopesheetEditor playhead overlay', () => {
     fireEvent.scroll(scrollContainer)
 
     expect(committed).toHaveStyle({ transform: 'translate3d(0px, 0, 0)' })
+  })
+
+  it('keeps the keyframe playhead stable during main-timeline edge scrolling', () => {
+    const scrollContainer = document.createElement('div')
+    scrollContainer.scrollLeft = 20
+    const timelineScrollContainerRef = { current: scrollContainer }
+    const globalFrameToPixels = (globalFrame: number) => globalFrame - scrollContainer.scrollLeft
+
+    act(() => usePlaybackStore.getState().setCurrentFrame(150))
+    render(
+      <DopesheetEditor
+        itemId="item-1"
+        keyframesByProperty={{ x: [] }}
+        currentFrame={50}
+        playheadFrame={50}
+        playheadClampToItemBounds={false}
+        itemFrom={100}
+        totalFrames={100}
+        frameViewport={{ startFrame: 0, endFrame: 100 }}
+        width={640}
+        height={240}
+        onSkim={() => {}}
+        globalFrameToPixels={globalFrameToPixels}
+        timelineScrollContainerRef={timelineScrollContainerRef}
+      />,
+    )
+
+    const playhead = screen.getByTestId('dopesheet-playhead-line')
+    const cursorLockedTransform = playhead.style.transform
+    mainTimelineScrubActiveRef.current = true
+    scrollContainer.scrollLeft = 60
+    scrollContainer.dispatchEvent(new Event(TIMELINE_LIVE_SCROLL_EVENT))
+
+    expect(playhead.style.transform).toBe(cursorLockedTransform)
+
+    notifyTimelineScrubVisualFrame(scrollContainer, { frame: 190, source: 'main' })
+    expect(playhead.style.transform).toBe(cursorLockedTransform)
+    mainTimelineScrubActiveRef.current = false
   })
 
   it('compositor-pans keyframe geometry between settled React viewport updates', () => {

--- a/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx
@@ -311,6 +311,69 @@ describe('DopesheetEditor playhead overlay', () => {
     animationFrameSpy.mockRestore()
   })
 
+  it('keeps the playhead cursor-locked between an edge scroll and its queued scrub frame', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const animationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const scrollContainer = document.createElement('div')
+    const timelineScrollContainerRef = { current: scrollContainer }
+    const pixelsPerFrame = 391 / 100
+    const onRulerEdgeScroll = vi.fn((deltaPixels: number) => {
+      const appliedPixels = Math.min(deltaPixels, 12)
+      scrollContainer.scrollLeft += appliedPixels
+      scrollContainer.dispatchEvent(new Event(TIMELINE_LIVE_SCROLL_EVENT))
+      return appliedPixels
+    })
+
+    render(
+      <DopesheetEditor
+        itemId="item-1"
+        keyframesByProperty={{ x: [] }}
+        currentFrame={0}
+        totalFrames={300}
+        frameViewport={{ startFrame: 0, endFrame: 100 }}
+        clampViewportToContent={false}
+        scrubClampToItemBounds={false}
+        presentation="classic"
+        width={640}
+        height={240}
+        onScrub={(frame) => usePlaybackStore.getState().setScrubFrame(frame)}
+        onRulerEdgeScroll={onRulerEdgeScroll}
+        globalFrameToPixels={(frame) => frame * pixelsPerFrame - scrollContainer.scrollLeft}
+        timelineScrollContainerRef={timelineScrollContainerRef}
+      />,
+    )
+
+    const ruler = screen.getByTestId('dopesheet-ruler')
+    vi.spyOn(ruler, 'getBoundingClientRect').mockReturnValue({
+      x: 249,
+      y: 0,
+      left: 249,
+      top: 0,
+      right: 640,
+      bottom: 22,
+      width: 391,
+      height: 22,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    fireEvent.pointerDown(ruler, { button: 0, pointerId: 91, clientX: 640 })
+    const playhead = screen.getByTestId('dopesheet-playhead-line')
+    const cursorLockedTransform = playhead.style.transform
+
+    act(() => frameCallbacks.shift()?.(16))
+
+    expect(onRulerEdgeScroll).toHaveBeenCalledOnce()
+    expect(playhead.style.transform).toBe(cursorLockedTransform)
+
+    fireEvent.pointerUp(ruler, { pointerId: 91, clientX: 640 })
+    animationFrameSpy.mockRestore()
+  })
+
   it('uses main-timeline wheel semantics in a standalone keyframe editor', () => {
     const onFrameViewportChange = vi.fn()
     render(

--- a/src/features/timeline/components/timeline-markers.test.tsx
+++ b/src/features/timeline/components/timeline-markers.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { usePlaybackStore } from '@/shared/state/playback'
+import {
+  mainTimelineScrubActiveRef,
+  resetTimelineSkimmerScrubForTest,
+  timelineSkimmerScrubSignal,
+} from '@/shared/timeline/main-timeline-scrub'
+import { useTimelineStore } from '../stores/timeline-store'
+import { TimelineMarkers } from './timeline-markers'
+
+vi.mock('../contexts/timeline-zoom-context', () => ({
+  useTimelineCommittedZoomContext: () => ({
+    timeToPixels: (time: number) => time * 100,
+    frameToPixels: (frame: number) => frame * (100 / 30),
+    pixelsPerSecond: 100,
+  }),
+}))
+
+describe('TimelineMarkers ruler scrub cancellation', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      currentFrame: 0,
+      previewFrame: null,
+      previewItemId: null,
+      isPlaying: false,
+    })
+    useTimelineStore.setState({ fps: 30, inPoint: null, outPoint: null, markers: [] })
+    mainTimelineScrubActiveRef.current = false
+    resetTimelineSkimmerScrubForTest()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ close: vi.fn() })),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('releases scrub ownership and cancels the RAF when the window loses focus', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const { container } = render(
+      <div className="timeline-container">
+        <TimelineMarkers duration={10} width={1000} />
+      </div>,
+    )
+    const scrollContainer = container.querySelector('.timeline-container') as HTMLDivElement
+    Object.defineProperties(scrollContainer, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1000 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    })
+    scrollContainer.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 300,
+      bottom: 200,
+      width: 300,
+      height: 200,
+      toJSON: () => ({}),
+    })
+    const ruler = container.querySelector('[style*="cursor: ew-resize"]') as HTMLDivElement
+    ruler.getBoundingClientRect = scrollContainer.getBoundingClientRect
+
+    fireEvent.mouseDown(ruler, { button: 0, clientX: 290 })
+    expect(mainTimelineScrubActiveRef.current).toBe(true)
+    expect(timelineSkimmerScrubSignal.current).toBe(true)
+    expect(frameCallbacks).toHaveLength(1)
+
+    fireEvent.blur(window)
+
+    expect(mainTimelineScrubActiveRef.current).toBe(false)
+    expect(timelineSkimmerScrubSignal.current).toBe(false)
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+    expect(usePlaybackStore.getState().previewFrame).toBeNull()
+    await waitFor(() => expect(document.body.style.cursor).toBe(''))
+  })
+})

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -15,6 +15,7 @@ import { TimelineProjectMarkers } from './timeline-project-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
 import { beginIoPointerDrag, IoRangeStrip } from '@/shared/timeline/io-range'
 import { mainTimelineScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
+import { notifyTimelineScrubVisualFrame } from '@/shared/timeline/live-scroll-sync'
 import { useSettingsStore } from '@/features/timeline/deps/settings'
 
 // Utilities and hooks
@@ -763,6 +764,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       for (const element of scrubPlayheadElementsRef.current) {
         element.style.transform = `translate3d(${visualTimelineX}px, 0, 0)`
       }
+      notifyTimelineScrubVisualFrame(scrollContainer, { frame, source: 'main' })
     }
 
     // --- STEP 3: Continue loop while scrubbing ---

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -1019,10 +1019,12 @@ export const TimelineMarkers = memo(function TimelineMarkers({
 
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
+    window.addEventListener('blur', handleMouseUp)
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
+      window.removeEventListener('blur', handleMouseUp)
       document.body.style.cursor = originalCursor
       // Ensure cleanup
       isScrubActiveRef.current = false

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -15,8 +15,9 @@ import { TimelineProjectMarkers } from './timeline-project-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
 import { beginIoPointerDrag, IoRangeStrip } from '@/shared/timeline/io-range'
 import {
+  beginTimelineSkimmerScrub,
+  endTimelineSkimmerScrub,
   mainTimelineScrubActiveRef,
-  timelineSkimmerScrubActiveRef,
 } from '@/shared/timeline/main-timeline-scrub'
 import {
   getTimelineScrubViewportProgress,
@@ -479,6 +480,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
   const scrubRAFIdRef = useRef<number | null>(null)
   const scrubAnimationTimeRef = useRef<number | null>(null)
   const scrubPlayheadElementsRef = useRef<HTMLElement[]>([])
+  const skimmerScrubOwnerRef = useRef({})
   const isScrubActiveRef = useRef(false)
   const scrubThrottleStateRef = useRef(createScrubThrottleState())
 
@@ -947,7 +949,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       scrubAnimationTimeRef.current = null
       isScrubActiveRef.current = true
       mainTimelineScrubActiveRef.current = true
-      timelineSkimmerScrubActiveRef.current = true
+      beginTimelineSkimmerScrub(skimmerScrubOwnerRef.current)
 
       pauseRef.current()
 
@@ -982,6 +984,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
 
   useEffect(() => {
     if (!isDragging) return
+    const skimmerScrubOwner = skimmerScrubOwnerRef.current
 
     const originalCursor = document.body.style.cursor
     document.body.style.cursor = 'ew-resize'
@@ -1011,7 +1014,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       // Clear after the preview notification so linked playheads retain the
       // final frame while their slower React props catch up.
       mainTimelineScrubActiveRef.current = false
-      timelineSkimmerScrubActiveRef.current = false
+      endTimelineSkimmerScrub(skimmerScrubOwner)
     }
 
     document.addEventListener('mousemove', handleMouseMove)
@@ -1024,7 +1027,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       // Ensure cleanup
       isScrubActiveRef.current = false
       mainTimelineScrubActiveRef.current = false
-      timelineSkimmerScrubActiveRef.current = false
+      endTimelineSkimmerScrub(skimmerScrubOwner)
       if (scrubRAFIdRef.current !== null) {
         cancelAnimationFrame(scrubRAFIdRef.current)
         scrubRAFIdRef.current = null

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -14,8 +14,14 @@ import { TimelineInOutMarkers } from './timeline-in-out-markers'
 import { TimelineProjectMarkers } from './timeline-project-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
 import { beginIoPointerDrag, IoRangeStrip } from '@/shared/timeline/io-range'
-import { mainTimelineScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
-import { notifyTimelineScrubVisualFrame } from '@/shared/timeline/live-scroll-sync'
+import {
+  mainTimelineScrubActiveRef,
+  timelineSkimmerScrubActiveRef,
+} from '@/shared/timeline/main-timeline-scrub'
+import {
+  getTimelineScrubViewportProgress,
+  notifyTimelineScrubVisualFrame,
+} from '@/shared/timeline/live-scroll-sync'
 import { useSettingsStore } from '@/features/timeline/deps/settings'
 
 // Utilities and hooks
@@ -58,6 +64,65 @@ const MINOR_TICK_HEIGHT = 4
 // occupies the remaining height below it (mirrors the Color workspace). Exported
 // so the ruler playhead can drop its flag below the lane.
 export const IO_LANE_HEIGHT = 12
+
+function applyMainTimelineScrubVisual({
+  scrollContainer,
+  clientX,
+  frame,
+  maxFrame,
+  frameToPixels,
+  playheadElements,
+}: {
+  scrollContainer: HTMLDivElement | null
+  clientX: number
+  frame: number
+  maxFrame: number
+  frameToPixels: (frame: number) => number
+  playheadElements: HTMLElement[]
+}): void {
+  if (!scrollContainer) return
+  const viewportRect = scrollContainer.getBoundingClientRect()
+  const visualClientX = getVisiblePlayheadClientX(clientX, viewportRect)
+  const pointerTimelineX = visualClientX - viewportRect.left + scrollContainer.scrollLeft
+  const visualTimelineX = Math.max(
+    scrollContainer.scrollLeft,
+    Math.min(pointerTimelineX, frameToPixels(maxFrame)),
+  )
+  for (const element of playheadElements) {
+    element.style.transform = `translate3d(${visualTimelineX}px, 0, 0)`
+  }
+  notifyTimelineScrubVisualFrame(scrollContainer, {
+    frame,
+    source: 'main',
+    viewportProgress: getTimelineScrubViewportProgress(
+      visualTimelineX - scrollContainer.scrollLeft,
+      viewportRect.width - 1,
+    ),
+  })
+}
+
+function applyMainTimelineEdgeScroll(
+  scrollContainer: HTMLDivElement | null,
+  clientX: number,
+  timestamp: number,
+  previousTimestamp: number | null,
+): number | null {
+  if (!scrollContainer) return null
+  const viewportRect = scrollContainer.getBoundingClientRect()
+  const velocity = getPlayheadEdgeScrollVelocity(clientX, viewportRect)
+  const canScroll =
+    (velocity < 0 && scrollContainer.scrollLeft > 0) ||
+    (velocity > 0 &&
+      scrollContainer.scrollLeft + scrollContainer.clientWidth < scrollContainer.scrollWidth)
+  if (velocity === 0 || !canScroll) return null
+
+  scrollContainer.scrollLeft += getEdgeScrollDelta(
+    velocity,
+    timestamp,
+    previousTimestamp ?? timestamp - 1000 / 60,
+  )
+  return timestamp
+}
 
 // Quantize pixelsPerSecond for cache keys to avoid redrawing on every minor zoom change
 // Uses logarithmic steps for perceptually uniform quantization across zoom range
@@ -705,36 +770,17 @@ export const TimelineMarkers = memo(function TimelineMarkers({
     const mouseClientX = scrubMouseClientXRef.current
 
     // --- STEP 1: Calculate and apply edge scroll ---
-    if (scrollContainer) {
-      const viewportRect = scrollContainer.getBoundingClientRect()
-      const velocity = getPlayheadEdgeScrollVelocity(mouseClientX, viewportRect)
-      const canScroll =
-        (velocity < 0 && scrollContainer.scrollLeft > 0) ||
-        (velocity > 0 &&
-          scrollContainer.scrollLeft + scrollContainer.clientWidth < scrollContainer.scrollWidth)
-      if (velocity !== 0 && canScroll) {
-        const previousTimestamp = scrubAnimationTimeRef.current ?? timestamp - 1000 / 60
-        scrollContainer.scrollLeft += getEdgeScrollDelta(velocity, timestamp, previousTimestamp)
-        scrubAnimationTimeRef.current = timestamp
-      } else {
-        scrubAnimationTimeRef.current = null
-      }
-    }
+    scrubAnimationTimeRef.current = applyMainTimelineEdgeScroll(
+      scrollContainer,
+      mouseClientX,
+      timestamp,
+      scrubAnimationTimeRef.current,
+    )
 
     // --- STEP 2: Update playhead with FRESH position ---
-    // Calculate position relative to scroll container + scroll offset
-    // This correctly handles when mouse is over track headers (left of timeline)
-    let x: number
-
-    if (scrollContainer) {
-      const scrollContainerRect = scrollContainer.getBoundingClientRect()
-      // Position relative to visible viewport left edge + scroll offset = timeline position
-      x = mouseClientX - scrollContainerRect.left + scrollContainer.scrollLeft
-    } else {
-      // Fallback to container rect
-      const containerRect = containerRef.current.getBoundingClientRect()
-      x = mouseClientX - containerRect.left
-    }
+    // The ruler itself is the time-axis origin. Its rect already incorporates
+    // native scroll, so no additional scrollLeft term belongs in this mapping.
+    const x = mouseClientX - containerRef.current.getBoundingClientRect().left
 
     // Calculate frame (pixel-perfect: round to whole frames)
     const maxFrame = Math.floor(durationRef.current * fpsRef.current)
@@ -753,19 +799,14 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       setScrubFrameRef.current(frame)
     }
 
-    if (scrollContainer) {
-      const viewportRect = scrollContainer.getBoundingClientRect()
-      const visualClientX = getVisiblePlayheadClientX(mouseClientX, viewportRect)
-      const pointerTimelineX = visualClientX - viewportRect.left + scrollContainer.scrollLeft
-      const visualTimelineX = Math.max(
-        scrollContainer.scrollLeft,
-        Math.min(pointerTimelineX, frameToPixelsRef.current(maxFrame)),
-      )
-      for (const element of scrubPlayheadElementsRef.current) {
-        element.style.transform = `translate3d(${visualTimelineX}px, 0, 0)`
-      }
-      notifyTimelineScrubVisualFrame(scrollContainer, { frame, source: 'main' })
-    }
+    applyMainTimelineScrubVisual({
+      scrollContainer,
+      clientX: mouseClientX,
+      frame,
+      maxFrame,
+      frameToPixels: frameToPixelsRef.current,
+      playheadElements: scrubPlayheadElementsRef.current,
+    })
 
     // --- STEP 3: Continue loop while scrubbing ---
     scrubRAFIdRef.current = requestAnimationFrame(runUnifiedScrubLoop)
@@ -773,17 +814,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
 
   const getTimelineXFromClientX = useCallback((clientX: number): number => {
     if (!containerRef.current) return 0
-
-    const scrollContainer = containerRef.current.closest(
-      '.timeline-container',
-    ) as HTMLDivElement | null
-    if (scrollContainer) {
-      const scrollContainerRect = scrollContainer.getBoundingClientRect()
-      return clientX - scrollContainerRect.left + scrollContainer.scrollLeft
-    }
-
-    const containerRect = containerRef.current.getBoundingClientRect()
-    return clientX - containerRect.left
+    return clientX - containerRef.current.getBoundingClientRect().left
   }, [])
 
   const getFrameFromClientX = useCallback(
@@ -916,35 +947,23 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       scrubAnimationTimeRef.current = null
       isScrubActiveRef.current = true
       mainTimelineScrubActiveRef.current = true
+      timelineSkimmerScrubActiveRef.current = true
 
       pauseRef.current()
 
-      // Immediate frame update on click (instant response)
-      // Use scroll container position + scroll offset for accurate timeline position
-      let x: number
-      if (scrollContainerRef.current) {
-        const scrollContainerRect = scrollContainerRef.current.getBoundingClientRect()
-        x = e.clientX - scrollContainerRect.left + scrollContainerRef.current.scrollLeft
-      } else {
-        const rect = containerRef.current.getBoundingClientRect()
-        x = e.clientX - rect.left
-      }
+      // Immediate frame update on click using the ruler's time-axis origin.
+      const x = e.clientX - containerRef.current.getBoundingClientRect().left
       const maxFrame = Math.floor(durationRef.current * fpsRef.current)
       const frame = Math.min(maxFrame, Math.max(0, Math.round(pixelsToFrameRef.current(x))))
       setScrubFrameRef.current(frame)
-      if (scrollContainerRef.current) {
-        const viewportRect = scrollContainerRef.current.getBoundingClientRect()
-        const visualClientX = getVisiblePlayheadClientX(e.clientX, viewportRect)
-        const pointerTimelineX =
-          visualClientX - viewportRect.left + scrollContainerRef.current.scrollLeft
-        const visualTimelineX = Math.max(
-          scrollContainerRef.current.scrollLeft,
-          Math.min(pointerTimelineX, frameToPixelsRef.current(maxFrame)),
-        )
-        for (const element of scrubPlayheadElementsRef.current) {
-          element.style.transform = `translate3d(${visualTimelineX}px, 0, 0)`
-        }
-      }
+      applyMainTimelineScrubVisual({
+        scrollContainer: scrollContainerRef.current,
+        clientX: e.clientX,
+        frame,
+        maxFrame,
+        frameToPixels: frameToPixelsRef.current,
+        playheadElements: scrubPlayheadElementsRef.current,
+      })
       scrubThrottleStateRef.current = createScrubThrottleState({
         pointerX: x,
         frame,
@@ -992,6 +1011,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       // Clear after the preview notification so linked playheads retain the
       // final frame while their slower React props catch up.
       mainTimelineScrubActiveRef.current = false
+      timelineSkimmerScrubActiveRef.current = false
     }
 
     document.addEventListener('mousemove', handleMouseMove)
@@ -1004,6 +1024,7 @@ export const TimelineMarkers = memo(function TimelineMarkers({
       // Ensure cleanup
       isScrubActiveRef.current = false
       mainTimelineScrubActiveRef.current = false
+      timelineSkimmerScrubActiveRef.current = false
       if (scrubRAFIdRef.current !== null) {
         cancelAnimationFrame(scrubRAFIdRef.current)
         scrubRAFIdRef.current = null

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -10,6 +10,7 @@ import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
 } from '@/shared/timeline/main-timeline-scrub'
+import { notifyTimelineScrubVisualFrame } from '@/shared/timeline/live-scroll-sync'
 
 describe('TimelinePlayhead', () => {
   beforeEach(() => {
@@ -124,6 +125,21 @@ describe('TimelinePlayhead', () => {
     fireEvent.mouseUp(document, { clientX: 130, clientY: 8 })
 
     expect(usePlaybackStore.getState().currentFrame).toBe(60)
+  })
+
+  it('follows a keyframe scrub visual frame before its throttled store update', () => {
+    const { container } = render(
+      <div className="timeline-container">
+        <TimelinePlayhead inRuler maxFrame={300} />
+      </div>,
+    )
+    const scrollContainer = container.querySelector('.timeline-container') as HTMLDivElement
+    const playhead = container.querySelector('[data-timeline-playhead="ruler"]') as HTMLDivElement
+
+    notifyTimelineScrubVisualFrame(scrollContainer, { frame: 90, source: 'keyframe' })
+
+    expect(playhead).toHaveStyle({ transform: 'translate3d(300px, 0, 0)' })
+    expect(usePlaybackStore.getState().currentFrame).toBe(12)
   })
 
   it('auto-scrolls at the viewport edge while keeping both playheads cursor-locked', () => {

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -88,6 +88,46 @@ describe('TimelinePlayhead', () => {
     })
   })
 
+  it('releases scrub ownership and cancels the RAF when the window loses focus', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const { container } = render(
+      <div className="timeline-ruler">
+        <TimelinePlayhead inRuler maxFrame={300} />
+      </div>,
+    )
+    const ruler = container.querySelector('.timeline-ruler') as HTMLDivElement
+    ruler.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 40,
+      width: 600,
+      height: 40,
+      toJSON: () => ({}),
+    })
+    const hitArea = container.querySelector('[style*="width: 20px"]') as HTMLDivElement
+
+    fireEvent.mouseDown(hitArea, { clientX: 120, clientY: 8, button: 0 })
+    expect(mainTimelineScrubActiveRef.current).toBe(true)
+    expect(timelineSkimmerScrubSignal.current).toBe(true)
+    expect(frameCallbacks).toHaveLength(1)
+
+    fireEvent.blur(window)
+
+    expect(mainTimelineScrubActiveRef.current).toBe(false)
+    expect(timelineSkimmerScrubSignal.current).toBe(false)
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+    expect(usePlaybackStore.getState().previewFrame).toBeNull()
+    await waitFor(() => expect(document.body.style.cursor).toBe(''))
+  })
+
   it('uses an explicit ruler origin when the unified playhead is its sibling', () => {
     const rulerRef = createRef<HTMLDivElement>()
     const { container } = render(

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -9,6 +9,7 @@ import { useTimelineStore } from '../stores/timeline-store'
 import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
+  timelineSkimmerScrubActiveRef,
 } from '@/shared/timeline/main-timeline-scrub'
 import { notifyTimelineScrubVisualFrame } from '@/shared/timeline/live-scroll-sync'
 
@@ -35,6 +36,7 @@ describe('TimelinePlayhead', () => {
     useZoomStore.getState().setZoomLevelSynchronized(1)
     mainTimelineScrubActiveRef.current = false
     mainTimelineScrubHandoffFrameRef.current = null
+    timelineSkimmerScrubActiveRef.current = false
   })
 
   it('uses atomic scrub updates while dragging and clears preview on release', async () => {
@@ -65,6 +67,7 @@ describe('TimelinePlayhead', () => {
 
     fireEvent.mouseDown(hitArea!, { clientX: 24, clientY: 8, button: 0 })
     expect(mainTimelineScrubActiveRef.current).toBe(true)
+    expect(timelineSkimmerScrubActiveRef.current).toBe(true)
     expect(document.body).toHaveStyle({ cursor: 'ew-resize' })
     fireEvent.mouseMove(document, { clientX: 120, clientY: 8 })
 
@@ -75,6 +78,7 @@ describe('TimelinePlayhead', () => {
 
     fireEvent.mouseUp(document, { clientX: 120, clientY: 8 })
     expect(mainTimelineScrubActiveRef.current).toBe(false)
+    expect(timelineSkimmerScrubActiveRef.current).toBe(false)
     expect(document.body.style.cursor).toBe('')
 
     await waitFor(() => {
@@ -135,11 +139,26 @@ describe('TimelinePlayhead', () => {
     )
     const scrollContainer = container.querySelector('.timeline-container') as HTMLDivElement
     const playhead = container.querySelector('[data-timeline-playhead="ruler"]') as HTMLDivElement
+    Object.defineProperties(scrollContainer, {
+      clientWidth: { configurable: true, value: 301 },
+      scrollLeft: { configurable: true, value: 100, writable: true },
+    })
 
-    notifyTimelineScrubVisualFrame(scrollContainer, { frame: 90, source: 'keyframe' })
+    notifyTimelineScrubVisualFrame(scrollContainer, {
+      frame: 90,
+      source: 'keyframe',
+      viewportProgress: 2 / 3,
+    })
 
     expect(playhead).toHaveStyle({ transform: 'translate3d(300px, 0, 0)' })
     expect(usePlaybackStore.getState().currentFrame).toBe(12)
+
+    notifyTimelineScrubVisualFrame(scrollContainer, {
+      frame: 300,
+      source: 'keyframe',
+      viewportProgress: 1,
+    })
+    expect(playhead).toHaveStyle({ transform: 'translate3d(400px, 0, 0)' })
   })
 
   it('auto-scrolls at the viewport edge while keeping both playheads cursor-locked', () => {
@@ -250,7 +269,9 @@ describe('TimelinePlayhead', () => {
     fireEvent.mouseDown(hitArea, { clientX: 250, clientY: 8, button: 0 })
     frameCallbacks.shift()?.(16)
 
-    expect(rulerPlayhead).toHaveStyle({ transform: 'translate3d(100px, 0, 0)' })
+    expect(rulerPlayhead).toHaveStyle({
+      transform: 'translate3d(100px, 0, 0)',
+    })
     expect(tracksPlayhead.style.transform).toBe(rulerPlayhead.style.transform)
     expect(usePlaybackStore.getState().currentFrame).toBe(30)
 

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -9,7 +9,8 @@ import { useTimelineStore } from '../stores/timeline-store'
 import {
   mainTimelineScrubActiveRef,
   mainTimelineScrubHandoffFrameRef,
-  timelineSkimmerScrubActiveRef,
+  resetTimelineSkimmerScrubForTest,
+  timelineSkimmerScrubSignal,
 } from '@/shared/timeline/main-timeline-scrub'
 import { notifyTimelineScrubVisualFrame } from '@/shared/timeline/live-scroll-sync'
 
@@ -36,7 +37,7 @@ describe('TimelinePlayhead', () => {
     useZoomStore.getState().setZoomLevelSynchronized(1)
     mainTimelineScrubActiveRef.current = false
     mainTimelineScrubHandoffFrameRef.current = null
-    timelineSkimmerScrubActiveRef.current = false
+    resetTimelineSkimmerScrubForTest()
   })
 
   it('uses atomic scrub updates while dragging and clears preview on release', async () => {
@@ -67,7 +68,7 @@ describe('TimelinePlayhead', () => {
 
     fireEvent.mouseDown(hitArea!, { clientX: 24, clientY: 8, button: 0 })
     expect(mainTimelineScrubActiveRef.current).toBe(true)
-    expect(timelineSkimmerScrubActiveRef.current).toBe(true)
+    expect(timelineSkimmerScrubSignal.current).toBe(true)
     expect(document.body).toHaveStyle({ cursor: 'ew-resize' })
     fireEvent.mouseMove(document, { clientX: 120, clientY: 8 })
 
@@ -78,7 +79,7 @@ describe('TimelinePlayhead', () => {
 
     fireEvent.mouseUp(document, { clientX: 120, clientY: 8 })
     expect(mainTimelineScrubActiveRef.current).toBe(false)
-    expect(timelineSkimmerScrubActiveRef.current).toBe(false)
+    expect(timelineSkimmerScrubSignal.current).toBe(false)
     expect(document.body.style.cursor).toBe('')
 
     await waitFor(() => {

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -12,8 +12,9 @@ import { createScrubThrottleState, shouldCommitScrubFrame } from '../utils/scrub
 import { withPerfMeasure, perfMarkRender } from '@/shared/logging/perf-marks'
 import { PlayheadMarks } from '@/shared/ui/playhead-marks'
 import {
+  beginTimelineSkimmerScrub,
+  endTimelineSkimmerScrub,
   mainTimelineScrubActiveRef,
-  timelineSkimmerScrubActiveRef,
 } from '@/shared/timeline/main-timeline-scrub'
 import {
   TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
@@ -128,6 +129,7 @@ export function TimelinePlayhead({
   const scrubScrollContainerRef = useRef<HTMLDivElement | null>(null)
   const scrubCoordinateSurfaceRef = useRef<HTMLDivElement | null>(null)
   const scrubPlayheadElementsRef = useRef<HTMLElement[]>([])
+  const skimmerScrubOwnerRef = useRef({})
   const scrubThrottleStateRef = useRef(
     createScrubThrottleState({
       frame: usePlaybackStore.getState().currentFrame,
@@ -258,7 +260,7 @@ export function TimelinePlayhead({
       })
       isDraggingRef.current = true
       mainTimelineScrubActiveRef.current = true
-      timelineSkimmerScrubActiveRef.current = true
+      beginTimelineSkimmerScrub(skimmerScrubOwnerRef.current)
       setPreviewFrameRef.current(null)
       setIsDragging(true)
     },
@@ -268,6 +270,7 @@ export function TimelinePlayhead({
   // Handle dragging
   useEffect(() => {
     if (!isDragging) return
+    const skimmerScrubOwner = skimmerScrubOwnerRef.current
 
     // Keep the horizontal scrub cursor stable while crossing timeline children.
     const originalCursor = document.body.style.cursor
@@ -383,7 +386,7 @@ export function TimelinePlayhead({
       // Keep the shared flag set through the preview-clear notification so the
       // keyframe playhead retains the final scrub position until props settle.
       mainTimelineScrubActiveRef.current = false
-      timelineSkimmerScrubActiveRef.current = false
+      endTimelineSkimmerScrub(skimmerScrubOwner)
       setIsDragging(false)
     }
 
@@ -403,7 +406,7 @@ export function TimelinePlayhead({
       }
       scrubAnimationTimeRef.current = null
       mainTimelineScrubActiveRef.current = false
-      timelineSkimmerScrubActiveRef.current = false
+      endTimelineSkimmerScrub(skimmerScrubOwner)
     }
   }, [isDragging]) // Stable dependencies - no stale closures
 

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -13,6 +13,11 @@ import { withPerfMeasure, perfMarkRender } from '@/shared/logging/perf-marks'
 import { PlayheadMarks } from '@/shared/ui/playhead-marks'
 import { mainTimelineScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
 import {
+  TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
+  notifyTimelineScrubVisualFrame,
+  type TimelineScrubVisualFrameDetail,
+} from '@/shared/timeline/live-scroll-sync'
+import {
   getEdgeScrollDelta,
   getPlayheadEdgeScrollVelocity,
   getVisiblePlayheadClientX,
@@ -177,6 +182,25 @@ export function TimelinePlayhead({
     playheadRef.current.style.transform = `translate3d(${leftPosition}px, 0, 0)`
   }, [frameToPixels, isDragging])
 
+  useEffect(() => {
+    const scrollContainer = playheadRef.current?.closest<HTMLDivElement>('.timeline-container')
+    if (!scrollContainer) return
+
+    const updateFromLinkedScrub = (event: Event) => {
+      const { frame, source } = (event as CustomEvent<TimelineScrubVisualFrameDetail>).detail
+      if (source !== 'keyframe' || !playheadRef.current) return
+      const clampedFrame = Math.max(0, Math.min(frame, maxFrameRef.current ?? frame))
+      playheadRef.current.style.transform = `translate3d(${Math.round(
+        frameToPixelsRef.current(clampedFrame),
+      )}px, 0, 0)`
+    }
+
+    scrollContainer.addEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, updateFromLinkedScrub)
+    return () => {
+      scrollContainer.removeEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, updateFromLinkedScrub)
+    }
+  }, [])
+
   // Track external drag operations to disable pointer events on hit areas
   useEffect(() => {
     const handleDragStart = () => setIsExternalDrag(true)
@@ -303,6 +327,10 @@ export function TimelinePlayhead({
         for (const element of scrubPlayheadElementsRef.current) {
           element.style.transform = `translate3d(${visualTimelineX}px, 0, 0)`
         }
+        notifyTimelineScrubVisualFrame(scrollContainer, {
+          frame: targetFrame,
+          source: 'main',
+        })
       })
 
       if (isDraggingRef.current) rafIdRef.current = requestAnimationFrame(runScrubLoop)

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -392,11 +392,13 @@ export function TimelinePlayhead({
 
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
+    window.addEventListener('blur', handleMouseUp)
     rafIdRef.current = requestAnimationFrame(runScrubLoop)
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
+      window.removeEventListener('blur', handleMouseUp)
       // Restore original cursor
       document.body.style.cursor = originalCursor
       // Cancel any pending RAF to prevent memory leaks

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -11,9 +11,14 @@ import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
 import { createScrubThrottleState, shouldCommitScrubFrame } from '../utils/scrub-throttle'
 import { withPerfMeasure, perfMarkRender } from '@/shared/logging/perf-marks'
 import { PlayheadMarks } from '@/shared/ui/playhead-marks'
-import { mainTimelineScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
+import {
+  mainTimelineScrubActiveRef,
+  timelineSkimmerScrubActiveRef,
+} from '@/shared/timeline/main-timeline-scrub'
 import {
   TIMELINE_SCRUB_VISUAL_FRAME_EVENT,
+  getTimelineScrubViewportProgress,
+  getTimelineScrubViewportX,
   notifyTimelineScrubVisualFrame,
   type TimelineScrubVisualFrameDetail,
 } from '@/shared/timeline/live-scroll-sync'
@@ -44,7 +49,10 @@ function getPlayheadDragSurfaces({
   coordinateSurface: HTMLDivElement | null
 } {
   if (!playhead) {
-    return { scrollContainer: null, coordinateSurface: explicitCoordinateSurface }
+    return {
+      scrollContainer: null,
+      coordinateSurface: explicitCoordinateSurface,
+    }
   }
 
   const scrollContainer = playhead.closest<HTMLDivElement>('.timeline-container')
@@ -187,12 +195,11 @@ export function TimelinePlayhead({
     if (!scrollContainer) return
 
     const updateFromLinkedScrub = (event: Event) => {
-      const { frame, source } = (event as CustomEvent<TimelineScrubVisualFrameDetail>).detail
+      const { source, viewportProgress } = (event as CustomEvent<TimelineScrubVisualFrameDetail>)
+        .detail
       if (source !== 'keyframe' || !playheadRef.current) return
-      const clampedFrame = Math.max(0, Math.min(frame, maxFrameRef.current ?? frame))
-      playheadRef.current.style.transform = `translate3d(${Math.round(
-        frameToPixelsRef.current(clampedFrame),
-      )}px, 0, 0)`
+      const viewportX = getTimelineScrubViewportX(viewportProgress, scrollContainer.clientWidth - 1)
+      playheadRef.current.style.transform = `translate3d(${scrollContainer.scrollLeft + viewportX}px, 0, 0)`
     }
 
     scrollContainer.addEventListener(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, updateFromLinkedScrub)
@@ -251,6 +258,8 @@ export function TimelinePlayhead({
       })
       isDraggingRef.current = true
       mainTimelineScrubActiveRef.current = true
+      timelineSkimmerScrubActiveRef.current = true
+      setPreviewFrameRef.current(null)
       setIsDragging(true)
     },
     [coordinateSurfaceRef, inRuler],
@@ -330,6 +339,10 @@ export function TimelinePlayhead({
         notifyTimelineScrubVisualFrame(scrollContainer, {
           frame: targetFrame,
           source: 'main',
+          viewportProgress: getTimelineScrubViewportProgress(
+            visualTimelineX - scrollLeft,
+            viewportBounds.width - 1,
+          ),
         })
       })
 
@@ -370,6 +383,7 @@ export function TimelinePlayhead({
       // Keep the shared flag set through the preview-clear notification so the
       // keyframe playhead retains the final scrub position until props settle.
       mainTimelineScrubActiveRef.current = false
+      timelineSkimmerScrubActiveRef.current = false
       setIsDragging(false)
     }
 
@@ -389,6 +403,7 @@ export function TimelinePlayhead({
       }
       scrubAnimationTimeRef.current = null
       mainTimelineScrubActiveRef.current = false
+      timelineSkimmerScrubActiveRef.current = false
     }
   }, [isDragging]) // Stable dependencies - no stale closures
 

--- a/src/features/timeline/components/timeline-preview-scrubber.tsx
+++ b/src/features/timeline/components/timeline-preview-scrubber.tsx
@@ -1,13 +1,10 @@
 import { TimelinePreviewScrubberVisual } from '@/shared/ui/timeline-preview-scrubber-visual'
-import { timelineSkimmerScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
+import { timelineSkimmerScrubSignal } from '@/shared/timeline/main-timeline-scrub'
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
 import { IO_LANE_HEIGHT } from './timeline-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
 
-const MAIN_TIMELINE_SKIMMER_SUPPRESS_REFS = [
-  previewScrubberSuppressRef,
-  timelineSkimmerScrubActiveRef,
-]
+const MAIN_TIMELINE_SKIMMER_SUPPRESS_REFS = [previewScrubberSuppressRef]
 
 interface TimelinePreviewScrubberProps {
   inRuler?: boolean
@@ -31,6 +28,7 @@ export function TimelinePreviewScrubber({
       maxFrame={maxFrame}
       rulerOffset={IO_LANE_HEIGHT}
       suppressRefs={MAIN_TIMELINE_SKIMMER_SUPPRESS_REFS}
+      suppressSignal={timelineSkimmerScrubSignal}
       zIndex={zIndex}
     />
   )

--- a/src/features/timeline/components/timeline-preview-scrubber.tsx
+++ b/src/features/timeline/components/timeline-preview-scrubber.tsx
@@ -1,7 +1,13 @@
 import { TimelinePreviewScrubberVisual } from '@/shared/ui/timeline-preview-scrubber-visual'
+import { timelineSkimmerScrubActiveRef } from '@/shared/timeline/main-timeline-scrub'
 import { useTimelineZoomContext } from '../contexts/timeline-zoom-context'
 import { IO_LANE_HEIGHT } from './timeline-markers'
 import { previewScrubberSuppressRef } from './preview-scrubber-suppress'
+
+const MAIN_TIMELINE_SKIMMER_SUPPRESS_REFS = [
+  previewScrubberSuppressRef,
+  timelineSkimmerScrubActiveRef,
+]
 
 interface TimelinePreviewScrubberProps {
   inRuler?: boolean
@@ -24,7 +30,7 @@ export function TimelinePreviewScrubber({
       inRuler={inRuler}
       maxFrame={maxFrame}
       rulerOffset={IO_LANE_HEIGHT}
-      suppressRef={previewScrubberSuppressRef}
+      suppressRefs={MAIN_TIMELINE_SKIMMER_SUPPRESS_REFS}
       zIndex={zIndex}
     />
   )

--- a/src/shared/timeline/live-scroll-sync.ts
+++ b/src/shared/timeline/live-scroll-sync.ts
@@ -4,7 +4,22 @@
  * overlays in a separate panel that must visually share the same axis.
  */
 export const TIMELINE_LIVE_SCROLL_EVENT = 'freecut:timeline-live-scroll'
+export const TIMELINE_SCRUB_VISUAL_FRAME_EVENT = 'freecut:timeline-scrub-visual-frame'
+
+export interface TimelineScrubVisualFrameDetail {
+  frame: number
+  source: 'main' | 'keyframe'
+}
 
 export function notifyTimelineLiveScroll(container: HTMLElement): void {
   container.dispatchEvent(new Event(TIMELINE_LIVE_SCROLL_EVENT))
+}
+
+export function notifyTimelineScrubVisualFrame(
+  container: HTMLElement | null | undefined,
+  detail: TimelineScrubVisualFrameDetail,
+): void {
+  container?.dispatchEvent(
+    new CustomEvent<TimelineScrubVisualFrameDetail>(TIMELINE_SCRUB_VISUAL_FRAME_EVENT, { detail }),
+  )
 }

--- a/src/shared/timeline/live-scroll-sync.ts
+++ b/src/shared/timeline/live-scroll-sync.ts
@@ -9,6 +9,17 @@ export const TIMELINE_SCRUB_VISUAL_FRAME_EVENT = 'freecut:timeline-scrub-visual-
 export interface TimelineScrubVisualFrameDetail {
   frame: number
   source: 'main' | 'keyframe'
+  /** Clamped playhead position within the visible axis, normalized to 0..1. */
+  viewportProgress: number
+}
+
+export function getTimelineScrubViewportProgress(viewportX: number, maxViewportX: number): number {
+  if (maxViewportX <= 0) return 0
+  return Math.max(0, Math.min(1, viewportX / maxViewportX))
+}
+
+export function getTimelineScrubViewportX(viewportProgress: number, maxViewportX: number): number {
+  return Math.max(0, Math.min(1, viewportProgress)) * Math.max(0, maxViewportX)
 }
 
 export function notifyTimelineLiveScroll(container: HTMLElement): void {

--- a/src/shared/timeline/main-timeline-scrub.ts
+++ b/src/shared/timeline/main-timeline-scrub.ts
@@ -7,6 +7,9 @@
  */
 export const mainTimelineScrubActiveRef = { current: false }
 
+/** Any linked ruler/playhead scrub that should own the cursor visual. */
+export const timelineSkimmerScrubActiveRef = { current: false }
+
 /** Final global frame retained until the linked editor's props catch up. */
 export const mainTimelineScrubHandoffFrameRef: { current: number | null } = {
   current: null,

--- a/src/shared/timeline/main-timeline-scrub.ts
+++ b/src/shared/timeline/main-timeline-scrub.ts
@@ -7,8 +7,45 @@
  */
 export const mainTimelineScrubActiveRef = { current: false }
 
-/** Any linked ruler/playhead scrub that should own the cursor visual. */
-export const timelineSkimmerScrubActiveRef = { current: false }
+type TimelineSkimmerScrubOwner = object
+type TimelineSkimmerScrubListener = () => void
+
+const timelineSkimmerScrubOwners = new Set<TimelineSkimmerScrubOwner>()
+const timelineSkimmerScrubListeners = new Set<TimelineSkimmerScrubListener>()
+
+/** Reactive imperative signal for any linked scrub that owns the cursor visual. */
+export const timelineSkimmerScrubSignal = {
+  get current(): boolean {
+    return timelineSkimmerScrubOwners.size > 0
+  },
+  subscribe(listener: TimelineSkimmerScrubListener): () => void {
+    timelineSkimmerScrubListeners.add(listener)
+    return () => timelineSkimmerScrubListeners.delete(listener)
+  },
+}
+
+function publishTimelineSkimmerScrubChange(wasActive: boolean): void {
+  if (wasActive === timelineSkimmerScrubSignal.current) return
+  for (const listener of timelineSkimmerScrubListeners) listener()
+}
+
+export function beginTimelineSkimmerScrub(owner: TimelineSkimmerScrubOwner): void {
+  const wasActive = timelineSkimmerScrubSignal.current
+  timelineSkimmerScrubOwners.add(owner)
+  publishTimelineSkimmerScrubChange(wasActive)
+}
+
+export function endTimelineSkimmerScrub(owner: TimelineSkimmerScrubOwner): void {
+  const wasActive = timelineSkimmerScrubSignal.current
+  timelineSkimmerScrubOwners.delete(owner)
+  publishTimelineSkimmerScrubChange(wasActive)
+}
+
+export function resetTimelineSkimmerScrubForTest(): void {
+  const wasActive = timelineSkimmerScrubSignal.current
+  timelineSkimmerScrubOwners.clear()
+  publishTimelineSkimmerScrubChange(wasActive)
+}
 
 /** Final global frame retained until the linked editor's props catch up. */
 export const mainTimelineScrubHandoffFrameRef: { current: number | null } = {

--- a/src/shared/ui/timeline-preview-scrubber-visual.test.tsx
+++ b/src/shared/ui/timeline-preview-scrubber-visual.test.tsx
@@ -2,11 +2,18 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vite-plus/test'
 
 import { usePlaybackStore } from '@/shared/state/playback'
+import {
+  beginTimelineSkimmerScrub,
+  endTimelineSkimmerScrub,
+  resetTimelineSkimmerScrubForTest,
+  timelineSkimmerScrubSignal,
+} from '@/shared/timeline/main-timeline-scrub'
 import { TimelinePreviewScrubberVisual } from './timeline-preview-scrubber-visual'
 
 describe('TimelinePreviewScrubberVisual', () => {
   beforeEach(() => {
     usePlaybackStore.setState({ previewFrame: null, previewItemId: null })
+    resetTimelineSkimmerScrubForTest()
   })
 
   it('preserves subpixel coordinates so shared timeline skim lines stay aligned', () => {
@@ -68,6 +75,30 @@ describe('TimelinePreviewScrubberVisual', () => {
 
     playheadDragActiveRef.current = false
     act(() => usePlaybackStore.getState().setPreviewFrame(12))
+    expect(skim).not.toHaveStyle({ display: 'none' })
+  })
+
+  it('hides immediately when a linked scrub starts and stays hidden through frame updates', () => {
+    const scrubOwner = {}
+    render(
+      <TimelinePreviewScrubberVisual
+        frameToPixels={(frame) => frame}
+        fps={30}
+        suppressSignal={timelineSkimmerScrubSignal}
+      />,
+    )
+
+    const skim = screen.getByTestId('timeline-preview-scrubber')
+    act(() => usePlaybackStore.getState().setPreviewFrame(20))
+    expect(skim).not.toHaveStyle({ display: 'none' })
+
+    act(() => beginTimelineSkimmerScrub(scrubOwner))
+    expect(skim).toHaveStyle({ display: 'none' })
+
+    act(() => usePlaybackStore.getState().setScrubFrame(21))
+    expect(skim).toHaveStyle({ display: 'none' })
+
+    act(() => endTimelineSkimmerScrub(scrubOwner))
     expect(skim).not.toHaveStyle({ display: 'none' })
   })
 })

--- a/src/shared/ui/timeline-preview-scrubber-visual.test.tsx
+++ b/src/shared/ui/timeline-preview-scrubber-visual.test.tsx
@@ -46,4 +46,28 @@ describe('TimelinePreviewScrubberVisual', () => {
 
     expect(skim).toHaveStyle({ transform: 'translate3d(45px, 0, 0)' })
   })
+
+  it('stays hidden while any imperative scrub gesture is active', () => {
+    const rangeDragActiveRef = { current: false }
+    const playheadDragActiveRef = { current: false }
+    render(
+      <TimelinePreviewScrubberVisual
+        frameToPixels={(frame) => frame}
+        fps={30}
+        suppressRefs={[rangeDragActiveRef, playheadDragActiveRef]}
+      />,
+    )
+
+    const skim = screen.getByTestId('timeline-preview-scrubber')
+    act(() => usePlaybackStore.getState().setPreviewFrame(10))
+    expect(skim).not.toHaveStyle({ display: 'none' })
+
+    playheadDragActiveRef.current = true
+    act(() => usePlaybackStore.getState().setPreviewFrame(11))
+    expect(skim).toHaveStyle({ display: 'none' })
+
+    playheadDragActiveRef.current = false
+    act(() => usePlaybackStore.getState().setPreviewFrame(12))
+    expect(skim).not.toHaveStyle({ display: 'none' })
+  })
 })

--- a/src/shared/ui/timeline-preview-scrubber-visual.tsx
+++ b/src/shared/ui/timeline-preview-scrubber-visual.tsx
@@ -32,7 +32,7 @@ interface TimelinePreviewScrubberVisualProps {
   rulerOffset?: number
   showTooltip?: boolean
   suppressed?: boolean
-  suppressRef?: MutableRefObject<boolean>
+  suppressRefs?: ReadonlyArray<MutableRefObject<boolean>>
   /** Reposition from the live mapper whenever an external timeline scrolls. */
   positionSyncTargetRef?: RefObject<HTMLElement | null>
   zIndex?: number
@@ -47,7 +47,7 @@ export function TimelinePreviewScrubberVisual({
   rulerOffset = 0,
   showTooltip = true,
   suppressed = false,
-  suppressRef,
+  suppressRefs,
   positionSyncTargetRef,
   zIndex = 20,
 }: TimelinePreviewScrubberVisualProps) {
@@ -59,7 +59,7 @@ export function TimelinePreviewScrubberVisual({
   const fpsRef = useRef(fps)
   const maxFrameRef = useRef(maxFrame)
   const suppressedRef = useRef(suppressed)
-  const suppressStateRef = useRef(suppressRef)
+  const suppressStateRefsRef = useRef(suppressRefs)
   // Positioning runs in a layout effect below, so these refs must already hold
   // this render's mapper. Updating them in a passive effect leaves the skim line
   // one zoom render behind.
@@ -67,7 +67,7 @@ export function TimelinePreviewScrubberVisual({
   fpsRef.current = fps
   maxFrameRef.current = maxFrame
   suppressedRef.current = suppressed
-  suppressStateRef.current = suppressRef
+  suppressStateRefsRef.current = suppressRefs
 
   const updatePosition = useCallback((previewFrame: number | null) => {
     const node = scrubberRef.current
@@ -76,7 +76,7 @@ export function TimelinePreviewScrubberVisual({
       shouldHidePreviewScrubber({
         previewFrame,
         suppressed: suppressedRef.current,
-        suppressRefActive: suppressStateRef.current?.current ?? false,
+        suppressRefActive: suppressStateRefsRef.current?.some((ref) => ref.current) ?? false,
       })
     ) {
       node.style.display = 'none'
@@ -158,7 +158,12 @@ export function TimelinePreviewScrubberVisual({
       <div
         ref={lineRef}
         className="absolute bg-white/30"
-        style={{ top: inRuler ? rulerOffset + FLAG_HEIGHT : 0, bottom: 0, left: 0, right: 0 }}
+        style={{
+          top: inRuler ? rulerOffset + FLAG_HEIGHT : 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+        }}
       />
 
       {inRuler ? (

--- a/src/shared/ui/timeline-preview-scrubber-visual.tsx
+++ b/src/shared/ui/timeline-preview-scrubber-visual.tsx
@@ -12,6 +12,18 @@ import { formatTimecode } from '@/shared/utils/time-utils'
 
 const FLAG_HEIGHT = 12
 
+interface ImperativeBooleanSignal {
+  readonly current: boolean
+  subscribe: (listener: () => void) => () => void
+}
+
+function isImperativelySuppressed(
+  suppressRefs: ReadonlyArray<MutableRefObject<boolean>> | undefined,
+  suppressSignal: ImperativeBooleanSignal | undefined,
+): boolean {
+  return (suppressRefs?.some((ref) => ref.current) ?? false) || (suppressSignal?.current ?? false)
+}
+
 function shouldHidePreviewScrubber({
   previewFrame,
   suppressed,
@@ -33,6 +45,7 @@ interface TimelinePreviewScrubberVisualProps {
   showTooltip?: boolean
   suppressed?: boolean
   suppressRefs?: ReadonlyArray<MutableRefObject<boolean>>
+  suppressSignal?: ImperativeBooleanSignal
   /** Reposition from the live mapper whenever an external timeline scrolls. */
   positionSyncTargetRef?: RefObject<HTMLElement | null>
   zIndex?: number
@@ -48,6 +61,7 @@ export function TimelinePreviewScrubberVisual({
   showTooltip = true,
   suppressed = false,
   suppressRefs,
+  suppressSignal,
   positionSyncTargetRef,
   zIndex = 20,
 }: TimelinePreviewScrubberVisualProps) {
@@ -60,6 +74,7 @@ export function TimelinePreviewScrubberVisual({
   const maxFrameRef = useRef(maxFrame)
   const suppressedRef = useRef(suppressed)
   const suppressStateRefsRef = useRef(suppressRefs)
+  const suppressSignalRef = useRef(suppressSignal)
   // Positioning runs in a layout effect below, so these refs must already hold
   // this render's mapper. Updating them in a passive effect leaves the skim line
   // one zoom render behind.
@@ -68,6 +83,7 @@ export function TimelinePreviewScrubberVisual({
   maxFrameRef.current = maxFrame
   suppressedRef.current = suppressed
   suppressStateRefsRef.current = suppressRefs
+  suppressSignalRef.current = suppressSignal
 
   const updatePosition = useCallback((previewFrame: number | null) => {
     const node = scrubberRef.current
@@ -76,7 +92,10 @@ export function TimelinePreviewScrubberVisual({
       shouldHidePreviewScrubber({
         previewFrame,
         suppressed: suppressedRef.current,
-        suppressRefActive: suppressStateRefsRef.current?.some((ref) => ref.current) ?? false,
+        suppressRefActive: isImperativelySuppressed(
+          suppressStateRefsRef.current,
+          suppressSignalRef.current,
+        ),
       })
     ) {
       node.style.display = 'none'
@@ -104,6 +123,13 @@ export function TimelinePreviewScrubberVisual({
     updatePosition(usePlaybackStore.getState().previewFrame)
     return usePlaybackStore.subscribe((state) => updatePosition(state.previewFrame))
   }, [updatePosition])
+
+  useEffect(() => {
+    if (!suppressSignal) return
+    return suppressSignal.subscribe(() => {
+      updatePosition(usePlaybackStore.getState().previewFrame)
+    })
+  }, [suppressSignal, updatePosition])
 
   useEffect(() => {
     const target = positionSyncTargetRef?.current


### PR DESCRIPTION
## Summary

- synchronize main and keyframe playheads with one normalized viewport-position contract
- derive keyframe edge-scroll frames from the live timeline zoom and native scroll position
- align ruler coordinate origins and project/viewport clamps in both scrub directions
- hide the preview skimmer synchronously while either linked timeline owns the scrub gesture

## Root cause

The linked playheads mixed rounded frame reconstruction, settled React viewport metrics, and different ruler origins. During edge scrolling, those paths could disagree with the live compositor geometry. The preview skimmer also observed scrub ownership through a passive ref, allowing an already-visible skimmer to repaint between keyframe-origin updates.

## Impact

Dragging either the main or keyframe playhead now keeps both playheads cursor-locked through auto edge scrolling. Their positions and clamps remain consistent regardless of which timeline owns the gesture, and the main preview skimmer no longer shakes during keyframe edge scrolling.

## Validation

- 191 timeline/keyframe regression tests passed
- focused linked-playhead/skimmer suite: 32 tests passed
- all seven pre-push quality gates passed
- Fallow changed health: no introduced dead code, complexity, or duplication
- `git merge-tree --write-tree origin/staging origin/develop` completed without conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scrubbing synchronization between the main timeline and dope sheet, including more precise visual-frame updates during linked/edge scrolling.
  * Preview scrubber visibility now automatically reflects active scrubbing state.
* **Bug Fixes**
  * Prevented stale-frame mappings and visual jumps by improving how playheads are positioned during scrolling and scrub transitions.
  * Improved timeline coordinate mapping near the project end to reduce clamping/offset issues.
* **Tests**
  * Added/expanded coverage for edge-scrolling behavior, cursor-lock stability, and visual-frame notification effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->