### PR TITLE
(feat): improve canvas crop and editing safeguards

### DIFF
--- a/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
@@ -101,6 +101,7 @@ function computeItemTypeInfo(items: TimelineItem[]) {
     hasVirtualSubtitleItems: items.some(
       (item) =>
         (item.type === 'video' || item.type === 'audio') &&
+        item.isReversed !== true &&
         item.transcriptCaptions?.type === 'transcript' &&
         item.transcriptCaptions.cues.length > 0,
     ),

--- a/src/features/editor/components/properties-sidebar/clip-panel/subtitle-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/subtitle-section.tsx
@@ -70,6 +70,7 @@ export const SubtitleSection = memo(function SubtitleSection({
           transcriptCaptions: NonNullable<(AudioItem | VideoItem)['transcriptCaptions']>
         } =>
           (item.type === 'video' || item.type === 'audio') &&
+          item.isReversed !== true &&
           item.transcriptCaptions?.type === 'transcript' &&
           item.transcriptCaptions.cues.length > 0,
       ),

--- a/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
@@ -38,8 +38,12 @@ import {
 
 const MIN_SPEED = 0.1
 const MAX_SPEED = 10.0
-const CROP_STEP = 0.1
+const CROP_STEP = 1
 const CROP_TOLERANCE = 0.01
+
+function snapCropPixels(value: number): number {
+  return Number.isFinite(value) ? Math.round(value) : 0
+}
 
 interface VideoSectionProps {
   items: TimelineItem[]
@@ -76,7 +80,7 @@ function buildCropUpdate(
   const dimension = edge === 'left' || edge === 'right' ? dimensions.width : dimensions.height
   return normalizeCropSettings({
     ...crop,
-    [edge]: cropPixelsToRatio(pixels, dimension),
+    [edge]: cropPixelsToRatio(snapCropPixels(pixels), dimension),
   })
 }
 
@@ -88,7 +92,7 @@ function buildCropSoftnessUpdate(
   return normalizeCropSettings({
     ...crop,
     softness: cropSignedPixelsToRatio(
-      pixels,
+      snapCropPixels(pixels),
       Math.max(1, getCropSoftnessReferenceDimension(dimensions.width, dimensions.height)),
     ),
   })
@@ -112,7 +116,7 @@ function getResolvedCropState(
 }
 
 function formatCropValue(value: number): string {
-  return value.toFixed(3)
+  return value.toFixed(0)
 }
 
 function getResolvedCropPropertyValue(
@@ -344,6 +348,7 @@ export function VideoSection({ items }: VideoSectionProps) {
   const commitCropEdge = useCallback(
     (edge: CropEdge, pixels: number) => {
       const property = CROP_EDGE_PROPERTY[edge]
+      const snappedPixels = snapCropPixels(pixels)
       const autoOps: AutoKeyframeOperation[] = []
 
       videoItems.forEach((item) => {
@@ -351,7 +356,7 @@ export function VideoSection({ items }: VideoSectionProps) {
           item,
           keyframesByItemId.get(item.id) ?? undefined,
           property,
-          pixels,
+          snappedPixels,
           currentFrame,
         )
         if (operation) {
@@ -360,7 +365,7 @@ export function VideoSection({ items }: VideoSectionProps) {
         }
 
         updateItem(item.id, {
-          crop: buildCropUpdate(item.crop, edge, pixels, getCropDimensions(item)),
+          crop: buildCropUpdate(item.crop, edge, snappedPixels, getCropDimensions(item)),
         })
       })
 
@@ -397,6 +402,7 @@ export function VideoSection({ items }: VideoSectionProps) {
 
   const commitCropSoftness = useCallback(
     (pixels: number) => {
+      const snappedPixels = snapCropPixels(pixels)
       const autoOps: AutoKeyframeOperation[] = []
 
       videoItems.forEach((item) => {
@@ -404,7 +410,7 @@ export function VideoSection({ items }: VideoSectionProps) {
           item,
           keyframesByItemId.get(item.id) ?? undefined,
           'cropSoftness',
-          pixels,
+          snappedPixels,
           currentFrame,
         )
         if (operation) {
@@ -413,7 +419,7 @@ export function VideoSection({ items }: VideoSectionProps) {
         }
 
         updateItem(item.id, {
-          crop: buildCropSoftnessUpdate(item.crop, pixels, getCropDimensions(item)),
+          crop: buildCropSoftnessUpdate(item.crop, snappedPixels, getCropDimensions(item)),
         })
       })
 

--- a/src/features/export/components/export-dialog.tsx
+++ b/src/features/export/components/export-dialog.tsx
@@ -390,17 +390,26 @@ export function ExportDialog({ open, onClose, onOpenRenderQueue }: ExportDialogP
 
   // Check if in/out points are set
   const hasInOutPoints = inPoint !== null && outPoint !== null && outPoint > inPoint
-  const hasTranscriptSubtitles = useMemo(
-    () =>
-      items.some(
-        (item) =>
-          (item.type === 'subtitle' && item.source.type === 'transcript') ||
-          ((item.type === 'video' || item.type === 'audio') &&
-            item.transcriptCaptions?.enabled === true &&
-            item.transcriptCaptions.type === 'transcript'),
-      ),
-    [items],
-  )
+  const hasTranscriptSubtitles = useMemo(() => {
+    const reversedClipIds = new Set(
+      items
+        .filter(
+          (item) =>
+            (item.type === 'video' || item.type === 'audio') && item.isReversed === true,
+        )
+        .map((item) => item.id),
+    )
+    return items.some(
+      (item) =>
+        (item.type === 'subtitle' &&
+          item.source.type === 'transcript' &&
+          !reversedClipIds.has(item.source.clipId)) ||
+        ((item.type === 'video' || item.type === 'audio') &&
+          item.isReversed !== true &&
+          item.transcriptCaptions?.enabled === true &&
+          item.transcriptCaptions.type === 'transcript'),
+    )
+  }, [items])
   // Soft (toggleable) subtitle tracks only work for Matroska (WebM/MKV). MP4/MOV
   // can't — mediabunny's WebVTT-in-ISOBMFF muxing is broken and players barely
   // support it anyway — so the "Embedded track" option is hidden there.

--- a/src/features/media-library/utils/caption-items.test.ts
+++ b/src/features/media-library/utils/caption-items.test.ts
@@ -820,6 +820,79 @@ describe('caption-items', () => {
     })
   })
 
+  it('suppresses all clip-owned captions while their source clip is reversed', () => {
+    const reversedClip = {
+      id: 'video-reversed',
+      type: 'video',
+      trackId: 'track-v',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Reversed',
+      mediaId: 'media-1',
+      src: 'blob:test',
+      isReversed: true,
+      transcriptCaptions: {
+        type: 'transcript',
+        mediaId: 'media-1',
+        enabled: true,
+        updatedAt: 1,
+        cues: [{ id: 'virtual', startSeconds: 0, endSeconds: 1, text: 'Virtual' }],
+      },
+    } satisfies TimelineItem
+    const attachedText = {
+      id: 'caption-text',
+      type: 'text',
+      trackId: 'track-captions',
+      from: 0,
+      durationInFrames: 30,
+      label: 'Caption',
+      text: 'Caption',
+      color: '#fff',
+      captionSource: {
+        type: 'ai-captions',
+        mediaId: 'media-1',
+        clipId: reversedClip.id,
+      },
+    } satisfies TimelineItem
+    const attachedSubtitle = {
+      id: 'subtitle-segment',
+      type: 'subtitle',
+      trackId: 'track-captions',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Subtitles',
+      color: '#fff',
+      source: { type: 'transcript', mediaId: 'media-1', clipId: reversedClip.id },
+      cues: [{ id: 'segment', startSeconds: 0, endSeconds: 1, text: 'Segment' }],
+    } satisfies TimelineItem
+    const title = {
+      id: 'title',
+      type: 'text',
+      trackId: 'track-captions',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Title',
+      text: 'Keep me',
+      color: '#fff',
+    } satisfies TimelineItem
+    const videoTrack = { ...makeTrack('track-v', 1), kind: 'video' as const, items: [reversedClip] }
+    const captionTrack = {
+      ...makeTrack('track-captions', 0),
+      items: [attachedText, attachedSubtitle, title],
+    }
+
+    const tracks = appendVirtualTranscriptCaptionTrack(
+      [videoTrack, captionTrack],
+      30,
+      1920,
+      1080,
+    )
+
+    expect(tracks).toHaveLength(2)
+    expect(tracks.find((track) => track.id === 'track-captions')?.items).toEqual([title])
+    expect(tracks.some((track) => track.id === VIRTUAL_TRANSCRIPT_CAPTION_TRACK_ID)).toBe(false)
+  })
+
   it('inherits linkedGroupId from the source clip when consolidating per-cue captions', () => {
     const items: TimelineItem[] = [
       {

--- a/src/features/media-library/utils/caption-items.ts
+++ b/src/features/media-library/utils/caption-items.ts
@@ -969,7 +969,34 @@ export function appendVirtualTranscriptCaptionTrack(
   canvasWidth: number,
   canvasHeight: number,
 ): TimelineTrack[] {
-  const baseTracks = tracks.filter((track) => track.id !== VIRTUAL_TRANSCRIPT_CAPTION_TRACK_ID)
+  const unfilteredBaseTracks = tracks.filter(
+    (track) => track.id !== VIRTUAL_TRANSCRIPT_CAPTION_TRACK_ID,
+  )
+  const reversedClipIds = new Set(
+    unfilteredBaseTracks.flatMap((track) =>
+      (track.items ?? [])
+        .filter(
+          (item) =>
+            (item.type === 'video' || item.type === 'audio') && item.isReversed === true,
+        )
+        .map((item) => item.id),
+    ),
+  )
+  const baseTracks = unfilteredBaseTracks.map((track) => {
+    const items = (track.items ?? []).filter((item) => {
+      if (item.type === 'text' && item.captionSource?.clipId) {
+        return !reversedClipIds.has(item.captionSource.clipId)
+      }
+      if (
+        item.type === 'subtitle' &&
+        (item.source.type === 'transcript' || item.source.type === 'embedded-subtitles')
+      ) {
+        return !reversedClipIds.has(item.source.clipId)
+      }
+      return true
+    })
+    return items.length === (track.items ?? []).length ? track : { ...track, items }
+  })
   const hasSoloTracks = baseTracks.some((track) => track.solo)
   const sourceTracks = baseTracks.filter((track) =>
     hasSoloTracks ? track.solo === true : track.visible !== false,
@@ -979,6 +1006,7 @@ export function appendVirtualTranscriptCaptionTrack(
   for (const track of sourceTracks) {
     for (const item of track.items ?? []) {
       if ((item.type !== 'video' && item.type !== 'audio') || !item.mediaId) continue
+      if (item.isReversed === true) continue
       const transcriptCaptions = item.transcriptCaptions
       if (
         !transcriptCaptions?.enabled ||

--- a/src/features/preview/components/gizmo-handles.tsx
+++ b/src/features/preview/components/gizmo-handles.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react'
+import type { CropEdge } from '../utils/crop-gizmo'
 import type { GizmoHandle } from '../types/gizmo'
 import { getScaleCursor, HANDLE_SIZE, ROTATION_HANDLE_OFFSET } from '../utils/coordinate-transform'
 
@@ -6,6 +7,7 @@ import { getScaleCursor, HANDLE_SIZE, ROTATION_HANDLE_OFFSET } from '../utils/co
  * Scale handle positions (corners and edges).
  */
 const SCALE_HANDLES: GizmoHandle[] = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w']
+const CORNER_SCALE_HANDLES = new Set<GizmoHandle>(['nw', 'ne', 'se', 'sw'])
 
 /**
  * Screen bounds for the gizmo container.
@@ -35,6 +37,10 @@ interface GizmoHandlesProps {
   onScaleStart: (handle: GizmoHandle, e: React.MouseEvent) => void
   /** Called when dragging starts on the rotation handle */
   onRotateStart: (e: React.MouseEvent) => void
+  /** Current crop viewport in screen pixels, relative to the gizmo container */
+  cropRect?: { left: number; top: number; width: number; height: number }
+  /** Called when dragging starts on a crop edge handle */
+  onCropStart?: (edge: CropEdge, e: React.MouseEvent) => void
 }
 
 /**
@@ -55,6 +61,8 @@ export function GizmoHandles({
   onTranslateStart,
   onScaleStart,
   onRotateStart,
+  cropRect,
+  onCropStart,
 }: GizmoHandlesProps) {
   // Get style for a scale handle
   const getHandleStyle = (handle: GizmoHandle): CSSProperties => {
@@ -110,31 +118,87 @@ export function GizmoHandles({
       />
 
       {/* Scale handles */}
-      {SCALE_HANDLES.map((handle) => {
-        const handleLabels: Record<GizmoHandle, string> = {
-          nw: 'Resize from top-left corner',
-          n: 'Resize from top edge',
-          ne: 'Resize from top-right corner',
-          e: 'Resize from right edge',
-          se: 'Resize from bottom-right corner',
-          s: 'Resize from bottom edge',
-          sw: 'Resize from bottom-left corner',
-          w: 'Resize from left edge',
-          rotate: 'Rotate element',
-        }
-        return (
+      {SCALE_HANDLES.filter((handle) => !cropRect || CORNER_SCALE_HANDLES.has(handle)).map(
+        (handle) => {
+          const handleLabels: Record<GizmoHandle, string> = {
+            nw: 'Resize from top-left corner',
+            n: 'Resize from top edge',
+            ne: 'Resize from top-right corner',
+            e: 'Resize from right edge',
+            se: 'Resize from bottom-right corner',
+            s: 'Resize from bottom edge',
+            sw: 'Resize from bottom-left corner',
+            w: 'Resize from left edge',
+            rotate: 'Rotate element',
+          }
+          return (
+            <div
+              key={handle}
+              className="bg-white border border-orange-500"
+              style={{ ...getHandleStyle(handle), zIndex: 102 }}
+              role="button"
+              aria-label={handleLabels[handle]}
+              tabIndex={0}
+              data-gizmo={`scale-${handle}`}
+              onMouseDown={(e) => onScaleStart(handle, e)}
+            />
+          )
+        },
+      )}
+
+      {cropRect && onCropStart && (
+        <>
           <div
-            key={handle}
-            className="bg-white border border-orange-500"
-            style={{ ...getHandleStyle(handle), zIndex: 102 }}
-            role="button"
-            aria-label={handleLabels[handle]}
-            tabIndex={0}
-            data-gizmo={`scale-${handle}`}
-            onMouseDown={(e) => onScaleStart(handle, e)}
+            className="pointer-events-none absolute border border-orange-400/80"
+            style={{
+              left: cropRect.left,
+              top: cropRect.top,
+              width: cropRect.width,
+              height: cropRect.height,
+              boxSizing: 'border-box',
+              zIndex: 102,
+            }}
+            data-gizmo="crop-outline"
           />
-        )
-      })}
+          {(['left', 'right', 'top', 'bottom'] as const).map((edge) => {
+            const horizontal = edge === 'top' || edge === 'bottom'
+            const width = horizontal ? 24 : 6
+            const height = horizontal ? 6 : 24
+            const left = horizontal
+              ? cropRect.left + cropRect.width / 2 - width / 2
+              : edge === 'left'
+                ? cropRect.left - width / 2
+                : cropRect.left + cropRect.width - width / 2
+            const top = horizontal
+              ? edge === 'top'
+                ? cropRect.top - height / 2
+                : cropRect.top + cropRect.height - height / 2
+              : cropRect.top + cropRect.height / 2 - height / 2
+            return (
+              <div
+                key={edge}
+                className="absolute border border-white bg-orange-500 shadow-sm"
+                style={{
+                  left,
+                  top,
+                  width,
+                  height,
+                  cursor: getScaleCursor(
+                    edge === 'left' ? 'w' : edge === 'right' ? 'e' : edge === 'top' ? 'n' : 's',
+                    rotation,
+                  ),
+                  zIndex: 103,
+                }}
+                role="button"
+                aria-label={`Crop ${edge} edge`}
+                tabIndex={0}
+                data-gizmo={`crop-${edge}`}
+                onMouseDown={(e) => onCropStart(edge, e)}
+              />
+            )
+          })}
+        </>
+      )}
 
       {/* Rotation handle */}
       <div

--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -45,16 +45,21 @@ import {
   worldPointToPositionKeyframeValue,
 } from '../utils/motion-path-edit'
 import { attachWindowMotionPathPointerInteraction } from '../utils/motion-path-pointer-interaction'
-import type { AutoKeyframeOperation } from '@/features/preview/deps/keyframes'
+import {
+  getAutoKeyframeOperation,
+  type AutoKeyframeOperation,
+} from '@/features/preview/deps/keyframes'
 import type { ItemKeyframes, SpatialBezierTangents } from '@/types/keyframe'
 import type { TimelineItem } from '@/types/timeline'
 import type { BoundingBox, CoordinateParams, Transform, Point } from '../types/gizmo'
 import type { ResolvedTransform, TransformProperties } from '@/types/transform'
+import { normalizeCropSettings } from '@/shared/utils/media-crop'
 import { getSourceDimensions, resolveTransform } from '@/features/preview/deps/composition-runtime'
 import {
   buildGizmoTransformCommit,
   resolveEditableGizmoTransform,
 } from '../utils/gizmo-transform-commit'
+import { CROP_EDGE_PROPERTY, type CropEdge } from '../utils/crop-gizmo'
 
 interface GizmoOverlayProps {
   containerRect: DOMRect | null
@@ -161,6 +166,8 @@ export function GizmoOverlay({
   const canvasSnapEnabled = useSettingsStore((s) => s.canvasSnapEnabled)
   const updateItemTransform = useTimelineStore((s) => s.updateItemTransform)
   const updateItemsTransformMap = useTimelineStore((s) => s.updateItemsTransformMap)
+  const updateItem = useTimelineStore((s) => s.updateItem)
+  const applyAutoKeyframeOperations = useTimelineStore((s) => s.applyAutoKeyframeOperations)
   const updateVectorKeyframe = useTimelineStore((s) => s.updateVectorKeyframe)
 
   // Ref to track if we just finished a drag (to prevent background click from deselecting)
@@ -631,9 +638,7 @@ export function GizmoOverlay({
               item.transform ?? null,
             )}:${JSON.stringify(item.transformParent ?? null)}:${JSON.stringify(
               item.motionModifiers ?? null,
-            )}:${JSON.stringify(
-              item.motionLayers ?? null,
-            )}`,
+            )}:${JSON.stringify(item.motionLayers ?? null)}`,
         )
         .join('|'),
     [selectedItems],
@@ -879,6 +884,55 @@ export function GizmoOverlay({
     ],
   )
 
+  const handleCropEnd = useCallback(
+    (itemId: string, edge: CropEdge, ratio: number) => {
+      const item = visualItems.find((candidate) => candidate.id === itemId)
+      if (!item || item.type !== 'video') return
+
+      const currentFrame = usePlaybackStore.getState().currentFrame
+      const sourceDimensions = getSourceDimensions(item) ?? {
+        width: Math.max(1, item.transform?.width ?? projectSize.width),
+        height: Math.max(1, item.transform?.height ?? projectSize.height),
+      }
+      const sourceDimension =
+        edge === 'left' || edge === 'right' ? sourceDimensions.width : sourceDimensions.height
+      const sourcePixels = Math.round(ratio * sourceDimension)
+      const operation = getAutoKeyframeOperation(
+        item,
+        useKeyframesStore.getState().keyframesByItemId[itemId],
+        CROP_EDGE_PROPERTY[edge],
+        sourcePixels,
+        currentFrame,
+      )
+
+      if (operation) {
+        applyAutoKeyframeOperations([operation])
+      } else {
+        updateItem(itemId, {
+          crop: normalizeCropSettings({ ...item.crop, [edge]: sourcePixels / sourceDimension }),
+        })
+      }
+
+      justFinishedDragRef.current = true
+      setTimeout(() => {
+        justFinishedDragRef.current = false
+      }, 100)
+      setOtherItemBounds([])
+      if (!usePlaybackStore.getState().isPlaying) {
+        usePreviewBridgeStore.getState().setDisplayedFrame(usePlaybackStore.getState().currentFrame)
+      }
+      setForceUpdate((value) => value + 1)
+    },
+    [
+      applyAutoKeyframeOperations,
+      projectSize.height,
+      projectSize.width,
+      setOtherItemBounds,
+      updateItem,
+      visualItems,
+    ],
+  )
+
   // Handle group transform end - commit transforms for all items as a single undo operation
   const handleGroupTransformEnd = useCallback(
     (transforms: Map<string, Transform>, operation: 'move' | 'resize' | 'rotate') => {
@@ -968,6 +1022,10 @@ export function GizmoOverlay({
     (itemId: string, e: React.MouseEvent) => {
       if (isExclusiveCanvasEditorActive) return
       e.stopPropagation()
+      // A crop handle moves away from the pointer as it is dragged inward.
+      // Suppress the click synthesized after mouseup so it cannot select a
+      // different item that is now underneath the pointer.
+      if (justFinishedDragRef.current) return
       const isSelected = selectedItemIdsSet.has(itemId)
       const isGroupSelection = selectedItemIds.length > 1
 
@@ -1231,6 +1289,7 @@ export function GizmoOverlay({
             onTransformEnd={(transform, operation) =>
               handleTransformEnd(selectedItems[0]!.id, transform, operation)
             }
+            onCropEnd={(edge, ratio) => handleCropEnd(selectedItems[0]!.id, edge, ratio)}
             isPlaying={isPlaying}
           />
         ) : selectedItems.length > 1 ? (

--- a/src/features/preview/components/transform-gizmo.tsx
+++ b/src/features/preview/components/transform-gizmo.tsx
@@ -1,26 +1,35 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react'
 import type { TimelineItem } from '@/types/timeline'
+import type { CropSettings } from '@/types/transform'
 import type { GizmoHandle, Transform, CoordinateParams } from '../types/gizmo'
 import { useGizmoStore } from '../stores/gizmo-store'
 import { useItemGizmoPreview } from '../stores/use-item-gizmo-preview'
-import { useAnimatedTransform } from '@/features/preview/deps/keyframes'
+import { resolveAnimatedCrop, useAnimatedTransform } from '@/features/preview/deps/keyframes'
+import { useKeyframesStore } from '@/features/preview/deps/timeline-store'
 import { useEscapeCancel } from '../hooks/use-drag-interaction'
 import { GizmoHandles } from './gizmo-handles'
 import {
+  getEffectiveScale,
   transformToScreenBounds,
   screenToCanvas,
   getScaleCursor,
   getScreenTransformOrigin,
 } from '../utils/coordinate-transform'
-import { attachWindowTransformInteraction } from '../utils/gizmo-transform-interaction'
-import { hasCornerPin } from '@/features/preview/deps/composition-runtime'
+import {
+  attachWindowTransformInteraction,
+  suppressReleaseClick,
+} from '../utils/gizmo-transform-interaction'
+import { getSourceDimensions, hasCornerPin } from '@/features/preview/deps/composition-runtime'
 import { expandTextTransformForPreview } from '../utils/text-layout'
+import { calculateMediaCropLayout, resolveCropSettings } from '@/shared/utils/media-crop'
+import { calculateCropFromDrag, type CropEdge } from '../utils/crop-gizmo'
 
 interface TransformGizmoProps {
   item: TimelineItem
   coordParams: CoordinateParams
   onTransformStart: () => void
   onTransformEnd: (transform: Transform, operation: 'move' | 'resize' | 'rotate') => void
+  onCropEnd: (edge: CropEdge, ratio: number) => void
   /** Whether video is currently playing - gizmo shows at lower opacity during playback */
   isPlaying?: boolean
 }
@@ -34,6 +43,7 @@ export function TransformGizmo({
   coordParams,
   onTransformStart,
   onTransformEnd,
+  onCropEnd,
   isPlaying = false,
 }: TransformGizmoProps) {
   const { activeGizmo, previewTransform, itemPreview } = useItemGizmoPreview(item.id)
@@ -44,16 +54,25 @@ export function TransformGizmo({
   const endInteraction = useGizmoStore((s) => s.endInteraction)
   const clearInteraction = useGizmoStore((s) => s.clearInteraction)
   const cancelInteraction = useGizmoStore((s) => s.cancelInteraction)
+  const setPropertiesPreviewNew = useGizmoStore((s) => s.setPropertiesPreviewNew)
+  const replaceItemPreview = useGizmoStore((s) => s.replaceItemPreview)
+  const [activeCropEdge, setActiveCropEdge] = useState<CropEdge | null>(null)
+  const cancelCropInteractionRef = useRef<(() => void) | null>(null)
 
-  const isInteracting = activeGizmo?.itemId === item.id
+  const isTransformInteracting = activeGizmo?.itemId === item.id
+  const isInteracting = isTransformInteracting || activeCropEdge !== null
 
   // Get animated transform using centralized hook
-  const { transform: animatedTransform } = useAnimatedTransform(item, coordParams.projectSize)
+  const { transform: animatedTransform, relativeFrame } = useAnimatedTransform(
+    item,
+    coordParams.projectSize,
+  )
+  const itemKeyframes = useKeyframesStore((state) => state.keyframesByItemId[item.id])
 
   // Get current transform (use preview during interaction, or properties panel preview)
   const currentTransform = useMemo((): Transform => {
     // If gizmo is being dragged, use its preview
-    if (isInteracting && previewTransform) {
+    if (isTransformInteracting && previewTransform) {
       return previewTransform
     }
 
@@ -89,7 +108,41 @@ export function TransformGizmo({
     }
 
     return baseTransform
-  }, [animatedTransform, isInteracting, previewTransform, item, itemPreview])
+  }, [animatedTransform, isTransformInteracting, previewTransform, item, itemPreview])
+
+  const sourceDimensions = useMemo(() => {
+    if (item.type !== 'video') return null
+    return (
+      getSourceDimensions(item) ?? {
+        width: Math.max(1, currentTransform.width),
+        height: Math.max(1, currentTransform.height),
+      }
+    )
+  }, [currentTransform.height, currentTransform.width, item])
+
+  const animatedCrop = useMemo(() => {
+    if (!sourceDimensions) return undefined
+    return resolveAnimatedCrop(item.crop, itemKeyframes, relativeFrame, sourceDimensions)
+  }, [item.crop, itemKeyframes, relativeFrame, sourceDimensions])
+
+  const currentCrop = itemPreview?.properties?.crop ?? animatedCrop
+
+  const cropLayout = useMemo(() => {
+    if (!sourceDimensions || hasCornerPin(item.cornerPin)) return null
+    return calculateMediaCropLayout(
+      sourceDimensions.width,
+      sourceDimensions.height,
+      currentTransform.width,
+      currentTransform.height,
+      currentCrop,
+    )
+  }, [
+    currentCrop,
+    currentTransform.height,
+    currentTransform.width,
+    item.cornerPin,
+    sourceDimensions,
+  ])
 
   // Convert to screen bounds, expanding for stroke width on shapes
   const screenBounds = useMemo(() => {
@@ -270,10 +323,134 @@ export function TransformGizmo({
     ],
   )
 
+  const handleCropStart = useCallback(
+    (edge: CropEdge, e: React.MouseEvent) => {
+      if (!cropLayout || !sourceDimensions) return
+      e.stopPropagation()
+      e.preventDefault()
+
+      const startPoint = toCanvasPoint(e)
+      const startCrop = resolveCropSettings(currentCrop)
+      const previousPreview = useGizmoStore.getState().preview?.[item.id] ?? null
+      let latestCrop: CropSettings = startCrop
+      let latestMouseEvent: MouseEvent | null = null
+      let animationFrame: number | null = null
+      let finished = false
+
+      const restorePreview = (deferred: boolean) => {
+        const restore = () => replaceItemPreview(item.id, previousPreview)
+        if (!deferred) {
+          restore()
+          return
+        }
+        requestAnimationFrame(() => requestAnimationFrame(restore))
+      }
+
+      const updateFromEvent = (moveEvent: MouseEvent) => {
+        latestCrop = calculateCropFromDrag({
+          edge,
+          startCrop,
+          startPoint,
+          currentPoint: toCanvasPoint(moveEvent),
+          rotation: currentTransform.rotation,
+          mediaRect: cropLayout.mediaRect,
+          sourceDimension:
+            edge === 'left' || edge === 'right' ? sourceDimensions.width : sourceDimensions.height,
+        })
+        setPropertiesPreviewNew({ [item.id]: { crop: latestCrop } })
+      }
+
+      const flushLatestEvent = () => {
+        if (animationFrame !== null) {
+          cancelAnimationFrame(animationFrame)
+          animationFrame = null
+        }
+        if (latestMouseEvent) {
+          updateFromEvent(latestMouseEvent)
+          latestMouseEvent = null
+        }
+      }
+
+      const removeListeners = () => {
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('mouseup', handleMouseUp)
+        cancelCropInteractionRef.current = null
+      }
+
+      const finish = (commit: boolean) => {
+        if (finished) return
+        finished = true
+        if (commit) {
+          flushLatestEvent()
+          suppressReleaseClick()
+        } else if (animationFrame !== null) cancelAnimationFrame(animationFrame)
+        removeListeners()
+        document.body.style.cursor = ''
+        setActiveCropEdge(null)
+
+        if (commit && Math.abs(latestCrop[edge]! - startCrop[edge]) > 0.000001) {
+          onCropEnd(edge, latestCrop[edge]!)
+          restorePreview(true)
+        } else {
+          restorePreview(false)
+        }
+      }
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        latestMouseEvent = moveEvent
+        if (animationFrame !== null) return
+        animationFrame = requestAnimationFrame(() => {
+          animationFrame = null
+          if (!latestMouseEvent) return
+          const eventToApply = latestMouseEvent
+          latestMouseEvent = null
+          updateFromEvent(eventToApply)
+        })
+      }
+      const handleMouseUp = (upEvent: MouseEvent) => {
+        latestMouseEvent = upEvent
+        finish(true)
+      }
+
+      cancelCropInteractionRef.current = () => finish(false)
+      setActiveCropEdge(edge)
+      onTransformStart()
+      document.body.style.cursor = getScaleCursor(
+        edge === 'left' ? 'w' : edge === 'right' ? 'e' : edge === 'top' ? 'n' : 's',
+        currentTransform.rotation,
+      )
+      window.addEventListener('mousemove', handleMouseMove)
+      window.addEventListener('mouseup', handleMouseUp)
+    },
+    [
+      cropLayout,
+      currentCrop,
+      currentTransform.rotation,
+      item.id,
+      onCropEnd,
+      onTransformStart,
+      replaceItemPreview,
+      setPropertiesPreviewNew,
+      sourceDimensions,
+      toCanvasPoint,
+    ],
+  )
+
+  useEffect(
+    () => () => {
+      cancelCropInteractionRef.current?.()
+    },
+    [],
+  )
+
   // Handle escape key to cancel interaction
   useEscapeCancel(
     isInteracting,
     useCallback(() => {
+      if (cancelCropInteractionRef.current) {
+        cancelCropInteractionRef.current()
+        return
+      }
       cancelInteraction()
       document.body.style.cursor = ''
     }, [cancelInteraction]),
@@ -314,6 +491,17 @@ export function TransformGizmo({
         onTranslateStart={handleTranslateStart}
         onScaleStart={handleScaleStart}
         onRotateStart={handleRotateStart}
+        cropRect={
+          cropLayout
+            ? {
+                left: cropLayout.cropViewportRect.x * getEffectiveScale(coordParams),
+                top: cropLayout.cropViewportRect.y * getEffectiveScale(coordParams),
+                width: cropLayout.cropViewportRect.width * getEffectiveScale(coordParams),
+                height: cropLayout.cropViewportRect.height * getEffectiveScale(coordParams),
+              }
+            : undefined
+        }
+        onCropStart={cropLayout ? handleCropStart : undefined}
       />
     </div>
   )

--- a/src/features/preview/deps/keyframes-contract.ts
+++ b/src/features/preview/deps/keyframes-contract.ts
@@ -4,6 +4,7 @@
  */
 
 export { useAnimatedTransform } from '@/features/keyframes/hooks/use-animated-transform'
+export { resolveAnimatedCrop } from '@/features/keyframes/utils/animated-crop-resolver'
 export {
   getAutoKeyframeOperation,
   getVectorAutoKeyframeOperation,

--- a/src/features/preview/utils/crop-gizmo.test.ts
+++ b/src/features/preview/utils/crop-gizmo.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { calculateCropFromDrag } from './crop-gizmo'
+
+const MEDIA_RECT = { x: 0, y: 0, width: 1000, height: 500 }
+
+describe('calculateCropFromDrag', () => {
+  it('maps each edge drag to its source-relative crop value', () => {
+    expect(
+      calculateCropFromDrag({
+        edge: 'left',
+        startCrop: undefined,
+        startPoint: { x: 0, y: 0 },
+        currentPoint: { x: 100, y: 0 },
+        rotation: 0,
+        mediaRect: MEDIA_RECT,
+        sourceDimension: 1000,
+      }).left,
+    ).toBeCloseTo(0.1)
+    expect(
+      calculateCropFromDrag({
+        edge: 'right',
+        startCrop: undefined,
+        startPoint: { x: 100, y: 0 },
+        currentPoint: { x: 50, y: 0 },
+        rotation: 0,
+        mediaRect: MEDIA_RECT,
+        sourceDimension: 1000,
+      }).right,
+    ).toBeCloseTo(0.05)
+    expect(
+      calculateCropFromDrag({
+        edge: 'top',
+        startCrop: undefined,
+        startPoint: { x: 0, y: 0 },
+        currentPoint: { x: 0, y: 50 },
+        rotation: 0,
+        mediaRect: MEDIA_RECT,
+        sourceDimension: 500,
+      }).top,
+    ).toBeCloseTo(0.1)
+    expect(
+      calculateCropFromDrag({
+        edge: 'bottom',
+        startCrop: undefined,
+        startPoint: { x: 0, y: 100 },
+        currentPoint: { x: 0, y: 50 },
+        rotation: 0,
+        mediaRect: MEDIA_RECT,
+        sourceDimension: 500,
+      }).bottom,
+    ).toBeCloseTo(0.1)
+  })
+
+  it('inverse-rotates pointer movement into the item axes', () => {
+    const crop = calculateCropFromDrag({
+      edge: 'left',
+      startCrop: undefined,
+      startPoint: { x: 0, y: 0 },
+      currentPoint: { x: 0, y: 100 },
+      rotation: 90,
+      mediaRect: MEDIA_RECT,
+      sourceDimension: 1000,
+    })
+
+    expect(crop.left).toBeCloseTo(0.1)
+  })
+
+  it('keeps a sliver visible and preserves the opposite crop edge', () => {
+    const crop = calculateCropFromDrag({
+      edge: 'left',
+      startCrop: { right: 0.25, softness: 0.2 },
+      startPoint: { x: 0, y: 0 },
+      currentPoint: { x: 2000, y: 0 },
+      rotation: 0,
+      mediaRect: MEDIA_RECT,
+      sourceDimension: 1000,
+    })
+
+    expect(crop.left).toBeCloseTo(0.749)
+    expect(crop.right).toBe(0.25)
+    expect(crop.softness).toBe(0.2)
+  })
+
+  it('clamps outward drags back to zero', () => {
+    const crop = calculateCropFromDrag({
+      edge: 'top',
+      startCrop: { top: 0.2 },
+      startPoint: { x: 0, y: 100 },
+      currentPoint: { x: 0, y: -100 },
+      rotation: 0,
+      mediaRect: MEDIA_RECT,
+      sourceDimension: 500,
+    })
+
+    expect(crop.top).toBe(0)
+  })
+
+  it('snaps a gizmo drag to whole intrinsic source pixels', () => {
+    const crop = calculateCropFromDrag({
+      edge: 'left',
+      startCrop: undefined,
+      startPoint: { x: 0, y: 0 },
+      currentPoint: { x: 10.4, y: 0 },
+      rotation: 0,
+      mediaRect: { x: 0, y: 0, width: 100, height: 50 },
+      sourceDimension: 1920,
+    })
+
+    expect(crop.left * 1920).toBe(200)
+  })
+})

--- a/src/features/preview/utils/crop-gizmo.ts
+++ b/src/features/preview/utils/crop-gizmo.ts
@@ -1,0 +1,90 @@
+import type { CropSettings } from '@/types/transform'
+import {
+  resolveCropSettings,
+  type Rect,
+  type ResolvedCropSettings,
+} from '@/shared/utils/media-crop'
+import type { Point } from '../types/gizmo'
+
+export type CropEdge = 'left' | 'right' | 'top' | 'bottom'
+
+export const CROP_EDGE_PROPERTY = {
+  left: 'cropLeft',
+  right: 'cropRight',
+  top: 'cropTop',
+  bottom: 'cropBottom',
+} as const
+
+const MIN_VISIBLE_RATIO = 0.001
+
+/**
+ * Resolve one crop-handle drag in item-local coordinates. Crop is stored as a
+ * source ratio, while pointer positions arrive in canvas pixels; the contained
+ * media rectangle is the bridge between the two spaces.
+ */
+export function calculateCropFromDrag({
+  edge,
+  startCrop,
+  startPoint,
+  currentPoint,
+  rotation,
+  mediaRect,
+  sourceDimension,
+}: {
+  edge: CropEdge
+  startCrop: CropSettings | undefined
+  startPoint: Point
+  currentPoint: Point
+  rotation: number
+  mediaRect: Rect
+  /** Intrinsic source width/height for the dragged edge, in pixels. */
+  sourceDimension: number
+}): ResolvedCropSettings {
+  const crop = resolveCropSettings(startCrop)
+  const radians = (rotation * Math.PI) / 180
+  const cos = Math.cos(radians)
+  const sin = Math.sin(radians)
+  const worldDeltaX = currentPoint.x - startPoint.x
+  const worldDeltaY = currentPoint.y - startPoint.y
+
+  // Inverse-rotate the pointer delta so a rotated clip still crops along its
+  // own horizontal and vertical axes.
+  const localDeltaX = worldDeltaX * cos + worldDeltaY * sin
+  const localDeltaY = -worldDeltaX * sin + worldDeltaY * cos
+  const horizontal = edge === 'left' || edge === 'right'
+  const dimension = horizontal ? mediaRect.width : mediaRect.height
+  if (
+    !Number.isFinite(dimension) ||
+    dimension <= 0 ||
+    !Number.isFinite(sourceDimension) ||
+    sourceDimension <= 0
+  ) {
+    return crop
+  }
+
+  const opposite =
+    edge === 'left'
+      ? crop.right
+      : edge === 'right'
+        ? crop.left
+        : edge === 'top'
+          ? crop.bottom
+          : crop.top
+  const signedDelta =
+    edge === 'left'
+      ? localDeltaX
+      : edge === 'right'
+        ? -localDeltaX
+        : edge === 'top'
+          ? localDeltaY
+          : -localDeltaY
+  const startInset = crop[edge] * dimension
+  const maxInset = Math.max(0, (1 - opposite - MIN_VISIBLE_RATIO) * dimension)
+  const nextInset = Math.min(maxInset, Math.max(0, startInset + signedDelta))
+  const requestedSourcePixels = Math.round((nextInset / dimension) * sourceDimension)
+  // Keep at least one intrinsic source pixel visible on this axis.
+  const maxSourcePixels = Math.max(0, Math.floor((1 - opposite) * sourceDimension) - 1)
+  const nextSourcePixels = Math.min(maxSourcePixels, Math.max(0, requestedSourcePixels))
+
+  return { ...crop, [edge]: nextSourcePixels / sourceDimension }
+}

--- a/src/features/preview/utils/gizmo-transform-interaction.test.ts
+++ b/src/features/preview/utils/gizmo-transform-interaction.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { suppressReleaseClick } from './gizmo-transform-interaction'
+
+describe('suppressReleaseClick', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('consumes the click synthesized immediately after a drag release', () => {
+    const backgroundClick = vi.fn()
+    window.addEventListener('click', backgroundClick)
+
+    suppressReleaseClick()
+    const releaseClick = new MouseEvent('click', { bubbles: true, cancelable: true })
+    window.dispatchEvent(releaseClick)
+
+    expect(releaseClick.defaultPrevented).toBe(true)
+    expect(backgroundClick).not.toHaveBeenCalled()
+    window.removeEventListener('click', backgroundClick)
+  })
+
+  it('does not consume a later explicit click', () => {
+    vi.useFakeTimers()
+    const backgroundClick = vi.fn()
+    window.addEventListener('click', backgroundClick)
+
+    suppressReleaseClick()
+    vi.runAllTimers()
+    window.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(backgroundClick).toHaveBeenCalledOnce()
+    window.removeEventListener('click', backgroundClick)
+  })
+})

--- a/src/features/preview/utils/gizmo-transform-interaction.ts
+++ b/src/features/preview/utils/gizmo-transform-interaction.ts
@@ -2,6 +2,29 @@ import type { Point, Transform } from '../types/gizmo'
 
 export type TransformOperation = 'move' | 'resize' | 'rotate'
 
+/**
+ * A mouse drag can still synthesize a click after mouseup. If the dragged
+ * handle moved away from the pointer, that click may be retargeted to the
+ * preview background and clear selection. Consume only that same-turn click;
+ * the listener is removed before a later, explicit user click can occur.
+ */
+export function suppressReleaseClick(): void {
+  let timeoutId: number | null = null
+  const cleanup = () => {
+    window.removeEventListener('click', handleClick, true)
+    if (timeoutId !== null) window.clearTimeout(timeoutId)
+  }
+  const handleClick = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    event.stopImmediatePropagation()
+    cleanup()
+  }
+
+  window.addEventListener('click', handleClick, true)
+  timeoutId = window.setTimeout(cleanup, 0)
+}
+
 function hasTransformChanged(a: Transform, b: Transform): boolean {
   const tolerance = 0.01
   return (

--- a/src/features/timeline/components/timeline-item/use-caption-dialog-state.ts
+++ b/src/features/timeline/components/timeline-item/use-caption-dialog-state.ts
@@ -107,11 +107,13 @@ export function useCaptionDialogState({
   const canManageCaptions =
     !!item.mediaId &&
     !isBroken &&
+    item.isReversed !== true &&
     (item.type === 'video' || (item.type === 'audio' && linkedVideoCaptionOwner === null))
 
   const canExtractEmbeddedSubtitles = !!(
     mediaForItem &&
     !isBroken &&
+    item.isReversed !== true &&
     isEmbeddedSubtitleContainer(mediaForItem.fileName, mediaForItem.mimeType)
   )
 
@@ -159,6 +161,7 @@ export function useCaptionDialogState({
   const hasConsolidatablePerCueCaptions = useTimelineStore(
     useCallback(
       (s) =>
+        item.isReversed !== true &&
         s.items.some(
           (other) =>
             other.type === 'text' &&
@@ -166,7 +169,7 @@ export function useCaptionDialogState({
               other.captionSource?.type === 'subtitle-import') &&
             other.captionSource.clipId === item.id,
         ),
-      [item.id],
+      [item.id, item.isReversed],
     ),
   )
 

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -64,6 +64,7 @@ describe('TimelinePlayhead', () => {
 
     const hitArea = container.querySelector('[style*="width: 20px"]') as HTMLDivElement | null
     expect(hitArea).toBeTruthy()
+    expect(hitArea).toHaveAttribute('data-playhead-handle')
     expect(hitArea).toHaveStyle({ cursor: 'ew-resize' })
 
     fireEvent.mouseDown(hitArea!, { clientX: 24, clientY: 8, button: 0 })

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -429,6 +429,7 @@ export function TimelinePlayhead({
       {/* Invisible larger hit area over the flag — draggable to scrub. */}
       {inRuler && (
         <div
+          data-playhead-handle
           className="absolute"
           style={{
             top: `${topOffsetPx}px`,

--- a/src/features/timeline/utils/transcript-edit-model.test.ts
+++ b/src/features/timeline/utils/transcript-edit-model.test.ts
@@ -82,6 +82,13 @@ describe('buildTranscriptTokens', () => {
     expect(tokens[0]?.itemId).toBe('a')
   })
 
+  it('skips reversed clips because source transcript order no longer matches playback', () => {
+    const item = makeItem({ id: 'reversed', mediaId: 'm1', isReversed: true })
+    const transcript = makeTranscript('m1', [{ text: 'backwards', start: 0, end: 0.5 }])
+
+    expect(buildTranscriptTokens([item], { m1: transcript }, FPS)).toEqual([])
+  })
+
   it('does not duplicate words for a linked video + audio pair', () => {
     // Same media, same source span (a linked companion) — words appear once.
     const video = makeItem({ id: 'v', type: 'video', mediaId: 'm1' })

--- a/src/features/timeline/utils/transcript-edit-model.ts
+++ b/src/features/timeline/utils/transcript-edit-model.ts
@@ -36,7 +36,12 @@ export type TranscriptableItem = Extract<TimelineItem, { type: 'video' | 'audio'
 }
 
 export function isTranscriptableItem(item: TimelineItem | undefined): item is TranscriptableItem {
-  return !!item && (item.type === 'video' || item.type === 'audio') && !!item.mediaId
+  return (
+    !!item &&
+    (item.type === 'video' || item.type === 'audio') &&
+    item.isReversed !== true &&
+    !!item.mediaId
+  )
 }
 
 function collectWords(transcript: MediaTranscript): MediaTranscriptWord[] {

--- a/src/shared/marquee/use-marquee-selection.test.tsx
+++ b/src/shared/marquee/use-marquee-selection.test.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, type ReactNode } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 import { useMarqueeSelection, type Rect } from './use-marquee-selection'
 
 interface MarqueeHarnessProps {
+  children?: ReactNode
   onSelectionChange: (ids: string[]) => void
   onPreviewSelectionChange: (ids: string[]) => void
   onGestureEnd: (event: MouseEvent, wasActualDrag: boolean) => void
@@ -22,6 +23,7 @@ function createRect(left: number, top: number, right: number, bottom: number): R
 }
 
 function MarqueeHarness({
+  children,
   onSelectionChange,
   onPreviewSelectionChange,
   onGestureEnd,
@@ -44,7 +46,11 @@ function MarqueeHarness({
     commitSelectionOnMouseUp: true,
   })
 
-  return <div ref={containerRef} data-testid="marquee-container" />
+  return (
+    <div ref={containerRef} data-testid="marquee-container">
+      {children}
+    </div>
+  )
 }
 
 describe('useMarqueeSelection deferred commits', () => {
@@ -123,5 +129,40 @@ describe('useMarqueeSelection deferred commits', () => {
     expect(onPreviewSelectionChange).toHaveBeenLastCalledWith([])
     expect(onSelectionChange).toHaveBeenCalledTimes(1)
     expect(onSelectionChange).toHaveBeenCalledWith(['clip-1', 'clip-2'])
+  })
+
+  it('does not claim a drag that starts on a playhead handle', () => {
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onPreviewSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onGestureEnd = vi.fn<(event: MouseEvent, wasActualDrag: boolean) => void>()
+    const { getByTestId } = render(
+      <MarqueeHarness
+        onSelectionChange={onSelectionChange}
+        onPreviewSelectionChange={onPreviewSelectionChange}
+        onGestureEnd={onGestureEnd}
+      >
+        <div data-playhead-handle data-testid="playhead-handle" />
+      </MarqueeHarness>,
+    )
+    const container = getByTestId('marquee-container')
+    const playheadHandle = getByTestId('playhead-handle')
+
+    Object.defineProperties(container, {
+      clientWidth: { configurable: true, value: 200 },
+      clientHeight: { configurable: true, value: 200 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => createRect(0, 0, 200, 200),
+      },
+    })
+
+    fireEvent.mouseDown(playheadHandle, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 100, clientY: 100 })
+    flushAnimationFrames()
+    fireEvent.mouseUp(document, { clientX: 100, clientY: 100 })
+
+    expect(onGestureEnd).not.toHaveBeenCalled()
+    expect(onPreviewSelectionChange).not.toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What changed

- Add source-aware crop handles to the canvas gizmo while keeping corner handles for resize.
- Keep crop sliders, gizmo edits, and crop keyframe commits on whole intrinsic source pixels.
- Preserve clip selection when a crop drag releases, while retaining explicit blank-canvas deselection.
- Suppress transcript captions for reversed clips across editing and export paths.
- Prevent marquee selection from claiming playhead drag gestures.

## Why

Crop values were only practical to edit from the inspector, and fractional source-pixel values could make crop boundaries inconsistent. Releasing a moving crop handle could also synthesize a background click and clear the active selection. Separately, reversed clips could expose transcript captions with invalid timing, while playhead drags could be mistaken for marquee selection.

## Impact

Editors can crop video directly on the canvas with predictable 1 px source-space precision, keyframe support, rotated-item behavior, and stable selection. Reversed-caption and playhead-drag edge cases now behave consistently across the editor and export workflow.

## Validation

- `npx vp check --no-fmt <20 changed files>` — 0 warnings, lint errors, or type errors
- 6 focused test files — 59 tests passed
- Live Chrome verification for all four crop handles, whole-pixel commits, rotated crop math, stable selection after release, and explicit blank-canvas deselection

## Range

- 3 commits
- 20 files changed
- 805 additions, 59 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive crop handles to the preview, including edge dragging and visual crop outlines.
  - Crop adjustments now support animated keyframes and preserve valid visible media areas.
  - Crop values are rounded to whole pixels for more consistent editing.

- **Bug Fixes**
  - Reversed clips no longer display or generate transcript-based subtitles and captions.
  - Reversed clips are excluded from transcript editing and caption management.
  - Prevented accidental selection changes after dragging and improved playhead interaction with marquee selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->