### PR TITLE
feat: improve browser transcription and timeline editing

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -16,6 +16,7 @@ interface ComboboxOption {
 }
 
 interface ComboboxProps {
+  id?: string
   value: string
   options: readonly ComboboxOption[]
   onValueChange: (value: string) => void
@@ -29,6 +30,7 @@ interface ComboboxProps {
 }
 
 export function Combobox({
+  id,
   value,
   options,
   onValueChange,
@@ -97,6 +99,7 @@ export function Combobox({
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
+            id={id}
             ref={triggerRef}
             type="button"
             variant="outline"

--- a/src/features/export/utils/client-render-engine.test.ts
+++ b/src/features/export/utils/client-render-engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test'
 import type { TimelineItem } from '@/types/timeline'
 import type { SubCompRenderData } from './canvas-item-renderer'
 import {
+  buildSubCompositionRenderTracks,
   collectPriorityMediaItemIds,
   collectPriorityMediaItemIdsForFrames,
   collectPriorityNestedVideoItemIds,
@@ -14,6 +15,74 @@ import {
   selectPreviewVideoSource,
   subCompositionRenderDataHasGpuEffects,
 } from './client-render-engine'
+
+describe('nested transcript captions', () => {
+  it('adds a virtual transcript track when a clip inside a compound has captions enabled', () => {
+    const video = {
+      id: 'nested-video',
+      type: 'video',
+      trackId: 'video-track',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Nested video',
+      mediaId: 'media-1',
+      src: 'blob:nested',
+      sourceStart: 0,
+      sourceEnd: 90,
+      sourceDuration: 90,
+      sourceFps: 30,
+      transcriptCaptions: {
+        type: 'transcript',
+        mediaId: 'media-1',
+        enabled: true,
+        updatedAt: 20,
+        cues: [
+          {
+            id: 'transcript-media-1-0',
+            startSeconds: 0.2,
+            endSeconds: 1.4,
+            text: 'Nested phrase',
+          },
+        ],
+      },
+    } satisfies TimelineItem
+    const tracks = buildSubCompositionRenderTracks({
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      items: [video],
+      tracks: [
+        {
+          id: 'video-track',
+          name: 'Video',
+          order: 1,
+          height: 64,
+          locked: false,
+          visible: true,
+          muted: false,
+          solo: false,
+          items: [],
+        },
+      ],
+    })
+
+    expect(tracks).toHaveLength(2)
+    const transcriptTrack = tracks.find((track) =>
+      track.items.some((item) => item.type === 'subtitle'),
+    )
+    expect(transcriptTrack?.items).toEqual([
+      expect.objectContaining({
+        type: 'subtitle',
+        source: expect.objectContaining({
+          type: 'transcript',
+          mediaId: 'media-1',
+          clipId: 'nested-video',
+        }),
+        cues: [expect.objectContaining({ text: 'Nested phrase' })],
+      }),
+    ])
+  })
+})
 
 describe('comparison preview resource selection', () => {
   it('uses nested proxy media for preview consumers and source media otherwise', () => {

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -75,6 +75,7 @@ import {
 import { doesMaskAffectTrack } from '@/shared/utils/mask-scope'
 import type { FrameInvalidationRequest } from '@/shared/utils/frame-invalidation'
 import { collectReachableCompositionIdsFromTracks } from '@/features/export/deps/timeline-compositions'
+import { appendVirtualTranscriptCaptionTrack } from '@/features/export/deps/caption-items'
 
 // Item renderer
 import {
@@ -112,6 +113,30 @@ import {
 
 function getLog() {
   return createLogger('ClientRenderEngine')
+}
+
+export function buildSubCompositionRenderTracks(
+  subComp: Pick<SubComposition, 'items' | 'tracks' | 'fps' | 'width' | 'height'>,
+): SubCompRenderData['sortedTracks'] {
+  const tracksWithItems = subComp.tracks.map((track) => ({
+    ...track,
+    items: subComp.items.filter((item) => item.trackId === track.id),
+  }))
+
+  return appendVirtualTranscriptCaptionTrack(
+    tracksWithItems,
+    subComp.fps,
+    subComp.width,
+    subComp.height,
+  )
+    .sort((left, right) => (right.order ?? 0) - (left.order ?? 0))
+    .map((track) => ({
+      order: track.order ?? 0,
+      visible: track.visible !== false,
+      items: (track.items ?? []).filter(
+        (item) => item.type !== 'audio' && item.type !== 'adjustment',
+      ),
+    }))
 }
 
 function getPrewarmVideoSourceTimeSeconds(item: VideoItem, frame: number, fps: number): number {
@@ -1136,14 +1161,7 @@ export async function createCompositionRenderer(
   const subCompRenderData = new Map<string, SubCompRenderData>()
 
   const buildSubCompRenderDataEntry = (subComp: SubComposition): SubCompRenderData => {
-    const sorted = [...subComp.tracks].sort((a, b) => (b.order ?? 0) - (a.order ?? 0))
-    const sortedWithItems = sorted.map((t) => ({
-      order: t.order ?? 0,
-      visible: t.visible !== false,
-      items: subComp.items.filter(
-        (i) => i.trackId === t.id && i.type !== 'audio' && i.type !== 'adjustment',
-      ),
-    }))
+    const sortedWithItems = buildSubCompositionRenderTracks(subComp)
     const subKfMap = new Map<string, ItemKeyframes>()
     for (const kf of subComp.keyframes ?? []) {
       subKfMap.set(kf.itemId, kf)

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -955,6 +955,12 @@ const MediaCardInternal = memo(function MediaCardInternal({
                 model: values.model,
                 quantization: values.quantization,
                 language: values.language || undefined,
+                onModelFallback: () => {
+                  store.showNotification({
+                    type: 'info',
+                    message: i18n.t('transcript.largeTurboFallback'),
+                  })
+                },
               })
               if (result.status === 'cancelled') {
                 continue

--- a/src/features/media-library/components/transcribe-dialog.test.tsx
+++ b/src/features/media-library/components/transcribe-dialog.test.tsx
@@ -38,14 +38,22 @@ vi.mock('@/shared/state/playback', () => ({
 }))
 
 vi.mock('../transcription/registry', () => ({
-  getMediaTranscriptionModelOptions: () => [{ value: 'whisper-base', label: 'Whisper Base' }],
+  getMediaTranscriptionModelOptions: () => [
+    { value: 'parakeet-tdt-v3', label: 'Parakeet (fast)' },
+    { value: 'whisper-base', label: 'Whisper Base' },
+    { value: 'whisper-large', label: 'Whisper Large v3 Turbo' },
+  ],
 }))
 
 vi.mock('@/shared/utils/whisper-settings', () => ({
-  getWhisperLanguageSelectValue: (value: string) => value,
-  getWhisperLanguageSettingValue: (value: string) => value,
+  getWhisperLanguageSelectValue: (value: string) => value || 'auto',
+  getWhisperLanguageSettingValue: (value: string) => (value === 'auto' ? '' : value),
   normalizeSelectableWhisperModel: (value: string) => value,
-  WHISPER_LANGUAGE_OPTIONS: [{ value: '', label: 'Auto-detect' }],
+  WHISPER_AUTO_LANGUAGE_VALUE: 'auto',
+  WHISPER_LANGUAGE_OPTIONS: [
+    { value: 'auto', label: 'Auto-detect' },
+    { value: 'zh', label: 'Chinese' },
+  ],
   WHISPER_QUANTIZATION_OPTIONS: [{ value: 'hybrid', label: 'Hybrid' }],
 }))
 
@@ -66,20 +74,25 @@ vi.mock('@/components/ui/button', () => ({
 }))
 
 vi.mock('@/components/ui/label', () => ({
-  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+  Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
 }))
 
 vi.mock('@/components/ui/combobox', () => ({
   Combobox: ({
+    id,
     value,
     onValueChange,
     disabled,
   }: {
+    id?: string
     value: string
     onValueChange: (value: string) => void
     disabled?: boolean
   }) => (
     <input
+      id={id}
       aria-label="Language"
       disabled={disabled}
       value={value}
@@ -185,6 +198,9 @@ import { TranscribeDialog } from './transcribe-dialog'
 describe('TranscribeDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    settingsStoreState.defaultWhisperModel = 'whisper-base'
+    settingsStoreState.defaultWhisperQuantization = 'hybrid'
+    settingsStoreState.defaultWhisperLanguage = ''
   })
 
   it('clears background skim and scrub previews when opened', () => {
@@ -257,5 +273,70 @@ describe('TranscribeDialog', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows Parakeet language coverage instead of a language selector', () => {
+    settingsStoreState.defaultWhisperModel = 'parakeet-tdt-v3'
+    settingsStoreState.defaultWhisperLanguage = 'zh'
+    const onStart = vi.fn()
+
+    render(
+      <TranscribeDialog
+        open
+        onOpenChange={vi.fn()}
+        fileName="clip.mp4"
+        hasTranscript={false}
+        isRunning={false}
+        progressPercent={null}
+        progressLabel="Idle"
+        onStart={onStart}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Automatically detects 25 European languages.')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'For Chinese, Japanese, Korean, and other languages, choose a Whisper model.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText('Language')).not.toBeInTheDocument()
+    expect(screen.queryByText('Quantization')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    expect(onStart).toHaveBeenCalledWith({
+      model: 'parakeet-tdt-v3',
+      quantization: 'hybrid',
+      language: '',
+    })
+  })
+
+  it('clears a Whisper-only language when switching to Parakeet', () => {
+    settingsStoreState.defaultWhisperLanguage = 'zh'
+
+    render(
+      <TranscribeDialog
+        open
+        onOpenChange={vi.fn()}
+        fileName="clip.mp4"
+        hasTranscript={false}
+        isRunning={false}
+        progressPercent={null}
+        progressLabel="Idle"
+        onStart={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText('Language')).toHaveValue('zh')
+    const modelAndQuantizationSelects = screen.getAllByRole('combobox')
+    expect(modelAndQuantizationSelects).toHaveLength(2)
+    fireEvent.change(modelAndQuantizationSelects[0]!, {
+      target: { value: 'parakeet-tdt-v3' },
+    })
+
+    expect(screen.queryByLabelText('Language')).not.toBeInTheDocument()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'whisper-large' } })
+    expect(screen.getByLabelText('Language')).toHaveValue('auto')
   })
 })

--- a/src/features/media-library/components/transcribe-dialog.tsx
+++ b/src/features/media-library/components/transcribe-dialog.tsx
@@ -24,11 +24,15 @@ import {
 } from '@/components/ui/select'
 import { useSettingsStore } from '@/features/media-library/deps/settings-contract'
 import { getMediaTranscriptionModelOptions } from '../transcription/registry'
-import { isParakeetModel } from '../transcription/transcription-engine'
+import {
+  isParakeetModel,
+  PARAKEET_SUPPORTED_LANGUAGES,
+} from '../transcription/transcription-engine'
 import {
   getWhisperLanguageSelectValue,
   getWhisperLanguageSettingValue,
   normalizeSelectableWhisperModel,
+  WHISPER_AUTO_LANGUAGE_VALUE,
   WHISPER_LANGUAGE_OPTIONS,
   WHISPER_QUANTIZATION_OPTIONS,
 } from '@/shared/utils/whisper-settings'
@@ -93,9 +97,14 @@ export function TranscribeDialog({
 
   useEffect(() => {
     if (!open) return
-    setModel(normalizeSelectableWhisperModel(defaultModel))
+    const nextModel = normalizeSelectableWhisperModel(defaultModel)
+    setModel(nextModel)
     setQuantization(defaultQuantization)
-    setLanguageValue(getWhisperLanguageSelectValue(defaultLanguage))
+    setLanguageValue(
+      isParakeetModel(nextModel)
+        ? WHISPER_AUTO_LANGUAGE_VALUE
+        : getWhisperLanguageSelectValue(defaultLanguage),
+    )
   }, [open, defaultLanguage, defaultModel, defaultQuantization])
 
   useEffect(() => {
@@ -121,8 +130,20 @@ export function TranscribeDialog({
     onStart({
       model,
       quantization,
-      language: getWhisperLanguageSettingValue(languageValue),
+      language: isParakeetModel(model)
+        ? getWhisperLanguageSettingValue(WHISPER_AUTO_LANGUAGE_VALUE)
+        : getWhisperLanguageSettingValue(languageValue),
     })
+  }
+
+  const handleModelChange = (value: string) => {
+    const nextModel = value as MediaTranscriptModel
+    setModel(nextModel)
+    if (isParakeetModel(nextModel)) {
+      // Parakeet detects its supported languages itself and does not accept a language hint.
+      // Clear a previous Whisper-only choice so the visible model always matches the engine used.
+      setLanguageValue(WHISPER_AUTO_LANGUAGE_VALUE)
+    }
   }
 
   const handleOpenChange = useCallback(
@@ -157,13 +178,11 @@ export function TranscribeDialog({
 
         <div className="space-y-3">
           <div className="space-y-1.5">
-            <Label className="text-sm">{t('media.transcribe.model')}</Label>
-            <Select
-              value={model}
-              onValueChange={(value) => setModel(value as MediaTranscriptModel)}
-              disabled={isRunning}
-            >
-              <SelectTrigger>
+            <Label htmlFor="transcribe-model" className="text-sm">
+              {t('media.transcribe.model')}
+            </Label>
+            <Select value={model} onValueChange={handleModelChange} disabled={isRunning}>
+              <SelectTrigger id="transcribe-model">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -178,13 +197,15 @@ export function TranscribeDialog({
 
           {!isParakeetModel(model) && (
             <div className="space-y-1.5">
-              <Label className="text-sm">{t('media.transcribe.quantization')}</Label>
+              <Label htmlFor="transcribe-quantization" className="text-sm">
+                {t('media.transcribe.quantization')}
+              </Label>
               <Select
                 value={quantization}
                 onValueChange={(value) => setQuantization(value as MediaTranscriptQuantization)}
                 disabled={isRunning}
               >
-                <SelectTrigger>
+                <SelectTrigger id="transcribe-quantization">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -198,18 +219,41 @@ export function TranscribeDialog({
             </div>
           )}
 
-          <div className="space-y-1.5">
-            <Label className="text-sm">{t('media.transcribe.language')}</Label>
-            <Combobox
-              value={languageValue}
-              onValueChange={setLanguageValue}
-              options={WHISPER_LANGUAGE_OPTIONS}
-              placeholder={t('media.transcribe.autoDetect')}
-              searchPlaceholder={t('media.transcribe.searchLanguages')}
-              emptyMessage={t('media.transcribe.noLanguages')}
-              disabled={isRunning}
-            />
-          </div>
+          {isParakeetModel(model) ? (
+            <div className="space-y-1.5">
+              <Label className="text-sm">{t('media.transcribe.language')}</Label>
+              <div className="rounded-md border border-border bg-secondary/35 px-3 py-2.5">
+                <div className="text-sm font-medium">{t('media.transcribe.autoDetect')}</div>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                  {t('media.transcribe.parakeetAutoDetects', {
+                    count: PARAKEET_SUPPORTED_LANGUAGES.size,
+                  })}
+                </p>
+                <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                  {t('media.transcribe.parakeetChooseWhisper')}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label htmlFor="transcribe-language" className="text-sm">
+                {t('media.transcribe.language')}
+              </Label>
+              <Combobox
+                id="transcribe-language"
+                value={languageValue}
+                onValueChange={setLanguageValue}
+                options={WHISPER_LANGUAGE_OPTIONS}
+                placeholder={t('media.transcribe.autoDetect')}
+                searchPlaceholder={t('media.transcribe.searchLanguages')}
+                emptyMessage={t('media.transcribe.noLanguages')}
+                disabled={isRunning}
+              />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {t('media.transcribe.whisperLanguageHint')}
+              </p>
+            </div>
+          )}
 
           {errorMessage && !isRunning && (
             <div

--- a/src/features/media-library/services/media-transcription-runner.test.ts
+++ b/src/features/media-library/services/media-transcription-runner.test.ts
@@ -91,6 +91,38 @@ describe('runMediaTranscriptionJob', () => {
     expect(storeState.clearTranscriptProgress).toHaveBeenCalledWith('media-1')
   })
 
+  it('retries Large Turbo with Whisper Small after an out-of-memory failure', async () => {
+    const transcript = { ...makeTranscript(), model: 'whisper-small' as const }
+    const onModelFallback = vi.fn()
+    mediaTranscriptionServiceMocks.transcribeMedia
+      .mockRejectedValueOnce(new Error('WebGPU device lost: out of memory'))
+      .mockResolvedValueOnce(transcript)
+
+    const result = await runMediaTranscriptionJob('media-1', {
+      model: 'whisper-large',
+      quantization: 'hybrid',
+      onModelFallback,
+    })
+
+    expect(result).toEqual({ status: 'completed', transcript })
+    expect(onModelFallback).toHaveBeenCalledWith('whisper-large', 'whisper-small')
+    expect(mediaTranscriptionServiceMocks.transcribeMedia).toHaveBeenNthCalledWith(
+      2,
+      'media-1',
+      expect.objectContaining({ model: 'whisper-small' }),
+    )
+    expect(storeState.setTranscriptStatus).toHaveBeenLastCalledWith('media-1', 'ready')
+  })
+
+  it('does not hide unrelated Large Turbo failures behind the fallback', async () => {
+    mediaTranscriptionServiceMocks.transcribeMedia.mockRejectedValue(new Error('Network failed'))
+
+    await expect(
+      runMediaTranscriptionJob('media-1', { model: 'whisper-large' }),
+    ).rejects.toThrow('Network failed')
+    expect(mediaTranscriptionServiceMocks.transcribeMedia).toHaveBeenCalledTimes(1)
+  })
+
   it('uses the shared cancel wrapper', () => {
     expect(cancelMediaTranscriptionJob('media-1')).toBe(true)
     expect(mediaTranscriptionServiceMocks.cancelTranscription).toHaveBeenCalledWith('media-1')

--- a/src/features/media-library/services/media-transcription-runner.ts
+++ b/src/features/media-library/services/media-transcription-runner.ts
@@ -3,7 +3,10 @@ import type {
   MediaTranscriptModel,
   MediaTranscriptQuantization,
 } from '@/types/storage'
-import { isTranscriptionCancellationError } from '@/shared/utils/transcription-cancellation'
+import {
+  isTranscriptionCancellationError,
+  isTranscriptionOutOfMemoryError,
+} from '@/shared/utils/transcription-cancellation'
 import type { TranscribeOptions } from '../transcription/types'
 import type { MediaTranscriptStatus } from '../types'
 import { useMediaLibraryStore } from '../stores/media-library-store'
@@ -22,6 +25,7 @@ export interface RunMediaTranscriptionJobOptions {
   updateProgress?: boolean
   onProgress?: TranscribeOptions['onProgress']
   onQueueStatusChange?: (state: QueueState) => void
+  onModelFallback?: (from: MediaTranscriptModel, to: MediaTranscriptModel) => void
 }
 
 export type MediaTranscriptionJobResult =
@@ -90,13 +94,28 @@ export async function runMediaTranscriptionJob(
   setInitialTranscriptionState(mediaId)
 
   try {
-    const transcript = await mediaTranscriptionService.transcribeMedia(mediaId, {
-      model: options.model,
-      quantization: options.quantization,
-      language: options.language || undefined,
-      onQueueStatusChange: createQueueStatusHandler(mediaId, options.onQueueStatusChange),
-      onProgress: createProgressHandler(mediaId, updateProgress, options.onProgress),
-    })
+    const transcribeWithModel = (model: MediaTranscriptModel | undefined) =>
+      mediaTranscriptionService.transcribeMedia(mediaId, {
+        model,
+        quantization: options.quantization,
+        language: options.language || undefined,
+        onQueueStatusChange: createQueueStatusHandler(mediaId, options.onQueueStatusChange),
+        onProgress: createProgressHandler(mediaId, updateProgress, options.onProgress),
+      })
+
+    let transcript: MediaTranscript
+    try {
+      transcript = await transcribeWithModel(options.model)
+    } catch (error) {
+      if (options.model !== 'whisper-large' || !isTranscriptionOutOfMemoryError(error)) {
+        throw error
+      }
+
+      const fallbackModel: MediaTranscriptModel = 'whisper-small'
+      options.onModelFallback?.(options.model, fallbackModel)
+      setInitialTranscriptionState(mediaId)
+      transcript = await transcribeWithModel(fallbackModel)
+    }
 
     useMediaLibraryStore.getState().setTranscriptStatus(mediaId, 'ready')
     useMediaLibraryStore.getState().clearTranscriptProgress(mediaId)

--- a/src/features/media-library/services/media-transcription-service.test.ts
+++ b/src/features/media-library/services/media-transcription-service.test.ts
@@ -943,6 +943,36 @@ describe('mediaTranscriptionService.transcribeMedia', () => {
     expect(saved.segments.every((segment) => segment.words!.length >= 2)).toBe(true)
   })
 
+  it('does not merge a trailing one-word caption across a long pause', async () => {
+    const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
+    getMediaMock.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'clip.mp3',
+      mimeType: 'audio/mpeg',
+      codec: 'mp3',
+      fileLastModified: 123,
+    })
+    getMediaFileMock.mockResolvedValue(sourceFile)
+    transcribeCollectMock.mockResolvedValue([
+      {
+        text: 'short phrase isolated',
+        start: 0,
+        end: 10.3,
+        words: [
+          { text: 'short', start: 0, end: 0.2 },
+          { text: 'phrase', start: 0.22, end: 0.5 },
+          { text: 'isolated', start: 10, end: 10.3 },
+        ],
+      },
+    ])
+
+    await mediaTranscriptionService.transcribeMedia('media-1')
+
+    const saved = saveTranscriptMock.mock.calls[0]?.[0] as MediaTranscript
+    expect(saved.segments.map((segment) => segment.text)).toEqual(['short phrase', 'isolated'])
+    expect(saved.segments.every((segment) => segment.end - segment.start <= 2.2)).toBe(true)
+  })
+
   it('keeps timestamped CJK captions as short phrases rather than individual words', async () => {
     const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
     getMediaMock.mockResolvedValue({

--- a/src/features/media-library/services/media-transcription-service.test.ts
+++ b/src/features/media-library/services/media-transcription-service.test.ts
@@ -6,6 +6,9 @@ import type { TimelineItem, TimelineTrack, VideoItem } from '@/types/timeline'
 const saveTranscriptMock = vi.fn()
 const getTranscriptMock = vi.fn()
 const useTimelineStoreGetStateMock = vi.fn()
+const useCompositionsStoreGetStateMock = vi.fn()
+const useCompositionNavigationStoreGetStateMock = vi.fn()
+const useCompositionNavigationStoreSetStateMock = vi.fn()
 const useProjectStoreGetStateMock = vi.fn()
 const useSelectionStoreGetStateMock = vi.fn()
 const usePlaybackStoreGetStateMock = vi.fn()
@@ -48,6 +51,13 @@ vi.mock('@/features/media-library/deps/timeline-stores', () => ({
   useTimelineStore: {
     getState: useTimelineStoreGetStateMock,
   },
+  useCompositionsStore: {
+    getState: useCompositionsStoreGetStateMock,
+  },
+  useCompositionNavigationStore: {
+    getState: useCompositionNavigationStoreGetStateMock,
+    setState: useCompositionNavigationStoreSetStateMock,
+  },
 }))
 
 vi.mock('@/features/media-library/deps/settings-contract', () => ({
@@ -84,6 +94,17 @@ vi.mock('@/features/media-library/deps/composition-runtime-contract', () => ({
 }))
 
 const { mediaTranscriptionService } = await import('./media-transcription-service')
+
+beforeEach(() => {
+  useCompositionsStoreGetStateMock.mockReturnValue({
+    compositions: [],
+    updateComposition: vi.fn(),
+  })
+  useCompositionNavigationStoreGetStateMock.mockReturnValue({
+    stashStack: [],
+    mainHolder: null,
+  })
+})
 
 function makeTrack(id: string, order: number): TimelineTrack {
   return {
@@ -241,8 +262,11 @@ describe('mediaTranscriptionService.insertTranscriptAsCaptions', () => {
         mediaId: 'media-1',
         clipId: 'clip-1',
       },
-      cues: [{ text: 'Hello there', startSeconds: 0, endSeconds: 2 }],
+      cues: [{ text: 'Hello there' }],
     })
+    const insertedCue = insertedItems[0]?.type === 'subtitle' ? insertedItems[0].cues[0] : undefined
+    expect(insertedCue?.startSeconds).toBeCloseTo(0)
+    expect(insertedCue?.endSeconds).toBeCloseTo(2)
     expect(removeItems).not.toHaveBeenCalled()
   })
 
@@ -574,8 +598,18 @@ describe('mediaTranscriptionService.enableTranscriptCaptions', () => {
             }),
           }),
           cues: [
-            { id: 'transcript-media-1-0', startSeconds: 0, endSeconds: 1, text: 'Fresh one' },
-            { id: 'transcript-media-1-1', startSeconds: 1, endSeconds: 3, text: 'Fresh two' },
+            {
+              id: 'transcript-media-1-0',
+              startSeconds: 0,
+              endSeconds: 1,
+              text: 'Fresh one',
+            },
+            {
+              id: 'transcript-media-1-1',
+              startSeconds: 1,
+              endSeconds: 3,
+              text: 'Fresh two',
+            },
           ],
         }),
       }),
@@ -648,6 +682,7 @@ describe('mediaTranscriptionService.transcribeMedia', () => {
     transcribeCollectMock.mockResolvedValue([{ text: ' hello ', start: 0, end: 1.2 }])
     startPreviewAudioConformMock.mockResolvedValue(undefined)
     resolvePreviewAudioConformUrlMock.mockResolvedValue(null)
+    useTimelineStoreGetStateMock.mockReturnValue({ items: [], updateItem: vi.fn() })
   })
 
   it('transcribes the original file for browser-decodable codecs', async () => {
@@ -667,6 +702,163 @@ describe('mediaTranscriptionService.transcribeMedia', () => {
     expect(transcribeMock).toHaveBeenCalledTimes(1)
     expect(transcribeMock.mock.calls[0]?.[0]).toBe(sourceFile)
     expect(saveTranscriptMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes existing canvas captions while preserving clip-owned presentation', async () => {
+    const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
+    const updateItem = vi.fn()
+    const clip: VideoItem = {
+      id: 'clip-1',
+      type: 'video',
+      trackId: 'track-video',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Clip',
+      mediaId: 'media-1',
+      src: 'blob:test',
+      transcriptCaptions: {
+        type: 'transcript',
+        mediaId: 'media-1',
+        enabled: false,
+        updatedAt: 10,
+        cues: [{ id: 'old-cue', startSeconds: 0, endSeconds: 1, text: 'Old text' }],
+        style: { color: '#ffcc00', fontSize: 48 },
+      },
+    }
+    useTimelineStoreGetStateMock.mockReturnValue({ items: [clip], updateItem })
+    getMediaMock.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'clip.mp3',
+      mimeType: 'audio/mpeg',
+      codec: 'mp3',
+      fileLastModified: 123,
+    })
+    getMediaFileMock.mockResolvedValue(sourceFile)
+    transcribeCollectMock.mockResolvedValue([{ text: 'Fresh text', start: 0.2, end: 1.4 }])
+
+    const transcript = await mediaTranscriptionService.transcribeMedia('media-1')
+
+    expect(updateItem).toHaveBeenCalledWith('clip-1', {
+      transcriptCaptions: expect.objectContaining({
+        enabled: false,
+        sourceTranscriptUpdatedAt: transcript.updatedAt,
+        style: { color: '#ffcc00', fontSize: 48 },
+        cues: [
+          {
+            id: 'transcript-media-1-0',
+            startSeconds: 0.2,
+            endSeconds: 1.4,
+            text: 'Fresh text',
+          },
+        ],
+      }),
+    })
+  })
+
+  it('refreshes transcript captions inside nested compositions and navigation stashes', async () => {
+    const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
+    const makeCaptionedClip = (id: string): VideoItem => ({
+      id,
+      type: 'video',
+      trackId: 'track-video',
+      from: 0,
+      durationInFrames: 90,
+      label: id,
+      mediaId: 'media-1',
+      src: 'blob:test',
+      transcriptCaptions: {
+        type: 'transcript',
+        mediaId: 'media-1',
+        enabled: true,
+        updatedAt: 10,
+        timingVersion: 3,
+        cues: [{ id: 'old-cue', startSeconds: 0, endSeconds: 1, text: 'Old text' }],
+      },
+    })
+    const nestedClip = makeCaptionedClip('nested-clip')
+    const stashedClip = makeCaptionedClip('stashed-clip')
+    const updateComposition = vi.fn()
+    useCompositionsStoreGetStateMock.mockReturnValue({
+      compositions: [
+        {
+          id: 'outer-comp',
+          items: [
+            {
+              id: 'inner-wrapper',
+              type: 'composition',
+              trackId: 'track-video',
+              from: 0,
+              durationInFrames: 90,
+              label: 'Inner',
+              compositionId: 'inner-comp',
+            },
+          ],
+        },
+        { id: 'inner-comp', items: [nestedClip] },
+      ],
+      updateComposition,
+    })
+    useCompositionNavigationStoreGetStateMock.mockReturnValue({
+      stashStack: [{ compositionId: 'inner-comp', items: [stashedClip] }],
+      mainHolder: null,
+    })
+    useTimelineStoreGetStateMock.mockReturnValue({ items: [], updateItem: vi.fn() })
+    getMediaMock.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'clip.mp3',
+      mimeType: 'audio/mpeg',
+      codec: 'mp3',
+      fileLastModified: 123,
+    })
+    getMediaFileMock.mockResolvedValue(sourceFile)
+    transcribeCollectMock.mockResolvedValue([
+      {
+        text: 'Fresh nested phrase',
+        start: 0.2,
+        end: 1.4,
+        words: [
+          { text: 'Fresh', start: 0.2, end: 0.5 },
+          { text: 'nested', start: 0.53, end: 0.9 },
+          { text: 'phrase', start: 0.93, end: 1.4 },
+        ],
+      },
+    ])
+
+    const transcript = await mediaTranscriptionService.transcribeMedia('media-1')
+
+    expect(updateComposition).toHaveBeenCalledTimes(1)
+    expect(updateComposition).toHaveBeenCalledWith('inner-comp', {
+      items: [
+        expect.objectContaining({
+          id: 'nested-clip',
+          transcriptCaptions: expect.objectContaining({
+            sourceTranscriptUpdatedAt: transcript.updatedAt,
+            timingVersion: 4,
+            cues: [
+              {
+                id: 'transcript-media-1-0',
+                startSeconds: 0.2,
+                endSeconds: 1.4,
+                text: 'Fresh nested phrase',
+              },
+            ],
+          }),
+        }),
+      ],
+    })
+    expect(useCompositionNavigationStoreSetStateMock).toHaveBeenCalledWith({
+      stashStack: [
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              id: 'stashed-clip',
+              transcriptCaptions: expect.objectContaining({ timingVersion: 4 }),
+            }),
+          ],
+        }),
+      ],
+      mainHolder: null,
+    })
   })
 
   it('splits word-timestamped Whisper chunks into readable caption segments', async () => {
@@ -708,13 +900,80 @@ describe('mediaTranscriptionService.transcribeMedia', () => {
 
     const saved = saveTranscriptMock.mock.calls[0]?.[0] as MediaTranscript
     expect(saved.segments.length).toBeGreaterThan(1)
-    expect(saved.segments.every((segment) => segment.text.length <= 72)).toBe(true)
+    expect(saved.segments.every((segment) => segment.text.length <= 42)).toBe(true)
+    expect(saved.segments.every((segment) => segment.end - segment.start <= 2.2)).toBe(true)
     expect(saved.segments.every((segment) => (segment.words?.length ?? 0) > 0)).toBe(true)
     expect(saved.segments.map((segment) => segment.text)).toEqual([
       'my sentences.',
-      "So once again, I'm going to talk about the Netherlands in this",
-      'video.',
+      "So once again, I'm going to talk about",
+      'the Netherlands in this video.',
     ])
+  })
+
+  it('groups nearby words into phrases and breaks at an audible pause', async () => {
+    const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
+    getMediaMock.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'clip.mp3',
+      mimeType: 'audio/mpeg',
+      codec: 'mp3',
+      fileLastModified: 123,
+    })
+    getMediaFileMock.mockResolvedValue(sourceFile)
+    transcribeCollectMock.mockResolvedValue([
+      {
+        text: 'take a look over there',
+        start: 4,
+        end: 5.4,
+        words: [
+          { text: 'take', start: 4, end: 4.24 },
+          { text: 'a', start: 4.27, end: 4.36 },
+          { text: 'look', start: 4.39, end: 4.66 },
+          { text: 'over', start: 4.9, end: 5.12 },
+          { text: 'there', start: 5.15, end: 5.4 },
+        ],
+      },
+    ])
+
+    await mediaTranscriptionService.transcribeMedia('media-1')
+
+    const saved = saveTranscriptMock.mock.calls[0]?.[0] as MediaTranscript
+    expect(saved.segments.map((segment) => segment.text)).toEqual(['take a look', 'over there'])
+    expect(saved.segments.map((segment) => segment.start)).toEqual([4, 4.9])
+    expect(saved.segments.every((segment) => segment.words!.length >= 2)).toBe(true)
+  })
+
+  it('keeps timestamped CJK captions as short phrases rather than individual words', async () => {
+    const sourceFile = new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' })
+    getMediaMock.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'clip.mp3',
+      mimeType: 'audio/mpeg',
+      codec: 'mp3',
+      fileLastModified: 123,
+    })
+    getMediaFileMock.mockResolvedValue(sourceFile)
+    const characters = ['難', '知', '足', '看', '似', '個', '燕', '陽', '蝴', '蝶']
+    transcribeCollectMock.mockResolvedValue([
+      {
+        text: characters.join(''),
+        start: 10,
+        end: 13.95,
+        words: characters.map((text, index) => ({
+          text,
+          start: 10 + index * 0.4,
+          end: 10.35 + index * 0.4,
+        })),
+      },
+    ])
+
+    await mediaTranscriptionService.transcribeMedia('media-1')
+
+    const saved = saveTranscriptMock.mock.calls[0]?.[0] as MediaTranscript
+    expect(saved.segments.map((segment) => segment.text)).toEqual(['難知足看似', '個燕陽蝴蝶'])
+    expect(saved.segments.map((segment) => segment.start)).toEqual([10, 12])
+    expect(saved.segments.every((segment) => segment.words!.length > 1)).toBe(true)
+    expect(saved.segments.every((segment) => segment.end - segment.start <= 2.2)).toBe(true)
   })
 
   it('transcribes a conformed wav for custom-decoded codecs like pcm-s16be', async () => {

--- a/src/features/media-library/services/media-transcription-service.ts
+++ b/src/features/media-library/services/media-transcription-service.ts
@@ -192,6 +192,28 @@ function shouldBreakTranscriptCaption(
   return false
 }
 
+function transcriptCaptionGroupFitsLimits(
+  words: ReturnType<typeof sanitizeTranscriptWord>[],
+): boolean {
+  const first = words[0]
+  const last = words.at(-1)
+  if (!first || !last) return false
+
+  const hasPhraseBreakingGap = words.some((word, index) => {
+    const previous = words[index - 1]
+    return (
+      previous !== undefined && word.start - previous.end >= TRANSCRIPT_CAPTION_BREAK_GAP_SECONDS
+    )
+  })
+
+  return (
+    words.length <= MAX_TRANSCRIPT_CAPTION_WORDS &&
+    joinTranscriptWords(words.map((word) => word.text)).length <= MAX_TRANSCRIPT_CAPTION_CHARS &&
+    last.end - first.start <= MAX_TRANSCRIPT_CAPTION_SECONDS &&
+    !hasPhraseBreakingGap
+  )
+}
+
 function segmentTranscriptForCaptions(segments: TranscriptSegment[]): MediaTranscriptSegment[] {
   const sanitizedBySegment = segments.map((segment) =>
     (segment.words?.map(sanitizeTranscriptWord) ?? []).filter(
@@ -226,9 +248,15 @@ function segmentTranscriptForCaptions(segments: TranscriptSegment[]): MediaTrans
   const previousGroup = captionWordGroups.at(-2)
   if (trailingGroup?.length === 1 && previousGroup) {
     if (previousGroup.length >= 3) {
-      const borrowedWord = previousGroup.pop()
-      if (borrowedWord) trailingGroup.unshift(borrowedWord)
-    } else {
+      const shortenedPreviousGroup = previousGroup.slice(0, -1)
+      const rebalancedTrailingGroup = [previousGroup.at(-1)!, ...trailingGroup]
+      if (
+        transcriptCaptionGroupFitsLimits(shortenedPreviousGroup) &&
+        transcriptCaptionGroupFitsLimits(rebalancedTrailingGroup)
+      ) {
+        captionWordGroups.splice(-2, 2, shortenedPreviousGroup, rebalancedTrailingGroup)
+      }
+    } else if (transcriptCaptionGroupFitsLimits([...previousGroup, ...trailingGroup])) {
       previousGroup.push(...trailingGroup)
       captionWordGroups.pop()
     }

--- a/src/features/media-library/services/media-transcription-service.ts
+++ b/src/features/media-library/services/media-transcription-service.ts
@@ -7,6 +7,7 @@ import {
 import { usePlaybackStore } from '@/shared/state/playback'
 import { useSelectionStore } from '@/shared/state/selection'
 import { createLogger } from '@/shared/logging/logger'
+import { joinTranscriptWords } from '@/shared/utils/transcript-text'
 import { DEFAULT_PROJECT_HEIGHT, DEFAULT_PROJECT_WIDTH } from '@/shared/projects/defaults'
 import type { MediaTranscript, MediaTranscriptModel, MediaTranscriptSegment } from '@/types/storage'
 import type {
@@ -37,6 +38,8 @@ import {
 import { useProjectStore } from '@/features/media-library/deps/projects'
 import {
   removeTimelineItemsExact,
+  useCompositionNavigationStore,
+  useCompositionsStore,
   useTimelineStore,
 } from '@/features/media-library/deps/timeline-stores'
 import { useSettingsStore } from '@/features/media-library/deps/settings-contract'
@@ -54,11 +57,14 @@ import { TRANSCRIPTION_CANCELLED_MESSAGE } from '@/shared/utils/transcription-ca
 
 const logger = createLogger('MediaTranscriptionService')
 const DEFAULT_MODEL: MediaTranscriptModel = DEFAULT_WHISPER_MODEL
-const MAX_TRANSCRIPT_CAPTION_CHARS = 72
-const MAX_TRANSCRIPT_CAPTION_WORDS = 12
-const MAX_TRANSCRIPT_CAPTION_SECONDS = 4.2
-const PREFERRED_TRANSCRIPT_CAPTION_SECONDS = 2.8
-const TRANSCRIPT_CAPTION_BREAK_GAP_SECONDS = 0.55
+const MAX_TRANSCRIPT_CAPTION_CHARS = 42
+const MAX_TRANSCRIPT_CAPTION_WORDS = 8
+const MAX_TRANSCRIPT_CAPTION_SECONDS = 2.2
+const PREFERRED_TRANSCRIPT_CAPTION_SECONDS = 1.4
+const MIN_TRANSCRIPT_CAPTION_WORDS = 2
+// A short but audible pause is a better phrase boundary than a blanket timing offset.
+const TRANSCRIPT_CAPTION_BREAK_GAP_SECONDS = 0.18
+const TRANSCRIPT_CAPTION_TIMING_VERSION = 4
 const SENTENCE_END_PATTERN = /[.!?。！？]$/
 const DEFAULT_QUANTIZATION = DEFAULT_WHISPER_QUANTIZATION
 
@@ -142,10 +148,7 @@ function buildTranscriptSegmentFromWords(
   if (!first || !last) return null
 
   return {
-    text: validWords
-      .map((word) => word.text)
-      .join(' ')
-      .trim(),
+    text: joinTranscriptWords(validWords.map((word) => word.text)),
     start: first.start,
     end: last.end,
     words: validWords,
@@ -160,18 +163,25 @@ function shouldBreakTranscriptCaption(
   const previous = currentWords.at(-1)
   if (!first || !previous) return false
 
-  const nextText = [...currentWords, nextWord]
-    .map((word) => word.text)
-    .join(' ')
-    .trim()
+  const nextText = joinTranscriptWords([...currentWords, nextWord].map((word) => word.text))
   const currentDuration = previous.end - first.start
   const nextDuration = nextWord.end - first.start
   const gap = nextWord.start - previous.end
 
-  if (gap >= TRANSCRIPT_CAPTION_BREAK_GAP_SECONDS) return true
-  if (currentWords.length >= MAX_TRANSCRIPT_CAPTION_WORDS) return true
-  if (nextText.length > MAX_TRANSCRIPT_CAPTION_CHARS) return true
-  if (nextDuration > MAX_TRANSCRIPT_CAPTION_SECONDS) return true
+  if (
+    currentWords.length >= MIN_TRANSCRIPT_CAPTION_WORDS &&
+    gap >= TRANSCRIPT_CAPTION_BREAK_GAP_SECONDS
+  ) {
+    return true
+  }
+  if (
+    currentWords.length >= MIN_TRANSCRIPT_CAPTION_WORDS &&
+    (currentWords.length >= MAX_TRANSCRIPT_CAPTION_WORDS ||
+      nextText.length > MAX_TRANSCRIPT_CAPTION_CHARS ||
+      nextDuration > MAX_TRANSCRIPT_CAPTION_SECONDS)
+  ) {
+    return true
+  }
   if (
     currentDuration >= PREFERRED_TRANSCRIPT_CAPTION_SECONDS &&
     SENTENCE_END_PATTERN.test(previous.text)
@@ -198,20 +208,35 @@ function segmentTranscriptForCaptions(segments: TranscriptSegment[]): MediaTrans
     }))
   }
 
-  const captionSegments: MediaTranscriptSegment[] = []
+  const captionWordGroups: (typeof words)[] = []
   let currentWords: typeof words = []
 
   for (const word of words) {
     if (currentWords.length > 0 && shouldBreakTranscriptCaption(currentWords, word)) {
-      const segment = buildTranscriptSegmentFromWords(currentWords)
-      if (segment) captionSegments.push(segment)
+      captionWordGroups.push(currentWords)
       currentWords = []
     }
     currentWords.push(word)
   }
 
-  const trailingSegment = buildTranscriptSegmentFromWords(currentWords)
-  if (trailingSegment) captionSegments.push(trailingSegment)
+  if (currentWords.length > 0) captionWordGroups.push(currentWords)
+
+  // Avoid ending on a one-word flash. Rebalance with the preceding phrase when possible.
+  const trailingGroup = captionWordGroups.at(-1)
+  const previousGroup = captionWordGroups.at(-2)
+  if (trailingGroup?.length === 1 && previousGroup) {
+    if (previousGroup.length >= 3) {
+      const borrowedWord = previousGroup.pop()
+      if (borrowedWord) trailingGroup.unshift(borrowedWord)
+    } else {
+      previousGroup.push(...trailingGroup)
+      captionWordGroups.pop()
+    }
+  }
+
+  const captionSegments = captionWordGroups
+    .map(buildTranscriptSegmentFromWords)
+    .filter((segment): segment is MediaTranscriptSegment => segment !== null)
 
   segments.forEach((segment, index) => {
     if ((sanitizedBySegment[index]?.length ?? 0) > 0) return
@@ -221,6 +246,67 @@ function segmentTranscriptForCaptions(segments: TranscriptSegment[]): MediaTrans
   })
 
   return captionSegments.toSorted((left, right) => left.start - right.start)
+}
+
+function buildTimelineTranscriptCaptionCues(
+  mediaId: string,
+  segments: readonly MediaTranscriptSegment[],
+): TimelineTranscriptCaptionCue[] {
+  return segmentTranscriptForCaptions([...segments]).map((segment, index) => ({
+    id: `transcript-${mediaId}-${index}`,
+    startSeconds: segment.start,
+    endSeconds: segment.end,
+    text: segment.text,
+  }))
+}
+
+function buildSyncedTranscriptCaptionItem(
+  item: TimelineItem,
+  mediaId: string,
+  transcript: MediaTranscript,
+  sourceCues: TimelineTranscriptCaptionCue[],
+): TimelineItem | null {
+  if (
+    (item.type !== 'video' && item.type !== 'audio') ||
+    item.mediaId !== mediaId ||
+    item.transcriptCaptions?.type !== 'transcript' ||
+    item.transcriptCaptions.mediaId !== mediaId ||
+    (item.transcriptCaptions.sourceTranscriptUpdatedAt === transcript.updatedAt &&
+      item.transcriptCaptions.timingVersion === TRANSCRIPT_CAPTION_TIMING_VERSION)
+  ) {
+    return null
+  }
+
+  return {
+    ...item,
+    transcriptCaptions: {
+      ...item.transcriptCaptions,
+      cues: sourceCues,
+      sourceTranscriptUpdatedAt: transcript.updatedAt,
+      timingVersion: TRANSCRIPT_CAPTION_TIMING_VERSION,
+      updatedAt: Date.now(),
+    },
+  }
+}
+
+function syncTranscriptCaptionItems(
+  items: readonly TimelineItem[],
+  mediaId: string,
+  transcript: MediaTranscript,
+  sourceCues: TimelineTranscriptCaptionCue[],
+): { items: TimelineItem[]; updatedClipCount: number } {
+  let updatedClipCount = 0
+  const nextItems = items.map((item) => {
+    const updatedItem = buildSyncedTranscriptCaptionItem(item, mediaId, transcript, sourceCues)
+    if (!updatedItem) return item
+    updatedClipCount += 1
+    return updatedItem
+  })
+
+  return {
+    items: updatedClipCount > 0 ? nextItems : [...items],
+    updatedClipCount,
+  }
 }
 
 class MediaTranscriptionService {
@@ -473,17 +559,14 @@ class MediaTranscriptionService {
       model: job.model,
       language: job.language,
       quantization: job.quantization,
-      text: segments
-        .map((segment) => segment.text.trim())
-        .filter(Boolean)
-        .join(' ')
-        .trim(),
+      text: joinTranscriptWords(segments.map((segment) => segment.text)),
       segments: segmentTranscriptForCaptions(segments),
       createdAt: Date.now(),
       updatedAt: Date.now(),
     }
 
     await saveTranscript(transcript)
+    this.syncExistingTranscriptCaptions(mediaId, transcript)
     this.emitTranscriptChanged(mediaId)
     logger.info('Saved transcript', {
       mediaId,
@@ -491,6 +574,65 @@ class MediaTranscriptionService {
       model: getMediaTranscriptionModelLabel(transcript.model),
     })
     return transcript
+  }
+
+  /**
+   * Refresh transcript-derived cues already attached to timeline clips. Caption
+   * visibility and styling remain clip-owned and are intentionally preserved.
+   */
+  syncExistingTranscriptCaptions(mediaId: string, transcript: MediaTranscript): number {
+    const timeline = useTimelineStore.getState()
+    const sourceCues = buildTimelineTranscriptCaptionCues(mediaId, transcript.segments)
+    let updatedClipCount = 0
+
+    for (const item of timeline.items ?? []) {
+      const updatedItem = buildSyncedTranscriptCaptionItem(item, mediaId, transcript, sourceCues)
+      if (!updatedItem) continue
+      timeline.updateItem?.(item.id, {
+        transcriptCaptions: updatedItem.transcriptCaptions,
+      } as Partial<TimelineItem>)
+      updatedClipCount += 1
+    }
+
+    // Compound contents are stored outside the active timeline. Refresh every
+    // registered composition so deeply nested and reused instances cannot keep
+    // an older transcript snapshot.
+    const compositionsState = useCompositionsStore.getState()
+    for (const composition of compositionsState.compositions) {
+      const synced = syncTranscriptCaptionItems(
+        composition.items,
+        mediaId,
+        transcript,
+        sourceCues,
+      )
+      if (synced.updatedClipCount === 0) continue
+      compositionsState.updateComposition(composition.id, { items: synced.items })
+      updatedClipCount += synced.updatedClipCount
+    }
+
+    // While drilling through compounds, parent timelines are held in navigation
+    // stashes and can later overwrite the composition registry. Keep those
+    // snapshots in sync too.
+    const navigationState = useCompositionNavigationStore.getState()
+    let updatedStashedClipCount = 0
+    const syncStash = <T extends { items: TimelineItem[] }>(stash: T): T => {
+      const synced = syncTranscriptCaptionItems(stash.items, mediaId, transcript, sourceCues)
+      updatedStashedClipCount += synced.updatedClipCount
+      return synced.updatedClipCount > 0 ? { ...stash, items: synced.items } : stash
+    }
+    const nextStashStack = navigationState.stashStack.map(syncStash)
+    const nextMainHolder = navigationState.mainHolder
+      ? syncStash(navigationState.mainHolder)
+      : null
+    if (updatedStashedClipCount > 0) {
+      useCompositionNavigationStore.setState({
+        stashStack: nextStashStack,
+        mainHolder: nextMainHolder,
+      })
+      updatedClipCount += updatedStashedClipCount
+    }
+
+    return updatedClipCount
   }
 
   private async resolveTranscriptionBlob(
@@ -592,12 +734,7 @@ class MediaTranscriptionService {
 
       const clipCaptionItem = buildSubtitleSegmentForClip({
         trackId: targetTrack.id,
-        cues: transcript.segments.map((segment, index) => ({
-          id: `transcript-${clip.id}-${index}`,
-          startSeconds: segment.start,
-          endSeconds: segment.end,
-          text: segment.text,
-        })),
+        cues: buildTimelineTranscriptCaptionCues(clip.id, transcript.segments),
         clip,
         timelineFps: timeline.fps,
         canvasWidth,
@@ -670,14 +807,7 @@ class MediaTranscriptionService {
       canvasWidth,
       canvasHeight,
     )
-    const sourceCues: TimelineTranscriptCaptionCue[] = transcript.segments.map(
-      (segment, index) => ({
-        id: `transcript-${mediaId}-${index}`,
-        startSeconds: segment.start,
-        endSeconds: segment.end,
-        text: segment.text,
-      }),
-    )
+    const sourceCues = buildTimelineTranscriptCaptionCues(mediaId, transcript.segments)
     const generatedCaptionIdsToRemove = options.replaceExisting
       ? new Set(
           targetClips.flatMap((clip) =>
@@ -715,6 +845,8 @@ class MediaTranscriptionService {
           mediaId,
           enabled: true,
           updatedAt: Date.now(),
+          sourceTranscriptUpdatedAt: transcript.updatedAt,
+          timingVersion: TRANSCRIPT_CAPTION_TIMING_VERSION,
           cues: sourceCues,
           ...(styleTemplate ? { style: styleTemplate } : {}),
         },

--- a/src/features/media-library/transcription/lib/whisper-runtime-options.test.ts
+++ b/src/features/media-library/transcription/lib/whisper-runtime-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getWhisperWebGpuBatchSize } from './whisper-runtime-options'
+
+describe('getWhisperWebGpuBatchSize', () => {
+  it('runs Large Turbo windows serially to bound WebGPU memory', () => {
+    expect(
+      getWhisperWebGpuBatchSize('onnx-community/whisper-large-v3-turbo_timestamped'),
+    ).toBe(1)
+  })
+
+  it('uses a conservative batch for Whisper Small', () => {
+    expect(getWhisperWebGpuBatchSize('onnx-community/whisper-small_timestamped')).toBe(4)
+  })
+
+  it('keeps the fast batch for smaller Whisper models', () => {
+    expect(getWhisperWebGpuBatchSize('onnx-community/whisper-base_timestamped')).toBe(8)
+    expect(getWhisperWebGpuBatchSize('onnx-community/whisper-tiny_timestamped')).toBe(8)
+  })
+})

--- a/src/features/media-library/transcription/lib/whisper-runtime-options.ts
+++ b/src/features/media-library/transcription/lib/whisper-runtime-options.ts
@@ -1,0 +1,13 @@
+const LARGE_TURBO_MODEL_FRAGMENT = 'whisper-large-v3-turbo'
+const SMALL_MODEL_FRAGMENT = 'whisper-small'
+
+/**
+ * Transformers.js batches the 30 s windows inside each decoded audio span.
+ * Large Turbo's activations are much heavier than Base's, so sharing Base's
+ * batch of eight can exhaust WebGPU memory before the first segment is emitted.
+ */
+export function getWhisperWebGpuBatchSize(modelId: string): number {
+  if (modelId.includes(LARGE_TURBO_MODEL_FRAGMENT)) return 1
+  if (modelId.includes(SMALL_MODEL_FRAGMENT)) return 4
+  return 8
+}

--- a/src/features/media-library/transcription/lib/whisper-word-timings.test.ts
+++ b/src/features/media-library/transcription/lib/whisper-word-timings.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWhisperWordTimings } from './whisper-word-timings'
+
+describe('resolveWhisperWordTimings', () => {
+  it('preserves fully timestamped words', () => {
+    expect(resolveWhisperWordTimings([{ text: 'hello', timestamp: [1, 1.4] }], 10, 30)).toEqual([
+      { text: 'hello', start: 11, end: 11.4 },
+    ])
+  })
+
+  it('preserves an open-ended final word', () => {
+    expect(
+      resolveWhisperWordTimings(
+        [
+          { text: '柔', timestamp: [4, 4.3] },
+          { text: '眠', timestamp: [4.3, null] },
+        ],
+        118,
+        12,
+      ),
+    ).toEqual([
+      { text: '柔', start: 122, end: 122.3 },
+      { text: '眠', start: 122.3, end: 122.8 },
+    ])
+  })
+
+  it('uses the next known start for a missing end timestamp', () => {
+    expect(
+      resolveWhisperWordTimings(
+        [
+          { text: 'one', timestamp: [1, null] },
+          { text: 'two', timestamp: [1.6, 2] },
+        ],
+        0,
+        10,
+      )[0],
+    ).toEqual({ text: 'one', start: 1, end: 1.6 })
+  })
+})

--- a/src/features/media-library/transcription/lib/whisper-word-timings.test.ts
+++ b/src/features/media-library/transcription/lib/whisper-word-timings.test.ts
@@ -36,4 +36,20 @@ describe('resolveWhisperWordTimings', () => {
       )[0],
     ).toEqual({ text: 'one', start: 1, end: 1.6 })
   })
+
+  it('preserves a fully open final word at the chunk boundary', () => {
+    expect(
+      resolveWhisperWordTimings(
+        [
+          { text: 'before', timestamp: [11.5, 12] },
+          { text: 'boundary', timestamp: [null, null] },
+        ],
+        118,
+        12,
+      ),
+    ).toEqual([
+      { text: 'before', start: 129.5, end: 130 },
+      { text: 'boundary', start: 129.99, end: 130 },
+    ])
+  })
 })

--- a/src/features/media-library/transcription/lib/whisper-word-timings.ts
+++ b/src/features/media-library/transcription/lib/whisper-word-timings.ts
@@ -53,6 +53,10 @@ export function resolveWhisperWordTimings(
     const nextStart = nextKnownStart(rawWords, index, start)
     let end = validTimestamp(rawEnd) && rawEnd > start ? rawEnd : null
     end ??= nextStart ?? Math.min(chunkDuration, start + FALLBACK_WORD_SECONDS)
+    if (end <= start && start === chunkDuration && chunkDuration > 0) {
+      start = Math.max(0, chunkDuration - MIN_WORD_SECONDS)
+      end = chunkDuration
+    }
     if (end <= start && start < chunkDuration) {
       end = Math.min(chunkDuration, start + MIN_WORD_SECONDS)
     }

--- a/src/features/media-library/transcription/lib/whisper-word-timings.ts
+++ b/src/features/media-library/transcription/lib/whisper-word-timings.ts
@@ -1,0 +1,71 @@
+import type { TranscriptWord } from '../types'
+
+export interface RawWhisperWord {
+  text: string
+  timestamp: [number | null, number | null]
+  confidence?: number
+}
+
+const FALLBACK_WORD_SECONDS = 0.5
+const MIN_WORD_SECONDS = 0.01
+
+function validTimestamp(value: number | null): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function nextKnownStart(
+  words: readonly RawWhisperWord[],
+  index: number,
+  after: number,
+): number | null {
+  for (let nextIndex = index + 1; nextIndex < words.length; nextIndex++) {
+    const start = words[nextIndex]?.timestamp[0] ?? null
+    if (validTimestamp(start) && start > after) return start
+  }
+  return null
+}
+
+/**
+ * Whisper can leave the first or final word timestamp open at a decoding boundary.
+ * Preserve that recognized text with a conservative inferred span instead of silently
+ * dropping it from the saved transcript.
+ */
+export function resolveWhisperWordTimings(
+  rawWords: readonly RawWhisperWord[],
+  chunkTimestamp: number,
+  chunkDuration: number,
+): TranscriptWord[] {
+  const words: TranscriptWord[] = []
+  let previousEnd = 0
+
+  rawWords.forEach((rawWord, index) => {
+    if (!rawWord.text.trim()) return
+
+    const rawStart = rawWord.timestamp[0]
+    const rawEnd = rawWord.timestamp[1]
+    let start = validTimestamp(rawStart)
+      ? rawStart
+      : validTimestamp(rawEnd)
+        ? Math.max(previousEnd, rawEnd - FALLBACK_WORD_SECONDS)
+        : previousEnd
+    start = Math.min(Math.max(0, start), chunkDuration)
+
+    const nextStart = nextKnownStart(rawWords, index, start)
+    let end = validTimestamp(rawEnd) && rawEnd > start ? rawEnd : null
+    end ??= nextStart ?? Math.min(chunkDuration, start + FALLBACK_WORD_SECONDS)
+    if (end <= start && start < chunkDuration) {
+      end = Math.min(chunkDuration, start + MIN_WORD_SECONDS)
+    }
+    if (end <= start) return
+
+    previousEnd = end
+    words.push({
+      text: rawWord.text,
+      start: start + chunkTimestamp,
+      end: end + chunkTimestamp,
+      ...(typeof rawWord.confidence === 'number' ? { confidence: rawWord.confidence } : {}),
+    })
+  })
+
+  return words
+}

--- a/src/features/media-library/transcription/registry.test.ts
+++ b/src/features/media-library/transcription/registry.test.ts
@@ -17,7 +17,7 @@ describe('mediaTranscriptionAdapterRegistry', () => {
     expect(getDefaultMediaTranscriptionModel()).toBe('parakeet-tdt-v3')
     expect(getMediaTranscriptionModelOptions()).toContainEqual({
       value: 'whisper-small',
-      label: 'Small',
+      label: 'Whisper Small',
     })
     expect(getMediaTranscriptionModelOptions()).not.toContainEqual({
       value: 'whisper-tiny',
@@ -26,6 +26,6 @@ describe('mediaTranscriptionAdapterRegistry', () => {
   })
 
   it('formats model labels through the active adapter', () => {
-    expect(getMediaTranscriptionModelLabel('whisper-large')).toBe('Large v3 Turbo')
+    expect(getMediaTranscriptionModelLabel('whisper-large')).toBe('Whisper Large v3 Turbo')
   })
 })

--- a/src/features/media-library/transcription/workers/whisper.worker.ts
+++ b/src/features/media-library/transcription/workers/whisper.worker.ts
@@ -11,6 +11,9 @@ import {
   updateDownloadProgress,
   type DownloadProgressCache,
 } from '@/shared/utils/download-progress'
+import { joinTranscriptWords } from '@/shared/utils/transcript-text'
+import { resolveWhisperWordTimings, type RawWhisperWord } from '../lib/whisper-word-timings'
+import { getWhisperWebGpuBatchSize } from '../lib/whisper-runtime-options'
 
 const logger = createLogger('TranscriptionWorker')
 
@@ -18,9 +21,6 @@ const TRANSFORMERS_CDN_URL = 'https://esm.sh/@huggingface/transformers@3.8.1?bun
 const WASM_CDN_URL = 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1/dist/'
 const WHISPER_CHUNK_SECONDS = 30
 const WHISPER_STRIDE_SECONDS = 5
-// Batch the internal 30 s windows of each span on WebGPU (measured ~1.5x faster on a
-// 120 s span). WASM gains nothing from batching and pays the memory, so keep it serial.
-const WHISPER_WEBGPU_BATCH_SIZE = 8
 const WHISPER_TASK = 'transcribe'
 const RECENT_WORD_RETENTION_SECONDS = 8
 const DUPLICATE_WORD_START_TOLERANCE_SECONDS = 0.5
@@ -300,7 +300,7 @@ async function transcribeChunk(chunk: PCMChunk): Promise<void> {
     return_timestamps: 'word',
     chunk_length_s: WHISPER_CHUNK_SECONDS,
     stride_length_s: WHISPER_STRIDE_SECONDS,
-    batch_size: activeDevice === 'webgpu' ? WHISPER_WEBGPU_BATCH_SIZE : 1,
+    batch_size: activeDevice === 'webgpu' ? getWhisperWebGpuBatchSize(currentModelId ?? '') : 1,
     force_full_sequences: false,
     top_k: 0,
     do_sample: false,
@@ -310,29 +310,11 @@ async function transcribeChunk(chunk: PCMChunk): Promise<void> {
 
   const output = result as {
     text?: string
-    chunks?: Array<{
-      text: string
-      timestamp: [number | null, number | null]
-      confidence?: number
-    }>
+    chunks?: RawWhisperWord[]
   }
 
   const words = dedupeOverlappingWords(
-    (output.chunks ?? []).flatMap((word): TranscriptWord[] => {
-      const start = word.timestamp[0]
-      const end = word.timestamp[1]
-      if (start === null || end === null || end <= start) {
-        return []
-      }
-      return [
-        {
-          text: word.text,
-          start: start + chunk.timestamp,
-          end: end + chunk.timestamp,
-          ...(typeof word.confidence === 'number' ? { confidence: word.confidence } : {}),
-        },
-      ]
-    }),
+    resolveWhisperWordTimings(output.chunks ?? [], chunk.timestamp, chunk.samples.length / 16_000),
   )
 
   if (words.length > 0) {
@@ -350,10 +332,7 @@ async function transcribeChunk(chunk: PCMChunk): Promise<void> {
     postMain({
       type: 'segment',
       segment: {
-        text: words
-          .map((word) => word.text)
-          .join(' ')
-          .trim(),
+        text: joinTranscriptWords(words.map((word) => word.text)),
         start: words[0]?.start ?? chunk.timestamp,
         end: words.at(-1)?.end ?? chunk.timestamp,
         words,

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -190,13 +190,14 @@ describe('TimelineContent playback selection behavior', () => {
   })
 
   it('renders one full-height playhead and one tool-only preview overlay', () => {
-    const { getAllByTestId, getByTestId } = render(
+    const { container, getAllByTestId, getByTestId } = render(
       <TimelineContent duration={10} tracks={[VIDEO_TRACK]} />,
     )
 
     expect(getAllByTestId('unified-timeline-playhead')).toHaveLength(1)
     expect(getAllByTestId('unified-timeline-preview-scrubber')).toHaveLength(1)
     expect(getByTestId('unified-timeline-preview-scrubber')).toBeInTheDocument()
+    expect(container.querySelector('.timeline-container')).toHaveClass('isolate')
   })
 
   it('keeps the selected clip selected after the playhead moves past it', async () => {

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -1978,7 +1978,7 @@ export const TimelineContent = memo(function TimelineContent({
       <div
         ref={mergedRef}
         data-timeline-scroll-container
-        className="timeline-container relative flex flex-1 flex-col overflow-x-auto overflow-y-hidden"
+        className="timeline-container isolate relative flex flex-1 flex-col overflow-x-auto overflow-y-hidden"
         style={{
           scrollBehavior: 'auto',
           willChange: 'scroll-position',

--- a/src/features/timeline/components/transcript-editor/transcript-editor-panel.tsx
+++ b/src/features/timeline/components/transcript-editor/transcript-editor-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import {
   Captions,
+  CircleCheck,
   ChevronDown,
   ChevronUp,
   Copy,
@@ -25,8 +26,17 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  TranscribeDialog,
+  type TranscribeDialogValues,
+} from '@/features/timeline/deps/transcribe-dialog'
 import { cn } from '@/shared/ui/cn'
 import { createLogger } from '@/shared/logging/logger'
+import { needsTranscriptWordSeparator } from '@/shared/utils/transcript-text'
+import {
+  isTranscriptionOutOfMemoryError,
+  TRANSCRIPTION_OOM_HINT,
+} from '@/shared/utils/transcription-cancellation'
 import { useSelectionStore } from '@/shared/state/selection'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { useClipboardStore } from '@/shared/state/clipboard'
@@ -43,6 +53,7 @@ import {
 import { buildTranscriptClipboardItems } from '../../utils/transcript-clipboard'
 import { registerTranscriptCopyHandler } from '../../utils/transcript-copy-bridge'
 import {
+  cancelMediaTranscriptionJob,
   mediaTranscriptionService,
   runMediaTranscriptionJob,
 } from '../../deps/media-transcription-service'
@@ -65,8 +76,8 @@ type TranscriptScope = 'selection' | 'project'
 /** Pause (seconds) that starts a new transcript paragraph. */
 const PARAGRAPH_GAP_SECONDS = 0.6
 /** Soft/hard word caps so pause-less speech still breaks into readable blocks. */
-const SEGMENT_SOFT_MAX_WORDS = 38
-const SEGMENT_HARD_MAX_WORDS = 60
+const SEGMENT_SOFT_MAX_WORDS = 28
+const SEGMENT_HARD_MAX_WORDS = 40
 
 /** Timeline seconds → compact `m:ss` (or `h:mm:ss`) timecode. */
 function formatTimecode(totalSeconds: number): string {
@@ -82,6 +93,7 @@ function formatTimecode(totalSeconds: number): string {
 interface MediaEntry {
   status: MediaStatus
   transcript?: MediaTranscript
+  errorMessage?: string
 }
 
 function hasWordTimings(
@@ -189,7 +201,7 @@ const TranscriptSegmentRow = memo(function TranscriptSegmentRow({
           <span className="h-px flex-1 bg-border" />
         </div>
       )}
-      <div className="group grid grid-cols-[3rem_1fr] gap-x-3 py-1.5">
+      <div className="group grid grid-cols-[3rem_minmax(0,1fr)] gap-x-3 py-1.5">
         <button
           type="button"
           onPointerDown={(event) => event.stopPropagation()}
@@ -202,10 +214,11 @@ const TranscriptSegmentRow = memo(function TranscriptSegmentRow({
         >
           {formatTimecode(segment.startSeconds)}
         </button>
-        <p className="text-[13px] leading-7">
+        <p className="min-w-0 break-words text-[13px] leading-7">
           {segment.indices.map((index) => {
             const token = tokens[index]
             if (!token) return null
+            const nextToken = index < segment.lastIndex ? tokens[index + 1] : undefined
             const isActive = index === activeIndex
             const isSelected = selectedKeys.has(token.key)
             const isMatch = matchKeys.has(token.key)
@@ -230,7 +243,8 @@ const TranscriptSegmentRow = memo(function TranscriptSegmentRow({
                   isIgnored && 'line-through decoration-from-font opacity-45',
                 )}
               >
-                {token.text}{' '}
+                {token.text}
+                {nextToken && needsTranscriptWordSeparator(token.text, nextToken.text) ? ' ' : ''}
               </span>
             )
           })}
@@ -266,6 +280,7 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
   const [anchorIndex, setAnchorIndex] = useState(-1)
   const [focusIndex, setFocusIndex] = useState(-1)
   const [query, setQuery] = useState('')
+  const [transcribeDialogOpen, setTranscribeDialogOpen] = useState(false)
   // -1 means "no match shown yet", so the first Next/Enter lands on match 0.
   const [matchCursor, setMatchCursor] = useState(-1)
   // Bumped when a stored transcript changes externally (e.g. deleted from the media
@@ -325,6 +340,17 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
   )
 
   const segments = useMemo(() => buildSegments(tokens, timelineFps), [tokens, timelineFps])
+
+  const sourceCoverage = useMemo(() => {
+    if (scope !== 'selection' || uniqueMediaIds.length !== 1 || tokens.length === 0) return null
+    return tokens.reduce(
+      (coverage, token) => ({
+        start: Math.min(coverage.start, token.sourceStart),
+        end: Math.max(coverage.end, token.sourceEnd),
+      }),
+      { start: Number.POSITIVE_INFINITY, end: 0 },
+    )
+  }, [scope, uniqueMediaIds, tokens])
 
   const selectedSlice = useMemo(
     () => getSelectedTokenSlice(tokens, anchorIndex, focusIndex),
@@ -424,6 +450,9 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
         try {
           const transcript = await mediaTranscriptionService.getTranscript(mediaId)
           if (!mountedRef.current) return
+          if (transcript) {
+            mediaTranscriptionService.syncExistingTranscriptCaptions(mediaId, transcript)
+          }
           setMediaState((prev) => ({
             ...prev,
             [mediaId]: hasWordTimings(transcript)
@@ -433,11 +462,18 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
         } catch (error) {
           if (!mountedRef.current) return
           logger.warn('Failed to load transcript', { mediaId, error })
-          setMediaState((prev) => ({ ...prev, [mediaId]: { status: 'error' } }))
+          const errorMessage =
+            error instanceof Error && error.message.trim().length > 0
+              ? error.message
+              : t('transcript.toastTranscribeFailed')
+          setMediaState((prev) => ({
+            ...prev,
+            [mediaId]: { status: 'error', errorMessage },
+          }))
         }
       }),
     )
-  }, [active, uniqueMediaIds, refreshNonce])
+  }, [active, uniqueMediaIds, refreshNonce, t])
 
   // Keep the active word in view during playback. Skip entirely when hidden — a
   // querySelector + scrollIntoView every frame on an off-screen panel is pure waste.
@@ -676,12 +712,14 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
     return status === 'loading' || status === 'transcribing'
   })
 
-  const handleTranscribe = useCallback(() => {
+  const handleTranscribe = useCallback((values: TranscribeDialogValues) => {
     const targets = uniqueMediaIds.filter((id) => {
       const status = mediaState[id]?.status
       return status === 'needs' || status === 'error'
     })
     if (targets.length === 0) return
+
+    setTranscribeDialogOpen(false)
 
     for (const id of targets) requestedRef.current.add(id)
     setMediaState((prev) => {
@@ -693,7 +731,12 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
     void Promise.all(
       targets.map(async (mediaId) => {
         try {
-          const result = await runMediaTranscriptionJob(mediaId)
+          const result = await runMediaTranscriptionJob(mediaId, {
+            ...values,
+            onModelFallback: () => {
+              toast.info(t('transcript.largeTurboFallback'))
+            },
+          })
           if (!mountedRef.current) return
           if (result.status === 'cancelled') {
             setMediaState((prev) => ({ ...prev, [mediaId]: { status: 'needs' } }))
@@ -708,14 +751,44 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
           }))
         } catch (error) {
           logger.warn('Transcription failed', { mediaId, error })
+          const errorMessage = isTranscriptionOutOfMemoryError(error)
+            ? TRANSCRIPTION_OOM_HINT
+            : error instanceof Error && error.message.trim().length > 0
+              ? error.message
+              : t('transcript.toastTranscribeFailed')
           if (mountedRef.current) {
-            setMediaState((prev) => ({ ...prev, [mediaId]: { status: 'error' } }))
+            setMediaState((prev) => ({
+              ...prev,
+              [mediaId]: { status: 'error', errorMessage },
+            }))
           }
-          toast.error(t('transcript.toastTranscribeFailed'))
+          toast.error(errorMessage)
         }
       }),
     )
   }, [uniqueMediaIds, mediaState, t])
+
+  const transcriptionError = useMemo(
+    () =>
+      needsTranscription
+        .map((mediaId) => mediaState[mediaId])
+        .find((entry) => entry?.status === 'error')?.errorMessage,
+    [mediaState, needsTranscription],
+  )
+
+  const transcriptionFileName = useMemo(() => {
+    if (needsTranscription.length !== 1) {
+      return t('transcript.selectedClips', {
+        defaultValue: '{{count}} selected clips',
+        count: needsTranscription.length,
+      })
+    }
+    const mediaId = needsTranscription[0]
+    return (
+      transcriptableItems.find((item) => item.mediaId === mediaId)?.label ??
+      t('transcript.selectedClip', { defaultValue: 'Selected clip' })
+    )
+  }, [needsTranscription, transcriptableItems, t])
 
   const selectionCount = selectedKeys.size
 
@@ -817,7 +890,7 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
       <div
         ref={scrollRef}
         onPointerMove={handlePointerMove}
-        className="min-h-0 flex-1 overflow-y-auto px-3 py-2"
+        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 py-2"
       >
         {transcriptableItems.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
@@ -833,10 +906,25 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
         ) : needsTranscription.length > 0 && tokens.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
             <Captions className="h-8 w-8 text-muted-foreground/60" />
-            <p className="text-sm text-muted-foreground">{t('transcript.noTranscript')}</p>
-            <Button size="sm" onClick={handleTranscribe} disabled={isBusy}>
+            <div className="max-w-[34ch] space-y-1">
+              <p className="text-sm text-muted-foreground">
+                {transcriptionError
+                  ? t('transcript.transcriptionFailed')
+                  : t('transcript.noTranscript')}
+              </p>
+              {transcriptionError && (
+                <p className="break-words text-xs leading-5 text-destructive">
+                  {transcriptionError}
+                </p>
+              )}
+            </div>
+            <Button size="sm" onClick={() => setTranscribeDialogOpen(true)} disabled={isBusy}>
               {isBusy && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
-              {isBusy ? t('transcript.transcribing') : t('transcript.generate')}
+              {isBusy
+                ? t('transcript.transcribing')
+                : transcriptionError
+                  ? t('transcript.tryAgain')
+                  : t('transcript.generate')}
             </Button>
           </div>
         ) : tokens.length === 0 && isBusy ? (
@@ -846,6 +934,26 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
           </div>
         ) : (
           <div className="mx-auto max-w-[62ch] select-none">
+            {sourceCoverage && (
+              <div className="mb-2 flex items-start gap-2 rounded-md border border-border/70 bg-secondary/30 px-2.5 py-2">
+                <CircleCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-foreground">
+                    {t('transcript.sourceAnalyzed', {
+                      defaultValue: 'Full source analyzed',
+                    })}
+                  </p>
+                  <p className="text-[11px] leading-4 text-muted-foreground">
+                    {t('transcript.detectedRange', {
+                      defaultValue:
+                        'Voice detected from {{start}} to {{end}}. Silent and music-only sections are omitted.',
+                      start: formatTimecode(sourceCoverage.start),
+                      end: formatTimecode(sourceCoverage.end),
+                    })}
+                  </p>
+                </div>
+              </div>
+            )}
             {segments.map((segment) => (
               <TranscriptSegmentRow
                 key={segment.key}
@@ -978,6 +1086,20 @@ export function TranscriptEditorPanel({ active }: TranscriptEditorPanelProps) {
           </Button>
         </div>
       </div>
+
+      <TranscribeDialog
+        open={transcribeDialogOpen}
+        onOpenChange={setTranscribeDialogOpen}
+        fileName={transcriptionFileName}
+        hasTranscript={false}
+        isRunning={isBusy}
+        progressPercent={null}
+        progressLabel={t('transcript.transcribing')}
+        onStart={handleTranscribe}
+        onCancel={() => {
+          for (const mediaId of uniqueMediaIds) cancelMediaTranscriptionJob(mediaId)
+        }}
+      />
     </div>
   )
 }

--- a/src/i18n/locales/partials/de/media.json
+++ b/src/i18n/locales/partials/de/media.json
@@ -277,12 +277,15 @@
       "language": "Sprache",
       "model": "Modell",
       "noLanguages": "Keine Sprachen verfügbar.",
+      "parakeetAutoDetects": "Erkennt {{count}} europäische Sprachen automatisch.",
+      "parakeetChooseWhisper": "Wähle für Chinesisch, Japanisch, Koreanisch und andere Sprachen ein Whisper-Modell.",
       "progressAria": "Transkriptionsfortschritt",
       "quantization": "Quantisierung",
       "refreshTitle": "Transkript aktualisieren",
       "searchLanguages": "Sprachen suchen",
       "start": "Starten",
-      "stop": "Stoppen"
+      "stop": "Stoppen",
+      "whisperLanguageHint": "Wähle für bessere Genauigkeit die gesprochene Sprache oder nutze die automatische Erkennung."
     },
     "type": {
       "audio": "Audio",

--- a/src/i18n/locales/partials/de/transcript.json
+++ b/src/i18n/locales/partials/de/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Gesamte Quelldatei analysiert",
+    "detectedRange": "Stimme von {{start}} bis {{end}} erkannt. Stille und reine Musikabschnitte werden ausgelassen.",
     "title": "Transkript",
     "tabLabel": "Transkript",
     "emptySelection": "Wähle einen Video- oder Audioclip, um sein Transkript zu bearbeiten.",
@@ -8,6 +10,9 @@
     "previousMatch": "Vorheriger Treffer",
     "clearSearch": "Suche löschen",
     "noTranscript": "Dieser Clip hat noch kein Transkript.",
+    "transcriptionFailed": "Transkription fehlgeschlagen.",
+    "tryAgain": "Erneut versuchen",
+    "largeTurboFallback": "Large Turbo hatte nicht genug Speicher. Neuer Versuch mit Whisper Small…",
     "generate": "Transkript erstellen",
     "transcribing": "Transkribieren…",
     "loading": "Transkript wird geladen…",

--- a/src/i18n/locales/partials/en/media.json
+++ b/src/i18n/locales/partials/en/media.json
@@ -290,12 +290,15 @@
       "language": "Language",
       "model": "Model",
       "noLanguages": "No languages available.",
+      "parakeetAutoDetects": "Automatically detects {{count}} European languages.",
+      "parakeetChooseWhisper": "For Chinese, Japanese, Korean, and other languages, choose a Whisper model.",
       "progressAria": "Transcription progress",
       "quantization": "Quantization",
       "refreshTitle": "Refresh transcript",
       "searchLanguages": "Search Languages",
       "start": "Start",
-      "stop": "Stop"
+      "stop": "Stop",
+      "whisperLanguageHint": "Choose the spoken language for better accuracy, or use auto detect."
     },
     "type": {
       "audio": "Audio",

--- a/src/i18n/locales/partials/en/transcript.json
+++ b/src/i18n/locales/partials/en/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Full source analyzed",
+    "detectedRange": "Voice detected from {{start}} to {{end}}. Silent and music-only sections are omitted.",
     "title": "Transcript",
     "tabLabel": "Transcript",
     "emptySelection": "Select a video or audio clip to edit its transcript.",
@@ -8,6 +10,9 @@
     "previousMatch": "Previous match",
     "clearSearch": "Clear search",
     "noTranscript": "This clip has no transcript yet.",
+    "transcriptionFailed": "Transcript generation failed.",
+    "tryAgain": "Try again",
+    "largeTurboFallback": "Large Turbo ran out of memory. Retrying with Whisper Small…",
     "generate": "Generate transcript",
     "transcribing": "Transcribing…",
     "loading": "Loading transcript…",

--- a/src/i18n/locales/partials/es/media.json
+++ b/src/i18n/locales/partials/es/media.json
@@ -277,12 +277,15 @@
       "language": "Idioma",
       "model": "Modelo",
       "noLanguages": "No hay idiomas disponibles.",
+      "parakeetAutoDetects": "Detecta automáticamente {{count}} idiomas europeos.",
+      "parakeetChooseWhisper": "Para chino, japonés, coreano y otros idiomas, elige un modelo Whisper.",
       "progressAria": "Progreso de la transcripción",
       "quantization": "Cuantización",
       "refreshTitle": "Actualizar transcripción",
       "searchLanguages": "Buscar idiomas",
       "start": "Iniciar",
-      "stop": "Detener"
+      "stop": "Detener",
+      "whisperLanguageHint": "Elige el idioma hablado para mejorar la precisión o usa la detección automática."
     },
     "type": {
       "audio": "Audio",

--- a/src/i18n/locales/partials/es/transcript.json
+++ b/src/i18n/locales/partials/es/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Fuente completa analizada",
+    "detectedRange": "Voz detectada de {{start}} a {{end}}. Se omiten las secciones silenciosas o solo musicales.",
     "title": "Transcripción",
     "tabLabel": "Transcripción",
     "emptySelection": "Selecciona un clip de vídeo o audio para editar su transcripción.",
@@ -8,6 +10,9 @@
     "previousMatch": "Coincidencia anterior",
     "clearSearch": "Borrar búsqueda",
     "noTranscript": "Este clip aún no tiene transcripción.",
+    "transcriptionFailed": "La transcripción falló.",
+    "tryAgain": "Intentar de nuevo",
+    "largeTurboFallback": "Large Turbo se quedó sin memoria. Reintentando con Whisper Small…",
     "generate": "Generar transcripción",
     "transcribing": "Transcribiendo…",
     "loading": "Cargando transcripción…",

--- a/src/i18n/locales/partials/fr/media.json
+++ b/src/i18n/locales/partials/fr/media.json
@@ -277,12 +277,15 @@
       "language": "Langue",
       "model": "Modèle",
       "noLanguages": "Aucune langue disponible.",
+      "parakeetAutoDetects": "Détecte automatiquement {{count}} langues européennes.",
+      "parakeetChooseWhisper": "Pour le chinois, le japonais, le coréen et les autres langues, choisissez un modèle Whisper.",
       "progressAria": "Progression de la transcription",
       "quantization": "Quantification",
       "refreshTitle": "Actualiser la transcription",
       "searchLanguages": "Rechercher une langue",
       "start": "Démarrer",
-      "stop": "Arrêter"
+      "stop": "Arrêter",
+      "whisperLanguageHint": "Choisissez la langue parlée pour améliorer la précision ou utilisez la détection automatique."
     },
     "type": {
       "audio": "Audio",

--- a/src/i18n/locales/partials/fr/transcript.json
+++ b/src/i18n/locales/partials/fr/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Source entière analysée",
+    "detectedRange": "Voix détectée de {{start}} à {{end}}. Les passages silencieux ou uniquement musicaux sont omis.",
     "title": "Transcription",
     "tabLabel": "Transcription",
     "emptySelection": "Sélectionnez un clip vidéo ou audio pour modifier sa transcription.",
@@ -8,6 +10,9 @@
     "previousMatch": "Résultat précédent",
     "clearSearch": "Effacer la recherche",
     "noTranscript": "Ce clip n’a pas encore de transcription.",
+    "transcriptionFailed": "Échec de la transcription.",
+    "tryAgain": "Réessayer",
+    "largeTurboFallback": "Large Turbo a manqué de mémoire. Nouvelle tentative avec Whisper Small…",
     "generate": "Générer la transcription",
     "transcribing": "Transcription…",
     "loading": "Chargement de la transcription…",

--- a/src/i18n/locales/partials/ja/media.json
+++ b/src/i18n/locales/partials/ja/media.json
@@ -277,12 +277,15 @@
       "language": "言語",
       "model": "モデル",
       "noLanguages": "利用できる言語がありません。",
+      "parakeetAutoDetects": "ヨーロッパの{{count}}言語を自動検出します。",
+      "parakeetChooseWhisper": "中国語、日本語、韓国語などには Whisper モデルを選択してください。",
       "progressAria": "文字起こしの進行状況",
       "quantization": "量子化",
       "refreshTitle": "文字起こしを更新",
       "searchLanguages": "言語を検索",
       "start": "開始",
-      "stop": "停止"
+      "stop": "停止",
+      "whisperLanguageHint": "精度を高めるには話されている言語を選択するか、自動検出を使用してください。"
     },
     "type": {
       "audio": "音声",

--- a/src/i18n/locales/partials/ja/transcript.json
+++ b/src/i18n/locales/partials/ja/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "ソース全体を解析済み",
+    "detectedRange": "音声を{{start}}〜{{end}}で検出しました。無音または音楽のみの区間は表示されません。",
     "title": "文字起こし",
     "tabLabel": "文字起こし",
     "emptySelection": "文字起こしを編集するには、動画または音声クリップを選択してください。",
@@ -8,6 +10,9 @@
     "previousMatch": "前の一致",
     "clearSearch": "検索をクリア",
     "noTranscript": "このクリップにはまだ文字起こしがありません。",
+    "transcriptionFailed": "文字起こしに失敗しました。",
+    "tryAgain": "再試行",
+    "largeTurboFallback": "Large Turbo のメモリが不足しました。Whisper Small で再試行しています…",
     "generate": "文字起こしを生成",
     "transcribing": "文字起こし中…",
     "loading": "文字起こしを読み込み中…",

--- a/src/i18n/locales/partials/ko/media.json
+++ b/src/i18n/locales/partials/ko/media.json
@@ -277,12 +277,15 @@
       "language": "언어",
       "model": "모델",
       "noLanguages": "사용 가능한 언어가 없습니다.",
+      "parakeetAutoDetects": "유럽 언어 {{count}}개를 자동으로 감지합니다.",
+      "parakeetChooseWhisper": "중국어, 일본어, 한국어 및 기타 언어에는 Whisper 모델을 선택하세요.",
       "progressAria": "전사 진행률",
       "quantization": "양자화",
       "refreshTitle": "전사 새로 고침",
       "searchLanguages": "언어 검색",
       "start": "시작",
-      "stop": "정지"
+      "stop": "정지",
+      "whisperLanguageHint": "정확도를 높이려면 음성 언어를 선택하거나 자동 감지를 사용하세요."
     },
     "type": {
       "audio": "오디오",

--- a/src/i18n/locales/partials/ko/transcript.json
+++ b/src/i18n/locales/partials/ko/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "전체 소스 분석 완료",
+    "detectedRange": "{{start}}~{{end}} 구간에서 음성을 감지했습니다. 무음 또는 음악만 있는 구간은 표시되지 않습니다.",
     "title": "전사",
     "tabLabel": "전사",
     "emptySelection": "전사를 편집하려면 비디오 또는 오디오 클립을 선택하세요.",
@@ -8,6 +10,9 @@
     "previousMatch": "이전 일치",
     "clearSearch": "검색 지우기",
     "noTranscript": "이 클립에는 아직 전사가 없습니다.",
+    "transcriptionFailed": "전사에 실패했습니다.",
+    "tryAgain": "다시 시도",
+    "largeTurboFallback": "Large Turbo의 메모리가 부족합니다. Whisper Small로 다시 시도 중…",
     "generate": "전사 생성",
     "transcribing": "전사 중…",
     "loading": "전사 불러오는 중…",

--- a/src/i18n/locales/partials/pt-BR/media.json
+++ b/src/i18n/locales/partials/pt-BR/media.json
@@ -277,12 +277,15 @@
       "language": "Idioma",
       "model": "Modelo",
       "noLanguages": "Nenhum idioma",
+      "parakeetAutoDetects": "Detecta automaticamente {{count}} idiomas europeus.",
+      "parakeetChooseWhisper": "Para chinês, japonês, coreano e outros idiomas, escolha um modelo Whisper.",
       "progressAria": "Progresso",
       "quantization": "Quantizacao",
       "refreshTitle": "Atualizar transcrição",
       "searchLanguages": "Pesquisar idiomas",
       "start": "Iniciar",
-      "stop": "Parar"
+      "stop": "Parar",
+      "whisperLanguageHint": "Escolha o idioma falado para melhorar a precisão ou use a detecção automática."
     },
     "type": {
       "audio": "Audio",

--- a/src/i18n/locales/partials/pt-BR/transcript.json
+++ b/src/i18n/locales/partials/pt-BR/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Fonte completa analisada",
+    "detectedRange": "Voz detectada de {{start}} a {{end}}. Trechos silenciosos ou apenas com música são omitidos.",
     "title": "Transcrição",
     "tabLabel": "Transcrição",
     "emptySelection": "Selecione um clipe de vídeo ou áudio para editar sua transcrição.",
@@ -8,6 +10,9 @@
     "previousMatch": "Ocorrência anterior",
     "clearSearch": "Limpar pesquisa",
     "noTranscript": "Este clipe ainda não tem transcrição.",
+    "transcriptionFailed": "Falha na transcrição.",
+    "tryAgain": "Tentar novamente",
+    "largeTurboFallback": "O Large Turbo ficou sem memória. Tentando novamente com o Whisper Small…",
     "generate": "Gerar transcrição",
     "transcribing": "Transcrevendo…",
     "loading": "Carregando transcrição…",

--- a/src/i18n/locales/partials/tr/media.json
+++ b/src/i18n/locales/partials/tr/media.json
@@ -277,12 +277,15 @@
       "language": "Dil",
       "model": "Model",
       "noLanguages": "Dil yok",
+      "parakeetAutoDetects": "{{count}} Avrupa dilini otomatik olarak algılar.",
+      "parakeetChooseWhisper": "Çince, Japonca, Korece ve diğer diller için bir Whisper modeli seçin.",
       "progressAria": "İlerleme",
       "quantization": "Niceleme",
       "refreshTitle": "Transkripsiyonu yenile",
       "searchLanguages": "Dillerde ara",
       "start": "Başlat",
-      "stop": "Durdur"
+      "stop": "Durdur",
+      "whisperLanguageHint": "Daha iyi doğruluk için konuşulan dili seçin veya otomatik algılamayı kullanın."
     },
     "type": {
       "audio": "Ses",

--- a/src/i18n/locales/partials/tr/transcript.json
+++ b/src/i18n/locales/partials/tr/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "Kaynağın tamamı analiz edildi",
+    "detectedRange": "{{start}}–{{end}} arasında ses algılandı. Sessiz veya yalnızca müzik içeren bölümler gösterilmez.",
     "title": "Transkript",
     "tabLabel": "Transkript",
     "emptySelection": "Transkriptini düzenlemek için bir video veya ses klibi seçin.",
@@ -8,6 +10,9 @@
     "previousMatch": "Önceki eşleşme",
     "clearSearch": "Aramayı temizle",
     "noTranscript": "Bu klibin henüz transkripti yok.",
+    "transcriptionFailed": "Yazıya dökme başarısız oldu.",
+    "tryAgain": "Tekrar dene",
+    "largeTurboFallback": "Large Turbo için bellek yetersiz kaldı. Whisper Small ile yeniden deneniyor…",
     "generate": "Transkript oluştur",
     "transcribing": "Yazıya dökülüyor…",
     "loading": "Transkript yükleniyor…",

--- a/src/i18n/locales/partials/zh/media.json
+++ b/src/i18n/locales/partials/zh/media.json
@@ -277,12 +277,15 @@
       "language": "语言",
       "model": "模型",
       "noLanguages": "暂无可用语言。",
+      "parakeetAutoDetects": "自动检测 {{count}} 种欧洲语言。",
+      "parakeetChooseWhisper": "如需转录中文、日语、韩语或其他语言，请选择 Whisper 模型。",
       "progressAria": "字幕进度",
       "quantization": "量化",
       "refreshTitle": "刷新字幕",
       "searchLanguages": "搜索语言",
       "start": "开始",
-      "stop": "停止"
+      "stop": "停止",
+      "whisperLanguageHint": "选择实际语种可提高准确度，也可以使用自动检测。"
     },
     "type": {
       "audio": "音频",

--- a/src/i18n/locales/partials/zh/transcript.json
+++ b/src/i18n/locales/partials/zh/transcript.json
@@ -1,5 +1,7 @@
 {
   "transcript": {
+    "sourceAnalyzed": "已分析完整源文件",
+    "detectedRange": "在 {{start}}–{{end}} 检测到人声。静音和纯音乐片段不会显示。",
     "title": "字幕稿",
     "tabLabel": "字幕稿",
     "emptySelection": "选择一个视频或音频片段以编辑其字幕稿。",
@@ -8,6 +10,9 @@
     "previousMatch": "上一个匹配",
     "clearSearch": "清除搜索",
     "noTranscript": "此片段尚无字幕稿。",
+    "transcriptionFailed": "转写失败。",
+    "tryAgain": "重试",
+    "largeTurboFallback": "Large Turbo 内存不足。正在改用 Whisper Small 重试…",
     "generate": "生成字幕稿",
     "transcribing": "转写中…",
     "loading": "正在加载字幕稿…",

--- a/src/shared/utils/browser-whisper-models.ts
+++ b/src/shared/utils/browser-whisper-models.ts
@@ -9,10 +9,10 @@ export const DEFAULT_BROWSER_WHISPER_MODEL: MediaTranscriptModel = 'parakeet-tdt
 
 export const BROWSER_WHISPER_MODEL_LABELS: Record<MediaTranscriptModel, string> = {
   'parakeet-tdt-v3': 'Parakeet (fast)',
-  'whisper-tiny': 'Tiny',
-  'whisper-base': 'Base',
-  'whisper-small': 'Small',
-  'whisper-large': 'Large v3 Turbo',
+  'whisper-tiny': 'Whisper Tiny',
+  'whisper-base': 'Whisper Base',
+  'whisper-small': 'Whisper Small',
+  'whisper-large': 'Whisper Large v3 Turbo',
 }
 
 export const BROWSER_WHISPER_MODEL_OPTIONS = [

--- a/src/shared/utils/transcript-text.test.ts
+++ b/src/shared/utils/transcript-text.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { joinTranscriptWords, needsTranscriptWordSeparator } from './transcript-text'
+
+describe('transcript text formatting', () => {
+  it('keeps spaces between Latin words', () => {
+    expect(joinTranscriptWords([' hello', 'world'])).toBe('hello world')
+  })
+
+  it('joins Chinese and Japanese tokens without artificial spaces', () => {
+    expect(joinTranscriptWords(['昨', '日', '像', '那', '流水'])).toBe('昨日像那流水')
+    expect(joinTranscriptWords(['これ', 'は', 'テスト'])).toBe('これはテスト')
+  })
+
+  it('does not add a space before punctuation', () => {
+    expect(joinTranscriptWords(['Hello', ',', 'world', '!'])).toBe('Hello, world!')
+  })
+
+  it('preserves Korean word separators', () => {
+    expect(needsTranscriptWordSeparator('안녕하세요', '세계')).toBe(true)
+  })
+})

--- a/src/shared/utils/transcript-text.ts
+++ b/src/shared/utils/transcript-text.ts
@@ -1,0 +1,32 @@
+const CJK_CHARACTER = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u
+const NO_SPACE_BEFORE = /^[\p{P}\p{S}]/u
+const NO_SPACE_AFTER = /[\p{Ps}\p{Pi}]$/u
+
+function lastCharacter(value: string): string {
+  return Array.from(value.trim()).at(-1) ?? ''
+}
+
+function firstCharacter(value: string): string {
+  return Array.from(value.trim())[0] ?? ''
+}
+
+export function needsTranscriptWordSeparator(previous: string, next: string): boolean {
+  const previousCharacter = lastCharacter(previous)
+  const nextCharacter = firstCharacter(next)
+  if (!previousCharacter || !nextCharacter) return false
+
+  if (CJK_CHARACTER.test(previousCharacter) || CJK_CHARACTER.test(nextCharacter)) {
+    return false
+  }
+
+  return !NO_SPACE_AFTER.test(previousCharacter) && !NO_SPACE_BEFORE.test(nextCharacter)
+}
+
+export function joinTranscriptWords(words: readonly string[]): string {
+  const normalized = words.map((word) => word.trim()).filter(Boolean)
+  return normalized.reduce((text, word, index) => {
+    if (index === 0) return word
+    const previous = normalized[index - 1] ?? ''
+    return `${text}${needsTranscriptWordSeparator(previous, word) ? ' ' : ''}${word}`
+  }, '')
+}

--- a/src/shared/utils/transcription-cancellation.ts
+++ b/src/shared/utils/transcription-cancellation.ts
@@ -42,4 +42,4 @@ export function isTranscriptionOutOfMemoryError(error: unknown): boolean {
 }
 
 export const TRANSCRIPTION_OOM_HINT =
-  'The model ran out of memory. Try a lower quantization (q8 or q4) or a smaller model in Settings → Whisper, then try again.'
+  'The model ran out of memory. Try Whisper Small or a lower quantization (q8 or q4), then try again.'

--- a/src/shared/utils/whisper-settings.test.ts
+++ b/src/shared/utils/whisper-settings.test.ts
@@ -31,6 +31,7 @@ describe('whisper-settings', () => {
 
   it('falls back to auto-detect when a stored language is unsupported', () => {
     expect(getWhisperLanguageSelectValue('english')).toBe(WHISPER_AUTO_LANGUAGE_VALUE)
+    expect(getWhisperLanguageSelectValue('yue')).toBe(WHISPER_AUTO_LANGUAGE_VALUE)
   })
 
   it('includes quantization guidance for memory tradeoffs', () => {

--- a/src/shared/utils/whisper-settings.ts
+++ b/src/shared/utils/whisper-settings.ts
@@ -154,7 +154,6 @@ const WHISPER_LANGUAGE_NAMES = {
   ba: 'bashkir',
   jw: 'javanese',
   su: 'sundanese',
-  yue: 'cantonese',
 } as const
 
 const WHISPER_LANGUAGE_VALUES = new Set(Object.keys(WHISPER_LANGUAGE_NAMES))

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -33,6 +33,10 @@ export interface TimelineTranscriptCaptions {
   mediaId: string
   enabled: boolean
   updatedAt: number
+  /** Version of the stored media transcript these cues were generated from. */
+  sourceTranscriptUpdatedAt?: number
+  /** Bump when transcript-to-caption phrase timing rules change. */
+  timingVersion?: number
   /** Source-relative transcript cues. Render/export trims them to the clip. */
   cues: TimelineTranscriptCaptionCue[]
   style?: TimelineTranscriptCaptionStyle


### PR DESCRIPTION
## Summary

- Improve Whisper model clarity, Large Turbo stability and fallback behavior, word timestamps, CJK transcript integrity, and full-source status/error UX.
- Group canvas captions by phrase timing and propagate and render refreshed transcript cues through nested compound clips.
- Isolate the timeline stacking context so the playhead stays behind context menus and dialogs.

## Validation

- 66 focused transcription and rendering tests passed.
- 18 timeline content, playhead, and marker tests passed.
- Focused static checks and `git diff --check` passed.
- `develop` merges cleanly into `staging` in a local merge simulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Parakeet transcription flow with automatic language detection and model-specific UI guidance.
  * Transcript captions now generate/refresh across clips, including nested compositions, when transcripts change.
* **Bug Fixes**
  * Whisper Large Turbo out-of-memory now retries with Whisper Small and shows clearer fallback messaging.
  * Improved transcript caption segmentation/timing and refined caption text formatting (punctuation and CJK spacing).
* **Localization**
  * Added/updated transcription and fallback strings, including analyzed source, detected range, retry prompts, and Large Turbo OOM fallback, across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->