### PR TITLE
feat: support cropping compound clips

### DIFF
--- a/src/features/editor/components/properties-sidebar/clip-panel/index.test.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.test.tsx
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { useEditorStore } from '@/shared/state/editor'
 import { useSelectionStore } from '@/shared/state/selection'
 import { useTimelineStore } from '@/features/editor/deps/timeline-store'
-import type { AudioItem, ControllerItem, TimelineItem, VideoItem } from '@/types/timeline'
+import type {
+  AudioItem,
+  CompositionItem,
+  ControllerItem,
+  TimelineItem,
+  VideoItem,
+} from '@/types/timeline'
 import { ClipPanel } from './index'
 
 vi.mock('./layout-section', () => ({
@@ -70,6 +76,18 @@ const AUDIO_ITEM: AudioItem = {
   label: 'clip.wav',
   src: 'blob:audio',
   mediaId: 'media-audio-1',
+}
+
+const COMPOSITION_ITEM: CompositionItem = {
+  id: 'composition-1',
+  type: 'composition',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 90,
+  label: 'Compound clip',
+  compositionId: 'nested-1',
+  compositionWidth: 1920,
+  compositionHeight: 1080,
 }
 
 const NULL_OBJECT: ControllerItem = {
@@ -159,6 +177,14 @@ describe('ClipPanel inspector tabs', () => {
     })
     expect(screen.getByRole('tab', { name: 'Audio' })).toHaveAttribute('data-state', 'active')
     expect(useEditorStore.getState().clipInspectorTab).toBe('audio')
+  })
+
+  it('shows visual media controls for a compound-only selection', () => {
+    resetStores([COMPOSITION_ITEM], [COMPOSITION_ITEM.id])
+
+    render(<ClipPanel />)
+
+    expect(screen.getByText('Video Body')).toBeInTheDocument()
   })
 
   it('embeds the complete motion library as a selected-layer tab in Motion', async () => {

--- a/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/index.tsx
@@ -91,6 +91,7 @@ function computeItemTypeInfo(items: TimelineItem[]) {
       types.has('lottie') ||
       types.has('controller'),
     hasVideoItems: types.has('video'),
+    hasCompositionItems: types.has('composition'),
     hasLottieItems: types.has('lottie'),
     hasGifItems,
     hasAudioItems: types.has('video') || types.has('audio'),
@@ -178,6 +179,7 @@ export const ClipPanel = memo(function ClipPanel() {
   const {
     hasVisualItems,
     hasVideoItems,
+    hasCompositionItems,
     hasLottieItems,
     hasGifItems,
     hasAudioItems,
@@ -369,7 +371,7 @@ export const ClipPanel = memo(function ClipPanel() {
                 />
               )}
               <CompositionControlsSection items={selectedItems} />
-              {hasVideoItems && <VideoSection items={selectedItems} />}
+              {(hasVideoItems || hasCompositionItems) && <VideoSection items={selectedItems} />}
               {paintableLayoutItems.length > 0 && (
                 <FillSection
                   items={paintableLayoutItems}

--- a/src/features/editor/components/properties-sidebar/clip-panel/video-section.test.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/video-section.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import type { ReactNode } from 'react'
+import type { CompositionItem, VideoItem } from '@/types/timeline'
+import { useKeyframesStore, useTimelineStore } from '@/features/editor/deps/timeline-store'
+import { VideoSection } from './video-section'
+
+const keyframeToggleSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/features/editor/deps/preview', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/editor/deps/preview')>()
+  return { ...actual, useThrottledFrame: () => 0 }
+})
+
+vi.mock('@/features/editor/deps/keyframes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/editor/deps/keyframes')>()
+  return {
+    ...actual,
+    KeyframeToggle: (props: unknown) => {
+      keyframeToggleSpy(props)
+      return null
+    },
+  }
+})
+
+vi.mock('../components', () => ({
+  PropertySection: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PropertyRow: ({ label, children }: { label: string; children: ReactNode }) => (
+    <div data-testid={`property-row-${label}`}>{children}</div>
+  ),
+  SliderInput: ({ max }: { max: number }) => <output data-testid="slider-input" data-max={max} />,
+}))
+
+const VIDEO_ITEM: VideoItem = {
+  id: 'video-1',
+  type: 'video',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 90,
+  label: 'video.mp4',
+  src: 'blob:video',
+  mediaId: 'media-1',
+  sourceWidth: 1920,
+  sourceHeight: 1080,
+}
+
+const COMPOSITION_ITEM: CompositionItem = {
+  id: 'composition-1',
+  type: 'composition',
+  trackId: 'track-2',
+  from: 0,
+  durationInFrames: 90,
+  label: 'Compound clip',
+  compositionId: 'nested-1',
+  compositionWidth: 3840,
+  compositionHeight: 2160,
+}
+
+function getCropSliderMax(property: 'cropLeft' | 'cropRight' | 'cropTop' | 'cropBottom'): number {
+  const row = screen.getByTestId(`property-row-editor.videoSection.${property}`)
+  return Number(within(row).getByTestId('slider-input').getAttribute('data-max'))
+}
+
+describe('VideoSection crop controls', () => {
+  beforeEach(() => {
+    keyframeToggleSpy.mockClear()
+    useTimelineStore.setState({ items: [VIDEO_ITEM, COMPOSITION_ITEM], fps: 30 })
+    useKeyframesStore.setState({ keyframesByItemId: {} })
+  })
+
+  it('caps mixed-selection crop ranges at the smallest selected source dimensions', () => {
+    render(<VideoSection items={[VIDEO_ITEM, COMPOSITION_ITEM]} />)
+
+    expect(getCropSliderMax('cropLeft')).toBe(1920)
+    expect(getCropSliderMax('cropRight')).toBe(1920)
+    expect(getCropSliderMax('cropTop')).toBe(1080)
+    expect(getCropSliderMax('cropBottom')).toBe(1080)
+  })
+
+  it('passes each selected item crop value to the multi-item keyframe toggle', () => {
+    const video = { ...VIDEO_ITEM, crop: { left: 0.25 } }
+    const composition = { ...COMPOSITION_ITEM, crop: { left: 0.25 } }
+
+    render(<VideoSection items={[video, composition]} />)
+
+    const cropLeftProps = keyframeToggleSpy.mock.calls
+      .map(
+        ([props]) => props as { property: string; currentValuesByItemId: Record<string, number> },
+      )
+      .find((props) => props.property === 'cropLeft')
+    expect(cropLeftProps?.currentValuesByItemId).toEqual({
+      [video.id]: 480,
+      [composition.id]: 960,
+    })
+  })
+})

--- a/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Crop, RotateCcw, Video } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { Button } from '@/components/ui/button'
-import type { TimelineItem, VideoItem, AudioItem } from '@/types/timeline'
+import type { TimelineItem, VideoItem, AudioItem, CompositionItem } from '@/types/timeline'
 import type { CropSettings } from '@/types/transform'
 import type { ItemKeyframes } from '@/types/keyframe'
 import {
@@ -52,6 +52,7 @@ interface VideoSectionProps {
 type CropEdge = 'left' | 'right' | 'top' | 'bottom'
 type CropProperty = 'cropLeft' | 'cropRight' | 'cropTop' | 'cropBottom' | 'cropSoftness'
 type CropDimensions = { width: number; height: number }
+type CropItem = VideoItem | CompositionItem
 type ResolvedCropState = {
   crop: CropSettings | undefined
   dimensions: CropDimensions
@@ -64,7 +65,14 @@ const CROP_EDGE_PROPERTY: Record<CropEdge, Exclude<CropProperty, 'cropSoftness'>
   bottom: 'cropBottom',
 }
 
-function getCropDimensions(item: VideoItem): CropDimensions {
+function getCropDimensions(item: CropItem): CropDimensions {
+  if (item.type === 'composition') {
+    return {
+      width: Math.max(1, item.compositionWidth),
+      height: Math.max(1, item.compositionHeight),
+    }
+  }
+
   return {
     width: Math.max(1, item.sourceWidth ?? item.transform?.width ?? DEFAULT_PROJECT_WIDTH),
     height: Math.max(1, item.sourceHeight ?? item.transform?.height ?? DEFAULT_PROJECT_HEIGHT),
@@ -99,7 +107,7 @@ function buildCropSoftnessUpdate(
 }
 
 function getResolvedCropState(
-  item: VideoItem,
+  item: CropItem,
   currentFrame: number,
   itemKeyframes: ItemKeyframes | null | undefined,
 ): ResolvedCropState {
@@ -148,7 +156,15 @@ export function VideoSection({ items }: VideoSectionProps) {
     [items],
   )
 
-  const itemIds = useMemo(() => videoItems.map((item) => item.id), [videoItems])
+  const cropItems = useMemo(
+    () =>
+      items.filter(
+        (item): item is CropItem => item.type === 'video' || item.type === 'composition',
+      ),
+    [items],
+  )
+  const videoItemIds = useMemo(() => videoItems.map((item) => item.id), [videoItems])
+  const cropItemIds = useMemo(() => cropItems.map((item) => item.id), [cropItems])
 
   const rateStretchableIds = useMemo(
     () =>
@@ -162,72 +178,75 @@ export function VideoSection({ items }: VideoSectionProps) {
 
   const itemKeyframes = useKeyframesStore(
     useShallow(
-      useCallback((s) => itemIds.map((itemId) => s.keyframesByItemId[itemId] ?? null), [itemIds]),
+      useCallback(
+        (s) => cropItemIds.map((itemId) => s.keyframesByItemId[itemId] ?? null),
+        [cropItemIds],
+      ),
     ),
   )
   const keyframesByItemId = useMemo(() => {
     const map = new Map<string, (typeof itemKeyframes)[number]>()
-    for (const [index, itemId] of itemIds.entries()) {
+    for (const [index, itemId] of cropItemIds.entries()) {
       map.set(itemId, itemKeyframes[index] ?? null)
     }
     return map
-  }, [itemIds, itemKeyframes])
+  }, [cropItemIds, itemKeyframes])
 
   const resolvedCropStatesByItem = useMemo(() => {
     const map = new Map<string, ResolvedCropState>()
-    for (const item of videoItems) {
+    for (const item of cropItems) {
       map.set(item.id, getResolvedCropState(item, currentFrame, keyframesByItemId.get(item.id)))
     }
     return map
-  }, [currentFrame, keyframesByItemId, videoItems])
+  }, [cropItems, currentFrame, keyframesByItemId])
 
   const speed = getMixedValue(videoItems, (item) => item.speed, 1)
   const fadeIn = getMixedValue(videoItems, (item) => item.fadeIn, 0)
   const fadeOut = getMixedValue(videoItems, (item) => item.fadeOut, 0)
   const cropLeft = getMixedValue(
-    videoItems,
+    cropItems,
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropLeft'),
     0,
   )
   const cropRight = getMixedValue(
-    videoItems,
+    cropItems,
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropRight'),
     0,
   )
   const cropTop = getMixedValue(
-    videoItems,
+    cropItems,
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropTop'),
     0,
   )
   const cropBottom = getMixedValue(
-    videoItems,
+    cropItems,
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropBottom'),
     0,
   )
   const cropSoftness = getMixedValue(
-    videoItems,
+    cropItems,
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropSoftness'),
     0,
   )
 
   const maxSourceWidth = useMemo(
-    () => Math.max(1, ...videoItems.map((item) => getCropDimensions(item).width)),
-    [videoItems],
+    () => Math.max(1, ...cropItems.map((item) => getCropDimensions(item).width)),
+    [cropItems],
   )
   const maxSourceHeight = useMemo(
-    () => Math.max(1, ...videoItems.map((item) => getCropDimensions(item).height)),
-    [videoItems],
+    () => Math.max(1, ...cropItems.map((item) => getCropDimensions(item).height)),
+    [cropItems],
   )
   const maxCropSoftness = useMemo(
     () =>
       Math.max(
         1,
-        ...videoItems.map((item) => {
+        ...cropItems.map((item) => {
           const dimensions = getCropDimensions(item)
           return Math.max(1, getCropSoftnessReferenceDimension(dimensions.width, dimensions.height))
         }),
       ),
-    [videoItems],
+    [cropItems],
   )
   const speedDragSnapshotRef = useRef<ReturnType<typeof captureSnapshot> | null>(null)
 
@@ -295,45 +314,45 @@ export function VideoSection({ items }: VideoSectionProps) {
   const handleFadeInLiveChange = useCallback(
     (value: number) => {
       const previews: Record<string, { fadeIn: number }> = {}
-      itemIds.forEach((id) => {
+      videoItemIds.forEach((id) => {
         previews[id] = { fadeIn: value }
       })
       setPropertiesPreviewNew(previews)
     },
-    [itemIds, setPropertiesPreviewNew],
+    [setPropertiesPreviewNew, videoItemIds],
   )
 
   const handleFadeInChange = useCallback(
     (value: number) => {
-      itemIds.forEach((id) => updateItem(id, { fadeIn: value }))
+      videoItemIds.forEach((id) => updateItem(id, { fadeIn: value }))
       commitPreviewClear()
     },
-    [itemIds, updateItem, commitPreviewClear],
+    [videoItemIds, updateItem, commitPreviewClear],
   )
 
   const handleFadeOutLiveChange = useCallback(
     (value: number) => {
       const previews: Record<string, { fadeOut: number }> = {}
-      itemIds.forEach((id) => {
+      videoItemIds.forEach((id) => {
         previews[id] = { fadeOut: value }
       })
       setPropertiesPreviewNew(previews)
     },
-    [itemIds, setPropertiesPreviewNew],
+    [setPropertiesPreviewNew, videoItemIds],
   )
 
   const handleFadeOutChange = useCallback(
     (value: number) => {
-      itemIds.forEach((id) => updateItem(id, { fadeOut: value }))
+      videoItemIds.forEach((id) => updateItem(id, { fadeOut: value }))
       commitPreviewClear()
     },
-    [itemIds, updateItem, commitPreviewClear],
+    [videoItemIds, updateItem, commitPreviewClear],
   )
 
   const previewCropEdge = useCallback(
     (edge: CropEdge, pixels: number) => {
-      const previews: Record<string, { crop: VideoItem['crop'] }> = {}
-      videoItems.forEach((item) => {
+      const previews: Record<string, { crop: CropItem['crop'] }> = {}
+      cropItems.forEach((item) => {
         const cropState = resolvedCropStatesByItem.get(item.id)
         if (!cropState) return
         previews[item.id] = {
@@ -342,7 +361,7 @@ export function VideoSection({ items }: VideoSectionProps) {
       })
       setPropertiesPreviewNew(previews)
     },
-    [resolvedCropStatesByItem, setPropertiesPreviewNew, videoItems],
+    [cropItems, resolvedCropStatesByItem, setPropertiesPreviewNew],
   )
 
   const commitCropEdge = useCallback(
@@ -351,7 +370,7 @@ export function VideoSection({ items }: VideoSectionProps) {
       const snappedPixels = snapCropPixels(pixels)
       const autoOps: AutoKeyframeOperation[] = []
 
-      videoItems.forEach((item) => {
+      cropItems.forEach((item) => {
         const operation = getAutoKeyframeOperation(
           item,
           keyframesByItemId.get(item.id) ?? undefined,
@@ -381,14 +400,14 @@ export function VideoSection({ items }: VideoSectionProps) {
       currentFrame,
       keyframesByItemId,
       updateItem,
-      videoItems,
+      cropItems,
     ],
   )
 
   const previewCropSoftness = useCallback(
     (pixels: number) => {
-      const previews: Record<string, { crop: VideoItem['crop'] }> = {}
-      videoItems.forEach((item) => {
+      const previews: Record<string, { crop: CropItem['crop'] }> = {}
+      cropItems.forEach((item) => {
         const cropState = resolvedCropStatesByItem.get(item.id)
         if (!cropState) return
         previews[item.id] = {
@@ -397,7 +416,7 @@ export function VideoSection({ items }: VideoSectionProps) {
       })
       setPropertiesPreviewNew(previews)
     },
-    [resolvedCropStatesByItem, setPropertiesPreviewNew, videoItems],
+    [cropItems, resolvedCropStatesByItem, setPropertiesPreviewNew],
   )
 
   const commitCropSoftness = useCallback(
@@ -405,7 +424,7 @@ export function VideoSection({ items }: VideoSectionProps) {
       const snappedPixels = snapCropPixels(pixels)
       const autoOps: AutoKeyframeOperation[] = []
 
-      videoItems.forEach((item) => {
+      cropItems.forEach((item) => {
         const operation = getAutoKeyframeOperation(
           item,
           keyframesByItemId.get(item.id) ?? undefined,
@@ -435,31 +454,31 @@ export function VideoSection({ items }: VideoSectionProps) {
       currentFrame,
       keyframesByItemId,
       updateItem,
-      videoItems,
+      cropItems,
     ],
   )
 
   const resetCropEdge = useCallback(
     (edge: CropEdge) => {
       const property = CROP_EDGE_PROPERTY[edge]
-      const needsUpdate = videoItems.some((item) => {
+      const needsUpdate = cropItems.some((item) => {
         const cropState = resolvedCropStatesByItem.get(item.id)
         return Math.abs(getResolvedCropPropertyValue(cropState, property) ?? 0) > CROP_TOLERANCE
       })
       if (!needsUpdate) return
       commitCropEdge(edge, 0)
     },
-    [commitCropEdge, resolvedCropStatesByItem, videoItems],
+    [commitCropEdge, cropItems, resolvedCropStatesByItem],
   )
 
   const resetCropSoftness = useCallback(() => {
-    const needsUpdate = videoItems.some((item) => {
+    const needsUpdate = cropItems.some((item) => {
       const cropState = resolvedCropStatesByItem.get(item.id)
       return Math.abs(getResolvedCropPropertyValue(cropState, 'cropSoftness') ?? 0) > CROP_TOLERANCE
     })
     if (!needsUpdate) return
     commitCropSoftness(0)
-  }, [commitCropSoftness, resolvedCropStatesByItem, videoItems])
+  }, [commitCropSoftness, cropItems, resolvedCropStatesByItem])
 
   const resetSpeedWithRipple = useTimelineStore(
     (s: TimelineState & TimelineActions) => s.resetSpeedWithRipple,
@@ -473,102 +492,104 @@ export function VideoSection({ items }: VideoSectionProps) {
     const currentItems = useTimelineStore.getState().items
     const needsUpdate = currentItems.some(
       (item: TimelineItem) =>
-        itemIds.includes(item.id) && ((item as VideoItem).fadeIn ?? 0) > tolerance,
+        videoItemIds.includes(item.id) && ((item as VideoItem).fadeIn ?? 0) > tolerance,
     )
     if (needsUpdate) {
-      itemIds.forEach((id) => updateItem(id, { fadeIn: 0 }))
+      videoItemIds.forEach((id) => updateItem(id, { fadeIn: 0 }))
     }
-  }, [itemIds, updateItem])
+  }, [updateItem, videoItemIds])
 
   const handleResetFadeOut = useCallback(() => {
     const tolerance = 0.01
     const currentItems = useTimelineStore.getState().items
     const needsUpdate = currentItems.some(
       (item: TimelineItem) =>
-        itemIds.includes(item.id) && ((item as VideoItem).fadeOut ?? 0) > tolerance,
+        videoItemIds.includes(item.id) && ((item as VideoItem).fadeOut ?? 0) > tolerance,
     )
     if (needsUpdate) {
-      itemIds.forEach((id) => updateItem(id, { fadeOut: 0 }))
+      videoItemIds.forEach((id) => updateItem(id, { fadeOut: 0 }))
     }
-  }, [itemIds, updateItem])
+  }, [updateItem, videoItemIds])
 
-  if (videoItems.length === 0) return null
+  if (cropItems.length === 0) return null
 
   return (
     <>
-      <PropertySection title={t('editor.videoSection.playback')} icon={Video} defaultOpen={true}>
-        <PropertyRow label={t('editor.videoSection.speed')}>
-          <div className="flex items-center gap-1 w-full">
-            <SliderInput
-              value={speed}
-              onChange={commitSpeedChange}
-              onLiveChange={handleSpeedLiveChange}
-              min={MIN_SPEED}
-              max={MAX_SPEED}
-              step={0.01}
-              unit="x"
-              className="flex-1 min-w-0"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 flex-shrink-0"
-              onClick={handleResetSpeed}
-              title={t('editor.videoSection.resetSpeed')}
-            >
-              <RotateCcw className="w-3.5 h-3.5" />
-            </Button>
-          </div>
-        </PropertyRow>
+      {videoItems.length > 0 && (
+        <PropertySection title={t('editor.videoSection.playback')} icon={Video} defaultOpen={true}>
+          <PropertyRow label={t('editor.videoSection.speed')}>
+            <div className="flex items-center gap-1 w-full">
+              <SliderInput
+                value={speed}
+                onChange={commitSpeedChange}
+                onLiveChange={handleSpeedLiveChange}
+                min={MIN_SPEED}
+                max={MAX_SPEED}
+                step={0.01}
+                unit="x"
+                className="flex-1 min-w-0"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 flex-shrink-0"
+                onClick={handleResetSpeed}
+                title={t('editor.videoSection.resetSpeed')}
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </PropertyRow>
 
-        <PropertyRow label={t('editor.videoSection.fadeIn')}>
-          <div className="flex items-center gap-1 w-full">
-            <SliderInput
-              value={fadeIn}
-              onChange={handleFadeInChange}
-              onLiveChange={handleFadeInLiveChange}
-              min={0}
-              max={5}
-              step={0.1}
-              unit="s"
-              className="flex-1 min-w-0"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 flex-shrink-0"
-              onClick={handleResetFadeIn}
-              title={t('editor.videoSection.resetToZero')}
-            >
-              <RotateCcw className="w-3.5 h-3.5" />
-            </Button>
-          </div>
-        </PropertyRow>
+          <PropertyRow label={t('editor.videoSection.fadeIn')}>
+            <div className="flex items-center gap-1 w-full">
+              <SliderInput
+                value={fadeIn}
+                onChange={handleFadeInChange}
+                onLiveChange={handleFadeInLiveChange}
+                min={0}
+                max={5}
+                step={0.1}
+                unit="s"
+                className="flex-1 min-w-0"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 flex-shrink-0"
+                onClick={handleResetFadeIn}
+                title={t('editor.videoSection.resetToZero')}
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </PropertyRow>
 
-        <PropertyRow label={t('editor.videoSection.fadeOut')}>
-          <div className="flex items-center gap-1 w-full">
-            <SliderInput
-              value={fadeOut}
-              onChange={handleFadeOutChange}
-              onLiveChange={handleFadeOutLiveChange}
-              min={0}
-              max={5}
-              step={0.1}
-              unit="s"
-              className="flex-1 min-w-0"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 flex-shrink-0"
-              onClick={handleResetFadeOut}
-              title={t('editor.videoSection.resetToZero')}
-            >
-              <RotateCcw className="w-3.5 h-3.5" />
-            </Button>
-          </div>
-        </PropertyRow>
-      </PropertySection>
+          <PropertyRow label={t('editor.videoSection.fadeOut')}>
+            <div className="flex items-center gap-1 w-full">
+              <SliderInput
+                value={fadeOut}
+                onChange={handleFadeOutChange}
+                onLiveChange={handleFadeOutLiveChange}
+                min={0}
+                max={5}
+                step={0.1}
+                unit="s"
+                className="flex-1 min-w-0"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 flex-shrink-0"
+                onClick={handleResetFadeOut}
+                title={t('editor.videoSection.resetToZero')}
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </PropertyRow>
+        </PropertySection>
+      )}
 
       <PropertySection title={t('editor.videoSection.cropping')} icon={Crop} defaultOpen={true}>
         <PropertyRow label={t('editor.videoSection.cropLeft')}>
@@ -586,7 +607,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               className="flex-1 min-w-0"
             />
             <KeyframeToggle
-              itemIds={itemIds}
+              itemIds={cropItemIds}
               property="cropLeft"
               currentValue={cropLeft === 'mixed' ? 0 : cropLeft}
             />
@@ -617,7 +638,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               className="flex-1 min-w-0"
             />
             <KeyframeToggle
-              itemIds={itemIds}
+              itemIds={cropItemIds}
               property="cropRight"
               currentValue={cropRight === 'mixed' ? 0 : cropRight}
             />
@@ -648,7 +669,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               className="flex-1 min-w-0"
             />
             <KeyframeToggle
-              itemIds={itemIds}
+              itemIds={cropItemIds}
               property="cropTop"
               currentValue={cropTop === 'mixed' ? 0 : cropTop}
             />
@@ -679,7 +700,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               className="flex-1 min-w-0"
             />
             <KeyframeToggle
-              itemIds={itemIds}
+              itemIds={cropItemIds}
               property="cropBottom"
               currentValue={cropBottom === 'mixed' ? 0 : cropBottom}
             />
@@ -710,7 +731,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               className="flex-1 min-w-0"
             />
             <KeyframeToggle
-              itemIds={itemIds}
+              itemIds={cropItemIds}
               property="cropSoftness"
               currentValue={cropSoftness === 'mixed' ? 0 : cropSoftness}
             />

--- a/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
+++ b/src/features/editor/components/properties-sidebar/clip-panel/video-section.tsx
@@ -79,6 +79,11 @@ function getCropDimensions(item: CropItem): CropDimensions {
   }
 }
 
+function getSharedCropDimension(items: CropItem[], dimension: keyof CropDimensions): number {
+  if (items.length === 0) return 1
+  return Math.min(...items.map((item) => getCropDimensions(item)[dimension]))
+}
+
 function buildCropUpdate(
   crop: CropSettings | undefined,
   edge: CropEdge,
@@ -133,6 +138,19 @@ function getResolvedCropPropertyValue(
 ): number | undefined {
   if (!state) return undefined
   return getCropPropertyValue(state.crop, property, state.dimensions)
+}
+
+function getCropPropertyValuesByItemId(
+  items: CropItem[],
+  statesByItem: ReadonlyMap<string, ResolvedCropState>,
+  property: CropProperty,
+): Record<string, number> {
+  return Object.fromEntries(
+    items.map((item) => [
+      item.id,
+      getResolvedCropPropertyValue(statesByItem.get(item.id), property) ?? 0,
+    ]),
+  )
 }
 
 /**
@@ -228,15 +246,23 @@ export function VideoSection({ items }: VideoSectionProps) {
     (item) => getResolvedCropPropertyValue(resolvedCropStatesByItem.get(item.id), 'cropSoftness'),
     0,
   )
+  const cropValuesByProperty = useMemo(
+    () => ({
+      cropLeft: getCropPropertyValuesByItemId(cropItems, resolvedCropStatesByItem, 'cropLeft'),
+      cropRight: getCropPropertyValuesByItemId(cropItems, resolvedCropStatesByItem, 'cropRight'),
+      cropTop: getCropPropertyValuesByItemId(cropItems, resolvedCropStatesByItem, 'cropTop'),
+      cropBottom: getCropPropertyValuesByItemId(cropItems, resolvedCropStatesByItem, 'cropBottom'),
+      cropSoftness: getCropPropertyValuesByItemId(
+        cropItems,
+        resolvedCropStatesByItem,
+        'cropSoftness',
+      ),
+    }),
+    [cropItems, resolvedCropStatesByItem],
+  )
 
-  const maxSourceWidth = useMemo(
-    () => Math.max(1, ...cropItems.map((item) => getCropDimensions(item).width)),
-    [cropItems],
-  )
-  const maxSourceHeight = useMemo(
-    () => Math.max(1, ...cropItems.map((item) => getCropDimensions(item).height)),
-    [cropItems],
-  )
+  const sharedSourceWidth = useMemo(() => getSharedCropDimension(cropItems, 'width'), [cropItems])
+  const sharedSourceHeight = useMemo(() => getSharedCropDimension(cropItems, 'height'), [cropItems])
   const maxCropSoftness = useMemo(
     () =>
       Math.max(
@@ -599,7 +625,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               onChange={(value) => commitCropEdge('left', value)}
               onLiveChange={(value) => previewCropEdge('left', value)}
               min={0}
-              max={maxSourceWidth}
+              max={sharedSourceWidth}
               step={CROP_STEP}
               unit="px"
               formatValue={formatCropValue}
@@ -610,6 +636,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               itemIds={cropItemIds}
               property="cropLeft"
               currentValue={cropLeft === 'mixed' ? 0 : cropLeft}
+              currentValuesByItemId={cropValuesByProperty.cropLeft}
             />
             <Button
               variant="ghost"
@@ -630,7 +657,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               onChange={(value) => commitCropEdge('right', value)}
               onLiveChange={(value) => previewCropEdge('right', value)}
               min={0}
-              max={maxSourceWidth}
+              max={sharedSourceWidth}
               step={CROP_STEP}
               unit="px"
               formatValue={formatCropValue}
@@ -641,6 +668,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               itemIds={cropItemIds}
               property="cropRight"
               currentValue={cropRight === 'mixed' ? 0 : cropRight}
+              currentValuesByItemId={cropValuesByProperty.cropRight}
             />
             <Button
               variant="ghost"
@@ -661,7 +689,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               onChange={(value) => commitCropEdge('top', value)}
               onLiveChange={(value) => previewCropEdge('top', value)}
               min={0}
-              max={maxSourceHeight}
+              max={sharedSourceHeight}
               step={CROP_STEP}
               unit="px"
               formatValue={formatCropValue}
@@ -672,6 +700,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               itemIds={cropItemIds}
               property="cropTop"
               currentValue={cropTop === 'mixed' ? 0 : cropTop}
+              currentValuesByItemId={cropValuesByProperty.cropTop}
             />
             <Button
               variant="ghost"
@@ -692,7 +721,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               onChange={(value) => commitCropEdge('bottom', value)}
               onLiveChange={(value) => previewCropEdge('bottom', value)}
               min={0}
-              max={maxSourceHeight}
+              max={sharedSourceHeight}
               step={CROP_STEP}
               unit="px"
               formatValue={formatCropValue}
@@ -703,6 +732,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               itemIds={cropItemIds}
               property="cropBottom"
               currentValue={cropBottom === 'mixed' ? 0 : cropBottom}
+              currentValuesByItemId={cropValuesByProperty.cropBottom}
             />
             <Button
               variant="ghost"
@@ -734,6 +764,7 @@ export function VideoSection({ items }: VideoSectionProps) {
               itemIds={cropItemIds}
               property="cropSoftness"
               currentValue={cropSoftness === 'mixed' ? 0 : cropSoftness}
+              currentValuesByItemId={cropValuesByProperty.cropSoftness}
             />
             <Button
               variant="ghost"

--- a/src/features/export/utils/canvas-item-renderer.composition-masks.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.composition-masks.test.ts
@@ -123,6 +123,47 @@ describe('canvas-item-renderer composition masks', () => {
     mockFns.rotatePathMock.mockClear()
   })
 
+  it('crops the flattened composition output in wrapper space', async () => {
+    const compositionItem: CompositionItem = {
+      id: 'cropped-comp-item',
+      type: 'composition',
+      compositionId: 'cropped-sub-comp',
+      trackId: 'track-parent',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Cropped composition',
+      compositionWidth: 640,
+      compositionHeight: 360,
+    }
+    const subData: SubCompRenderData = {
+      fps: 30,
+      durationInFrames: 60,
+      sortedTracks: [],
+      keyframesMap: new Map(),
+    }
+    const { rootCtx, rctx, transform } = createCompositionMaskRenderHarness({
+      compositionItem,
+      subData,
+    })
+    rctx.keyframesMap.set(compositionItem.id, {
+      itemId: compositionItem.id,
+      properties: [
+        {
+          property: 'cropLeft',
+          keyframes: [
+            { id: 'crop-start', frame: 0, value: 0, easing: 'linear' },
+            { id: 'crop-end', frame: 30, value: 320, easing: 'linear' },
+          ],
+        },
+      ],
+    })
+
+    await renderItem(rootCtx, compositionItem, transform, 15, rctx)
+
+    expect(rootCtx.rect).toHaveBeenCalledWith(480, 180, 480, 360)
+    expect(rootCtx.drawImage).toHaveBeenCalledWith(expect.anything(), 320, 180, 640, 360)
+  })
+
   it('resolves nested shape properties from the sub-composition keyframes', async () => {
     const subContentItem: ShapeItem = {
       id: 'animated-sub-shape',

--- a/src/features/export/utils/canvas-item-renderer.corner-pin.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.corner-pin.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import type { ShapeItem, TextItem } from '@/types/timeline'
+import type { CompositionItem, ShapeItem, TextItem } from '@/types/timeline'
+import type { EffectSourceMask } from './canvas-effects'
 import type { ItemRenderContext } from './canvas-item-renderer'
 import { TextMeasurementCache } from './canvas-pool'
 import {
@@ -9,8 +10,14 @@ import {
 } from './canvas-item-renderer-test-helpers'
 
 const mockFns = vi.hoisted(() => ({
+  applyMasksMock: vi.fn(),
   drawCornerPinImageMock: vi.fn(),
   renderShapeMock: vi.fn(),
+  resolveCornerPinTargetRectMock: vi.fn(),
+}))
+
+vi.mock('./canvas-masks', () => ({
+  applyMasks: mockFns.applyMasksMock,
 }))
 
 vi.mock('./canvas-shapes', () => ({
@@ -24,6 +31,10 @@ vi.mock('@/features/export/deps/composition-runtime', async () => {
   return {
     ...actual,
     drawCornerPinImage: mockFns.drawCornerPinImageMock,
+    resolveCornerPinTargetRect: (...args: Parameters<typeof actual.resolveCornerPinTargetRect>) => {
+      mockFns.resolveCornerPinTargetRectMock(...args)
+      return actual.resolveCornerPinTargetRect(...args)
+    },
   }
 })
 
@@ -51,8 +62,10 @@ describe('canvas-item-renderer corner pin export path', () => {
   })
 
   beforeEach(() => {
+    mockFns.applyMasksMock.mockReset()
     mockFns.drawCornerPinImageMock.mockReset()
     mockFns.renderShapeMock.mockReset()
+    mockFns.resolveCornerPinTargetRectMock.mockReset()
   })
 
   it('uses the default corner pin mesh when opacity is fully opaque', async () => {
@@ -266,5 +279,55 @@ describe('canvas-item-renderer corner pin export path', () => {
     expect(ctx.translate).toHaveBeenNthCalledWith(1, 550, 320)
     expect(ctx.rotate).toHaveBeenCalledWith((45 * Math.PI) / 180)
     expect(ctx.translate).toHaveBeenNthCalledWith(2, -550, -320)
+  })
+
+  it('keeps cropped compound geometry when a mask is applied before corner pinning', async () => {
+    const item: CompositionItem = {
+      id: 'composition-1',
+      type: 'composition',
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Pinned compound',
+      compositionId: 'nested-1',
+      compositionWidth: 3840,
+      compositionHeight: 2160,
+      crop: { left: 0.25, top: 0.1 },
+      cornerPin: {
+        topLeft: [0, 0],
+        topRight: [20, -10],
+        bottomRight: [8, 12],
+        bottomLeft: [-12, 6],
+      },
+      transform: {
+        x: 0,
+        y: 0,
+        width: 640,
+        height: 360,
+        rotation: 0,
+        opacity: 1,
+      },
+    }
+    const mask: EffectSourceMask = {
+      path: {} as Path2D,
+      inverted: false,
+      feather: 0,
+      opacity: 1,
+      maskType: 'clip',
+    }
+    const ctx = createMockCanvasContext()
+    const rctx = createItemRenderContext()
+    const transform = createItemTransform({ width: 640, height: 360 })
+
+    await renderItem(ctx, item, transform, 1, rctx, 0, undefined, [mask])
+
+    expect(mockFns.applyMasksMock).toHaveBeenCalledTimes(1)
+    expect(mockFns.resolveCornerPinTargetRectMock).toHaveBeenCalledWith(640, 360, {
+      sourceWidth: 3840,
+      sourceHeight: 2160,
+      crop: expect.objectContaining(item.crop),
+      fitMode: 'fill',
+    })
+    expect(mockFns.drawCornerPinImageMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.transition-state.test.ts
@@ -1573,6 +1573,7 @@ describe('renderTransitionToGpuTexture', () => {
     } as ShapeItem
     const rightClip = createSubCompositionTransitionClip({
       compositionId: 'sub-comp-1',
+      crop: { left: 0.25 },
     })
     const activeTransition = createActiveTransition({ leftClip, rightClip, progress: 0.5 })
     const leftTexture = createMockGpuTexture()
@@ -1933,7 +1934,8 @@ describe('renderTransitionToGpuTexture', () => {
       expect.objectContaining({
         sourceWidth: 640,
         sourceHeight: 360,
-        destRect: { x: 640, y: 360, width: 640, height: 360 },
+        sourceRect: { x: 160, y: 0, width: 480, height: 360 },
+        destRect: { x: 800, y: 360, width: 480, height: 360 },
       }),
     )
     expect(atlasTextTexture.destroy).not.toHaveBeenCalled()

--- a/src/features/export/utils/canvas-item-renderer/composition.ts
+++ b/src/features/export/utils/canvas-item-renderer/composition.ts
@@ -24,7 +24,7 @@ import {
 } from '../render-span'
 import type { CanvasSettings, ItemRenderContext, ItemTransform, SubCompRenderData } from './types'
 import { log } from './shared'
-import { calculateMediaDrawDimensions } from './media-draw'
+import { drawContainedMediaSource } from './media-draw'
 import { resolveSubCompRenderDataForInstance } from './composition-instance'
 
 /**
@@ -291,20 +291,19 @@ export async function renderCompositionItem(
 
     subCtx.drawImage(subContentCanvas, 0, 0)
 
-    // Draw the sub-composition result onto the main canvas at the CompositionItem's position
-    const drawDimensions = calculateMediaDrawDimensions(
+    // Crop the flattened sub-composition in wrapper space before parent-level
+    // effects, masks, and corner pinning are applied.
+    drawContainedMediaSource(
+      ctx,
+      subCanvas,
       subCanvas.width,
       subCanvas.height,
       transform,
       rctx.canvasSettings,
-    )
-
-    ctx.drawImage(
-      subCanvas,
-      drawDimensions.x,
-      drawDimensions.y,
-      drawDimensions.width,
-      drawDimensions.height,
+      item.crop,
+      undefined,
+      rctx.canvasPool,
+      'fill',
     )
   } finally {
     rctx.canvasPool.release(subContentCanvas)

--- a/src/features/export/utils/canvas-item-renderer/gpu.ts
+++ b/src/features/export/utils/canvas-item-renderer/gpu.ts
@@ -56,11 +56,7 @@ import {
   log,
   resolveItemTransform,
 } from './shared'
-import {
-  calculateContainedMediaDrawLayout,
-  calculateMediaDrawDimensions,
-  hasCropFeather,
-} from './media-draw'
+import { calculateContainedMediaDrawLayout, hasCropFeather } from './media-draw'
 import {
   createSubCompositionRenderContext,
   findSubCompOcclusionCutoffOrder,
@@ -68,14 +64,136 @@ import {
 } from './composition'
 import { resolveVideoParticipantSourceTime } from './video'
 
+type GpuParticipantRenderOptions = { clear?: boolean; blend?: boolean }
+
+function renderGpuShapeParticipantToTexture(
+  prepared: PreparedGpuMediaParticipant,
+  rctx: ItemRenderContext,
+  outputTexture: GPUTexture,
+  options?: GpuParticipantRenderOptions,
+): boolean {
+  const { media, participant } = prepared
+  if (media.kind !== 'shape') return false
+
+  return (
+    rctx.gpuShapePipeline?.renderShapeToTexture(outputTexture, {
+      outputWidth: rctx.canvasSettings.width,
+      outputHeight: rctx.canvasSettings.height,
+      transformRect: prepared.transformRect,
+      rotationRad: prepared.rotationRad,
+      opacity: participant.transform.opacity,
+      shapeType: media.item.shapeType,
+      fillColor: media.fillColor,
+      strokeColor: media.strokeColor,
+      strokeWidth: media.item.strokeWidth,
+      cornerRadius: media.item.cornerRadius,
+      direction: media.item.direction,
+      points: media.item.points,
+      innerRadius: media.item.innerRadius,
+      trimPathStart: media.item.trimPathStart,
+      trimPathEnd: media.item.trimPathEnd,
+      trimPathOffset: media.item.trimPathOffset,
+      taperStartWidth: media.item.taperStartWidth,
+      taperEndWidth: media.item.taperEndWidth,
+      taperStartLength: media.item.taperStartLength,
+      taperEndLength: media.item.taperEndLength,
+      aspectRatioLocked: participant.item.transform?.aspectRatioLocked,
+      pathVertices: media.pathVertices,
+      pathClosed: media.item.pathClosed,
+      clear: options?.clear,
+      blend: options?.blend,
+    }) ?? false
+  )
+}
+
+function renderGpuTextureParticipantToTexture(
+  prepared: PreparedGpuMediaParticipant,
+  rctx: ItemRenderContext,
+  outputTexture: GPUTexture,
+  options?: GpuParticipantRenderOptions,
+): boolean {
+  const { media, participant } = prepared
+  if (media.kind !== 'text' && media.kind !== 'composition') return false
+
+  const isComposition = media.kind === 'composition'
+  return (
+    rctx.gpuMediaPipeline?.renderTextureToTexture(media.texture, outputTexture, {
+      sourceWidth: media.sourceWidth,
+      sourceHeight: media.sourceHeight,
+      outputWidth: rctx.canvasSettings.width,
+      outputHeight: rctx.canvasSettings.height,
+      sourceRect: isComposition
+        ? prepared.sourceRect
+        : { x: 0, y: 0, width: media.sourceWidth, height: media.sourceHeight },
+      destRect: prepared.destRect,
+      transformRect: prepared.transformRect,
+      featherPixels: isComposition ? prepared.featherPixels : undefined,
+      cornerRadius: prepared.cornerRadius,
+      cornerPin: prepared.cornerPin,
+      opacity: participant.transform.opacity,
+      rotationRad: prepared.rotationRad,
+      clear: options?.clear,
+      blend: options?.blend,
+    }) ?? false
+  )
+}
+
+function renderGpuSourceParticipantToTexture(
+  prepared: PreparedGpuMediaParticipant,
+  rctx: ItemRenderContext,
+  outputTexture: GPUTexture,
+  options?: GpuParticipantRenderOptions,
+): boolean {
+  const { media, participant } = prepared
+  if (media.kind !== 'media') return false
+
+  return (
+    rctx.gpuMediaPipeline?.renderSourceToTexture(media.source, outputTexture, {
+      sourceWidth: media.sourceWidth,
+      sourceHeight: media.sourceHeight,
+      outputWidth: rctx.canvasSettings.width,
+      outputHeight: rctx.canvasSettings.height,
+      sourceRect: prepared.sourceRect,
+      destRect: prepared.destRect,
+      transformRect: prepared.transformRect,
+      featherPixels: prepared.featherPixels,
+      cornerRadius: prepared.cornerRadius,
+      cornerPin: prepared.cornerPin,
+      opacity: participant.transform.opacity,
+      rotationRad: prepared.rotationRad,
+      flipX: prepared.flipX,
+      flipY: prepared.flipY,
+      clear: options?.clear,
+      blend: options?.blend,
+    }) ?? false
+  )
+}
+
+function renderPreparedGpuParticipantToTexture(
+  prepared: PreparedGpuMediaParticipant,
+  rctx: ItemRenderContext,
+  outputTexture: GPUTexture,
+  options?: GpuParticipantRenderOptions,
+): boolean {
+  switch (prepared.media.kind) {
+    case 'shape':
+      return renderGpuShapeParticipantToTexture(prepared, rctx, outputTexture, options)
+    case 'text':
+    case 'composition':
+      return renderGpuTextureParticipantToTexture(prepared, rctx, outputTexture, options)
+    case 'media':
+      return renderGpuSourceParticipantToTexture(prepared, rctx, outputTexture, options)
+  }
+}
+
 export async function renderGpuMediaParticipantToTexture(
   prepared: PreparedGpuMediaParticipant,
   rctx: ItemRenderContext,
   gpuTexturePool: Pick<GpuTexturePool, 'acquire' | 'release'>,
   outputTexture: GPUTexture,
-  options?: { clear?: boolean; blend?: boolean },
+  options?: GpuParticipantRenderOptions,
 ): Promise<boolean> {
-  const { participant, media } = prepared
+  const { participant } = prepared
 
   const mediaOutputTexture =
     participant.effects.length > 0
@@ -83,69 +201,12 @@ export async function renderGpuMediaParticipantToTexture(
       : outputTexture
 
   try {
-    const renderedMedia =
-      media.kind === 'shape'
-        ? (rctx.gpuShapePipeline?.renderShapeToTexture(mediaOutputTexture, {
-            outputWidth: rctx.canvasSettings.width,
-            outputHeight: rctx.canvasSettings.height,
-            transformRect: prepared.transformRect,
-            rotationRad: prepared.rotationRad,
-            opacity: participant.transform.opacity,
-            shapeType: media.item.shapeType,
-            fillColor: media.fillColor,
-            strokeColor: media.strokeColor,
-            strokeWidth: media.item.strokeWidth,
-            cornerRadius: media.item.cornerRadius,
-            direction: media.item.direction,
-            points: media.item.points,
-            innerRadius: media.item.innerRadius,
-            trimPathStart: media.item.trimPathStart,
-            trimPathEnd: media.item.trimPathEnd,
-            trimPathOffset: media.item.trimPathOffset,
-            taperStartWidth: media.item.taperStartWidth,
-            taperEndWidth: media.item.taperEndWidth,
-            taperStartLength: media.item.taperStartLength,
-            taperEndLength: media.item.taperEndLength,
-            aspectRatioLocked: participant.item.transform?.aspectRatioLocked,
-            pathVertices: media.pathVertices,
-            pathClosed: media.item.pathClosed,
-            clear: options?.clear,
-            blend: options?.blend,
-          }) ?? false)
-        : media.kind === 'text' || media.kind === 'composition'
-          ? (rctx.gpuMediaPipeline?.renderTextureToTexture(media.texture, mediaOutputTexture, {
-              sourceWidth: media.sourceWidth,
-              sourceHeight: media.sourceHeight,
-              outputWidth: rctx.canvasSettings.width,
-              outputHeight: rctx.canvasSettings.height,
-              sourceRect: { x: 0, y: 0, width: media.sourceWidth, height: media.sourceHeight },
-              destRect: prepared.destRect,
-              transformRect: prepared.transformRect,
-              cornerRadius: prepared.cornerRadius,
-              cornerPin: prepared.cornerPin,
-              opacity: participant.transform.opacity,
-              rotationRad: prepared.rotationRad,
-              clear: options?.clear,
-              blend: options?.blend,
-            }) ?? false)
-          : (rctx.gpuMediaPipeline?.renderSourceToTexture(media.source, mediaOutputTexture, {
-              sourceWidth: media.sourceWidth,
-              sourceHeight: media.sourceHeight,
-              outputWidth: rctx.canvasSettings.width,
-              outputHeight: rctx.canvasSettings.height,
-              sourceRect: prepared.sourceRect,
-              destRect: prepared.destRect,
-              transformRect: prepared.transformRect,
-              featherPixels: prepared.featherPixels,
-              cornerRadius: prepared.cornerRadius,
-              cornerPin: prepared.cornerPin,
-              opacity: participant.transform.opacity,
-              rotationRad: prepared.rotationRad,
-              flipX: prepared.flipX,
-              flipY: prepared.flipY,
-              clear: options?.clear,
-              blend: options?.blend,
-            }) ?? false)
+    const renderedMedia = renderPreparedGpuParticipantToTexture(
+      prepared,
+      rctx,
+      mediaOutputTexture,
+      options,
+    )
     if (!renderedMedia) return false
     if (mediaOutputTexture === outputTexture) return true
     if (!rctx.gpuPipeline) return false
@@ -495,37 +556,13 @@ export async function prepareGpuMediaParticipant(
     }
   }
 
-  if (media.kind === 'composition') {
-    const transformRect = calculateMediaDrawDimensions(
-      media.sourceWidth,
-      media.sourceHeight,
-      participant.transform,
-      rctx.canvasSettings,
-    )
-    if (transformRect.width <= 0 || transformRect.height <= 0) {
-      media.close?.()
-      return null
-    }
-    return {
-      participant,
-      media,
-      sourceRect: { x: 0, y: 0, width: media.sourceWidth, height: media.sourceHeight },
-      destRect: transformRect,
-      transformRect,
-      featherPixels: { left: 0, right: 0, top: 0, bottom: 0 },
-      cornerRadius: participant.transform.cornerRadius,
-      rotationRad: (participant.transform.rotation * Math.PI) / 180,
-      flipX: false,
-      flipY: false,
-    }
-  }
-
   const layout = calculateContainedMediaDrawLayout(
     media.sourceWidth,
     media.sourceHeight,
     participant.transform,
     rctx.canvasSettings,
     media.item.crop,
+    media.kind === 'composition' ? 'fill' : 'contain',
   )
   if (layout.viewportRect.width <= 0 || layout.viewportRect.height <= 0) {
     media.close?.()
@@ -1465,7 +1502,7 @@ function logGpuTextTextureCacheEvent(
 }
 
 function resolveGpuMediaCornerPin(
-  item: ImageItem | VideoItem | TextItem,
+  item: CompositionItem | ImageItem | VideoItem | TextItem,
   mediaRect: GpuMediaRect,
 ): NonNullable<GpuMediaRenderParams['cornerPin']> | undefined {
   if (!hasCornerPin(item.cornerPin)) return undefined

--- a/src/features/export/utils/canvas-item-renderer/media-draw.ts
+++ b/src/features/export/utils/canvas-item-renderer/media-draw.ts
@@ -4,43 +4,9 @@
  */
 
 import type { VideoItem } from '@/types/timeline'
-import { calculateMediaCropLayout } from '@/shared/utils/media-crop'
+import { calculateMediaCropLayout, type MediaCropFitMode } from '@/shared/utils/media-crop'
 import type { CanvasPool } from '../canvas-pool'
 import type { CanvasSettings } from './types'
-
-/**
- * Calculate draw dimensions for content that should fill the item's transform box.
- * Used by composition items, which scale their authored canvas into the target bounds.
- */
-export function calculateMediaDrawDimensions(
-  sourceWidth: number,
-  sourceHeight: number,
-  transform: { x: number; y: number; width: number; height: number },
-  canvas: CanvasSettings,
-): { x: number; y: number; width: number; height: number } {
-  if (transform.width && transform.height) {
-    return {
-      x: canvas.width / 2 + transform.x - transform.width / 2,
-      y: canvas.height / 2 + transform.y - transform.height / 2,
-      width: transform.width,
-      height: transform.height,
-    }
-  }
-
-  const scaleX = canvas.width / sourceWidth
-  const scaleY = canvas.height / sourceHeight
-  const fitScale = Math.min(scaleX, scaleY)
-
-  const drawWidth = sourceWidth * fitScale
-  const drawHeight = sourceHeight * fitScale
-
-  return {
-    x: (canvas.width - drawWidth) / 2 + transform.x,
-    y: (canvas.height - drawHeight) / 2 + transform.y,
-    width: drawWidth,
-    height: drawHeight,
-  }
-}
 
 export function calculateContainedMediaDrawLayout(
   sourceWidth: number,
@@ -48,6 +14,7 @@ export function calculateContainedMediaDrawLayout(
   transform: { x: number; y: number; width: number; height: number },
   canvas: CanvasSettings,
   crop?: VideoItem['crop'],
+  fitMode: MediaCropFitMode = 'contain',
 ): {
   mediaRect: { x: number; y: number; width: number; height: number }
   viewportRect: { x: number; y: number; width: number; height: number }
@@ -61,6 +28,7 @@ export function calculateContainedMediaDrawLayout(
     transform.width,
     transform.height,
     crop,
+    fitMode,
   )
 
   return {
@@ -194,6 +162,7 @@ export function drawContainedMediaSource(
   crop?: VideoItem['crop'],
   sourceRect?: { x: number; y: number; width: number; height: number },
   canvasPool?: CanvasPool,
+  fitMode: MediaCropFitMode = 'contain',
 ): boolean {
   const drawLayout = calculateContainedMediaDrawLayout(
     sourceWidth,
@@ -201,6 +170,7 @@ export function drawContainedMediaSource(
     transform,
     canvas,
     crop,
+    fitMode,
   )
   if (drawLayout.viewportRect.width <= 0 || drawLayout.viewportRect.height <= 0) {
     return false

--- a/src/features/export/utils/canvas-item-renderer/render-item.ts
+++ b/src/features/export/utils/canvas-item-renderer/render-item.ts
@@ -331,16 +331,14 @@ async function renderItemWithCornerPin(
   const cornerPinTargetRect = resolveCornerPinTargetRect(
     itemW,
     itemH,
-    preCornerPinMasks.length > 0
-      ? undefined
-      : item.type === 'video' || item.type === 'image' || item.type === 'composition'
-        ? {
-            sourceWidth: item.type === 'composition' ? item.compositionWidth : item.sourceWidth,
-            sourceHeight: item.type === 'composition' ? item.compositionHeight : item.sourceHeight,
-            crop: item.crop,
-            fitMode: item.type === 'composition' ? ('fill' as const) : ('contain' as const),
-          }
-        : undefined,
+    item.type === 'video' || item.type === 'image' || item.type === 'composition'
+      ? {
+          sourceWidth: item.type === 'composition' ? item.compositionWidth : item.sourceWidth,
+          sourceHeight: item.type === 'composition' ? item.compositionHeight : item.sourceHeight,
+          crop: item.crop,
+          fitMode: item.type === 'composition' ? ('fill' as const) : ('contain' as const),
+        }
+      : undefined,
   )
   const pinSourceWidth = Math.max(1, Math.round(cornerPinTargetRect.width))
   const pinSourceHeight = Math.max(1, Math.round(cornerPinTargetRect.height))

--- a/src/features/export/utils/canvas-item-renderer/render-item.ts
+++ b/src/features/export/utils/canvas-item-renderer/render-item.ts
@@ -333,11 +333,12 @@ async function renderItemWithCornerPin(
     itemH,
     preCornerPinMasks.length > 0
       ? undefined
-      : item.type === 'video' || item.type === 'image'
+      : item.type === 'video' || item.type === 'image' || item.type === 'composition'
         ? {
-            sourceWidth: item.sourceWidth,
-            sourceHeight: item.sourceHeight,
+            sourceWidth: item.type === 'composition' ? item.compositionWidth : item.sourceWidth,
+            sourceHeight: item.type === 'composition' ? item.compositionHeight : item.sourceHeight,
             crop: item.crop,
+            fitMode: item.type === 'composition' ? ('fill' as const) : ('contain' as const),
           }
         : undefined,
   )

--- a/src/features/export/utils/canvas-item-renderer/shared.ts
+++ b/src/features/export/utils/canvas-item-renderer/shared.ts
@@ -64,7 +64,7 @@ export function applyAnimatedCropToItem<TItem extends TimelineItem>(
   rctx: ItemRenderContext,
   renderSpan?: RenderTimelineSpan,
 ): TItem {
-  if (item.type !== 'video' && item.type !== 'image') {
+  if (item.type !== 'video' && item.type !== 'image' && item.type !== 'composition') {
     return item
   }
 

--- a/src/features/export/utils/canvas-keyframes.test.ts
+++ b/src/features/export/utils/canvas-keyframes.test.ts
@@ -110,8 +110,7 @@ describe('canvas-keyframes transform parenting', () => {
       height: 1080,
       fps: 30,
       getExpressionItem: (itemId) => items.get(itemId),
-      getExpressionKeyframes: (itemId) =>
-        itemId === parent.id ? parentKeyframes : undefined,
+      getExpressionKeyframes: (itemId) => (itemId === parent.id ? parentKeyframes : undefined),
     })
     expect(resolved.x).toBeCloseTo(60)
   })
@@ -268,6 +267,36 @@ describe('canvas-keyframes crop animation', () => {
     })
 
     expect(crop?.left).toBeCloseTo(0.05, 5)
+  })
+
+  it('uses authored compound dimensions for crop keyframes', () => {
+    const item: CompositionItem = {
+      id: 'composition-crop-1',
+      type: 'composition',
+      compositionId: 'sub-comp-1',
+      compositionWidth: 1280,
+      compositionHeight: 720,
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Compound clip',
+    }
+    const keyframes: ItemKeyframes = {
+      itemId: item.id,
+      properties: [
+        {
+          property: 'cropTop',
+          keyframes: [
+            { id: 'k1', frame: 0, value: 0, easing: 'linear' },
+            { id: 'k2', frame: 10, value: 360, easing: 'linear' },
+          ],
+        },
+      ],
+    }
+
+    const crop = getAnimatedCrop(item, keyframes, 5, { width: 1920, height: 1080 })
+
+    expect(crop?.top).toBeCloseTo(0.25, 5)
   })
 })
 

--- a/src/features/export/utils/canvas-keyframes.ts
+++ b/src/features/export/utils/canvas-keyframes.ts
@@ -109,14 +109,29 @@ interface CanvasRenderSettings {
   getPreviewTransform?: (itemId: string) => Partial<ResolvedTransform> | undefined
 }
 
+function isDefinedDimension(value: number | undefined): value is number {
+  return value !== undefined
+}
+
+function getFirstDefinedDimension(...values: Array<number | undefined>): number {
+  return Math.max(1, values.find(isDefinedDimension) ?? 1)
+}
+
 function getCropSourceDimensions(
   item: TimelineItem,
   canvas: Pick<CanvasRenderSettings, 'width' | 'height'>,
 ): { width: number; height: number } | null {
   if (item.type === 'video' || item.type === 'image') {
     return {
-      width: Math.max(1, item.sourceWidth ?? item.transform?.width ?? canvas.width),
-      height: Math.max(1, item.sourceHeight ?? item.transform?.height ?? canvas.height),
+      width: getFirstDefinedDimension(item.sourceWidth, item.transform?.width, canvas.width),
+      height: getFirstDefinedDimension(item.sourceHeight, item.transform?.height, canvas.height),
+    }
+  }
+
+  if (item.type === 'composition') {
+    return {
+      width: Math.max(1, item.compositionWidth),
+      height: Math.max(1, item.compositionHeight),
     }
   }
 

--- a/src/features/keyframes/components/keyframe-toggle.test.tsx
+++ b/src/features/keyframes/components/keyframe-toggle.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { CompositionItem, VideoItem } from '@/types/timeline'
+import {
+  useItemsStore,
+  useKeyframesStore,
+  useTransitionsStore,
+} from '@/features/keyframes/deps/timeline'
+import { KeyframeToggle } from './keyframe-toggle'
+
+const mocks = vi.hoisted(() => ({
+  addKeyframes: vi.fn(),
+  removeKeyframes: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/features/keyframes/deps/preview-contract', () => ({
+  useThrottledFrame: () => 10,
+}))
+
+vi.mock('@/features/keyframes/deps/timeline', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/keyframes/deps/timeline')>()
+  return {
+    ...actual,
+    useTimelineStore: (
+      selector: (state: {
+        addKeyframes: typeof mocks.addKeyframes
+        removeKeyframes: typeof mocks.removeKeyframes
+      }) => unknown,
+    ) =>
+      selector({
+        addKeyframes: mocks.addKeyframes,
+        removeKeyframes: mocks.removeKeyframes,
+      }),
+  }
+})
+
+const VIDEO_ITEM: VideoItem = {
+  id: 'video-1',
+  type: 'video',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 90,
+  label: 'video.mp4',
+  src: 'blob:video',
+  mediaId: 'media-1',
+}
+
+const COMPOSITION_ITEM: CompositionItem = {
+  id: 'composition-1',
+  type: 'composition',
+  trackId: 'track-2',
+  from: 5,
+  durationInFrames: 90,
+  label: 'Compound clip',
+  compositionId: 'nested-1',
+  compositionWidth: 3840,
+  compositionHeight: 2160,
+}
+
+function renderToggle() {
+  render(
+    <TooltipProvider>
+      <KeyframeToggle
+        itemIds={[VIDEO_ITEM.id, COMPOSITION_ITEM.id]}
+        property="cropLeft"
+        currentValue={0}
+        currentValuesByItemId={{
+          [VIDEO_ITEM.id]: 480,
+          [COMPOSITION_ITEM.id]: 960,
+        }}
+      />
+    </TooltipProvider>,
+  )
+}
+
+describe('KeyframeToggle multi-selection', () => {
+  beforeEach(() => {
+    mocks.addKeyframes.mockReset()
+    mocks.removeKeyframes.mockReset()
+    useItemsStore.getState().setItems([VIDEO_ITEM, COMPOSITION_ITEM])
+    useKeyframesStore.setState({ keyframesByItemId: {} })
+    useTransitionsStore.setState({ transitions: [] })
+  })
+
+  it('adds one keyframe per selected item using its relative frame and current value', () => {
+    renderToggle()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mocks.addKeyframes).toHaveBeenCalledWith([
+      { itemId: VIDEO_ITEM.id, property: 'cropLeft', frame: 10, value: 480 },
+      { itemId: COMPOSITION_ITEM.id, property: 'cropLeft', frame: 5, value: 960 },
+    ])
+    expect(mocks.removeKeyframes).not.toHaveBeenCalled()
+  })
+
+  it('removes the current keyframe from every selected item as one batch', () => {
+    useKeyframesStore.setState({
+      keyframesByItemId: {
+        [VIDEO_ITEM.id]: {
+          itemId: VIDEO_ITEM.id,
+          properties: [
+            {
+              property: 'cropLeft',
+              keyframes: [{ id: 'video-key', frame: 10, value: 480, easing: 'linear' }],
+            },
+          ],
+        },
+        [COMPOSITION_ITEM.id]: {
+          itemId: COMPOSITION_ITEM.id,
+          properties: [
+            {
+              property: 'cropLeft',
+              keyframes: [{ id: 'composition-key', frame: 5, value: 960, easing: 'linear' }],
+            },
+          ],
+        },
+      },
+    })
+    renderToggle()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mocks.removeKeyframes).toHaveBeenCalledWith([
+      { itemId: VIDEO_ITEM.id, property: 'cropLeft', keyframeId: 'video-key' },
+      { itemId: COMPOSITION_ITEM.id, property: 'cropLeft', keyframeId: 'composition-key' },
+    ])
+    expect(mocks.addKeyframes).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/keyframes/components/keyframe-toggle.tsx
+++ b/src/features/keyframes/components/keyframe-toggle.tsx
@@ -18,7 +18,9 @@ import {
   useTransitionsStore,
 } from '@/features/keyframes/deps/timeline'
 import { useThrottledFrame } from '@/features/keyframes/deps/preview-contract'
-import type { AnimatableProperty } from '@/types/keyframe'
+import type { AnimatableProperty, ItemKeyframes, Keyframe } from '@/types/keyframe'
+import type { TimelineItem } from '@/types/timeline'
+import type { Transition } from '@/types/transition'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { isFrameInTransitionRegion, getTransitionBlockedMessage } from '../utils/transition-region'
 
@@ -29,155 +31,237 @@ interface KeyframeToggleProps {
   property: AnimatableProperty
   /** Current value of the property (used when adding keyframe) */
   currentValue: number
+  /** Per-item values for mixed selections; falls back to currentValue when omitted */
+  currentValuesByItemId?: Readonly<Record<string, number>>
   /** Optional class name for the button */
   className?: string
   /** Disabled state */
   disabled?: boolean
 }
 
-/**
- * Keyframe toggle button for property panels.
- * Adds or removes a keyframe at the current playhead position.
- */
-export function KeyframeToggle({
-  itemIds,
-  property,
-  currentValue,
-  className,
-  disabled = false,
-}: KeyframeToggleProps) {
-  const { t } = useTranslation()
-  // Get current frame (throttled to reduce re-renders during playback)
-  const currentFrame = useThrottledFrame()
+interface KeyframeToggleTargetState {
+  itemId: string
+  item: TimelineItem | undefined
+  relativeFrame: number
+  propertyKeyframes: ItemKeyframes['properties'][number] | undefined
+  keyframeAtFrame: Keyframe | undefined
+  transitionBlockedRange: ReturnType<typeof isFrameInTransitionRegion>
+}
 
-  // Get keyframes for the first item (for multi-select, we show state of first item)
-  const firstItemId = itemIds[0]
-  const itemKeyframes = useKeyframesStore(
-    useCallback((s) => (firstItemId ? s.keyframesByItemId[firstItemId] : undefined), [firstItemId]),
+type TimelineStoreState = ReturnType<typeof useTimelineStore.getState>
+
+function getRelevantTransitions(transitions: Transition[], itemIds: string[]): Transition[] {
+  if (itemIds.length === 0) return []
+  return transitions.filter(
+    (transition) =>
+      itemIds.includes(transition.leftClipId) || itemIds.includes(transition.rightClipId),
   )
+}
 
-  // Get store actions
-  const addKeyframe = useTimelineStore((s) => s.addKeyframe)
-  const removeKeyframe = useTimelineStore((s) => s.removeKeyframe)
-
-  // Get the first item to calculate relative frame
-  const firstItem = useItemsStore(
-    useCallback((s) => (firstItemId ? s.itemById[firstItemId] : undefined), [firstItemId]),
-  )
-
-  // Get transitions to check for blocked regions
-  const transitions = useTransitionsStore(
-    useShallow(
-      useCallback(
-        (s) =>
-          firstItemId
-            ? s.transitions.filter(
-                (transition) =>
-                  transition.leftClipId === firstItemId || transition.rightClipId === firstItemId,
-              )
-            : [],
-        [firstItemId],
+function buildTargetStates(
+  itemIds: string[],
+  selectedItems: Array<TimelineItem | undefined>,
+  selectedItemKeyframes: Array<ItemKeyframes | undefined>,
+  currentFrame: number,
+  property: AnimatableProperty,
+  transitions: Transition[],
+): KeyframeToggleTargetState[] {
+  return itemIds.map((itemId, index) => {
+    const item = selectedItems[index]
+    const itemKeyframes = selectedItemKeyframes[index]
+    const relativeFrame = item ? currentFrame - item.from : 0
+    const propertyKeyframes = itemKeyframes?.properties.find((entry) => entry.property === property)
+    return {
+      itemId,
+      item,
+      relativeFrame,
+      propertyKeyframes,
+      keyframeAtFrame: propertyKeyframes?.keyframes.find(
+        (keyframe) => keyframe.frame === relativeFrame,
       ),
+      transitionBlockedRange: item
+        ? isFrameInTransitionRegion(relativeFrame, itemId, item, transitions)
+        : undefined,
+    }
+  })
+}
+
+function toggleTargetKeyframes(
+  states: KeyframeToggleTargetState[],
+  property: AnimatableProperty,
+  currentValue: number,
+  currentValuesByItemId: Readonly<Record<string, number>> | undefined,
+  removeKeyframes: TimelineStoreState['removeKeyframes'],
+  addKeyframes: TimelineStoreState['addKeyframes'],
+): void {
+  const allHaveKeyframes =
+    states.length > 0 && states.every((state) => state.keyframeAtFrame !== undefined)
+  if (allHaveKeyframes) {
+    removeKeyframes(
+      states.flatMap((state) =>
+        state.keyframeAtFrame
+          ? [{ itemId: state.itemId, property, keyframeId: state.keyframeAtFrame.id }]
+          : [],
+      ),
+    )
+    return
+  }
+
+  addKeyframes(
+    states.flatMap((state) =>
+      state.keyframeAtFrame
+        ? []
+        : [
+            {
+              itemId: state.itemId,
+              property,
+              frame: state.relativeFrame,
+              value: currentValuesByItemId?.[state.itemId] ?? currentValue,
+            },
+          ],
     ),
   )
+}
 
-  // Calculate frame relative to item start
-  const relativeFrame = useMemo(() => {
-    if (!firstItem) return 0
-    return currentFrame - firstItem.from
-  }, [currentFrame, firstItem])
+interface KeyframeToggleButtonProps {
+  className?: string
+  effectiveDisabled: boolean
+  hasAnyKeyframes: boolean
+  hasKeyframe: boolean
+  isInTransition: boolean
+  isOutsideBounds: boolean
+  onToggle: () => void
+  relativeFrame: number
+  transitionBlockedRange: ReturnType<typeof isFrameInTransitionRegion>
+}
 
-  // Check if frame is in a transition region (blocked for keyframes)
-  const transitionBlockedRange = useMemo(() => {
-    if (!firstItem || !firstItemId) return undefined
-    return isFrameInTransitionRegion(relativeFrame, firstItemId, firstItem, transitions)
-  }, [relativeFrame, firstItemId, firstItem, transitions])
+type Translate = ReturnType<typeof useTranslation>['t']
 
-  const isInTransition = transitionBlockedRange !== undefined
+function getToggleInteractionClasses(
+  effectiveDisabled: boolean,
+  isInTransition: boolean,
+): string[] {
+  const classes: string[] = []
+  if (effectiveDisabled) classes.push('opacity-50 cursor-not-allowed')
+  if (isInTransition) classes.push('line-through')
+  return classes
+}
 
-  // Check if keyframe exists at current frame
-  const keyframeAtFrame = useMemo(() => {
-    if (!itemKeyframes) return undefined
-    const propKeyframes = itemKeyframes.properties.find((p) => p.property === property)
-    if (!propKeyframes) return undefined
-    return propKeyframes.keyframes.find((k) => k.frame === relativeFrame)
-  }, [itemKeyframes, property, relativeFrame])
+function getToggleKeyframeColorClass(
+  hasAnyKeyframes: boolean,
+  hasKeyframe: boolean,
+  isInTransition: boolean,
+): string {
+  if (isInTransition) return 'text-muted-foreground/50'
+  if (hasKeyframe) return 'text-amber-500'
+  if (hasAnyKeyframes) return 'text-amber-500/50'
+  return 'text-muted-foreground'
+}
 
-  const hasKeyframe = keyframeAtFrame !== undefined
+function getToggleButtonClassName(
+  className: string | undefined,
+  effectiveDisabled: boolean,
+  hasAnyKeyframes: boolean,
+  hasKeyframe: boolean,
+  isInTransition: boolean,
+): string {
+  return cn(
+    'flex items-center justify-center w-5 h-5 rounded-sm transition-colors',
+    'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+    ...getToggleInteractionClasses(effectiveDisabled, isInTransition),
+    getToggleKeyframeColorClass(hasAnyKeyframes, hasKeyframe, isInTransition),
+    className,
+  )
+}
 
-  // Check if property has any keyframes at all
-  const hasAnyKeyframes = useMemo(() => {
-    if (!itemKeyframes) return false
-    const propKeyframes = itemKeyframes.properties.find((p) => p.property === property)
-    return propKeyframes ? propKeyframes.keyframes.length > 0 : false
-  }, [itemKeyframes, property])
+function getToggleButtonLabel(
+  t: Translate,
+  isInTransition: boolean,
+  isOutsideBounds: boolean,
+  hasKeyframe: boolean,
+): string {
+  if (isInTransition) {
+    return t('timeline.keyframeEditor.keyframesBlockedTransition', {
+      defaultValue: 'Keyframes blocked (transition region)',
+    })
+  }
+  if (isOutsideBounds) {
+    return t('timeline.keyframeEditor.playheadOutsideClipBounds', {
+      defaultValue: 'Playhead outside clip bounds',
+    })
+  }
+  return hasKeyframe
+    ? t('timeline.keyframeEditor.removeKeyframe', { defaultValue: 'Remove keyframe' })
+    : t('timeline.keyframeEditor.addKeyframe', { defaultValue: 'Add keyframe' })
+}
 
-  // Handle toggle click
-  const handleToggle = useCallback(() => {
-    if (disabled || isInTransition || !firstItemId || relativeFrame < 0) return
+function KeyframeToggleTooltipBody({
+  hasKeyframe,
+  isInTransition,
+  isOutsideBounds,
+  relativeFrame,
+  transitionBlockedRange,
+}: Pick<
+  KeyframeToggleButtonProps,
+  'hasKeyframe' | 'isInTransition' | 'isOutsideBounds' | 'relativeFrame' | 'transitionBlockedRange'
+>) {
+  const { t } = useTranslation()
+  if (isInTransition && transitionBlockedRange) {
+    return <>{getTransitionBlockedMessage(transitionBlockedRange)}</>
+  }
+  if (isOutsideBounds) {
+    return (
+      <>
+        {t('timeline.keyframeEditor.playheadIsOutsideClipBounds', {
+          defaultValue: 'Playhead is outside clip bounds',
+        })}
+      </>
+    )
+  }
+  return hasKeyframe ? (
+    <>
+      {t('timeline.keyframeEditor.removeKeyframeAtFrame', {
+        frame: relativeFrame,
+        defaultValue: 'Remove keyframe at frame {{frame}}',
+      })}
+    </>
+  ) : (
+    <>
+      {t('timeline.keyframeEditor.addKeyframeAtFrame', {
+        frame: relativeFrame,
+        defaultValue: 'Add keyframe at frame {{frame}}',
+      })}
+    </>
+  )
+}
 
-    if (hasKeyframe && keyframeAtFrame) {
-      // Remove keyframe
-      removeKeyframe(firstItemId, property, keyframeAtFrame.id)
-    } else {
-      // Add keyframe at current frame with current value
-      addKeyframe(firstItemId, property, relativeFrame, currentValue)
-    }
-  }, [
-    disabled,
-    isInTransition,
-    firstItemId,
-    relativeFrame,
-    hasKeyframe,
-    keyframeAtFrame,
-    removeKeyframe,
-    addKeyframe,
-    property,
-    currentValue,
-  ])
-
-  // Disable when playhead is outside item bounds
-  const isOutsideBounds =
-    !firstItem || relativeFrame < 0 || relativeFrame >= firstItem.durationInFrames
-
-  // Compute effective disabled state
-  const effectiveDisabled = disabled || isInTransition || isOutsideBounds
-
+function KeyframeToggleButton({
+  className,
+  effectiveDisabled,
+  hasAnyKeyframes,
+  hasKeyframe,
+  isInTransition,
+  isOutsideBounds,
+  onToggle,
+  relativeFrame,
+  transitionBlockedRange,
+}: KeyframeToggleButtonProps) {
+  const { t } = useTranslation()
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
           type="button"
-          onClick={handleToggle}
+          onClick={onToggle}
           disabled={effectiveDisabled}
-          className={cn(
-            'flex items-center justify-center w-5 h-5 rounded-sm transition-colors',
-            'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-            effectiveDisabled && 'opacity-50 cursor-not-allowed',
-            isInTransition && 'line-through',
-            hasKeyframe && !isInTransition && 'text-amber-500',
-            !hasKeyframe && hasAnyKeyframes && !isInTransition && 'text-amber-500/50',
-            !hasKeyframe && !hasAnyKeyframes && !isInTransition && 'text-muted-foreground',
-            isInTransition && 'text-muted-foreground/50',
+          className={getToggleButtonClassName(
             className,
+            effectiveDisabled,
+            hasAnyKeyframes,
+            hasKeyframe,
+            isInTransition,
           )}
-          aria-label={
-            isInTransition
-              ? t('timeline.keyframeEditor.keyframesBlockedTransition', {
-                  defaultValue: 'Keyframes blocked (transition region)',
-                })
-              : isOutsideBounds
-                ? t('timeline.keyframeEditor.playheadOutsideClipBounds', {
-                    defaultValue: 'Playhead outside clip bounds',
-                  })
-                : hasKeyframe
-                  ? t('timeline.keyframeEditor.removeKeyframe', {
-                      defaultValue: 'Remove keyframe',
-                    })
-                  : t('timeline.keyframeEditor.addKeyframe', {
-                      defaultValue: 'Add keyframe',
-                    })
-          }
+          aria-label={getToggleButtonLabel(t, isInTransition, isOutsideBounds, hasKeyframe)}
         >
           <Diamond
             className={cn(
@@ -188,30 +272,115 @@ export function KeyframeToggle({
         </button>
       </TooltipTrigger>
       <TooltipContent side="top" className="text-xs max-w-[200px]">
-        {isInTransition && transitionBlockedRange ? (
-          <>{getTransitionBlockedMessage(transitionBlockedRange)}</>
-        ) : isOutsideBounds ? (
-          <>
-            {t('timeline.keyframeEditor.playheadIsOutsideClipBounds', {
-              defaultValue: 'Playhead is outside clip bounds',
-            })}
-          </>
-        ) : hasKeyframe ? (
-          <>
-            {t('timeline.keyframeEditor.removeKeyframeAtFrame', {
-              frame: relativeFrame,
-              defaultValue: 'Remove keyframe at frame {{frame}}',
-            })}
-          </>
-        ) : (
-          <>
-            {t('timeline.keyframeEditor.addKeyframeAtFrame', {
-              frame: relativeFrame,
-              defaultValue: 'Add keyframe at frame {{frame}}',
-            })}
-          </>
-        )}
+        <KeyframeToggleTooltipBody
+          hasKeyframe={hasKeyframe}
+          isInTransition={isInTransition}
+          isOutsideBounds={isOutsideBounds}
+          relativeFrame={relativeFrame}
+          transitionBlockedRange={transitionBlockedRange}
+        />
       </TooltipContent>
     </Tooltip>
+  )
+}
+
+/**
+ * Keyframe toggle button for property panels.
+ * Adds or removes a keyframe at the current playhead position.
+ */
+export function KeyframeToggle({
+  itemIds,
+  property,
+  currentValue,
+  currentValuesByItemId,
+  className,
+  disabled = false,
+}: KeyframeToggleProps) {
+  // Get current frame (throttled to reduce re-renders during playback)
+  const currentFrame = useThrottledFrame()
+  const addKeyframes = useTimelineStore((s) => s.addKeyframes)
+  const removeKeyframes = useTimelineStore((s) => s.removeKeyframes)
+
+  const selectedItemKeyframes = useKeyframesStore(
+    useShallow(useCallback((s) => itemIds.map((itemId) => s.keyframesByItemId[itemId]), [itemIds])),
+  )
+  const selectedItems = useItemsStore(
+    useShallow(useCallback((s) => itemIds.map((itemId) => s.itemById[itemId]), [itemIds])),
+  )
+
+  // Get transitions to check for blocked regions
+  const transitions = useTransitionsStore(
+    useShallow(useCallback((s) => getRelevantTransitions(s.transitions, itemIds), [itemIds])),
+  )
+
+  const targetStates = useMemo(
+    () =>
+      buildTargetStates(
+        itemIds,
+        selectedItems,
+        selectedItemKeyframes,
+        currentFrame,
+        property,
+        transitions,
+      ),
+    [currentFrame, itemIds, property, selectedItemKeyframes, selectedItems, transitions],
+  )
+
+  const transitionBlockedRange = targetStates.find(
+    (state) => state.transitionBlockedRange !== undefined,
+  )?.transitionBlockedRange
+  const isInTransition = transitionBlockedRange !== undefined
+  const isOutsideBounds =
+    targetStates.length === 0 ||
+    targetStates.some(
+      ({ item, relativeFrame }) =>
+        !item || relativeFrame < 0 || relativeFrame >= item.durationInFrames,
+    )
+  const hasKeyframe =
+    targetStates.length > 0 && targetStates.every((state) => state.keyframeAtFrame !== undefined)
+  const hasAnyKeyframes = targetStates.some(
+    (state) => (state.propertyKeyframes?.keyframes.length ?? 0) > 0,
+  )
+  const relativeFrame = targetStates[0]?.relativeFrame ?? 0
+
+  // Handle toggle click
+  const handleToggle = useCallback(() => {
+    if (disabled || isInTransition || isOutsideBounds) return
+
+    toggleTargetKeyframes(
+      targetStates,
+      property,
+      currentValue,
+      currentValuesByItemId,
+      removeKeyframes,
+      addKeyframes,
+    )
+  }, [
+    disabled,
+    isInTransition,
+    isOutsideBounds,
+    property,
+    targetStates,
+    removeKeyframes,
+    addKeyframes,
+    currentValuesByItemId,
+    currentValue,
+  ])
+
+  // Compute effective disabled state
+  const effectiveDisabled = disabled || isInTransition || isOutsideBounds
+
+  return (
+    <KeyframeToggleButton
+      className={className}
+      effectiveDisabled={effectiveDisabled}
+      hasAnyKeyframes={hasAnyKeyframes}
+      hasKeyframe={hasKeyframe}
+      isInTransition={isInTransition}
+      isOutsideBounds={isOutsideBounds}
+      onToggle={handleToggle}
+      relativeFrame={relativeFrame}
+      transitionBlockedRange={transitionBlockedRange}
+    />
   )
 }

--- a/src/features/keyframes/utils/animatable-properties.test.ts
+++ b/src/features/keyframes/utils/animatable-properties.test.ts
@@ -38,7 +38,7 @@ describe('getAnimatablePropertiesForItem', () => {
     ])
   })
 
-  it('includes anchor properties for composition items', () => {
+  it('includes anchor and crop properties for composition items', () => {
     expect(
       getAnimatablePropertiesForItem({
         ...createItem('composition'),
@@ -56,6 +56,11 @@ describe('getAnimatablePropertiesForItem', () => {
       'cornerRadius',
       'anchorX',
       'anchorY',
+      'cropLeft',
+      'cropRight',
+      'cropTop',
+      'cropBottom',
+      'cropSoftness',
       'volume',
     ])
   })

--- a/src/features/keyframes/utils/animatable-properties.ts
+++ b/src/features/keyframes/utils/animatable-properties.ts
@@ -48,8 +48,7 @@ export function getAnimatablePropertiesForItem(item: TimelineItem): AnimatablePr
     case 'composition':
       return [
         ...VISUAL_ANIMATABLE_PROPERTIES,
-        'anchorX',
-        'anchorY',
+        ...VIDEO_ANIMATABLE_PROPERTIES,
         ...AUDIO_ANIMATABLE_PROPERTIES,
         ...effectProperties,
       ]

--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -887,7 +887,7 @@ export function GizmoOverlay({
   const handleCropEnd = useCallback(
     (itemId: string, edge: CropEdge, ratio: number) => {
       const item = visualItems.find((candidate) => candidate.id === itemId)
-      if (!item || item.type !== 'video') return
+      if (!item || (item.type !== 'video' && item.type !== 'composition')) return
 
       const currentFrame = usePlaybackStore.getState().currentFrame
       const sourceDimensions = getSourceDimensions(item) ?? {

--- a/src/features/preview/components/transform-gizmo.tsx
+++ b/src/features/preview/components/transform-gizmo.tsx
@@ -111,7 +111,7 @@ export function TransformGizmo({
   }, [animatedTransform, isTransformInteracting, previewTransform, item, itemPreview])
 
   const sourceDimensions = useMemo(() => {
-    if (item.type !== 'video') return null
+    if (item.type !== 'video' && item.type !== 'composition') return null
     return (
       getSourceDimensions(item) ?? {
         width: Math.max(1, currentTransform.width),
@@ -135,12 +135,14 @@ export function TransformGizmo({
       currentTransform.width,
       currentTransform.height,
       currentCrop,
+      item.type === 'composition' ? 'fill' : 'contain',
     )
   }, [
     currentCrop,
     currentTransform.height,
     currentTransform.width,
     item.cornerPin,
+    item.type,
     sourceDimensions,
   ])
 

--- a/src/features/timeline/stores/timeline-store-facade.ts
+++ b/src/features/timeline/stores/timeline-store-facade.ts
@@ -169,6 +169,7 @@ function getSnapshot(): TimelineState & TimelineActions {
       promoteTransformToVector: timelineActions.promoteTransformToVector,
       applyAutoKeyframeOperations: timelineActions.applyAutoKeyframeOperations,
       removeKeyframe: timelineActions.removeKeyframe,
+      removeKeyframes: timelineActions.removeKeyframes,
       removeKeyframesForItem: timelineActions.removeKeyframesForItem,
       removeKeyframesForProperty: timelineActions.removeKeyframesForProperty,
       getKeyframesForItem: timelineActions.getKeyframesForItem,

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -13,6 +13,7 @@ import type {
   ItemKeyframes,
   AnimatableProperty,
   Keyframe,
+  KeyframeRef,
   EasingType,
   EasingConfig,
   VectorAnimatableProperty,
@@ -260,6 +261,7 @@ export interface TimelineActions {
   ) => void
   applyAutoKeyframeOperations: (operations: AutoKeyframeOperation[]) => void
   removeKeyframe: (itemId: string, property: AnimatableProperty, keyframeId: string) => void
+  removeKeyframes: (refs: KeyframeRef[]) => void
   removeKeyframesForItem: (itemId: string) => void
   removeKeyframesForProperty: (itemId: string, property: AnimatableProperty) => void
   getKeyframesForItem: (itemId: string) => ItemKeyframes | undefined

--- a/src/runtime/composition-runtime/components/contained-media-layout.test.tsx
+++ b/src/runtime/composition-runtime/components/contained-media-layout.test.tsx
@@ -48,6 +48,28 @@ describe('ContainedMediaLayout', () => {
     expect(style).toContain('mask-image')
   })
 
+  it('preserves fill-fitted compound bounds while applying crop', () => {
+    const { container } = render(
+      <ContainedMediaLayout
+        sourceWidth={1920}
+        sourceHeight={1080}
+        containerWidth={400}
+        containerHeight={400}
+        crop={{ left: 0.1 }}
+        fitMode="fill"
+      >
+        <div data-testid="composition" />
+      </ContainedMediaLayout>,
+    )
+
+    const mediaRect = container.querySelectorAll('div')[1] as HTMLDivElement | undefined
+    expect(mediaRect?.style.left).toBe('0%')
+    expect(mediaRect?.style.top).toBe('0%')
+    expect(mediaRect?.style.width).toBe('100%')
+    expect(mediaRect?.style.height).toBe('100%')
+    expect(mediaRect?.style.maskImage).toContain('linear-gradient')
+  })
+
   it('renders without mask when no crop is set', () => {
     const { container } = render(
       <ContainedMediaLayout

--- a/src/runtime/composition-runtime/components/contained-media-layout.tsx
+++ b/src/runtime/composition-runtime/components/contained-media-layout.tsx
@@ -1,6 +1,10 @@
 import type React from 'react'
 import type { CropSettings } from '@/types/transform'
-import { calculateMediaCropLayout, type MediaCropLayout } from '@/shared/utils/media-crop'
+import {
+  calculateMediaCropLayout,
+  type MediaCropFitMode,
+  type MediaCropLayout,
+} from '@/shared/utils/media-crop'
 
 interface ContainedMediaLayoutProps {
   sourceWidth: number
@@ -8,6 +12,7 @@ interface ContainedMediaLayoutProps {
   containerWidth: number
   containerHeight: number
   crop?: CropSettings
+  fitMode?: MediaCropFitMode
   children: React.ReactNode
 }
 
@@ -81,6 +86,7 @@ export function ContainedMediaLayout({
   containerWidth,
   containerHeight,
   crop,
+  fitMode = 'contain',
   children,
 }: ContainedMediaLayoutProps) {
   const layout = calculateMediaCropLayout(
@@ -89,6 +95,7 @@ export function ContainedMediaLayout({
     containerWidth,
     containerHeight,
     crop,
+    fitMode,
   )
 
   if (layout.mediaRect.width <= 0 || layout.mediaRect.height <= 0) {

--- a/src/runtime/composition-runtime/components/item-content.test.tsx
+++ b/src/runtime/composition-runtime/components/item-content.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { VideoConfigProvider } from '@/runtime/composition-runtime/deps/player'
-import type { ControllerItem } from '@/types/timeline'
+import type { CompositionItem, ControllerItem } from '@/types/timeline'
 import { ItemContent } from './item-content'
 
 describe('ItemContent', () => {
@@ -34,5 +34,42 @@ describe('ItemContent', () => {
     )
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('applies wrapper crop to flattened composition content', () => {
+    const composition: CompositionItem = {
+      id: 'composition-1',
+      type: 'composition',
+      compositionId: 'sub-comp-1',
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+      trackId: 'track-1',
+      from: 0,
+      durationInFrames: 30,
+      label: 'Compound clip',
+      crop: { left: 0.25 },
+      transform: {
+        x: 0,
+        y: 0,
+        width: 1000,
+        height: 1000,
+        rotation: 0,
+        opacity: 1,
+      },
+    }
+
+    render(
+      <VideoConfigProvider fps={30} width={1920} height={1080} durationInFrames={30}>
+        <ItemContent
+          item={composition}
+          renderCompositionContent={() => <div data-testid="composition-content" />}
+        />
+      </VideoConfigProvider>,
+    )
+
+    const cropSurface = screen.getByTestId('composition-content').parentElement
+    expect(cropSurface?.style.width).toBe('100%')
+    expect(cropSurface?.style.height).toBe('100%')
+    expect(cropSurface?.style.maskImage).toContain('linear-gradient')
   })
 })

--- a/src/runtime/composition-runtime/components/item-content.tsx
+++ b/src/runtime/composition-runtime/components/item-content.tsx
@@ -606,7 +606,16 @@ export const ItemContent = React.memo<ItemProps>(
       // Render sub-composition contents inline
       // Pass parent muted so muting the track silences all sub-comp audio
       return (
-        <ItemVisualWrapper item={item} masks={masks}>
+        <ItemVisualWrapper
+          item={item}
+          masks={masks}
+          mediaContent={{
+            fitMode: 'fill',
+            sourceWidth: item.compositionWidth,
+            sourceHeight: item.compositionHeight,
+            crop: item.crop,
+          }}
+        >
           {renderCompositionContent({
             item,
             parentMuted: muted,

--- a/src/runtime/composition-runtime/components/item-visual-wrapper.tsx
+++ b/src/runtime/composition-runtime/components/item-visual-wrapper.tsx
@@ -16,6 +16,7 @@ import { renderSvgMaskPathsToDataUrl } from '../utils/clip-mask-raster'
 import { getRasterizedMaskLayerSettingsList } from '../utils/mask-preview'
 import type { MaskInfo } from './item'
 import type { CropSettings } from '@/types/transform'
+import type { MediaCropFitMode } from '@/shared/utils/media-crop'
 import { ContainedMediaLayout } from './contained-media-layout'
 import { ItemVisualTransformProvider } from '../contexts/item-visual-transform-context'
 
@@ -23,7 +24,7 @@ interface ItemVisualWrapperProps {
   item: TimelineItem
   masks?: MaskInfo[]
   mediaContent?: {
-    fitMode: 'contain'
+    fitMode: MediaCropFitMode
     sourceWidth?: number
     sourceHeight?: number
     crop?: CropSettings
@@ -374,26 +375,32 @@ export const ItemVisualWrapper: React.FC<ItemVisualWrapperProps> = ({
     s.editingItemId === item.id ? s.previewCornerPin : null,
   )
   const effectiveCornerPin = cornerPinPreview ?? item.cornerPin
+  const hasMediaContent = mediaContent !== undefined
+  const mediaFitMode = mediaContent?.fitMode
+  const mediaSourceWidth = mediaContent?.sourceWidth
+  const mediaSourceHeight = mediaContent?.sourceHeight
   const effectiveCrop = state.propertiesPreview?.crop ?? state.animatedCrop ?? mediaContent?.crop
   const cornerPinTargetRect = useMemo(() => {
     if (state.maskType !== null) {
       return resolveCornerPinTargetRect(state.transform.width, state.transform.height)
     }
 
-    if (mediaContent?.fitMode === 'contain') {
+    if (hasMediaContent && mediaFitMode) {
       return resolveCornerPinTargetRect(state.transform.width, state.transform.height, {
-        sourceWidth: mediaContent.sourceWidth ?? state.transform.width,
-        sourceHeight: mediaContent.sourceHeight ?? state.transform.height,
+        sourceWidth: mediaSourceWidth ?? state.transform.width,
+        sourceHeight: mediaSourceHeight ?? state.transform.height,
         crop: effectiveCrop,
+        fitMode: mediaFitMode,
       })
     }
 
     return resolveCornerPinTargetRect(state.transform.width, state.transform.height)
   }, [
     effectiveCrop,
-    mediaContent?.fitMode,
-    mediaContent?.sourceHeight,
-    mediaContent?.sourceWidth,
+    hasMediaContent,
+    mediaFitMode,
+    mediaSourceHeight,
+    mediaSourceWidth,
     state.maskType,
     state.transform.height,
     state.transform.width,
@@ -529,23 +536,23 @@ export const ItemVisualWrapper: React.FC<ItemVisualWrapperProps> = ({
     }
   }, [maskStyle, blendModeCss])
 
-  const effectiveMediaChildren =
-    mediaContent?.fitMode === 'contain' ? (
-      <ContainedMediaLayout
-        sourceWidth={mediaContent.sourceWidth ?? state.transform.width}
-        sourceHeight={mediaContent.sourceHeight ?? state.transform.height}
-        containerWidth={state.transform.width}
-        containerHeight={state.transform.height}
-        crop={effectiveCrop}
-      >
-        {children}
-      </ContainedMediaLayout>
-    ) : (
-      children
-    )
+  const effectiveMediaChildren = mediaContent ? (
+    <ContainedMediaLayout
+      sourceWidth={mediaContent.sourceWidth ?? state.transform.width}
+      sourceHeight={mediaContent.sourceHeight ?? state.transform.height}
+      containerWidth={state.transform.width}
+      containerHeight={state.transform.height}
+      crop={effectiveCrop}
+      fitMode={mediaContent.fitMode}
+    >
+      {children}
+    </ContainedMediaLayout>
+  ) : (
+    children
+  )
 
   const cornerPinFrameStyle = useMemo((): React.CSSProperties => {
-    if (mediaContent?.fitMode === 'contain' && cornerPinStyle) {
+    if (hasMediaContent && cornerPinStyle) {
       return containedMediaStyle
     }
 
@@ -553,22 +560,22 @@ export const ItemVisualWrapper: React.FC<ItemVisualWrapperProps> = ({
       width: '100%',
       height: '100%',
     }
-  }, [containedMediaStyle, cornerPinStyle, mediaContent?.fitMode])
+  }, [containedMediaStyle, cornerPinStyle, hasMediaContent])
 
-  const pinnedMediaBody =
-    mediaContent?.fitMode === 'contain' ? (
-      <ContainedMediaLayout
-        sourceWidth={cornerPinTargetRect.width}
-        sourceHeight={cornerPinTargetRect.height}
-        containerWidth={cornerPinTargetRect.width}
-        containerHeight={cornerPinTargetRect.height}
-        crop={effectiveCrop}
-      >
-        {children}
-      </ContainedMediaLayout>
-    ) : (
-      children
-    )
+  const pinnedMediaBody = mediaContent ? (
+    <ContainedMediaLayout
+      sourceWidth={cornerPinTargetRect.width}
+      sourceHeight={cornerPinTargetRect.height}
+      containerWidth={cornerPinTargetRect.width}
+      containerHeight={cornerPinTargetRect.height}
+      crop={effectiveCrop}
+      fitMode={mediaContent.fitMode}
+    >
+      {children}
+    </ContainedMediaLayout>
+  ) : (
+    children
+  )
 
   const pinnedMediaContent = (
     <div

--- a/src/runtime/composition-runtime/utils/corner-pin.ts
+++ b/src/runtime/composition-runtime/utils/corner-pin.ts
@@ -17,7 +17,11 @@
 
 import type { TimelineItemCornerPin } from '@/types/timeline'
 import type { CropSettings } from '@/types/transform'
-import { calculateMediaCropLayout, type Rect } from '@/shared/utils/media-crop'
+import {
+  calculateMediaCropLayout,
+  type MediaCropFitMode,
+  type Rect,
+} from '@/shared/utils/media-crop'
 
 export interface CornerPinOffsets {
   topLeft: [number, number]
@@ -30,6 +34,7 @@ export interface CornerPinTargetRectOptions {
   sourceWidth?: number
   sourceHeight?: number
   crop?: CropSettings
+  fitMode?: MediaCropFitMode
 }
 
 export type CornerPinHomography = [
@@ -111,6 +116,7 @@ export function resolveCornerPinTargetRect(
       containerWidth,
       containerHeight,
       options.crop,
+      options.fitMode,
     ).mediaRect
   }
 

--- a/src/shared/utils/media-crop.test.ts
+++ b/src/shared/utils/media-crop.test.ts
@@ -72,6 +72,13 @@ describe('media-crop', () => {
     })
   })
 
+  it('crops fill-fitted compound output without changing its stretched bounds', () => {
+    const layout = calculateMediaCropLayout(1920, 1080, 400, 400, { left: 0.1, top: 0.25 }, 'fill')
+
+    expect(layout.mediaRect).toEqual({ x: 0, y: 0, width: 400, height: 400 })
+    expect(layout.viewportRect).toEqual({ x: 40, y: 100, width: 360, height: 300 })
+  })
+
   it('round-trips crop ratios through source pixels', () => {
     expect(cropRatioToPixels(0.125, 1920)).toBe(240)
     expect(cropPixelsToRatio(240, 1920)).toBeCloseTo(0.125)

--- a/src/shared/utils/media-crop.ts
+++ b/src/shared/utils/media-crop.ts
@@ -32,6 +32,8 @@ export interface MediaCropLayout {
   featherPixels: CropInsets
 }
 
+export type MediaCropFitMode = 'contain' | 'fill'
+
 const MAX_EDGE_SUM = 0.999
 
 function clamp01(value: number): number {
@@ -181,13 +183,17 @@ export function calculateMediaCropLayout(
   containerWidth: number,
   containerHeight: number,
   crop?: CropSettings,
+  fitMode: MediaCropFitMode = 'contain',
 ): MediaCropLayout {
-  const mediaRect = calculateContainedRect(
-    sourceWidth,
-    sourceHeight,
-    containerWidth,
-    containerHeight,
-  )
+  const mediaRect =
+    fitMode === 'fill'
+      ? {
+          x: 0,
+          y: 0,
+          width: Math.max(0, containerWidth),
+          height: Math.max(0, containerHeight),
+        }
+      : calculateContainedRect(sourceWidth, sourceHeight, containerWidth, containerHeight)
   const resolvedCrop = resolveCropSettings(crop)
 
   const cropPixels: CropInsets = {


### PR DESCRIPTION
## Summary

- enable inspector crop controls and on-canvas crop handles for compound clips
- apply compound crop consistently across preview, keyframes, flattened export, GPU transitions, masks, and corner-pin rendering
- preserve linked audio and the existing fill-fitted compound geometry

## Why

Compound items already persisted crop data through the shared timeline item contract, but the editor controls and several preview/export paths only accepted video and image items. This connects the existing crop contract end to end for compound clips without requiring a project schema migration.

## User impact

Editors can now crop compound clips with the same hard/soft and keyframed workflow used for video, while linked audio remains unchanged.

## Validation

- full test suite: 587 files, 4,050 tests passed
- focused export regression suite: 36 tests passed after the changed-health refactor
- build, feature-boundary, dependency-contract, legacy-import, wrapper-health, changed-health, edge-budget, lint, and type checks passed
- changed-health reports zero introduced dead code, complexity, or duplication findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cropping support for compound/composition items across the editor, preview, keyframes, and export paths.
  - Composition media crops now support fill-based fitting, animated crop updates, softness, masks, and corner-pin handling.
  - Updated keyframe toggling to work across multiple selected items with per-item values.

- **Bug Fixes**
  - Ensured composition-only selections display the correct “Video”/visual controls.
  - Fixed export rendering and crop application so flattened compositions respect crop/fit and preserve correct geometry through masking and corner pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->