### PR TITLE
fix: stabilize icon button tooltips

### DIFF
--- a/src/components/ui/global-tooltip.test.tsx
+++ b/src/components/ui/global-tooltip.test.tsx
@@ -1,0 +1,55 @@
+import { act, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { GlobalTooltip } from './global-tooltip'
+
+describe('GlobalTooltip', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps the button tooltip active while the pointer moves across its icon', () => {
+    vi.useFakeTimers()
+    const { getByRole, getByTestId } = render(
+      <>
+        <button data-tooltip="Media">
+          <svg data-testid="icon" />
+        </button>
+        <GlobalTooltip />
+      </>,
+    )
+    const button = getByRole('button')
+    const icon = getByTestId('icon')
+    const tooltip = document.querySelector('[role="tooltip"]')
+
+    fireEvent.mouseEnter(button)
+    act(() => vi.advanceTimersByTime(200))
+
+    fireEvent.mouseEnter(icon, { relatedTarget: button })
+    act(() => vi.advanceTimersByTime(100))
+
+    expect(tooltip).toHaveAttribute('data-visible', 'true')
+    expect(tooltip).toHaveTextContent('Media')
+
+    fireEvent.mouseLeave(icon, { relatedTarget: button })
+    expect(tooltip).toHaveAttribute('data-visible', 'true')
+  })
+
+  it('hides the tooltip after the pointer leaves the owning button', () => {
+    vi.useFakeTimers()
+    const { getByRole } = render(
+      <>
+        <button data-tooltip="Media" />
+        <GlobalTooltip />
+      </>,
+    )
+    const button = getByRole('button')
+    const tooltip = document.querySelector('[role="tooltip"]')
+
+    fireEvent.mouseEnter(button)
+    act(() => vi.advanceTimersByTime(300))
+    expect(tooltip).toHaveAttribute('data-visible', 'true')
+
+    fireEvent.mouseLeave(button)
+    expect(tooltip).toHaveAttribute('data-visible', 'false')
+  })
+})

--- a/src/components/ui/global-tooltip.tsx
+++ b/src/components/ui/global-tooltip.tsx
@@ -124,6 +124,12 @@ export function GlobalTooltip() {
       const target = (eventTarget as Element).closest('[data-tooltip]') as HTMLElement
       if (!target) return
 
+      // `mouseenter` is captured for every descendant (for example, the SVG
+      // inside an icon button). Moving from the button surface onto that icon
+      // is still inside the same tooltip trigger and must not restart its
+      // delay or visible state.
+      if (e.relatedTarget instanceof Node && target.contains(e.relatedTarget)) return
+
       // Clear any pending hide timeout
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
@@ -147,7 +153,12 @@ export function GlobalTooltip() {
           ? (eventTarget as Element)
           : eventTarget?.parentElement
 
-      if (!element || !element.closest('[data-tooltip]')) return
+      const target = element?.closest('[data-tooltip]') as HTMLElement | null
+      if (!target) return
+
+      // Ignore movement between descendants of the same trigger. Without this,
+      // leaving an SVG path for its button is interpreted as leaving the button.
+      if (e.relatedTarget instanceof Node && target.contains(e.relatedTarget)) return
 
       // Clear show timeout if leaving before it fires
       if (timeoutRef.current) {


### PR DESCRIPTION
## What changed

- Treat pointer movement between a tooltip button and its nested icon as one continuous hover boundary.
- Preserve the tooltip show delay and visible state while moving across descendants.
- Add regression coverage for icon transitions and true button exits.

## Why

The global tooltip listener captures `mouseenter` and `mouseleave` events from nested SVG elements. In the left sidebar, moving between an icon and the surrounding button could therefore restart or hide the tooltip, producing a flicker even though the pointer never left the button.

## Impact

Left-sidebar icon buttons now have stable hover tooltips. The fix applies consistently to all buttons using the shared `data-tooltip` behavior.

## Validation

- `npm run test:run -- src/components/ui/global-tooltip.test.tsx`
- `npx vp check --no-fmt src/components/ui/global-tooltip.tsx src/components/ui/global-tooltip.test.tsx`
- `npm run check:changed-health`
- Pre-push seven-gate quality suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tooltip behavior when moving the pointer between a control and its child elements.
  - Prevented tooltips from unnecessarily restarting, hiding, or flickering during internal pointer movement.

- **Tests**
  - Added coverage for tooltip visibility and text behavior.
  - Verified tooltips remain visible during movement within a trigger and hide after leaving it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->