### PR TITLE
fix: stabilize timeline preview rendering and interactions

### DIFF
--- a/src/features/export/deps/composition-runtime-contract.ts
+++ b/src/features/export/deps/composition-runtime-contract.ts
@@ -19,6 +19,7 @@ export {
   resolveLiveTransitionRenderPlan,
   collectFrameVideoCandidates,
   resolveFrameRenderScene,
+  resolveTrackRenderState,
 } from '@/runtime/composition-runtime/utils/scene-assembly'
 export type { FrameRenderTask } from '@/runtime/composition-runtime/utils/scene-assembly'
 export { getShapePath, rotatePath } from '@/runtime/composition-runtime/utils/shape-path'

--- a/src/features/export/utils/client-render-engine.test.ts
+++ b/src/features/export/utils/client-render-engine.test.ts
@@ -82,6 +82,45 @@ describe('nested transcript captions', () => {
       }),
     ])
   })
+
+  it('uses the shared solo semantics for compound render tracks', () => {
+    const makeTrack = ({
+      id,
+      visible,
+      solo,
+      order,
+    }: {
+      id: string
+      visible: boolean
+      solo: boolean
+      order: number
+    }) => ({
+      id,
+      name: id,
+      order,
+      height: 64,
+      locked: false,
+      visible,
+      muted: false,
+      solo,
+      items: [],
+    })
+    const tracks = buildSubCompositionRenderTracks({
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      items: [],
+      tracks: [
+        makeTrack({ id: 'visible-non-solo', visible: true, solo: false, order: 1 }),
+        makeTrack({ id: 'hidden-solo', visible: false, solo: true, order: 2 }),
+      ],
+    })
+
+    expect(tracks).toEqual([
+      expect.objectContaining({ order: 2, visible: true }),
+      expect.objectContaining({ order: 1, visible: false }),
+    ])
+  })
 })
 
 describe('comparison preview resource selection', () => {

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -87,6 +87,7 @@ import {
   collectFrameVideoCandidates,
   getVideoTargetTimeSeconds,
   resolveFrameRenderScene,
+  resolveTrackRenderState,
 } from '@/features/export/deps/composition-runtime'
 import {
   renderItem,
@@ -123,16 +124,19 @@ export function buildSubCompositionRenderTracks(
     items: subComp.items.filter((item) => item.trackId === track.id),
   }))
 
-  return appendVirtualTranscriptCaptionTrack(
+  const renderTracks = appendVirtualTranscriptCaptionTrack(
     tracksWithItems,
     subComp.fps,
     subComp.width,
     subComp.height,
   )
+  const { visibleTrackIds } = resolveTrackRenderState(renderTracks)
+
+  return renderTracks
     .sort((left, right) => (right.order ?? 0) - (left.order ?? 0))
     .map((track) => ({
       order: track.order ?? 0,
-      visible: track.visible !== false,
+      visible: visibleTrackIds.has(track.id),
       items: (track.items ?? []).filter(
         (item) => item.type !== 'audio' && item.type !== 'adjustment',
       ),
@@ -1167,8 +1171,7 @@ export async function createCompositionRenderer(
       subKfMap.set(kf.itemId, kf)
     }
     const subAdjustmentLayers: AdjustmentLayerWithTrackOrder[] = []
-    for (const t of subComp.tracks) {
-      if (t.visible === false) continue
+    for (const t of resolveTrackRenderState(subComp.tracks).visibleTracks) {
       const trackOrder = t.order ?? 0
       for (const i of subComp.items) {
         if (i.trackId === t.id && i.type === 'adjustment') {

--- a/src/features/preview/components/inline-composition-preview.test.tsx
+++ b/src/features/preview/components/inline-composition-preview.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import type { CompositionInputProps } from '@/types/export'
 
 class FakeOffscreenCanvas {
@@ -49,6 +49,8 @@ const buildSubCompositionInputMock = vi.hoisted(() => vi.fn())
 const buildSubCompositionPreviewSignatureMock = vi.hoisted(() => vi.fn())
 const resolveMediaUrlsMock = vi.hoisted(() => vi.fn())
 const createCompositionRendererMock = vi.hoisted(() => vi.fn())
+let clearDisplayCanvasMock: ReturnType<typeof vi.fn>
+let drawDisplayCanvasMock: ReturnType<typeof vi.fn>
 
 vi.mock('@/shared/state/playback', () => {
   const usePlaybackStore = Object.assign(
@@ -92,12 +94,14 @@ import { disposeComparisonCompositionRenderSessionsForTest } from './comparison-
 describe('InlineCompositionPreview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearDisplayCanvasMock = vi.fn()
+    drawDisplayCanvasMock = vi.fn()
     const canvasPrototype = HTMLCanvasElement.prototype as unknown as {
       getContext: () => CanvasRenderingContext2D
     }
     vi.spyOn(canvasPrototype, 'getContext').mockReturnValue({
-      clearRect: vi.fn(),
-      drawImage: vi.fn(),
+      clearRect: clearDisplayCanvasMock,
+      drawImage: drawDisplayCanvasMock,
     } as unknown as CanvasRenderingContext2D)
     signatureState.counter += 1
     signatureState.value = `composition-graph-${signatureState.counter}`
@@ -286,6 +290,61 @@ describe('InlineCompositionPreview', () => {
     expect(createCompositionRendererMock).toHaveBeenCalledTimes(1)
     expect(renderer.preload).toHaveBeenCalledTimes(1)
     expect(renderer.dispose).not.toHaveBeenCalled()
+  })
+
+  it('presents an in-flight frame and coalesces continuous drag updates', async () => {
+    const pendingRenders: Array<{ frame: number; resolve: () => void }> = []
+    const renderer = {
+      preload: vi.fn().mockResolvedValue(undefined),
+      renderFrame: vi.fn(
+        (renderFrame: number) =>
+          new Promise<void>((resolve) => {
+            pendingRenders.push({ frame: renderFrame, resolve })
+          }),
+      ),
+      warmGpuPipeline: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+    }
+    createCompositionRendererMock.mockResolvedValue(renderer)
+
+    const renderFramePreview = (seekFrame: number) => (
+      <InlineCompositionPreview
+        compositionId="composition-1"
+        seekFrame={seekFrame}
+        containerSize={{ width: 320, height: 180 }}
+        presentation="frame"
+      />
+    )
+    const { rerender } = render(renderFramePreview(12))
+
+    await waitFor(() => expect(renderer.renderFrame).toHaveBeenCalledWith(12))
+    await waitFor(() => expect(screen.getByText('Loading compound clip...')).toBeTruthy())
+
+    rerender(renderFramePreview(13))
+    rerender(renderFramePreview(14))
+    rerender(renderFramePreview(15))
+
+    expect(renderer.renderFrame).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      const firstRender = pendingRenders[0]
+      if (!firstRender) throw new Error('Expected the initial comparison frame render')
+      firstRender.resolve()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(drawDisplayCanvasMock).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.queryByText('Loading compound clip...')).toBeNull())
+    await waitFor(() => expect(renderer.renderFrame).toHaveBeenCalledTimes(2))
+    expect(pendingRenders.map(({ frame }) => frame)).toEqual([12, 15])
+
+    await act(async () => {
+      const latestRender = pendingRenders[1]
+      if (!latestRender) throw new Error('Expected the latest comparison frame render')
+      latestRender.resolve()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(drawDisplayCanvasMock).toHaveBeenCalledTimes(2))
   })
 
   it('renders priority video-only frames before background preload completes', async () => {

--- a/src/features/preview/components/use-comparison-composition-frame.ts
+++ b/src/features/preview/components/use-comparison-composition-frame.ts
@@ -31,12 +31,16 @@ export function useComparisonCompositionFrame({
   onError,
 }: UseComparisonCompositionFrameOptions): boolean {
   const leaseRef = useRef<ComparisonCompositionRenderLease | null>(null)
+  const scheduleFrameRef = useRef<(frame: number) => void>(() => undefined)
   const lastPresentedFrameRef = useRef<number | null>(null)
   const frameRef = useRef(frame)
   frameRef.current = frame
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
+    lastPresentedFrameRef.current = null
+    setReady(false)
+    scheduleFrameRef.current = () => undefined
     if (!enabled || !input || !sessionKey || typeof OffscreenCanvas === 'undefined') return
 
     const lease = acquireComparisonCompositionRenderSession({
@@ -48,38 +52,83 @@ export function useComparisonCompositionFrame({
       useProxyMedia,
       priorityFrame: frameRef.current,
     })
+    const controller = new AbortController()
+    let active = true
+    let inFlightFrame: number | null = null
+    let pendingFrame: number | null = null
+
     leaseRef.current = lease
-    lastPresentedFrameRef.current = null
-    setReady(false)
+
+    const pumpLatestFrame = () => {
+      if (!active || inFlightFrame !== null || pendingFrame === null) return
+
+      const requestedFrame = pendingFrame
+      const display = displayCanvasRef.current
+      if (!display) return
+
+      pendingFrame = null
+      inFlightFrame = requestedFrame
+
+      void lease
+        .requestFrame(requestedFrame, display, controller.signal)
+        .then((presented) => {
+          if (!active || !presented) return
+          lastPresentedFrameRef.current = requestedFrame
+          setReady(true)
+        })
+        .catch((error) => onError(!active || controller.signal.aborted, error))
+        .finally(() => {
+          if (!active) return
+          inFlightFrame = null
+          if (pendingFrame !== null) {
+            queueMicrotask(pumpLatestFrame)
+          }
+        })
+    }
+
+    const scheduleFrame = (nextFrame: number) => {
+      if (!active) return
+      if (inFlightFrame === nextFrame) {
+        pendingFrame = null
+        return
+      }
+      if (pendingFrame === nextFrame) return
+      if (inFlightFrame === null && lastPresentedFrameRef.current === nextFrame) {
+        pendingFrame = null
+        return
+      }
+      pendingFrame = nextFrame
+      pumpLatestFrame()
+    }
+
+    scheduleFrameRef.current = scheduleFrame
+    scheduleFrame(frameRef.current)
 
     return () => {
+      active = false
+      controller.abort()
+      pendingFrame = null
+      if (scheduleFrameRef.current === scheduleFrame) {
+        scheduleFrameRef.current = () => undefined
+      }
       lease.release()
       if (leaseRef.current === lease) leaseRef.current = null
     }
-  }, [compositionId, enabled, height, input, sessionKey, useProxyMedia, width])
+  }, [
+    compositionId,
+    displayCanvasRef,
+    enabled,
+    height,
+    input,
+    onError,
+    sessionKey,
+    useProxyMedia,
+    width,
+  ])
 
   useEffect(() => {
-    if (!enabled || !sessionKey || lastPresentedFrameRef.current === frame) return
-    const lease = leaseRef.current
-    const display = displayCanvasRef.current
-    if (!lease || !display) return
-
-    let cancelled = false
-    const controller = new AbortController()
-    void lease
-      .requestFrame(frame, display, controller.signal)
-      .then((presented) => {
-        if (cancelled || !presented) return
-        lastPresentedFrameRef.current = frame
-        setReady(true)
-      })
-      .catch((error) => onError(cancelled, error))
-
-    return () => {
-      cancelled = true
-      controller.abort()
-    }
-  }, [displayCanvasRef, enabled, frame, onError, sessionKey])
+    scheduleFrameRef.current(frame)
+  }, [frame])
 
   return ready
 }

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -15,6 +15,8 @@ import { useMediaLibraryStore } from '@/features/preview/deps/media-library'
 import { useGizmoStore } from '../stores/gizmo-store'
 import { useMaskEditorStore } from '../stores/mask-editor-store'
 
+const DEFAULT_PROJECT = { width: 1920, height: 1080, backgroundColor: '#000000' }
+
 const seekToMock = vi.fn<(frame: number) => void>()
 const playMock = vi.fn()
 const pauseMock = vi.fn()
@@ -78,6 +80,8 @@ let completeDeferredPlayerSeek: ((frameOverride?: number) => void) | null = null
 let lastPlayerDimensions: { width: number; height: number } | null = null
 let playerDimensionsHistory: Array<{ width: number; height: number }> = []
 let canvasGetContextSpy: ReturnType<typeof vi.spyOn> | null = null
+let canvasPixelReadbackEnabled = false
+let blankCanvasState = new WeakSet<HTMLCanvasElement>()
 let lastCompositionKeyframes: Array<{
   itemId: string
   properties: Array<{
@@ -131,12 +135,34 @@ const rendererMockState = vi.hoisted(() => {
 
 const createCompositionRendererMock = rendererMockState.create
 
-function createMockCanvasContext(): CanvasRenderingContext2D {
+function setMockCanvasBlank(canvas: HTMLCanvasElement, blank: boolean) {
+  if (blank) {
+    blankCanvasState.add(canvas)
+  } else {
+    blankCanvasState.delete(canvas)
+  }
+}
+
+function createMockCanvasContext(canvas?: HTMLCanvasElement): CanvasRenderingContext2D {
   return {
-    clearRect: vi.fn(),
-    drawImage: vi.fn(),
+    canvas,
+    clearRect: vi.fn(() => {
+      if (canvasPixelReadbackEnabled && canvas) setMockCanvasBlank(canvas, true)
+    }),
+    drawImage: vi.fn((source: CanvasImageSource) => {
+      if (!canvasPixelReadbackEnabled || !canvas) return
+      setMockCanvasBlank(
+        canvas,
+        source instanceof HTMLCanvasElement && blankCanvasState.has(source),
+      )
+    }),
     fillRect: vi.fn(),
-    getImageData: vi.fn(),
+    getImageData: vi.fn(() => {
+      if (!canvasPixelReadbackEnabled) return undefined
+      const data = new Uint8ClampedArray(8 * 8 * 4)
+      if (!canvas || !blankCanvasState.has(canvas)) data[0] = 255
+      return { data }
+    }),
     putImageData: vi.fn(),
     save: vi.fn(),
     restore: vi.fn(),
@@ -419,6 +445,16 @@ vi.mock('@/features/preview/deps/composition-runtime', () => ({
         ),
       ),
   ),
+  resolveTrackRenderState: (tracks: Array<{ id: string; visible?: boolean; solo?: boolean }>) => {
+    const hasSoloTracks = tracks.some((track) => track.solo)
+    const visibleTracks = tracks.filter((track) =>
+      hasSoloTracks ? track.solo === true : track.visible !== false,
+    )
+    return {
+      visibleTracks,
+      visibleTrackIds: new Set(visibleTracks.map((track) => track.id)),
+    }
+  },
 }))
 
 vi.mock('./gizmo-overlay', () => ({
@@ -511,6 +547,7 @@ function resetStores() {
     captureFrame: null,
     captureFrameImageData: null,
     captureCanvasSource: null,
+    postEditWarmRequest: null,
   })
 
   useItemsStore.getState().setTracks([])
@@ -705,10 +742,7 @@ function setCrossfadeTransitionFixture() {
 
 function renderDefaultPreview() {
   return render(
-    <VideoPreview
-      project={{ width: 1920, height: 1080, backgroundColor: '#000000' }}
-      containerSize={{ width: 1280, height: 720 }}
-    />,
+    <VideoPreview project={DEFAULT_PROJECT} containerSize={{ width: 1280, height: 720 }} />,
   )
 }
 
@@ -789,7 +823,8 @@ async function renderReadySingleRendererPreview(
   expectedFrame: number,
   options: { expectedDisplayedFrame?: number; expectVisible?: boolean } = {},
 ) {
-  const { container } = renderDefaultPreview()
+  const rendered = renderDefaultPreview()
+  const { container } = rendered
   const scrubCanvas = getScrubCanvas(container)
 
   const renderer = await waitFor(() => {
@@ -800,7 +835,7 @@ async function renderReadySingleRendererPreview(
 
   await waitForRendererFrame(renderer, expectedFrame, scrubCanvas, options)
 
-  return { container, renderer, scrubCanvas }
+  return { ...rendered, renderer, scrubCanvas }
 }
 
 async function waitForSingleRendererFrame(
@@ -826,7 +861,13 @@ async function waitForLatestRendererFrame(
 ) {
   const renderer = await waitFor(() => {
     expect(rendererMockState.instances.length).toBeGreaterThan(0)
-    return rendererMockState.instances[rendererMockState.instances.length - 1]!
+    const rendererForFrame = [...rendererMockState.instances]
+      .reverse()
+      .find((instance) =>
+        instance.renderFrame.mock.calls.some(([frame]) => frame === expectedFrame),
+      )
+    expect(rendererForFrame).toBeDefined()
+    return rendererForFrame!
   })
 
   await waitForRendererFrame(renderer, expectedFrame, scrubCanvas, options)
@@ -865,6 +906,8 @@ describe('VideoPreview sync behavior', () => {
     resolveProxyUrlMock.mockClear()
     createCompositionRendererMock.mockClear()
     rendererMockState.instances.length = 0
+    canvasPixelReadbackEnabled = false
+    blankCanvasState = new WeakSet<HTMLCanvasElement>()
     canvasGetContextSpy?.mockRestore()
     canvasGetContextSpy = vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
     ;(
@@ -873,9 +916,9 @@ describe('VideoPreview sync behavior', () => {
           implementation: (contextId: string) => CanvasRenderingContext2D | null,
         ) => void
       }
-    ).mockImplementation((contextId) => {
+    ).mockImplementation(function (this: HTMLCanvasElement, contextId) {
       if (contextId === '2d') {
-        return createMockCanvasContext()
+        return createMockCanvasContext(this)
       }
       return null
     })
@@ -2846,6 +2889,115 @@ describe('VideoPreview sync behavior', () => {
     })
   })
 
+  it('serializes a post-edit warm request with a compound ruler skim', async () => {
+    setSingleCompoundItemWithGpuEffectAtFrame(47)
+    const { scrubCanvas, renderer } = await renderReadySingleRendererPreview(47)
+
+    renderer.renderFrame.mockClear()
+    renderer.prewarmFrames.mockClear()
+
+    let resolveWarm: (() => void) | null = null
+    let activeRendererOperations = 0
+    let maxActiveRendererOperations = 0
+    let shouldHoldWarm = true
+    renderer.prewarmFrames.mockImplementation(async () => {
+      activeRendererOperations += 1
+      maxActiveRendererOperations = Math.max(maxActiveRendererOperations, activeRendererOperations)
+      try {
+        if (shouldHoldWarm) {
+          shouldHoldWarm = false
+          await new Promise<void>((resolve) => {
+            resolveWarm = resolve
+          })
+        }
+      } finally {
+        activeRendererOperations -= 1
+      }
+    })
+    renderer.renderFrame.mockImplementation(async () => {
+      activeRendererOperations += 1
+      maxActiveRendererOperations = Math.max(maxActiveRendererOperations, activeRendererOperations)
+      await Promise.resolve()
+      activeRendererOperations -= 1
+    })
+
+    act(() => {
+      usePreviewBridgeStore.getState().requestPostEditWarm(47, ['compound-item'], [47, 48, 49])
+    })
+    await waitFor(() => {
+      expect(renderer.prewarmFrames).toHaveBeenCalled()
+    })
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(48)
+    })
+    expect(getDisplayedFrame()).toBe(47)
+    expect(scrubCanvas.style.visibility).toBe('visible')
+
+    await act(async () => {
+      resolveWarm?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(renderer.renderFrame).toHaveBeenCalledWith(48)
+      expect(getDisplayedFrame()).toBe(48)
+      expect(scrubCanvas.style.visibility).toBe('visible')
+    })
+    expect(renderer.renderFrame).not.toHaveBeenCalledWith(47)
+    expect(maxActiveRendererOperations).toBe(1)
+  })
+
+  it('hands an in-flight compound skim to the replacement render-pump generation', async () => {
+    setSingleCompoundItemWithGpuEffectAtFrame(47)
+    const { scrubCanvas, renderer, rerender } = await renderReadySingleRendererPreview(47)
+
+    let resolveOldFrame48: (() => void) | null = null
+    renderer.renderFrame.mockClear()
+    renderer.renderFrame.mockImplementation(async (frame: number) => {
+      if (frame === 48) {
+        await new Promise<void>((resolve) => {
+          resolveOldFrame48 = resolve
+        })
+      }
+    })
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(48)
+    })
+    await waitFor(() => {
+      expect(renderer.renderFrame).toHaveBeenCalledWith(48)
+      expect(resolveOldFrame48).not.toBeNull()
+    })
+
+    rerender(
+      <VideoPreview
+        project={{ ...DEFAULT_PROJECT, backgroundColor: '#010101' }}
+        containerSize={{ width: 1280, height: 720 }}
+      />,
+    )
+    await waitFor(() => {
+      expect(renderer.dispose).toHaveBeenCalled()
+    })
+
+    await act(async () => {
+      resolveOldFrame48?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const replacementRenderer = await waitFor(() => {
+      expect(rendererMockState.instances.length).toBe(2)
+      return rendererMockState.instances[1]!
+    })
+    await waitFor(() => {
+      expect(replacementRenderer.renderFrame).toHaveBeenCalledWith(48)
+      expect(getDisplayedFrame()).toBe(48)
+      expect(scrubCanvas.style.visibility).toBe('visible')
+    })
+  })
+
   it('drops an in-flight compound skim frame after the pointer leaves the ruler', async () => {
     setSingleCompoundItemWithGpuEffectAtFrame(47)
     const { scrubCanvas, renderer } = await renderReadySingleRendererPreview(47)
@@ -2944,7 +3096,7 @@ describe('VideoPreview sync behavior', () => {
     expect(scrubCanvas.style.visibility).toBe('visible')
   })
 
-  it('does not restore a hidden stale scrub canvas after a fast ruler swipe', async () => {
+  it('keeps the last valid front buffer visible until a fast ruler swipe settles', async () => {
     setSingleVideoItemAtFrame({ id: 'item-fast-swipe-release' }, 47)
     const { scrubCanvas, renderer } = await renderReadySingleRendererPreview(47, {
       expectVisible: false,
@@ -2981,11 +3133,162 @@ describe('VideoPreview sync behavior', () => {
       usePlaybackStore.getState().setPreviewFrame(null)
     })
 
-    expect(scrubCanvas.style.visibility).toBe('hidden')
+    await waitFor(() => {
+      expect(renderer.renderFrame).toHaveBeenCalledWith(47)
+      expect(resolveCommittedFrame).not.toBeNull()
+    })
+    expect(getDisplayedFrame()).toBe(50)
+    expect(scrubCanvas.style.visibility).toBe('visible')
 
     await act(async () => {
       resolveCommittedFrame?.()
       await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(getDisplayedFrame()).toBe(47)
+      expect(scrubCanvas.style.visibility).toBe('visible')
+    })
+  })
+
+  it('rejects and evicts a delayed blank render after restoring the committed scrub frame', async () => {
+    canvasPixelReadbackEnabled = true
+    setSingleCompoundItemWithGpuEffectAtFrame(47)
+    const { scrubCanvas, renderer, rerender } = await renderReadySingleRendererPreview(47)
+    const rendererCanvas = (
+      createCompositionRendererMock.mock.calls[0] as unknown as [unknown, HTMLCanvasElement]
+    )[1]
+    expect(rendererCanvas).toBeDefined()
+    expect(blankCanvasState.has(scrubCanvas)).toBe(false)
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(48)
+    })
+    await waitFor(() => {
+      expect(getDisplayedFrame()).toBe(48)
+    })
+
+    let resolveBlankCommittedFrame: (() => void) | null = null
+    renderer.renderFrame.mockImplementation(async (frame: number) => {
+      if (frame !== 47) {
+        setMockCanvasBlank(rendererCanvas, false)
+        return
+      }
+      await new Promise<void>((resolve) => {
+        resolveBlankCommittedFrame = resolve
+      })
+      setMockCanvasBlank(rendererCanvas, true)
+    })
+    renderer.renderFrame.mockClear()
+    renderer.invalidateFrameCache.mockClear()
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(null)
+    })
+    await waitFor(() => {
+      expect(resolveBlankCommittedFrame).not.toBeNull()
+      expect(getDisplayedFrame()).toBe(47)
+    })
+
+    // Model a layout resize clearing the visible canvas while the stale render
+    // is outstanding. The layout presenter must redraw the immutable snapshot
+    // without consulting the in-flight shared offscreen surface.
+    setMockCanvasBlank(scrubCanvas, true)
+    rerender(
+      <VideoPreview project={DEFAULT_PROJECT} containerSize={{ width: 1200, height: 675 }} />,
+    )
+    await waitFor(() => {
+      expect(blankCanvasState.has(scrubCanvas)).toBe(false)
+      expect(getDisplayedFrame()).toBe(47)
+    })
+
+    // The delayed blank completion must still be rejected and evicted.
+    setMockCanvasBlank(scrubCanvas, true)
+    await act(async () => {
+      resolveBlankCommittedFrame?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(renderer.invalidateFrameCache).toHaveBeenCalledWith({ frames: [47] })
+      expect(getDisplayedFrame()).toBe(47)
+      expect(blankCanvasState.has(scrubCanvas)).toBe(false)
+    })
+  })
+
+  it('allows an intentional same-frame blank after an item edit invalidates the release guard', async () => {
+    canvasPixelReadbackEnabled = true
+    setSingleCompoundItemWithGpuEffectAtFrame(47)
+    const { scrubCanvas, renderer } = await renderReadySingleRendererPreview(47)
+    const rendererCanvas = (
+      createCompositionRendererMock.mock.calls[0] as unknown as [unknown, HTMLCanvasElement]
+    )[1]
+
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(48)
+    })
+    await waitFor(() => {
+      expect(getDisplayedFrame()).toBe(48)
+    })
+
+    renderer.renderFrame.mockImplementation(async (frame: number) => {
+      if (frame === 47) setMockCanvasBlank(rendererCanvas, true)
+    })
+    renderer.renderFrame.mockClear()
+    renderer.invalidateFrameCache.mockClear()
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(null)
+    })
+    await waitFor(() => {
+      expect(renderer.invalidateFrameCache).toHaveBeenCalledWith({ frames: [47] })
+      expect(getDisplayedFrame()).toBe(47)
+      expect(blankCanvasState.has(scrubCanvas)).toBe(false)
+    })
+
+    // A same-frame item edit invalidates the old release snapshot. Its
+    // deliberately blank result must be allowed through instead of being
+    // mistaken for the cancelled render above.
+    renderer.renderFrame.mockImplementation(async () => {
+      setMockCanvasBlank(rendererCanvas, true)
+    })
+    renderer.renderFrame.mockClear()
+    act(() => {
+      useItemsStore
+        .getState()
+        .setItems(
+          useItemsStore
+            .getState()
+            .items.map((item) =>
+              item.id === 'compound-gpu-item' ? { ...item, label: 'Edited Compound GPU' } : item,
+            ),
+        )
+    })
+    await waitFor(() => {
+      expect(renderer.renderFrame).toHaveBeenCalledWith(47)
+      expect(getDisplayedFrame()).toBe(47)
+      expect(blankCanvasState.has(scrubCanvas)).toBe(true)
+    })
+
+    renderer.renderFrame.mockImplementation(async () => {
+      setMockCanvasBlank(rendererCanvas, false)
+    })
+    renderer.renderFrame.mockClear()
+    renderer.invalidateFrameCache.mockClear()
+    act(() => {
+      useItemsStore
+        .getState()
+        .setItems(
+          useItemsStore
+            .getState()
+            .items.map((item) =>
+              item.id === 'compound-gpu-item' ? { ...item, label: 'Compound GPU' } : item,
+            ),
+        )
+    })
+    await waitFor(() => {
+      expect(renderer.renderFrame).toHaveBeenCalledWith(47)
+      expect(blankCanvasState.has(scrubCanvas)).toBe(false)
     })
   })
 
@@ -3031,6 +3334,43 @@ describe('VideoPreview sync behavior', () => {
     })
 
     expect(renderer.renderFrame).toHaveBeenCalledWith(30)
+  })
+
+  it('does not tag an aborted shared-canvas capture as a rendered frame', async () => {
+    setSingleVideoItemAtFrame({ id: 'item-aborted-scope-capture' })
+    const { renderer } = await renderReadySingleRendererPreview(24, { expectVisible: false })
+    const captureCanvasSource = await waitFor(() => {
+      const fn = usePreviewBridgeStore.getState().captureCanvasSource
+      expect(fn).not.toBeNull()
+      return fn!
+    })
+
+    act(() => {
+      // Prefer-rendered capture follows this presented frame without changing
+      // playback, so the render pump cannot race the capture under test.
+      usePreviewBridgeStore.getState().setDisplayedFrame(25)
+    })
+    renderer.renderFrame.mockClear()
+    let abortNextCapture = true
+    renderer.wasLastRenderAborted.mockImplementation(() => {
+      const aborted = abortNextCapture
+      abortNextCapture = false
+      return aborted
+    })
+
+    let abortedSource: OffscreenCanvas | HTMLCanvasElement | null = null
+    await act(async () => {
+      abortedSource = await captureCanvasSource({ fresh: true, preferRenderedFrame: true })
+    })
+    expect(abortedSource).toBeNull()
+
+    let recoveredSource: OffscreenCanvas | HTMLCanvasElement | null = null
+    await act(async () => {
+      recoveredSource = await captureCanvasSource({ fresh: true, preferRenderedFrame: true })
+    })
+
+    expect(recoveredSource).not.toBeNull()
+    expect(renderer.renderFrame.mock.calls.filter(([frame]) => frame === 25)).toHaveLength(2)
   })
 
   it('captures a refreshed paused scope sample after a live gpu effect preview changes', async () => {
@@ -3947,9 +4287,7 @@ describe('VideoPreview sync behavior', () => {
       const displayedFrame = getDisplayedFrame()
       expect(displayedFrame).not.toBeNull()
       expect(
-        document.querySelector(
-          '[data-dom-text-scrub-overlay] [data-testid="mock-player-frame"]',
-        ),
+        document.querySelector('[data-dom-text-scrub-overlay] [data-testid="mock-player-frame"]'),
       ).toHaveTextContent(String(displayedFrame))
       const keyframesForItem = lastCompositionKeyframes.find((entry) => entry.itemId === 'item-1')
       const xProperty = keyframesForItem?.properties.find((property) => property.property === 'x')

--- a/src/features/preview/deps/composition-runtime-contract.ts
+++ b/src/features/preview/deps/composition-runtime-contract.ts
@@ -8,9 +8,7 @@ export {
   resolveTransform,
   getSourceDimensions,
 } from '@/runtime/composition-runtime/utils/transform-resolver'
-export {
-  resolveItemTransformAtFrame,
-} from '@/runtime/composition-runtime/utils/frame-scene'
+export { resolveItemTransformAtFrame } from '@/runtime/composition-runtime/utils/frame-scene'
 export type { PreviewPathVerticesOverride } from '@/runtime/composition-runtime/utils/preview-path-override'
 export { expandTextTransformToFitContent } from '@/runtime/composition-runtime/utils/text-layout'
 export {
@@ -26,6 +24,7 @@ export {
   getVideoTargetTimeSeconds,
   snapSourceTime,
 } from '@/runtime/composition-runtime/utils/video-timing'
+export { resolveTrackRenderState } from '@/runtime/composition-runtime/utils/scene-assembly'
 export {
   ensureAudioContextResumed,
   getPreviewAudioContextState,

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -20,15 +20,13 @@ import {
   replaceActivePreviewSourceTargets,
   settleActivePreviewRenderTarget,
   subscribeActivePreviewReady,
+  isActivePreviewFrameDecodeReady,
 } from '../utils/decoder-prewarm'
 import { getDirectionalPrewarmOffsets } from '../utils/fast-scrub-prewarm'
 import { resolveProxyUrl } from '../utils/media-resolver'
 import { scheduleScrubProxyFallback } from '../utils/scrub-proxy-fallback'
 import { shouldShowFastScrubOverlay } from '../utils/fast-scrub-overlay-guard'
-import {
-  hasPendingPreviewInput,
-  yieldToPendingPreviewInput,
-} from '../utils/preview-input-yield'
+import { hasPendingPreviewInput, yieldToPendingPreviewInput } from '../utils/preview-input-yield'
 import { resolvePlaybackTransitionOverlayState } from '../utils/playback-transition-overlay'
 import {
   FAST_SCRUB_DIRECTIONAL_PREWARM_BACKWARD_STEPS,
@@ -47,13 +45,16 @@ import {
   resolveActivePreviewPresentationTarget,
   resolveBackwardScrubFlags,
   resolveBackwardScrubFramePlan,
+  resolveReleasedScrubSnapshotGuardUntilMs,
   resolveRenderPumpTargetFrame,
   resolveScrubDirectionPlan,
   selectBoundaryPrewarmFrames,
   selectBoundarySourcePrewarmSources,
   shouldDropStalePausedPreviewRender,
   shouldPreservePausedTransportPresentation,
+  shouldRejectBlankReleasedScrubHandoff,
   shouldRejectBlankTransportHandoff,
+  shouldRecoverFailedActivePreseekSchedule,
   shouldRestoreCommittedPreviewSnapshot,
 } from '../utils/render-pump-frame-plan'
 import {
@@ -85,7 +86,10 @@ import {
   resolveScrubPrewarmIdleDelayMs,
   shouldUseCompositionScrubPrewarm,
 } from '../utils/render-pump-prewarm-plan'
-import { drawSourceToPreviewDisplayCanvas } from '../utils/preview-display-canvas'
+import {
+  drawSourceToPreviewDisplayCanvas,
+  type CommittedPreviewSnapshotState,
+} from '../utils/preview-display-canvas'
 import type { TransitionPreviewSessionTrace } from './use-preview-transition-session-controller'
 import { createLogger } from '@/shared/logging/logger'
 import { isPreviewTraceEnabled, recordPumpTrace } from '@/shared/logging/preview-trace'
@@ -202,6 +206,7 @@ interface UsePreviewRenderPumpParams {
   scrubPrewarmedSourceTouchFrameRef: MutableRefObject<Map<string, number>>
   scrubOffscreenCanvasRef: MutableRefObject<OffscreenCanvas | null>
   scrubOffscreenRenderedFrameRef: MutableRefObject<number | null>
+  committedPreviewSnapshotRef: MutableRefObject<CommittedPreviewSnapshotState>
   bgTransitionRenderInFlightRef: MutableRefObject<boolean>
   resumeScrubLoopRef: MutableRefObject<() => void>
   lastBackwardScrubPreloadAtRef: MutableRefObject<number>
@@ -284,6 +289,7 @@ export function usePreviewRenderPump({
   scrubPrewarmedSourceTouchFrameRef,
   scrubOffscreenCanvasRef,
   scrubOffscreenRenderedFrameRef,
+  committedPreviewSnapshotRef,
   bgTransitionRenderInFlightRef,
   resumeScrubLoopRef,
   lastBackwardScrubPreloadAtRef,
@@ -340,14 +346,18 @@ export function usePreviewRenderPump({
   }, [])
 
   useEffect(() => {
+    let effectDisposed = false
     scrubMountedRef.current = true
 
     let transportSettlingUntilMs = 0
     let pausedTransportHeldFrame: number | null = null
     let pausedTransportHoldUntilMs = 0
     let blankProbeCanvas: OffscreenCanvas | null = null
-    let committedPreviewSnapshotCanvas: OffscreenCanvas | null = null
-    let committedPreviewSnapshotFrame: number | null = null
+    const committedPreviewSnapshot = committedPreviewSnapshotRef.current
+    const clearReleasedScrubSnapshotGuard = () => {
+      committedPreviewSnapshot.guardFrame = null
+      committedPreviewSnapshot.guardUntilMs = 0
+    }
 
     const captureCommittedPreviewSnapshot = (frame: number) => {
       const displayCanvas = scrubCanvasRef.current
@@ -359,24 +369,35 @@ export function usePreviewRenderPump({
         // A hidden scrub canvas is not the visible committed presentation.
         // It may contain an old partial render even though its frame tag still
         // matches the playhead. Never promote those pixels on gesture entry.
-        committedPreviewSnapshotFrame = null
+        // A transient ruler -> track -> ruler handoff can attempt another
+        // capture while the hover frame is on top. Preserve an earlier
+        // authoritative snapshot for the same committed playhead frame.
+        if (committedPreviewSnapshot.frame !== frame) {
+          committedPreviewSnapshot.frame = null
+          clearReleasedScrubSnapshotGuard()
+        }
         return
       }
       if (
-        !committedPreviewSnapshotCanvas ||
-        committedPreviewSnapshotCanvas.width !== displayCanvas.width ||
-        committedPreviewSnapshotCanvas.height !== displayCanvas.height
+        !committedPreviewSnapshot.canvas ||
+        committedPreviewSnapshot.canvas.width !== displayCanvas.width ||
+        committedPreviewSnapshot.canvas.height !== displayCanvas.height
       ) {
-        committedPreviewSnapshotCanvas = new OffscreenCanvas(
+        committedPreviewSnapshot.canvas = new OffscreenCanvas(
           displayCanvas.width,
           displayCanvas.height,
         )
       }
-      const context = committedPreviewSnapshotCanvas.getContext('2d')
+      const context = committedPreviewSnapshot.canvas.getContext('2d')
       if (!context) return
-      context.clearRect(0, 0, committedPreviewSnapshotCanvas.width, committedPreviewSnapshotCanvas.height)
+      context.clearRect(
+        0,
+        0,
+        committedPreviewSnapshot.canvas.width,
+        committedPreviewSnapshot.canvas.height,
+      )
       context.drawImage(displayCanvas, 0, 0)
-      committedPreviewSnapshotFrame = frame
+      committedPreviewSnapshot.frame = frame
     }
 
     const isEffectivelyBlankPreviewSource = (
@@ -392,9 +413,7 @@ export function usePreviewRenderPump({
         let rgbTotal = 0
         for (let index = 0; index < pixels.length; index += 4) {
           rgbTotal +=
-            (pixels.at(index) ?? 0) +
-            (pixels.at(index + 1) ?? 0) +
-            (pixels.at(index + 2) ?? 0)
+            (pixels.at(index) ?? 0) + (pixels.at(index + 1) ?? 0) + (pixels.at(index + 2) ?? 0)
           if (rgbTotal > 8) return false
         }
         return true
@@ -416,6 +435,41 @@ export function usePreviewRenderPump({
       if (!displayCtx) return
       const displayedFrame = usePreviewBridgeStore.getState().displayedFrame
       const playbackState = usePlaybackStore.getState()
+      if (
+        committedPreviewSnapshot.guardFrame !== null &&
+        performance.now() > committedPreviewSnapshot.guardUntilMs
+      ) {
+        clearReleasedScrubSnapshotGuard()
+      }
+      if (
+        committedPreviewSnapshot.guardFrame !== null &&
+        committedPreviewSnapshot.canvas &&
+        shouldRejectBlankReleasedScrubHandoff({
+          releaseGuardFrame: committedPreviewSnapshot.guardFrame,
+          renderedFrame,
+          currentFrame: playbackState.currentFrame,
+          previewFrame: playbackState.previewFrame,
+          isPlaying: playbackState.isPlaying,
+          snapshotFrame: committedPreviewSnapshot.frame,
+          renderedFrameBlank: isEffectivelyBlankPreviewSource(source),
+          snapshotFrameBlank: isEffectivelyBlankPreviewSource(committedPreviewSnapshot.canvas),
+        })
+      ) {
+        if (source === scrubOffscreenCanvasRef.current) {
+          scrubOffscreenRenderedFrameRef.current = null
+          scrubRendererRef.current?.invalidateFrameCache({ frames: [renderedFrame] })
+        }
+        // A resize or layout rebuild can clear the display canvas while this
+        // delayed render is in flight. Reassert the immutable committed copy
+        // instead of merely declining the blank replacement.
+        drawSourceToPreviewDisplayCanvas(displayCtx, displayCanvas, committedPreviewSnapshot.canvas)
+        setDisplayedFrame(renderedFrame)
+        return
+      }
+      const shouldReleaseScrubSnapshotGuardAfterDraw =
+        committedPreviewSnapshot.guardFrame === renderedFrame &&
+        source !== committedPreviewSnapshot.canvas &&
+        !isEffectivelyBlankPreviewSource(source)
       if (
         shouldPreservePausedTransportPresentation({
           holdActive: performance.now() <= pausedTransportHoldUntilMs,
@@ -455,8 +509,16 @@ export function usePreviewRenderPump({
         playbackState.previewFrame === null &&
         playbackState.currentFrame === renderedFrame
       ) {
-        captureCommittedPreviewSnapshot(renderedFrame)
+        if (source !== committedPreviewSnapshot.canvas) {
+          captureCommittedPreviewSnapshot(renderedFrame)
+        }
         settleActivePreviewRenderTarget(renderedFrame)
+      }
+      if (shouldReleaseScrubSnapshotGuardAfterDraw) {
+        // Only a replacement that actually reached the front buffer may
+        // release the guard. Earlier transport/pause checks can reject a
+        // nonblank candidate without presenting it.
+        clearReleasedScrubSnapshotGuard()
       }
       resolvePlaybackColdStartVisibleFrame(renderedFrame, 'rendered_overlay')
     }
@@ -566,6 +628,7 @@ export function usePreviewRenderPump({
     }
 
     const scheduleOpportunisticTransitionPrepare = () => {
+      if (effectDisposed) return
       const deferredFrame = deferredPlaybackTransitionPrepareFrameRef.current
       if (deferredFrame === null) {
         clearScheduledTransitionPrepare()
@@ -577,7 +640,7 @@ export function usePreviewRenderPump({
 
       transitionPrepareTimeoutRef.current = window.setTimeout(() => {
         transitionPrepareTimeoutRef.current = null
-        if (!scrubMountedRef.current) return
+        if (effectDisposed || !scrubMountedRef.current) return
 
         const playbackState = usePlaybackStore.getState()
         if (!playbackState.isPlaying) return
@@ -618,7 +681,7 @@ export function usePreviewRenderPump({
     let scrubPrewarmIdleDelayMs = 40
     let lastActivePreviewTargetAtMs = 0
     let lastActivePreviewSourceTimes = new Map<string, number>()
-    let scrubTargetsInGesture = 0
+    let activeScrubPreseekScheduleVersion = 0
     const cancelScrubPrewarmIdleRestart = () => {
       if (scrubPrewarmIdleTimeoutId === null) return
       clearTimeout(scrubPrewarmIdleTimeoutId)
@@ -626,15 +689,19 @@ export function usePreviewRenderPump({
     }
 
     const scheduleScrubPrewarmIdleRestart = (minimumDelayMs = 0) => {
+      if (effectDisposed) return
       cancelScrubPrewarmIdleRestart()
       const elapsedSinceInput = performance.now() - lastScrubTargetAtMs
-      const remainingDelay = Math.max(
-        minimumDelayMs,
-        scrubPrewarmIdleDelayMs - elapsedSinceInput,
-      )
+      const remainingDelay = Math.max(minimumDelayMs, scrubPrewarmIdleDelayMs - elapsedSinceInput)
       scrubPrewarmIdleTimeoutId = setTimeout(() => {
         scrubPrewarmIdleTimeoutId = null
-        if (!scrubMountedRef.current || scrubPrewarmQueueRef.current.length === 0) return
+        if (
+          effectDisposed ||
+          !scrubMountedRef.current ||
+          scrubPrewarmQueueRef.current.length === 0
+        ) {
+          return
+        }
         if (scrubRequestedFrameRef.current !== null || scrubRenderInFlightRef.current) {
           scheduleScrubPrewarmIdleRestart(16)
           return
@@ -644,10 +711,13 @@ export function usePreviewRenderPump({
     }
 
     const scheduleRenderPumpRestart = () => {
-      if (renderPumpRestartTimeoutId !== null || !scrubMountedRef.current) return
+      if (effectDisposed || renderPumpRestartTimeoutId !== null || !scrubMountedRef.current) {
+        return
+      }
       renderPumpRestartTimeoutId = setTimeout(() => {
         renderPumpRestartTimeoutId = null
         if (
+          !effectDisposed &&
           scrubMountedRef.current &&
           !scrubRenderInFlightRef.current &&
           scrubRequestedFrameRef.current !== null
@@ -667,7 +737,7 @@ export function usePreviewRenderPump({
       // Fast bail-out: check if this pump has been superseded by a newer
       // seek/play cycle. Checked after every await to abandon stale work
       // as early as possible, freeing GPU/decoder resources for the new frame.
-      const isStale = () => scrubRenderGenerationRef.current !== generation
+      const isStale = () => effectDisposed || scrubRenderGenerationRef.current !== generation
 
       try {
         const enqueuePrewarmFrame = (frame: number) => {
@@ -763,7 +833,7 @@ export function usePreviewRenderPump({
         }
 
         let prewarmBudgetStart = 0
-        while (scrubMountedRef.current) {
+        while (!effectDisposed && scrubMountedRef.current) {
           if (isStale()) break
           const inputState = usePlaybackStore.getState()
           if (hasPendingPreviewInput(inputState.isPlaying || inputState.previewFrame !== null)) {
@@ -891,10 +961,7 @@ export function usePreviewRenderPump({
             const renderStartMs = performance.now()
             recordPreviewScrubRenderStarted(frameToRender)
             await renderer.renderFrame(frameToRender)
-            if (
-              'wasLastRenderAborted' in renderer &&
-              renderer.wasLastRenderAborted?.()
-            ) {
+            if ('wasLastRenderAborted' in renderer && renderer.wasLastRenderAborted?.()) {
               recordPreviewScrubRenderCompleted(frameToRender)
               // The renderer clears the shared offscreen canvas before it can
               // discover that a nested source is still settling. Never leave
@@ -903,12 +970,16 @@ export function usePreviewRenderPump({
               scrubOffscreenRenderedFrameRef.current = null
               continue
             }
+            if (isStale()) {
+              recordPreviewScrubRenderCompleted(frameToRender)
+              // Renderer disposal can start a replacement pump before the old
+              // render promise settles. Drop that generation before it reads
+              // or tags the replacement renderer's shared canvas refs.
+              scrubOffscreenRenderedFrameRef.current = null
+              break
+            }
             priorityRenderUsedFallback =
-              'wasLastRenderFallback' in renderer &&
-              renderer.wasLastRenderFallback?.() === true
-            // Don't check isStale() here — the priority frame is fully rendered
-            // and should always be displayed. Discarding it wastes the decode work
-            // and reduces scrub hit rate.
+              'wasLastRenderFallback' in renderer && renderer.wasLastRenderFallback?.() === true
             const renderMs = performance.now() - renderStartMs
             recordPreviewScrubRenderCompleted(frameToRender)
             const renderedSource = scrubOffscreenCanvasRef.current
@@ -1161,10 +1232,7 @@ export function usePreviewRenderPump({
               scheduleOpportunisticTransitionPrepare()
             }
             prewarmBudgetStart = performance.now()
-            if (
-              playbackState.previewFrame !== null &&
-              scrubPrewarmQueueRef.current.length > 0
-            ) {
+            if (playbackState.previewFrame !== null && scrubPrewarmQueueRef.current.length > 0) {
               // Directional decode lookahead shares the same renderer lane as
               // the visible target. Do not enter an uninterruptible prewarm
               // await while pointer input is active; restart after an adaptive
@@ -1189,11 +1257,15 @@ export function usePreviewRenderPump({
           disposeFastScrubRenderer()
         }
       } finally {
-        const isCurrentGeneration = scrubRenderGenerationRef.current === generation
+        const isCurrentGeneration =
+          !effectDisposed && scrubRenderGenerationRef.current === generation
         // A lifecycle change invalidates this request, but never transfers
         // ownership while renderFrame is still touching the shared canvas.
         scrubRenderInFlightRef.current = false
-        if (scrubRequestedFrameRef.current === scrubOffscreenRenderedFrameRef.current) {
+        if (
+          isCurrentGeneration &&
+          scrubRequestedFrameRef.current === scrubOffscreenRenderedFrameRef.current
+        ) {
           scrubRequestedFrameRef.current = null
         }
         if (isCurrentGeneration) {
@@ -1209,7 +1281,13 @@ export function usePreviewRenderPump({
           // Break the promise-recursion chain. Under synchronous test doubles
           // (and occasionally a run of cache hits in browsers), an immediate
           // restart can recurse until the stack overflows.
-          scheduleRenderPumpRestart()
+          if (effectDisposed) {
+            queueMicrotask(() => {
+              void resumeScrubLoopRef.current()
+            })
+          } else {
+            scheduleRenderPumpRestart()
+          }
         }
       }
     }
@@ -1379,7 +1457,7 @@ export function usePreviewRenderPump({
     // main-timeline and sub-comp items alike.
     const resolvePreseekComposition = (compositionId: string) => {
       const comp = useCompositionsStore.getState().compositions.find((c) => c.id === compositionId)
-      return comp ? { fps: comp.fps, items: comp.items } : null
+      return comp ? { fps: comp.fps, items: comp.items, tracks: comp.tracks } : null
     }
     const resolvePreseekItemSrc = (item: VideoItem) => {
       const proxyUrl = item.mediaId ? resolveProxyUrl(item.mediaId) : null
@@ -1408,10 +1486,10 @@ export function usePreviewRenderPump({
       }
 
       const bySource = collectVisibleTrackVideoSourceTimesBySrc(combinedTracks, targetFrame, fps, {
-          requireExplicitSourceFps: true,
-          resolveComposition: resolvePreseekComposition,
-          resolveItemSrc: resolvePreseekItemSrc,
-        })
+        requireExplicitSourceFps: true,
+        resolveComposition: resolvePreseekComposition,
+        resolveItemSrc: resolvePreseekItemSrc,
+      })
       recordPreviewPreseekPlan(targetFrame, bySource)
       runBatchPreseek(bySource)
     }
@@ -1420,7 +1498,9 @@ export function usePreviewRenderPump({
       targetFrame: number,
       direction: -1 | 0 | 1,
       nowMs: number,
+      retryFailedTarget: boolean,
     ) => {
+      const scheduleVersion = ++activeScrubPreseekScheduleVersion
       const bySource = collectVisibleTrackVideoSourceTimesBySrc(combinedTracks, targetFrame, fps, {
         // Match renderVideoItem's sourceFps ?? compositionFps fallback. Older
         // compound items may not persist sourceFps; excluding them here leaves
@@ -1430,7 +1510,14 @@ export function usePreviewRenderPump({
         resolveComposition: resolvePreseekComposition,
         resolveItemSrc: resolvePreseekItemSrc,
       })
-      if (bySource.size === 0) return
+      if (bySource.size === 0) {
+        // There is no worker-backed source to gate this frame. Drop any source
+        // targets left by the previous hover so images/text and the normal
+        // renderer path cannot be held behind an unrelated cancelled decode.
+        setActivePreviewRenderTarget(null)
+        replaceActivePreviewSourceTargets(bySource)
+        return
+      }
 
       recordPreviewPreseekPlan(targetFrame, bySource)
       const elapsedMs =
@@ -1440,6 +1527,48 @@ export function usePreviewRenderPump({
       lastActivePreviewTargetAtMs = nowMs
       const nextSourceTimes = new Map<string, number>()
       let usedDedicatedLane = false
+      let recoveredFailedSchedule = false
+      const requiredPreseekPromises: Array<Promise<ImageBitmap | null>> = []
+      const recoverFailedSchedule = () => {
+        const playbackState = usePlaybackStore.getState()
+        const currentTarget = playbackState.previewFrame ?? playbackState.currentFrame
+        if (
+          !shouldRecoverFailedActivePreseekSchedule({
+            effectDisposed,
+            recoveredFailedSchedule,
+            scheduleVersion,
+            activeScheduleVersion: activeScrubPreseekScheduleVersion,
+            mounted: scrubMountedRef.current,
+            isPlaying: playbackState.isPlaying,
+            currentTarget,
+            targetFrame,
+          })
+        ) {
+          return
+        }
+
+        recoveredFailedSchedule = true
+        // A latest-target worker failure/cancellation has no ready
+        // notification. Leaving the active gate pinned would make every retry
+        // abort forever until the pointer requested a different frame. Unpin
+        // this exact schedule and retry through the normal DOM/MediaBunny
+        // renderer while preserving the visible front buffer.
+        setActivePreviewRenderTarget(null)
+        if (scrubOffscreenRenderedFrameRef.current === targetFrame) {
+          scrubOffscreenRenderedFrameRef.current = null
+        }
+        if (!retryFailedTarget) return
+        scrubRequestedFrameRef.current = targetFrame
+        if (!scrubRenderInFlightRef.current) {
+          void pumpRenderLoop()
+        }
+      }
+      const observeRequiredPreseek = (promise: Promise<ImageBitmap | null>) => {
+        requiredPreseekPromises.push(promise)
+        void promise.then((bitmap) => {
+          if (!bitmap) recoverFailedSchedule()
+        })
+      }
 
       for (const [src, timestamps] of bySource) {
         const exactTimestamp = timestamps[0]
@@ -1449,20 +1578,22 @@ export function usePreviewRenderPump({
 
         if (!usedDedicatedLane) {
           usedDedicatedLane = true
-          void activePreviewPreseek({
-            src,
-            timestamp: exactTimestamp,
-            lookaheadTimestamps: resolveActivePreviewLookaheadTimestamps({
-              sourceTime: exactTimestamp,
-              previousSourceTime: lastActivePreviewSourceTimes.get(src) ?? null,
-              elapsedMs,
-              sourceFps: fps,
-              fallbackDirection: direction,
+          observeRequiredPreseek(
+            activePreviewPreseek({
+              src,
+              timestamp: exactTimestamp,
+              lookaheadTimestamps: resolveActivePreviewLookaheadTimestamps({
+                sourceTime: exactTimestamp,
+                previousSourceTime: lastActivePreviewSourceTimes.get(src) ?? null,
+                elapsedMs,
+                sourceFps: fps,
+                fallbackDirection: direction,
+              }),
             }),
-          })
+          )
           if (timestamps.length > 1) {
             for (const timestamp of timestamps.slice(1)) {
-              void workerBackgroundPreseek(src, timestamp)
+              observeRequiredPreseek(workerBackgroundPreseek(src, timestamp))
             }
           }
           continue
@@ -1471,12 +1602,25 @@ export function usePreviewRenderPump({
         // Stacked secondary sources retain the existing bounded pool. The
         // top active source always owns the isolated latency-critical lane.
         for (const timestamp of timestamps) {
-          void workerBackgroundPreseek(src, timestamp)
+          observeRequiredPreseek(workerBackgroundPreseek(src, timestamp))
         }
       }
 
       replaceActivePreviewSourceTargets(bySource)
       lastActivePreviewSourceTimes = nextSourceTimes
+      void Promise.allSettled(requiredPreseekPromises).then(() => {
+        if (
+          !effectDisposed &&
+          scheduleVersion === activeScrubPreseekScheduleVersion &&
+          !isActivePreviewFrameDecodeReady(targetFrame)
+        ) {
+          // The bounded background queue can resolve an older same-source
+          // request with the newer bitmap that replaced it. Re-check the exact
+          // registered target set after all work settles instead of treating a
+          // non-null promise value as proof that every compound source arrived.
+          recoverFailedSchedule()
+        }
+      })
     }
 
     const primeActivePreviewDecoderAtFrame = (targetFrame: number) => {
@@ -1485,9 +1629,7 @@ export function usePreviewRenderPump({
         resolveComposition: resolvePreseekComposition,
         resolveItemSrc: resolvePreseekItemSrc,
       })
-      const primarySource = bySource.entries().next().value as
-        | [string, number[]]
-        | undefined
+      const primarySource = bySource.entries().next().value as [string, number[]] | undefined
       if (!primarySource) return
 
       const [src, timestamps] = primarySource
@@ -1824,46 +1966,52 @@ export function usePreviewRenderPump({
             pinTransitionPlaybackSession(tw)
             if (lastPausedPrearmTargetRef.current !== pausedPrewarmStartFrame) {
               void (async () => {
-                const mainRenderer = await ensureFastScrubRenderer()
-                if (mainRenderer && 'prewarmItems' in mainRenderer) {
-                  await mainRenderer.prewarmItems?.(
-                    [tw.leftClip.id, tw.rightClip.id],
-                    tw.startFrame,
+                if (bgTransitionRenderInFlightRef.current) return
+                bgTransitionRenderInFlightRef.current = true
+                try {
+                  const bgRenderer = await ensureBgTransitionRenderer()
+                  if (bgRenderer && 'prewarmItems' in bgRenderer) {
+                    await bgRenderer.prewarmItems?.(
+                      [tw.leftClip.id, tw.rightClip.id],
+                      tw.startFrame,
+                    )
+                  }
+                  runBatchPreseek(
+                    collectClipVideoSourceTimesBySrcForFrame(
+                      [tw.leftClip, tw.rightClip],
+                      tw.startFrame,
+                      fps,
+                      { requireExplicitSourceFps: true },
+                    ),
                   )
-                }
-                runBatchPreseek(
-                  collectClipVideoSourceTimesBySrcForFrame(
-                    [tw.leftClip, tw.rightClip],
-                    tw.startFrame,
-                    fps,
-                    { requireExplicitSourceFps: true },
-                  ),
-                )
-                if (!usePlaybackStore.getState().isPlaying && mainRenderer) {
-                  const preRenderCount = Math.min(
-                    playbackTransitionPrerenderRunwayFrames,
-                    tw.endFrame - tw.startFrame,
-                  )
-                  for (let fi = 0; fi < preRenderCount; fi++) {
-                    if (usePlaybackStore.getState().isPlaying) break
-                    const frame = tw.startFrame + fi
-                    try {
-                      await mainRenderer.renderFrame(frame)
-                      if ('getCanvas' in mainRenderer) {
-                        const srcCanvas = (
-                          mainRenderer as { getCanvas: () => OffscreenCanvas }
-                        ).getCanvas()
-                        const snapshot = new OffscreenCanvas(srcCanvas.width, srcCanvas.height)
-                        const snapshotCtx = snapshot.getContext('2d')
-                        if (snapshotCtx) {
-                          snapshotCtx.drawImage(srcCanvas, 0, 0)
-                          transitionSessionBufferedFramesRef.current.set(frame, snapshot)
+                  if (!usePlaybackStore.getState().isPlaying && bgRenderer) {
+                    const preRenderCount = Math.min(
+                      playbackTransitionPrerenderRunwayFrames,
+                      tw.endFrame - tw.startFrame,
+                    )
+                    for (let fi = 0; fi < preRenderCount; fi++) {
+                      if (usePlaybackStore.getState().isPlaying) break
+                      const frame = tw.startFrame + fi
+                      try {
+                        await bgRenderer.renderFrame(frame)
+                        if ('getCanvas' in bgRenderer) {
+                          const srcCanvas = (
+                            bgRenderer as { getCanvas: () => OffscreenCanvas }
+                          ).getCanvas()
+                          const snapshot = new OffscreenCanvas(srcCanvas.width, srcCanvas.height)
+                          const snapshotCtx = snapshot.getContext('2d')
+                          if (snapshotCtx) {
+                            snapshotCtx.drawImage(srcCanvas, 0, 0)
+                            transitionSessionBufferedFramesRef.current.set(frame, snapshot)
+                          }
                         }
+                      } catch {
+                        break
                       }
-                    } catch {
-                      break
                     }
                   }
+                } finally {
+                  bgTransitionRenderInFlightRef.current = false
                 }
               })()
             }
@@ -1903,17 +2051,15 @@ export function usePreviewRenderPump({
 
     const handleScrubTargetUpdate = (state: PlaybackStoreSnapshot, prev: PlaybackStoreSnapshot) => {
       if (state.previewFrame !== null && prev.previewFrame === null) {
-        scrubTargetsInGesture = 1
+        clearReleasedScrubSnapshotGuard()
         // Snapshot at gesture entry, not only when the committed render first
         // completed. The preview controller can be rebuilt between those two
         // moments (resize/workspace/layout changes), while the visible canvas
         // remains the authoritative frame the hover must return to.
         captureCommittedPreviewSnapshot(prev.currentFrame)
-      } else if (
-        state.previewFrame !== null &&
-        state.previewFrame !== prev.previewFrame
-      ) {
-        scrubTargetsInGesture += 1
+      }
+      if (state.isPlaying || state.currentFrame !== prev.currentFrame) {
+        clearReleasedScrubSnapshotGuard()
       }
       if (
         state.isPlaying ||
@@ -1925,30 +2071,29 @@ export function usePreviewRenderPump({
       }
       const settlingReleasedScrubFrame =
         state.previewFrame === null && prev.previewFrame !== null ? state.currentFrame : null
-      const isSequentialSwipeRelease =
-        settlingReleasedScrubFrame !== null && scrubTargetsInGesture >= 3
       const shouldRestoreCommittedSnapshot =
-        committedPreviewSnapshotCanvas &&
+        committedPreviewSnapshot.canvas &&
         shouldRestoreCommittedPreviewSnapshot({
           previewFrame: state.previewFrame,
           previousPreviewFrame: prev.previewFrame,
           currentFrame: state.currentFrame,
-          snapshotFrame: committedPreviewSnapshotFrame,
+          snapshotFrame: committedPreviewSnapshot.frame,
         })
-      if (shouldRestoreCommittedSnapshot && committedPreviewSnapshotCanvas) {
+      if (shouldRestoreCommittedSnapshot && committedPreviewSnapshot.canvas) {
         // Hover skimming may end on a nested frame whose sources were still
         // settling. Restore the last committed pixels synchronously instead
         // of leaving that transient frame visible while currentFrame rerenders.
-        drawSourceToDisplay(committedPreviewSnapshotCanvas, state.currentFrame)
-      } else if (isSequentialSwipeRelease) {
-        // If the gesture began on the live Player, there is no authoritative
-        // canvas snapshot to restore. Hide the skim layer immediately and let
-        // the already-correct Player remain visible while an exact canvas
-        // render for the committed frame is prepared.
-        scrubOffscreenRenderedFrameRef.current = null
-        hideFastScrubOverlay()
+        drawSourceToDisplay(committedPreviewSnapshot.canvas, state.currentFrame)
+        // Keep guarding until a nonblank exact render proves it can replace
+        // this snapshot. Cancelled compound work can complete much later than
+        // the pointer release and otherwise cache/present its cleared canvas.
+        committedPreviewSnapshot.guardFrame = state.currentFrame
+        committedPreviewSnapshot.guardUntilMs = resolveReleasedScrubSnapshotGuardUntilMs({
+          nowMs: performance.now(),
+        })
+      } else if (settlingReleasedScrubFrame !== null) {
+        clearReleasedScrubSnapshotGuard()
       }
-      if (settlingReleasedScrubFrame !== null) scrubTargetsInGesture = 0
       const activePreviewPresentationTarget = resolveActivePreviewPresentationTarget({
         state,
         prev,
@@ -2079,7 +2224,8 @@ export function usePreviewRenderPump({
             prevTargetFrame === null
               ? 0
               : Math.abs(activePreviewPresentationTarget - prevTargetFrame),
-          elapsedMs: lastScrubTargetAtMs === 0 ? Number.POSITIVE_INFINITY : nowMs - lastScrubTargetAtMs,
+          elapsedMs:
+            lastScrubTargetAtMs === 0 ? Number.POSITIVE_INFINITY : nowMs - lastScrubTargetAtMs,
           fps,
         })
         lastScrubTargetAtMs = nowMs
@@ -2095,6 +2241,7 @@ export function usePreviewRenderPump({
           activePreviewPresentationTarget,
           scrubDirectionRef.current,
           nowMs,
+          state.previewFrame !== null || settlingReleasedScrubFrame !== null,
         )
       }
 
@@ -2296,6 +2443,7 @@ export function usePreviewRenderPump({
 
       const playbackState = usePlaybackStore.getState()
       const currentFrame = playbackState.currentFrame
+      clearReleasedScrubSnapshotGuard()
       const gradeBypassChanged =
         state.colorGradeBypassed !== prev.colorGradeBypassed ||
         state.colorGradeComparisonMode !== prev.colorGradeComparisonMode
@@ -2334,6 +2482,7 @@ export function usePreviewRenderPump({
         return
 
       const currentFrame = playbackState.currentFrame
+      clearReleasedScrubSnapshotGuard()
       if (scrubRendererRef.current) {
         scrubRendererRef.current.invalidateFrameCache({ frames: [currentFrame] })
       }
@@ -2356,6 +2505,7 @@ export function usePreviewRenderPump({
       )
         return
 
+      clearReleasedScrubSnapshotGuard()
       if (scrubRendererRef.current) {
         scrubRendererRef.current.invalidateFrameCache({ frames: [targetFrame] })
       }
@@ -2548,6 +2698,7 @@ export function usePreviewRenderPump({
     }
 
     return () => {
+      effectDisposed = true
       scrubMountedRef.current = false
       resetScrubLoopState()
       clearScheduledTransitionPrepare()
@@ -2606,6 +2757,7 @@ export function usePreviewRenderPump({
     bgTransitionRenderInFlightRef,
     bypassPreviewSeekRef,
     cacheTransitionSessionFrame,
+    committedPreviewSnapshotRef,
     combinedTracks,
     deferredPlaybackTransitionPrepareFrameRef,
     ensureBgTransitionRenderer,

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -39,6 +39,7 @@ import {
   copyPreviewDisplayCanvasContent,
   drawSourceToPreviewDisplayCanvas,
   getPreviewDisplayCanvasBackingSize,
+  type CommittedPreviewSnapshotState,
 } from '../utils/preview-display-canvas'
 import { setActivePreviewScrubbingCache } from '../utils/preview-scrubbing-cache-bridge'
 import { warmDecoderPrewarmWorkerPool } from '../utils/decoder-prewarm'
@@ -66,6 +67,45 @@ const CAPTURE_RENDER_LOCK_WAIT_MS = 150
 const CAPTURE_RENDER_LOCK_POLL_MS = 8
 
 export type PreviewCompositionRenderer = CompositionRendererInstance
+
+function wasRendererFrameAborted(renderer: PreviewCompositionRenderer): boolean {
+  return 'wasLastRenderAborted' in renderer && renderer.wasLastRenderAborted?.() === true
+}
+
+function itemOccupiesFrame(item: TimelineItem | undefined, frame: number): boolean {
+  return Boolean(
+    item &&
+    Number.isFinite(item.from) &&
+    Number.isFinite(item.durationInFrames) &&
+    frame >= item.from &&
+    frame < item.from + item.durationInFrames,
+  )
+}
+
+function hasItemChangeAtFrame(
+  previousItems: TimelineItem[],
+  nextItems: TimelineItem[],
+  frame: number,
+): boolean {
+  const previousById = new Map(previousItems.map((item) => [item.id, item]))
+  const nextById = new Map(nextItems.map((item) => [item.id, item]))
+
+  for (const [itemId, previousItem] of previousById) {
+    const nextItem = nextById.get(itemId)
+    if (
+      nextItem !== previousItem &&
+      (itemOccupiesFrame(previousItem, frame) || itemOccupiesFrame(nextItem, frame))
+    ) {
+      return true
+    }
+  }
+  for (const [itemId, nextItem] of nextById) {
+    if (!previousById.has(itemId) && itemOccupiesFrame(nextItem, frame)) {
+      return true
+    }
+  }
+  return false
+}
 
 interface UsePreviewRendererControllerParams {
   fps: number
@@ -107,6 +147,7 @@ interface UsePreviewRendererControllerParams {
   scrubPrewarmedSourceOrderRef: MutableRefObject<string[]>
   scrubPrewarmedSourceTouchFrameRef: MutableRefObject<Map<string, number>>
   scrubOffscreenRenderedFrameRef: MutableRefObject<number | null>
+  committedPreviewSnapshotRef: MutableRefObject<CommittedPreviewSnapshotState>
   playbackTransitionPreparePromiseRef: MutableRefObject<Promise<boolean> | null>
   playbackTransitionPreparingFrameRef: MutableRefObject<number | null>
   deferredPlaybackTransitionPrepareFrameRef: MutableRefObject<number | null>
@@ -169,6 +210,7 @@ export function usePreviewRendererController({
   scrubOffscreenCtxRef,
   scrubRendererStructureKeyRef,
   scrubRenderInFlightRef,
+  scrubRenderGenerationRef,
   scrubRequestedFrameRef,
   bgTransitionRendererRef,
   bgTransitionInitPromiseRef,
@@ -182,6 +224,7 @@ export function usePreviewRendererController({
   scrubPrewarmedSourceOrderRef,
   scrubPrewarmedSourceTouchFrameRef,
   scrubOffscreenRenderedFrameRef,
+  committedPreviewSnapshotRef,
   playbackTransitionPreparePromiseRef,
   playbackTransitionPreparingFrameRef,
   deferredPlaybackTransitionPrepareFrameRef,
@@ -227,6 +270,12 @@ export function usePreviewRendererController({
   const liveScopeCaptureCanvasRef = useRef<OffscreenCanvas | null>(null)
   const liveScopeCaptureCtxRef = useRef<OffscreenCanvasRenderingContext2D | null>(null)
   const liveScopeCaptureStructureKeyRef = useRef<string | null>(null)
+  const invalidateCommittedPreviewSnapshot = useCallback(() => {
+    const snapshot = committedPreviewSnapshotRef.current
+    snapshot.frame = null
+    snapshot.guardFrame = null
+    snapshot.guardUntilMs = 0
+  }, [committedPreviewSnapshotRef])
 
   useLayoutEffect(() => {
     const canvas = scrubCanvasRef.current
@@ -235,16 +284,42 @@ export function usePreviewRendererController({
     if (canvas.width !== backingSize.width) canvas.width = backingSize.width
     if (canvas.height !== backingSize.height) canvas.height = backingSize.height
     if (!showFastScrubOverlayRef.current && !showPlaybackTransitionOverlayRef.current) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    const committedSnapshot = committedPreviewSnapshotRef.current
+    const playbackState = usePlaybackStore.getState()
+    if (
+      committedSnapshot.guardFrame !== null &&
+      performance.now() > committedSnapshot.guardUntilMs
+    ) {
+      committedSnapshot.guardFrame = null
+      committedSnapshot.guardUntilMs = 0
+    }
+    if (
+      committedSnapshot.canvas &&
+      committedSnapshot.frame !== null &&
+      committedSnapshot.guardFrame === committedSnapshot.frame &&
+      playbackState.previewFrame === null &&
+      !playbackState.isPlaying &&
+      playbackState.currentFrame === committedSnapshot.frame
+    ) {
+      // Resizing a canvas clears its backing store. During a committed-frame
+      // scrub handoff, repaint from the immutable front-buffer snapshot rather
+      // than the shared offscreen surface that a cancelled render may still be
+      // clearing or mutating.
+      drawSourceToPreviewDisplayCanvas(ctx, canvas, committedSnapshot.canvas)
+      setDisplayedFrame(committedSnapshot.frame)
+      return
+    }
     const renderedFrame = scrubOffscreenRenderedFrameRef.current
     const offscreen = scrubOffscreenCanvasRef.current
     if (renderedFrame === null || !offscreen) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
     drawSourceToPreviewDisplayCanvas(ctx, canvas, offscreen)
     setDisplayedFrame(renderedFrame)
   }, [
     playerRenderSize,
     playerSize,
+    committedPreviewSnapshotRef,
     scrubCanvasRef,
     scrubOffscreenCanvasRef,
     scrubOffscreenRenderedFrameRef,
@@ -254,11 +329,14 @@ export function usePreviewRendererController({
   ])
 
   const disposeFastScrubRenderer = useCallback(() => {
+    // Any renderer disposal invalidates async pump work that may still be
+    // awaiting the previous renderer. The replacement pump must never tag or
+    // present pixels through that stale generation's shared refs.
+    scrubRenderGenerationRef.current += 1
     resetPlaybackStartReadiness()
     scrubInitPromiseRef.current = null
     scrubPreloadPromiseRef.current = null
     scrubRequestedFrameRef.current = null
-    scrubRenderInFlightRef.current = false
     scrubPrewarmQueueRef.current = []
     scrubPrewarmQueuedSetRef.current.clear()
     scrubPrewarmedFramesRef.current = []
@@ -341,7 +419,7 @@ export function usePreviewRendererController({
     scrubPrewarmedSourceOrderRef,
     scrubPrewarmedSourceTouchFrameRef,
     scrubPrewarmedSourcesRef,
-    scrubRenderInFlightRef,
+    scrubRenderGenerationRef,
     scrubRendererRef,
     scrubRendererStructureKeyRef,
     scrubRequestedFrameRef,
@@ -698,6 +776,7 @@ export function usePreviewRendererController({
           )
         }
         await renderer.renderFrame(targetFrame)
+        if (wasRendererFrameAborted(renderer)) return null
         return offscreen
       }
 
@@ -724,6 +803,10 @@ export function usePreviewRendererController({
         }
         if (scrubOffscreenRenderedFrameRef.current !== targetFrame || isPlayingForCapture) {
           await renderer.renderFrame(targetFrame)
+          if (wasRendererFrameAborted(renderer)) {
+            scrubOffscreenRenderedFrameRef.current = null
+            return null
+          }
           scrubOffscreenRenderedFrameRef.current = targetFrame
         }
         return offscreen
@@ -744,6 +827,9 @@ export function usePreviewRendererController({
   useEffect(() => {
     const hadRenderer =
       scrubRendererRef.current !== null || bgTransitionRendererRef.current !== null
+    if (hadRenderer) {
+      invalidateCommittedPreviewSnapshot()
+    }
     disposeFastScrubRenderer()
 
     if (!hadRenderer) {
@@ -772,6 +858,7 @@ export function usePreviewRendererController({
     disposeFastScrubRenderer,
     fastScrubRendererStructureKey,
     forceFastScrubOverlay,
+    invalidateCommittedPreviewSnapshot,
     renderSize.height,
     renderSize.width,
     resumeScrubLoopRef,
@@ -796,6 +883,11 @@ export function usePreviewRendererController({
     })
     if (visualInvalidationRanges.length === 0) {
       return
+    }
+
+    const snapshotFrame = committedPreviewSnapshotRef.current.frame
+    if (snapshotFrame !== null && isFrameInRanges(snapshotFrame, visualInvalidationRanges)) {
+      invalidateCommittedPreviewSnapshot()
     }
 
     const scrubRenderer = scrubRendererRef.current
@@ -857,6 +949,8 @@ export function usePreviewRendererController({
     fastScrubScaledKeyframes,
     fastScrubScaledTracks,
     forceFastScrubOverlay,
+    committedPreviewSnapshotRef,
+    invalidateCommittedPreviewSnapshot,
     lastPausedPrearmTargetRef,
     resumeScrubLoopRef,
     scrubOffscreenRenderedFrameRef,
@@ -907,6 +1001,11 @@ export function usePreviewRendererController({
       return
     }
 
+    const snapshotFrame = committedPreviewSnapshotRef.current.frame
+    if (snapshotFrame !== null && hasItemChangeAtFrame(previousItems, items, snapshotFrame)) {
+      invalidateCommittedPreviewSnapshot()
+    }
+
     const scrubRenderer = scrubRendererRef.current
     const scrubRendererMatchesStructure =
       scrubRendererStructureKeyRef.current === fastScrubRendererStructureKey
@@ -935,6 +1034,8 @@ export function usePreviewRendererController({
   }, [
     fastScrubRendererStructureKey,
     forceFastScrubOverlay,
+    committedPreviewSnapshotRef,
+    invalidateCommittedPreviewSnapshot,
     items,
     resumeScrubLoopRef,
     scrubOffscreenRenderedFrameRef,
@@ -967,7 +1068,6 @@ export function usePreviewRendererController({
         scrubRendererStructureKeyRef.current === fastScrubRendererStructureKey
       const bgRendererMatchesStructure =
         bgTransitionRendererStructureKeyRef.current === fastScrubRendererStructureKey
-      if (!scrubRenderer && !bgRenderer) return
 
       const playbackState = usePlaybackStore.getState()
       const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame
@@ -991,6 +1091,14 @@ export function usePreviewRendererController({
       const normalized = normalizeFrameRanges(ranges)
       const request: FrameInvalidationRequest =
         normalized.length > 0 ? { ranges: normalized } : { frames: [targetFrame] }
+      const snapshotFrame = committedPreviewSnapshotRef.current.frame
+      if (
+        snapshotFrame !== null &&
+        (normalized.length === 0 || isFrameInRanges(snapshotFrame, normalized))
+      ) {
+        invalidateCommittedPreviewSnapshot()
+      }
+      if (!scrubRenderer && !bgRenderer) return
 
       if (scrubRenderer && scrubRendererMatchesStructure) {
         scrubRenderer.invalidateFrameCache(request)
@@ -1049,6 +1157,7 @@ export function usePreviewRendererController({
       ) {
         return
       }
+      invalidateCommittedPreviewSnapshot()
       queueMicrotask(() => {
         const scrubRenderer = scrubRendererRef.current
         const bgRenderer = bgTransitionRendererRef.current
@@ -1090,8 +1199,10 @@ export function usePreviewRendererController({
   }, [
     bgTransitionRendererRef,
     bgTransitionRendererStructureKeyRef,
+    committedPreviewSnapshotRef,
     fastScrubRendererStructureKey,
     forceFastScrubOverlay,
+    invalidateCommittedPreviewSnapshot,
     resumeScrubLoopRef,
     scrubOffscreenRenderedFrameRef,
     scrubRendererRef,
@@ -1137,15 +1248,48 @@ export function usePreviewRendererController({
               ),
             )
 
-            if ('prewarmFrames' in renderer && warmRunwayFrames.length > 0) {
-              await renderer.prewarmFrames?.(warmRunwayFrames)
-            }
-            if ('prewarmItems' in renderer && request.itemIds.length > 0) {
-              await renderer.prewarmItems?.(request.itemIds, request.frame)
-            }
-            if (scrubOffscreenRenderedFrameRef.current !== request.frame) {
-              await renderer.renderFrame(request.frame)
-              scrubOffscreenRenderedFrameRef.current = request.frame
+            const shouldResumeRenderPump = await withScrubRenderLock(async () => {
+              const playbackBeforeWarm = usePlaybackStore.getState()
+              if (
+                scrubRendererRef.current !== renderer ||
+                isResolving ||
+                playbackBeforeWarm.isPlaying ||
+                playbackBeforeWarm.previewFrame !== null ||
+                playbackBeforeWarm.currentFrame !== request.frame
+              ) {
+                return null
+              }
+
+              if ('prewarmFrames' in renderer && warmRunwayFrames.length > 0) {
+                await renderer.prewarmFrames?.(warmRunwayFrames)
+              }
+              if ('prewarmItems' in renderer && request.itemIds.length > 0) {
+                await renderer.prewarmItems?.(request.itemIds, request.frame)
+              }
+
+              const playbackAfterWarm = usePlaybackStore.getState()
+              if (
+                scrubRendererRef.current !== renderer ||
+                isResolving ||
+                playbackAfterWarm.isPlaying ||
+                playbackAfterWarm.previewFrame !== null ||
+                playbackAfterWarm.currentFrame !== request.frame
+              ) {
+                return null
+              }
+
+              if (scrubOffscreenRenderedFrameRef.current !== request.frame) {
+                // Only the render pump may render into and tag the shared
+                // offscreen surface. A warm request can outlive an edit and
+                // overlap a ruler skim; rendering here would let both owners
+                // clear the same canvas and publish a black/stale frame.
+                scrubRequestedFrameRef.current = request.frame
+                return true
+              }
+              return false
+            })
+            if (shouldResumeRenderPump) {
+              void resumeScrubLoopRef.current()
             }
           } catch {
             // Best effort only.
@@ -1167,7 +1311,15 @@ export function usePreviewRendererController({
       pendingPostEditWarmRequestRef.current = request
       void flushPostEditWarmRequest()
     })
-  }, [ensureFastScrubRenderer, isResolving, scrubOffscreenRenderedFrameRef])
+  }, [
+    ensureFastScrubRenderer,
+    isResolving,
+    scrubOffscreenRenderedFrameRef,
+    scrubRendererRef,
+    scrubRequestedFrameRef,
+    resumeScrubLoopRef,
+    withScrubRenderLock,
+  ])
 
   const resolveCaptureTargetFrame = useCallback(
     (options?: CaptureOptions) => {
@@ -1248,6 +1400,7 @@ export function usePreviewRendererController({
         renderer.setDomVideoElementProvider?.(getBestDomVideoElementForItem)
       }
       await renderer.renderFrame(targetFrame)
+      if (wasRendererFrameAborted(renderer)) return null
 
       let snapshot = captureLiveScopeSnapshotCanvasRef.current
       if (!snapshot || snapshot.width !== offscreen.width || snapshot.height !== offscreen.height) {
@@ -1514,6 +1667,10 @@ export function usePreviewRendererController({
             }
             if (scrubOffscreenRenderedFrameRef.current !== targetFrame || isPlayingForCapture) {
               await renderer.renderFrame(targetFrame)
+              if (wasRendererFrameAborted(renderer)) {
+                scrubOffscreenRenderedFrameRef.current = null
+                return null
+              }
               scrubOffscreenRenderedFrameRef.current = targetFrame
             }
 

--- a/src/features/preview/hooks/use-preview-runtime-refs.ts
+++ b/src/features/preview/hooks/use-preview-runtime-refs.ts
@@ -3,6 +3,7 @@ import type { PlayerRef } from '@/features/preview/deps/player-core'
 import type { TimelineItem } from '@/types/timeline'
 import type { ResolvedTransitionWindow } from '@/shared/timeline/transitions/transition-planner'
 import { createAdaptivePreviewQualityState } from '../utils/adaptive-preview-quality'
+import type { CommittedPreviewSnapshotState } from '../utils/preview-display-canvas'
 import type { PreviewCompositionRenderer } from './use-preview-renderer-controller'
 import type {
   TransitionPreviewSessionTrace,
@@ -47,6 +48,12 @@ export function usePreviewRuntimeRefs() {
   const scrubPrewarmedSourceOrderRef = useRef<string[]>([])
   const scrubPrewarmedSourceTouchFrameRef = useRef<Map<string, number>>(new Map())
   const scrubOffscreenRenderedFrameRef = useRef<number | null>(null)
+  const committedPreviewSnapshotRef = useRef<CommittedPreviewSnapshotState>({
+    canvas: null,
+    frame: null,
+    guardFrame: null,
+    guardUntilMs: 0,
+  })
   const scrubDirectionRef = useRef<-1 | 0 | 1>(0)
   const suppressScrubBackgroundPrewarmRef = useRef(false)
   const fallbackToPlayerScrubRef = useRef(false)
@@ -137,6 +144,7 @@ export function usePreviewRuntimeRefs() {
       scrubPrewarmedSourceOrderRef,
       scrubPrewarmedSourceTouchFrameRef,
       scrubOffscreenRenderedFrameRef,
+      committedPreviewSnapshotRef,
       playbackTransitionPreparePromiseRef,
       playbackTransitionPreparingFrameRef,
       deferredPlaybackTransitionPrepareFrameRef,
@@ -174,6 +182,7 @@ export function usePreviewRuntimeRefs() {
       scrubPrewarmedSourceTouchFrameRef,
       scrubOffscreenCanvasRef,
       scrubOffscreenRenderedFrameRef,
+      committedPreviewSnapshotRef,
       bgTransitionRenderInFlightRef,
       resumeScrubLoopRef,
       lastBackwardScrubPreloadAtRef,

--- a/src/features/preview/utils/preview-display-canvas.ts
+++ b/src/features/preview/utils/preview-display-canvas.ts
@@ -10,6 +10,13 @@ type PreviewCanvasSize = {
   height: number
 }
 
+export interface CommittedPreviewSnapshotState {
+  canvas: OffscreenCanvas | null
+  frame: number | null
+  guardFrame: number | null
+  guardUntilMs: number
+}
+
 export function getPreviewDisplayEdgePadding(
   playerSize: PreviewCanvasSize,
   renderSize: PreviewCanvasSize,
@@ -17,17 +24,13 @@ export function getPreviewDisplayEdgePadding(
 ): number {
   const scaleX = renderSize.width > 0 ? playerSize.width / renderSize.width : 1
   const scaleY = renderSize.height > 0 ? playerSize.height / renderSize.height : 1
-  const smallestDeviceScale = Math.max(
-    Number.EPSILON,
-    Math.min(scaleX, scaleY) * devicePixelRatio,
-  )
+  const smallestDeviceScale = Math.max(Number.EPSILON, Math.min(scaleX, scaleY) * devicePixelRatio)
   const minimumPadding = Math.min(
     MAX_PREVIEW_DISPLAY_EDGE_PADDING_PX,
     Math.max(
       MIN_PREVIEW_DISPLAY_EDGE_PADDING_PX,
       Math.ceil(
-        MIN_PREVIEW_DISPLAY_EDGE_OVERSCAN_DEVICE_PX / smallestDeviceScale -
-          PIXEL_ALIGNMENT_EPSILON,
+        MIN_PREVIEW_DISPLAY_EDGE_OVERSCAN_DEVICE_PX / smallestDeviceScale - PIXEL_ALIGNMENT_EPSILON,
       ),
     ),
   )
@@ -36,11 +39,7 @@ export function getPreviewDisplayEdgePadding(
     minimumPadding + MAX_PIXEL_ALIGNMENT_SEARCH_STEPS,
   )
 
-  for (
-    let padding = minimumPadding;
-    padding <= alignmentSearchEnd;
-    padding++
-  ) {
+  for (let padding = minimumPadding; padding <= alignmentSearchEnd; padding++) {
     const xDevicePixels = padding * scaleX * devicePixelRatio
     const yDevicePixels = padding * scaleY * devicePixelRatio
     if (

--- a/src/features/preview/utils/render-pump-frame-plan.test.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.test.ts
@@ -7,12 +7,15 @@ import {
   resolveBackwardScrubFlags,
   resolveBackwardScrubFramePlan,
   resolveRenderPumpTargetFrame,
+  resolveReleasedScrubSnapshotGuardUntilMs,
   resolveScrubDirectionPlan,
   selectBoundaryPrewarmFrames,
   selectBoundarySourcePrewarmSources,
   shouldDropStalePausedPreviewRender,
   shouldPreservePausedTransportPresentation,
+  shouldRejectBlankReleasedScrubHandoff,
   shouldRejectBlankTransportHandoff,
+  shouldRecoverFailedActivePreseekSchedule,
   shouldRestoreCommittedPreviewSnapshot,
   type RenderPumpFrameState,
 } from './render-pump-frame-plan'
@@ -131,12 +134,69 @@ describe('render pump frame plan', () => {
       displayedFrameBlank: false,
     }
 
-    expect(
-      shouldRejectBlankTransportHandoff({ ...base, isTransportSettling: false }),
-    ).toBe(false)
+    expect(shouldRejectBlankTransportHandoff({ ...base, isTransportSettling: false })).toBe(false)
     expect(shouldRejectBlankTransportHandoff({ ...base, displayedFrame: 98 })).toBe(false)
     expect(shouldRejectBlankTransportHandoff({ ...base, renderedFrameBlank: false })).toBe(false)
     expect(shouldRejectBlankTransportHandoff({ ...base, displayedFrameBlank: true })).toBe(false)
+  })
+
+  it('keeps a known-good committed frame when a delayed scrub-release render is blank', () => {
+    const base = {
+      releaseGuardFrame: 100,
+      renderedFrame: 100,
+      currentFrame: 100,
+      previewFrame: null,
+      isPlaying: false,
+      snapshotFrame: 100,
+      renderedFrameBlank: true,
+      snapshotFrameBlank: false,
+    }
+
+    expect(shouldRejectBlankReleasedScrubHandoff(base)).toBe(true)
+    expect(shouldRejectBlankReleasedScrubHandoff({ ...base, releaseGuardFrame: null })).toBe(false)
+    expect(shouldRejectBlankReleasedScrubHandoff({ ...base, renderedFrame: 101 })).toBe(false)
+    expect(shouldRejectBlankReleasedScrubHandoff({ ...base, previewFrame: 101 })).toBe(false)
+    expect(shouldRejectBlankReleasedScrubHandoff({ ...base, renderedFrameBlank: false })).toBe(
+      false,
+    )
+    expect(shouldRejectBlankReleasedScrubHandoff({ ...base, snapshotFrameBlank: true })).toBe(false)
+  })
+
+  it('bounds committed snapshot ownership so later same-frame edits can take over', () => {
+    expect(
+      resolveReleasedScrubSnapshotGuardUntilMs({
+        nowMs: 2_500,
+      }),
+    ).toBe(32_500)
+  })
+
+  it('does not let a disposed render-pump generation release a newer active preseek gate', () => {
+    const currentSchedule = {
+      effectDisposed: false,
+      recoveredFailedSchedule: false,
+      scheduleVersion: 2,
+      activeScheduleVersion: 2,
+      mounted: true,
+      isPlaying: false,
+      currentTarget: 120,
+      targetFrame: 120,
+    }
+
+    expect(shouldRecoverFailedActivePreseekSchedule(currentSchedule)).toBe(true)
+    expect(
+      shouldRecoverFailedActivePreseekSchedule({
+        ...currentSchedule,
+        // Models an old promise settling after the replacement effect has set
+        // the shared mounted ref back to true.
+        effectDisposed: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldRecoverFailedActivePreseekSchedule({
+        ...currentSchedule,
+        scheduleVersion: 1,
+      }),
+    ).toBe(false)
   })
 
   it('pins the current rendered frame across forced-overlay play and pause handoffs', () => {

--- a/src/features/preview/utils/render-pump-frame-plan.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.ts
@@ -13,6 +13,8 @@ import {
   type FastScrubBoundarySource,
 } from './preview-constants'
 
+const COMMITTED_SCRUB_SNAPSHOT_GUARD_MS = 30_000
+
 export type RenderPumpFrameState = Pick<
   PlaybackState,
   'currentFrame' | 'currentFrameEpoch' | 'previewFrame' | 'previewFrameEpoch'
@@ -47,6 +49,17 @@ interface ShouldRejectBlankTransportHandoffParams {
   displayedFrameBlank: boolean
 }
 
+interface ShouldRejectBlankReleasedScrubHandoffParams {
+  releaseGuardFrame: number | null
+  renderedFrame: number
+  currentFrame: number
+  previewFrame: number | null
+  isPlaying: boolean
+  snapshotFrame: number | null
+  renderedFrameBlank: boolean
+  snapshotFrameBlank: boolean
+}
+
 interface ShouldPreservePausedTransportPresentationParams {
   holdActive: boolean
   heldFrame: number | null
@@ -69,6 +82,17 @@ interface ShouldRestoreCommittedPreviewSnapshotParams {
   previousPreviewFrame: number | null
   currentFrame: number
   snapshotFrame: number | null
+}
+
+interface ShouldRecoverFailedActivePreseekScheduleParams {
+  effectDisposed: boolean
+  recoveredFailedSchedule: boolean
+  scheduleVersion: number
+  activeScheduleVersion: number
+  mounted: boolean
+  isPlaying: boolean
+  currentTarget: number
+  targetFrame: number
 }
 
 /**
@@ -109,6 +133,38 @@ export function shouldRejectBlankTransportHandoff({
     renderedFrameBlank &&
     !displayedFrameBlank
   )
+}
+
+/**
+ * A committed snapshot is authoritative for the exact frame from which a
+ * ruler skim began. A delayed/cancelled compound render may finish after
+ * release with a cleared canvas; it must not replace that known-good frame or
+ * become the cached representation for the playhead.
+ */
+export function shouldRejectBlankReleasedScrubHandoff({
+  releaseGuardFrame,
+  renderedFrame,
+  currentFrame,
+  previewFrame,
+  isPlaying,
+  snapshotFrame,
+  renderedFrameBlank,
+  snapshotFrameBlank,
+}: ShouldRejectBlankReleasedScrubHandoffParams): boolean {
+  return (
+    releaseGuardFrame !== null &&
+    renderedFrame === releaseGuardFrame &&
+    currentFrame === releaseGuardFrame &&
+    previewFrame === null &&
+    !isPlaying &&
+    snapshotFrame === releaseGuardFrame &&
+    renderedFrameBlank &&
+    !snapshotFrameBlank
+  )
+}
+
+export function resolveReleasedScrubSnapshotGuardUntilMs({ nowMs }: { nowMs: number }): number {
+  return nowMs + COMMITTED_SCRUB_SNAPSHOT_GUARD_MS
 }
 
 /** Prevents a delayed quality/decoder pass from visibly replacing the frame
@@ -153,10 +209,32 @@ export function shouldRestoreCommittedPreviewSnapshot({
   currentFrame,
   snapshotFrame,
 }: ShouldRestoreCommittedPreviewSnapshotParams): boolean {
+  return previewFrame === null && previousPreviewFrame !== null && snapshotFrame === currentFrame
+}
+
+/**
+ * A decoder promise can settle after the render-pump effect that created it
+ * has been replaced. The shared mounted ref may already be true for the new
+ * effect, so the old effect's own disposed state must participate in the
+ * generation check before it can release the active-preview gate.
+ */
+export function shouldRecoverFailedActivePreseekSchedule({
+  effectDisposed,
+  recoveredFailedSchedule,
+  scheduleVersion,
+  activeScheduleVersion,
+  mounted,
+  isPlaying,
+  currentTarget,
+  targetFrame,
+}: ShouldRecoverFailedActivePreseekScheduleParams): boolean {
   return (
-    previewFrame === null &&
-    previousPreviewFrame !== null &&
-    snapshotFrame === currentFrame
+    !effectDisposed &&
+    !recoveredFailedSchedule &&
+    scheduleVersion === activeScheduleVersion &&
+    mounted &&
+    !isPlaying &&
+    currentTarget === targetFrame
   )
 }
 

--- a/src/features/preview/utils/render-pump-preseek.test.ts
+++ b/src/features/preview/utils/render-pump-preseek.test.ts
@@ -153,6 +153,83 @@ describe('render pump preseek helpers', () => {
     )
   })
 
+  it('does not register hidden root tracks as active preview dependencies', () => {
+    const visibleTrack = makeTrack([
+      makeVideoItem({
+        id: 'visible',
+        src: 'visible.mp4',
+        from: 0,
+        durationInFrames: 20,
+        sourceStart: 0,
+        sourceFps: 30,
+        speed: 1,
+      }),
+    ])
+    const hiddenTrack = {
+      ...makeTrack([
+        makeVideoItem({
+          id: 'hidden',
+          trackId: 'track-hidden',
+          src: 'hidden.mp4',
+          from: 0,
+          durationInFrames: 20,
+          sourceStart: 0,
+          sourceFps: 30,
+          speed: 1,
+        }),
+      ]),
+      id: 'track-hidden',
+      visible: false,
+    }
+
+    expectMapCloseTo(
+      collectVisibleTrackVideoSourceTimesBySrc([visibleTrack, hiddenTrack], 10, 30),
+      new Map([['visible.mp4', [10 / 30]]]),
+    )
+  })
+
+  it('registers only solo root tracks when any track is soloed', () => {
+    const visibleNonSoloTrack = {
+      ...makeTrack([
+        makeVideoItem({
+          id: 'visible-non-solo',
+          trackId: 'track-visible',
+          src: 'visible.mp4',
+          from: 0,
+          durationInFrames: 20,
+          sourceStart: 0,
+          sourceFps: 30,
+          speed: 1,
+        }),
+      ]),
+      id: 'track-visible',
+      visible: true,
+      solo: false,
+    }
+    const hiddenSoloTrack = {
+      ...makeTrack([
+        makeVideoItem({
+          id: 'hidden-solo',
+          trackId: 'track-solo',
+          src: 'solo.mp4',
+          from: 0,
+          durationInFrames: 20,
+          sourceStart: 0,
+          sourceFps: 30,
+          speed: 1,
+        }),
+      ]),
+      id: 'track-solo',
+      visible: false,
+      solo: true,
+    }
+
+    expectMapCloseTo(
+      collectVisibleTrackVideoSourceTimesBySrc([visibleNonSoloTrack, hiddenSoloTrack], 10, 30),
+      new Map([['solo.mp4', [10 / 30]]]),
+    )
+  })
+
   it('collects transition clip source times for a frame range', () => {
     const items = [
       makeVideoItem({
@@ -542,6 +619,63 @@ describe('compound clip preseek recursion', () => {
     // relativeFrame 90 -> subCompFrame 90 -> localFrame 30 @30fps = 1.0s
     expect(result.size).toBe(1)
     expect(result.get('blob:fresh')![0]).toBeCloseTo(1.0)
+  })
+
+  it('does not gate a compound frame on video from a hidden nested track', () => {
+    const tracks = [makeMixedTrack([makeCompositionItem()])]
+    const hiddenNestedTrack = {
+      ...makeMixedTrack([]),
+      id: 'sub-track-1',
+      visible: false,
+    }
+    const result = collectVisibleTrackVideoSourceTimesBySrc(tracks, 190, 30, {
+      requireExplicitSourceFps: true,
+      resolveComposition: () => ({
+        fps: 30,
+        items: [makeSubVideoItem()],
+        tracks: [hiddenNestedTrack],
+      }),
+      resolveItemSrc: () => 'blob:hidden',
+    })
+
+    expect(result.size).toBe(0)
+  })
+
+  it('registers only solo nested tracks when a compound track is soloed', () => {
+    const tracks = [makeMixedTrack([makeCompositionItem()])]
+    const visibleNonSoloTrack = {
+      ...makeMixedTrack([]),
+      id: 'sub-track-visible',
+      visible: true,
+      solo: false,
+    }
+    const hiddenSoloTrack = {
+      ...makeMixedTrack([]),
+      id: 'sub-track-solo',
+      visible: false,
+      solo: true,
+    }
+    const result = collectVisibleTrackVideoSourceTimesBySrc(tracks, 190, 30, {
+      requireExplicitSourceFps: true,
+      resolveComposition: () => ({
+        fps: 30,
+        items: [
+          makeSubVideoItem({
+            id: 'visible-non-solo',
+            trackId: 'sub-track-visible',
+            src: 'blob:visible',
+          }),
+          makeSubVideoItem({
+            id: 'hidden-solo',
+            trackId: 'sub-track-solo',
+            src: 'blob:solo',
+          }),
+        ],
+        tracks: [visibleNonSoloTrack, hiddenSoloTrack],
+      }),
+    })
+
+    expectMapCloseTo(result, new Map([['blob:solo', [1]]]))
   })
 
   it('collects video through two nested compound clips', () => {

--- a/src/features/preview/utils/render-pump-preseek.ts
+++ b/src/features/preview/utils/render-pump-preseek.ts
@@ -1,4 +1,7 @@
-import { getVideoTargetTimeSeconds } from '@/features/preview/deps/composition-runtime'
+import {
+  getVideoTargetTimeSeconds,
+  resolveTrackRenderState,
+} from '@/features/preview/deps/composition-runtime'
 import { timelineToSourceFrames } from '@/features/preview/deps/timeline-utils'
 import type { CompositionItem, TimelineItem, TimelineTrack, VideoItem } from '@/types/timeline'
 
@@ -6,6 +9,7 @@ import type { CompositionItem, TimelineItem, TimelineTrack, VideoItem } from '@/
 export interface PreseekSubComposition {
   fps: number
   items: TimelineItem[]
+  tracks?: TimelineTrack[]
 }
 
 export interface RenderPumpSourceTimeOptions {
@@ -148,7 +152,11 @@ function collectSubCompositionVideoSourceTimes(
 
   visitedCompositionIds.add(item.compositionId)
   try {
+    const visibleTrackIds = subComp.tracks
+      ? resolveTrackRenderState(subComp.tracks).visibleTrackIds
+      : null
     for (const subItem of subComp.items) {
+      if (visibleTrackIds && !visibleTrackIds.has(subItem.trackId)) continue
       if (subItem.type === 'composition') {
         collectSubCompositionVideoSourceTimes(
           bySource,
@@ -188,7 +196,7 @@ export function collectVisibleTrackVideoSourceTimesBySrc(
 ): Map<string, number[]> {
   const bySource = new Map<string, number[]>()
 
-  for (const track of tracks) {
+  for (const track of resolveTrackRenderState(tracks).visibleTracks) {
     for (const item of track.items) {
       if (item.type === 'composition') {
         collectSubCompositionVideoSourceTimes(
@@ -443,18 +451,12 @@ export function resolveActivePreviewLookaheadTimestamps({
   const frameDuration = 1 / normalizedFps
   const sourceDelta = previousSourceTime === null ? 0 : sourceTime - previousSourceTime
   const direction: -1 | 0 | 1 =
-    Math.abs(sourceDelta) > frameDuration / 4
-      ? sourceDelta > 0
-        ? 1
-        : -1
-      : fallbackDirection
+    Math.abs(sourceDelta) > frameDuration / 4 ? (sourceDelta > 0 ? 1 : -1) : fallbackDirection
   if (direction === 0) return []
 
   const safeElapsedMs = Number.isFinite(elapsedMs) && elapsedMs > 0 ? elapsedMs : 1000
   const velocityFramesPerSecond =
-    previousSourceTime === null
-      ? 0
-      : (Math.abs(sourceDelta) * normalizedFps * 1000) / safeElapsedMs
+    previousSourceTime === null ? 0 : (Math.abs(sourceDelta) * normalizedFps * 1000) / safeElapsedMs
   const strideFrames =
     velocityFramesPerSecond >= 36
       ? Math.max(4, Math.min(120, Math.round(velocityFramesPerSecond * 0.05)))

--- a/src/features/timeline/components/timeline-header.test.tsx
+++ b/src/features/timeline/components/timeline-header.test.tsx
@@ -6,7 +6,10 @@ import { useZoomStore } from '../stores/zoom-store'
 import { useSelectionStore } from '@/shared/state/selection'
 import { TimelineHeader } from './timeline-header'
 
-const { micRenderSpy } = vi.hoisted(() => ({ micRenderSpy: vi.fn() }))
+const { micRenderSpy, sliderInput } = vi.hoisted(() => ({
+  micRenderSpy: vi.fn(),
+  sliderInput: { value: 0.75 },
+}))
 
 vi.mock('@/components/ui/slider', async () => {
   const { forwardRef } = await vi.importActual<typeof import('react')>('react')
@@ -30,8 +33,8 @@ vi.mock('@/components/ui/slider', async () => {
               type="button"
               role="slider"
               aria-valuenow={value?.[0]}
-              onMouseDown={() => onValueChange?.([0.75])}
-              onMouseUp={() => onValueCommit?.([0.75])}
+              onMouseDown={() => onValueChange?.([sliderInput.value])}
+              onMouseUp={() => onValueCommit?.([sliderInput.value])}
             />
           </span>
         </span>
@@ -50,6 +53,7 @@ vi.mock('./mic-record-control', () => ({
 describe('TimelineHeader zoom slider', () => {
   beforeEach(() => {
     micRenderSpy.mockClear()
+    sliderInput.value = 0.75
     useZoomStore.getState().setZoomLevelSynchronized(1)
     useSelectionStore.setState({
       selectedItemIds: [],
@@ -88,6 +92,23 @@ describe('TimelineHeader zoom slider', () => {
     expect(micRenderSpy).toHaveBeenCalledTimes(1)
 
     animationFrameSpy.mockRestore()
+  })
+
+  it('releases a max-zoom preview when a later zoom supersedes its queued target', () => {
+    sliderInput.value = 1
+    const onZoomChange = vi.fn()
+
+    render(<TimelineHeader onZoomChange={onZoomChange} />)
+    const slider = screen.getByTestId('zoom-slider')
+
+    fireEvent.mouseDown(screen.getByRole('slider'))
+    fireEvent.mouseUp(screen.getByRole('slider'))
+    expect(onZoomChange).toHaveBeenLastCalledWith(ZOOM_MAX)
+
+    act(() => useZoomStore.getState().setZoomLevelSynchronized(ZOOM_MIN))
+
+    expect(Number(slider.dataset.value)).toBeCloseTo(0)
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '0')
   })
 
   it('toggles the keyframe panel without a selected clip', () => {

--- a/src/features/timeline/components/timeline-header.tsx
+++ b/src/features/timeline/components/timeline-header.tsx
@@ -34,6 +34,7 @@ import { formatHotkeyBinding } from '@/config/hotkeys'
 import { useTimelineZoom } from '../hooks/use-timeline-zoom'
 import { useTimelineStore } from '../stores/timeline-store'
 import { useTimelineCommandStore } from '../stores/timeline-command-store'
+import { useZoomStore } from '../stores/zoom-store'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { useEditorStore } from '@/shared/state/editor'
 import { useSelectionStore } from '@/shared/state/selection'
@@ -95,6 +96,11 @@ function isDifferentSliderValue(previousValue: number | null, nextValue: number)
   return previousValue === null || Math.abs(previousValue - nextValue) > 0.000001
 }
 
+function isSameZoomLevel(left: number, right: number): boolean {
+  const tolerance = Math.max(0.000001, Math.max(Math.abs(left), Math.abs(right)) * 0.0001)
+  return Math.abs(left - right) <= tolerance
+}
+
 function blurActiveElement(): void {
   if (document.activeElement instanceof HTMLElement) {
     document.activeElement.blur()
@@ -113,6 +119,8 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
   const sliderRafRef = useRef<number | null>(null)
   const pendingSliderValueRef = useRef<number | null>(null)
   const latestSliderValueRef = useRef<number | null>(null)
+  const sliderInteractionRef = useRef<'idle' | 'dragging' | 'awaiting-zoom'>('idle')
+  const sliderCommitBaseZoomRef = useRef<number | null>(null)
   const btnSize = {
     width: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
     height: EDITOR_LAYOUT_CSS_VALUES.toolbarButtonSize,
@@ -168,12 +176,17 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
   useLayoutEffect(() => {
     const sliderPreviewValue = latestSliderValueRef.current
     if (sliderPreviewValue === null) return
-    const previewZoom = sliderToZoom(sliderPreviewValue)
-    const tolerance = Math.max(0.000001, previewZoom * 0.0001)
-    if (Math.abs(zoomLevel - previewZoom) <= tolerance) {
-      latestSliderValueRef.current = null
-    }
-  }, [sliderToZoom, zoomLevel])
+    if (sliderInteractionRef.current === 'dragging') return
+
+    const commitBaseZoom = sliderCommitBaseZoomRef.current
+    if (commitBaseZoom !== null && isSameZoomLevel(zoomLevel, commitBaseZoom)) return
+
+    // The first store update after release owns the controlled value even when
+    // another zoom gesture superseded the slider's queued target.
+    latestSliderValueRef.current = null
+    sliderCommitBaseZoomRef.current = null
+    sliderInteractionRef.current = 'idle'
+  }, [zoomLevel])
 
   useEffect(() => {
     return () => {
@@ -186,6 +199,8 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
   const handleSliderChange = useCallback(
     (values: number[]) => {
       const sliderValue = values[0] ?? 0.5
+      sliderInteractionRef.current = 'dragging'
+      sliderCommitBaseZoomRef.current = null
       latestSliderValueRef.current = sliderValue
       renderSliderPreview(sliderValue)
       if (onZoomChange) {
@@ -229,6 +244,8 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
     (values: number[]) => {
       const sliderValue = values[0] ?? 0.5
       const latestSliderValue = latestSliderValueRef.current
+      sliderInteractionRef.current = 'awaiting-zoom'
+      sliderCommitBaseZoomRef.current = useZoomStore.getState().level
       latestSliderValueRef.current = sliderValue
       renderSliderPreview(sliderValue)
       commitSliderZoom(sliderValue, latestSliderValue)
@@ -236,6 +253,15 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
     },
     [commitSliderZoom, renderSliderPreview],
   )
+
+  const controlledSliderValue = zoomToSlider(zoomLevel)
+  const sliderCommitBaseZoom = sliderCommitBaseZoomRef.current
+  const shouldRenderSliderPreview =
+    latestSliderValueRef.current !== null &&
+    (sliderInteractionRef.current === 'dragging' ||
+      (sliderInteractionRef.current === 'awaiting-zoom' &&
+        sliderCommitBaseZoom !== null &&
+        isSameZoomLevel(zoomLevel, sliderCommitBaseZoom)))
 
   return (
     <div className="flex items-center justify-end gap-1.5">
@@ -252,7 +278,11 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
 
       <Slider
         ref={sliderRef}
-        value={[latestSliderValueRef.current ?? zoomToSlider(zoomLevel)]}
+        value={[
+          shouldRenderSliderPreview
+            ? (latestSliderValueRef.current ?? controlledSliderValue)
+            : controlledSliderValue,
+        ]}
         onValueChange={handleSliderChange}
         onValueCommit={handleSliderCommit}
         min={0}

--- a/src/features/timeline/components/timeline-markers.test.tsx
+++ b/src/features/timeline/components/timeline-markers.test.tsx
@@ -125,6 +125,67 @@ describe('TimelineMarkers ruler scrub cancellation', () => {
     expect(playhead).toHaveStyle({ transform: 'translate3d(23px, 0, 0)' })
   })
 
+  it('keeps the skim target while moving from the ruler into timeline tracks', () => {
+    const { container } = render(
+      <div className="timeline-container" data-timeline-scroll-container>
+        <TimelineMarkers duration={10} width={1000} />
+        <div data-testid="timeline-track" />
+      </div>,
+    )
+    const ruler = container.querySelector('[style*="cursor: ew-resize"]') as HTMLDivElement
+    const track = container.querySelector('[data-testid="timeline-track"]') as HTMLDivElement
+
+    ruler.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 34,
+      width: 1000,
+      height: 34,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.mouseMove(ruler, { clientX: 100 })
+    expect(usePlaybackStore.getState().previewFrame).toBe(30)
+
+    fireEvent.mouseLeave(ruler, { relatedTarget: track })
+
+    expect(usePlaybackStore.getState().previewFrame).toBe(30)
+  })
+
+  it('clears the skim target when the pointer truly leaves the timeline', () => {
+    const { container } = render(
+      <div className="timeline-container" data-timeline-scroll-container>
+        <TimelineMarkers duration={10} width={1000} />
+      </div>,
+    )
+    const ruler = container.querySelector('[style*="cursor: ew-resize"]') as HTMLDivElement
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+
+    ruler.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 34,
+      width: 1000,
+      height: 34,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.mouseMove(ruler, { clientX: 100 })
+    expect(usePlaybackStore.getState().previewFrame).toBe(30)
+
+    fireEvent.mouseLeave(ruler, { relatedTarget: outside })
+
+    expect(usePlaybackStore.getState().previewFrame).toBeNull()
+    outside.remove()
+  })
+
   it('keeps the IO strip in its own lane above the viewport ruler canvas', () => {
     useTimelineStore.setState({ inPoint: 15, outPoint: 45 })
 

--- a/src/features/timeline/components/timeline-markers.tsx
+++ b/src/features/timeline/components/timeline-markers.tsx
@@ -859,10 +859,23 @@ export const TimelineMarkers = memo(function TimelineMarkers({
     [getFrameFromClientX, isDragging, isRangeDragging],
   )
 
-  const handleRulerMouseLeave = useCallback(() => {
-    if (isDragging || isRangeDragging) return
-    setPreviewFrameRef.current(null)
-  }, [isDragging, isRangeDragging])
+  const handleRulerMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isDragging || isRangeDragging) return
+
+      const timelineContainer = e.currentTarget.closest('[data-timeline-scroll-container]')
+      if (e.relatedTarget instanceof Node && timelineContainer?.contains(e.relatedTarget)) {
+        // The parent timeline owns skimming across both its ruler and tracks.
+        // Crossing that internal boundary is not a skim release: clearing here
+        // briefly retargets the committed frame and cancels compound-frame work
+        // before the parent publishes the next hovered frame.
+        return
+      }
+
+      setPreviewFrameRef.current(null)
+    },
+    [isDragging, isRangeDragging],
+  )
 
   const handleRangeMouseDown = useCallback(
     (e: React.PointerEvent) => {

--- a/src/features/timeline/hooks/use-timeline-slip-slide.test.tsx
+++ b/src/features/timeline/hooks/use-timeline-slip-slide.test.tsx
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from 'vite-plus/test'
+import { act, renderHook } from '@testing-library/react'
+import type { CompositionItem, TimelineItem } from '@/types/timeline'
+import { useEditorStore } from '@/shared/state/editor'
+import { resetPlaybackPreviewState } from '@/shared/state/playback-preview-test-helpers'
+import { useSelectionStore } from '@/shared/state/selection'
+import { makeTimelineTrack, makeTimelineVideoItem } from '../test-helpers'
+import { useItemsStore } from '../stores/items-store'
+import { useKeyframesStore } from '../stores/keyframes-store'
+import { useLinkedEditPreviewStore } from '../stores/linked-edit-preview-store'
+import { useSlideEditPreviewStore } from '../stores/slide-edit-preview-store'
+import { useSlipEditPreviewStore } from '../stores/slip-edit-preview-store'
+import { useTimelineCommandStore } from '../stores/timeline-command-store'
+import { useTimelineSettingsStore } from '../stores/timeline-settings-store'
+import { useTransitionsStore } from '../stores/transitions-store'
+import { useZoomStore } from '../stores/zoom-store'
+import { useTimelineSlipSlide } from './use-timeline-slip-slide'
+
+const TIMELINE_DURATION = 600
+
+/**
+ * Zoom is pinned so 1 px == 1 frame: pixelsPerSecond 30 at 30 fps means
+ * deltaFrames === deltaX in every gesture below.
+ */
+function setupStores(snapEnabled: boolean) {
+  useTimelineCommandStore.getState().clearHistory()
+  useTimelineSettingsStore.setState({ fps: 30, isDirty: false, snapEnabled })
+  useZoomStore.setState({ level: 0.3, pixelsPerSecond: 30 })
+  useItemsStore
+    .getState()
+    .setTracks([
+      makeTimelineTrack({ id: 'track-v1', name: 'V1', kind: 'video', order: 0 }),
+      makeTimelineTrack({ id: 'track-v2', name: 'V2', kind: 'video', order: 1 }),
+    ])
+  useItemsStore.getState().setItems([])
+  useTransitionsStore.getState().setTransitions([])
+  useKeyframesStore.getState().setKeyframes([])
+  useEditorStore.setState({ linkedSelectionEnabled: false })
+  useSelectionStore.getState().setDragState(null)
+  useSelectionStore.getState().setActiveSnapTarget(null)
+  useSlipEditPreviewStore.getState().clearPreview()
+  useSlideEditPreviewStore.getState().clearPreview()
+  useLinkedEditPreviewStore.getState().clear()
+  resetPlaybackPreviewState()
+}
+
+function makeSlideItems(): {
+  left: CompositionItem
+  center: CompositionItem
+  right: CompositionItem
+} {
+  const makeCompositionItem = (overrides: Partial<CompositionItem> = {}): CompositionItem => ({
+    id: 'composition-item',
+    type: 'composition',
+    trackId: 'track-v1',
+    from: 0,
+    durationInFrames: 60,
+    label: 'Compound Clip',
+    compositionId: 'composition-1',
+    compositionWidth: 1920,
+    compositionHeight: 1080,
+    sourceStart: 0,
+    sourceEnd: 60,
+    sourceDuration: 180,
+    sourceFps: 30,
+    ...overrides,
+  })
+
+  return {
+    left: makeCompositionItem({
+      id: 'left',
+      from: 0,
+      sourceStart: 0,
+      sourceEnd: 60,
+      sourceDuration: 180,
+    }),
+    center: makeCompositionItem({
+      id: 'center',
+      from: 60,
+      sourceStart: 30,
+      sourceEnd: 90,
+      sourceDuration: 180,
+    }),
+    right: makeCompositionItem({
+      id: 'right',
+      from: 120,
+      sourceStart: 40,
+      sourceEnd: 100,
+      sourceDuration: 180,
+    }),
+  }
+}
+
+function getItem(id: string): TimelineItem {
+  const item = useItemsStore.getState().itemById[id]
+  expect(item).toBeDefined()
+  return item as TimelineItem
+}
+
+function startSlide(result: { current: ReturnType<typeof useTimelineSlipSlide> }) {
+  const event = {
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    stopPropagation: () => {},
+    preventDefault: () => {},
+  } as unknown as React.MouseEvent
+
+  act(() => {
+    result.current.handleSlipSlideStart(event, 'slide')
+  })
+}
+
+function moveMouse(clientX: number) {
+  act(() => {
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX }))
+  })
+}
+
+function releaseMouse() {
+  act(() => {
+    window.dispatchEvent(new MouseEvent('mouseup'))
+  })
+}
+
+describe('useTimelineSlipSlide', () => {
+  beforeEach(() => setupStores(false))
+
+  it('preserves slide bounds and enables snapping when snap is toggled on mid-drag', () => {
+    const { left, center, right } = makeSlideItems()
+    const snapTarget = makeTimelineVideoItem({
+      id: 'snap-target',
+      trackId: 'track-v2',
+      from: 82,
+      durationInFrames: 10,
+      sourceEnd: 10,
+    })
+    useItemsStore.getState().setItems([left, center, right, snapTarget])
+    const { result } = renderHook(() => useTimelineSlipSlide(center, TIMELINE_DURATION))
+
+    startSlide(result)
+    moveMouse(10)
+
+    expect(useSlideEditPreviewStore.getState()).toMatchObject({
+      itemId: 'center',
+      leftNeighborId: 'left',
+      rightNeighborId: 'right',
+      slideDelta: 10,
+      minDelta: -40,
+      maxDelta: 59,
+    })
+
+    act(() => {
+      useTimelineSettingsStore.getState().toggleSnap()
+    })
+
+    expect(result.current.isSlipSlideActive).toBe(true)
+    expect(useSelectionStore.getState().dragState).not.toBeNull()
+    expect(useSlideEditPreviewStore.getState()).toMatchObject({
+      itemId: 'center',
+      leftNeighborId: 'left',
+      rightNeighborId: 'right',
+      slideDelta: 10,
+      minDelta: -40,
+      maxDelta: 59,
+    })
+
+    moveMouse(19)
+
+    expect(useSlideEditPreviewStore.getState()).toMatchObject({
+      itemId: 'center',
+      slideDelta: 22,
+      minDelta: -40,
+      maxDelta: 59,
+    })
+
+    releaseMouse()
+
+    expect(getItem('center').from).toBe(82)
+    expect(useSlideEditPreviewStore.getState().itemId).toBeNull()
+    expect(result.current.isSlipSlideActive).toBe(false)
+  })
+
+  it('commits the current slide when snap is toggled off before mouseup', () => {
+    setupStores(true)
+    const { left, center, right } = makeSlideItems()
+    useItemsStore.getState().setItems([left, center, right])
+    const { result } = renderHook(() => useTimelineSlipSlide(center, TIMELINE_DURATION))
+
+    startSlide(result)
+    moveMouse(10)
+
+    act(() => {
+      useTimelineSettingsStore.getState().toggleSnap()
+    })
+    releaseMouse()
+
+    expect(getItem('center').from).toBe(70)
+    expect(useSelectionStore.getState().dragState).toBeNull()
+    expect(useSlideEditPreviewStore.getState().itemId).toBeNull()
+    expect(result.current.isSlipSlideActive).toBe(false)
+  })
+
+  it('abandons the active preview when the timeline item unmounts', () => {
+    const { left, center, right } = makeSlideItems()
+    useItemsStore.getState().setItems([left, center, right])
+    const { result, unmount } = renderHook(() => useTimelineSlipSlide(center, TIMELINE_DURATION))
+
+    startSlide(result)
+    moveMouse(10)
+    expect(useSlideEditPreviewStore.getState().itemId).toBe('center')
+    expect(useSelectionStore.getState().dragState).not.toBeNull()
+
+    unmount()
+
+    expect(useSlideEditPreviewStore.getState().itemId).toBeNull()
+    expect(useSelectionStore.getState().dragState).toBeNull()
+  })
+})

--- a/src/features/timeline/hooks/use-timeline-slip-slide.ts
+++ b/src/features/timeline/hooks/use-timeline-slip-slide.ts
@@ -247,6 +247,8 @@ export function useTimelineSlipSlide(
   const latestDeltaRef = useRef(0)
   const pendingStartCleanupRef = useRef<(() => void) | null>(null)
   const slideGestureContextRef = useRef<SlideGestureContext | null>(null)
+  const snapEnabledRef = useRef(snapEnabled)
+  snapEnabledRef.current = snapEnabled
 
   const getItemFromStore = useCallback(() => {
     return useTimelineStore.getState().items.find((i) => i.id === item.id) ?? item
@@ -303,7 +305,10 @@ export function useTimelineSlipSlide(
         [currentItem.id, leftNeighbor?.id ?? '', rightNeighbor?.id ?? ''].filter(Boolean),
       )
       const snapExcludeIds = new Set<string>(slideItemIds)
-      const snapTargets = snapEnabled ? getMagneticSnapTargets() : []
+      // Cache targets for the whole gesture even when snapping starts disabled.
+      // This lets S enable snapping mid-drag without rebuilding the gesture
+      // context (which also owns the stable preview bounds).
+      const snapTargets = getMagneticSnapTargets()
       const primaryNearestNeighbors = findNearestNeighbors(currentItem, allItems)
       const leftNeighborNearestStart = leftNeighbor
         ? findNearestStartAtOrAfter(leftNeighbor, allItems, slideItemIds)
@@ -373,7 +378,7 @@ export function useTimelineSlipSlide(
         relatedTransitions,
       }
     },
-    [getMagneticSnapTargets, snapEnabled],
+    [getMagneticSnapTargets],
   )
 
   const beginSlipSlideGesture = useCallback(
@@ -946,7 +951,7 @@ export function useTimelineSlipSlide(
         const storeItem = slideContext?.currentItem ?? getItemFromStore()
 
         // Apply snapping for slide (clip edges snap to items/playhead/grid)
-        if (snapEnabled) {
+        if (snapEnabledRef.current) {
           const targets = slideContext?.snapTargets ?? getMagneticSnapTargets()
           const excludeIds =
             slideContext?.snapExcludeIds ??
@@ -1147,7 +1152,6 @@ export function useTimelineSlipSlide(
       clampSlideDelta,
       clampSlideDeltaToPreserveTransitionsWithContext,
       clampSlideDeltaWithContext,
-      snapEnabled,
       getMagneticSnapTargets,
       getSnapThresholdFrames,
     ],
@@ -1202,22 +1206,22 @@ export function useTimelineSlipSlide(
       return () => {
         window.removeEventListener('mousemove', handleMouseMove)
         window.removeEventListener('mouseup', handleMouseUp)
-        // If unmounting mid-drag, clear preview and drag state
-        if (stateRef.current.isActive) {
-          useSlipEditPreviewStore.getState().clearPreview()
-          useSlideEditPreviewStore.getState().clearPreview()
-          useLinkedEditPreviewStore.getState().clear()
-          setDragState(null)
-          latestDeltaRef.current = 0
-          slideGestureContextRef.current = null
-        }
       }
     }
-  }, [state.isActive, handleMouseMove, handleMouseUp, setDragState])
+  }, [state.isActive, handleMouseMove, handleMouseUp])
 
   useEffect(
     () => () => {
       pendingStartCleanupRef.current?.()
+      // Effect dependency changes may replace the window listeners during an
+      // active gesture. Only a true unmount should abandon its preview state.
+      if (stateRef.current.isActive) {
+        useSlipEditPreviewStore.getState().clearPreview()
+        useSlideEditPreviewStore.getState().clearPreview()
+        useLinkedEditPreviewStore.getState().clear()
+        useSelectionStore.getState().setDragState(null)
+        latestDeltaRef.current = 0
+      }
       slideGestureContextRef.current = null
     },
     [],


### PR DESCRIPTION
## What changed

- Keep compound 2-up/4-up comparison previews responsive during continuous held scrubbing by coalescing frame requests and recovering failed or superseded decode gates.
- Preserve slide-operation preview bounds when snapping is toggled with `S` mid-drag.
- Keep ruler-to-track skimming continuous instead of treating internal pointer movement as a preview release.
- Prevent cancelled or stale render generations from presenting or caching a delayed black frame, while still invalidating the committed-frame safeguard for legitimate same-frame content changes.
- Release superseded timeline zoom preview work from the preceding `develop` change included in this promotion.

## Why

High-frequency pointer movement could repeatedly cancel compound-frame work, rebuild gesture-owned state, or allow an obsolete renderer generation to publish after a newer frame had committed. This produced persistent loading states, incorrect slide bounds, and stale black preview frames at valid playhead positions.

## Impact

Compound slip/slide previews now settle continuously while the mouse remains down, snap toggling is stable during slide edits, and rapid horizontal or vertical timeline skimming retains the newest valid frame instead of being overwritten by cancelled work.

## Validation

- Focused preview/timeline regression suites: 9 files, 189 tests passed
- Full preview synchronization suite: 68/68 passed
- Preview synchronization stress: 5/5 repeated runs passed
- Production build passed
- Static checks: 0 errors (one unrelated pre-existing Fast Refresh warning)
- Feature boundary, dependency-contract, edge-budget, changed-code health, formatting, and `git diff --check` gates passed
- Local `origin/staging` + `origin/develop` merge-tree completed without conflicts