### PR TITLE
Nest expanded Motion property rows

### DIFF
--- a/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
+++ b/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
@@ -2593,7 +2593,7 @@ describe('CompositingTimeline', { timeout: 15_000 }, () => {
     expect(screen.getByTestId(`motion-layer-span-${shape.id}`)).toBeInTheDocument()
 
     const rowBefore = screen.getByText('Position').closest('.group')
-    expect(rowBefore).toHaveClass('pl-6')
+    expect(rowBefore).toHaveClass('pl-9', 'before:left-3')
     expect(screen.getByTestId('motion-layer-scroll-area')).toHaveClass(
       'overflow-x-hidden',
       'overflow-y-auto',

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -3624,10 +3624,15 @@ export const DopesheetEditor = memo(function DopesheetEditor({
         <div
           className={cn(
             'group h-full px-1 flex items-center gap-px bg-muted/8',
-            // Indent child property rows under their group header and draw a
-            // faint vertical spine so the column reads as a tree.
-            options?.indented &&
-              "relative pl-6 before:absolute before:inset-y-0 before:left-3 before:w-px before:bg-border/40 before:content-['']",
+            // Motion lanes sit beneath a layer row, so preserve that outer tree
+            // level before applying the existing property-group indentation.
+            presentation === 'lanes' &&
+              "relative before:absolute before:inset-y-0 before:left-3 before:w-px before:bg-border/40 before:content-['']",
+            presentation === 'lanes'
+              ? options?.indented
+                ? 'pl-9'
+                : 'pl-4'
+              : options?.indented && 'pl-6',
             row.controls.hasKeyframeAtCurrentFrame &&
               (presentation === 'lanes' ? 'bg-accent/70' : 'bg-primary/10'),
             showGraphPane && graphVisibleProperties.has(row.property) && 'bg-accent/40',
@@ -4289,7 +4294,13 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       )
 
       return (
-        <div className="group flex h-full items-center gap-px border-y border-border/60 bg-muted/70 pl-3 pr-0.5">
+        <div
+          className={cn(
+            'group flex h-full items-center gap-px border-y border-border/60 bg-muted/70 pl-3 pr-0.5',
+            presentation === 'lanes' &&
+              "relative pl-6 before:absolute before:inset-y-0 before:left-3 before:w-px before:bg-border/40 before:content-['']",
+          )}
+        >
           <div className="flex items-center gap-px self-stretch">
             <Button
               type="button"
@@ -4499,6 +4510,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       isPropertyLocked,
       onNavigateToKeyframe,
       onResetPropertiesToDefault,
+      presentation,
       setAllGroupsExpanded,
       setAllRowsLocked,
       setGroupLocked,

--- a/src/features/keyframes/components/dopesheet-editor/property-groups-ui.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/property-groups-ui.test.tsx
@@ -1070,6 +1070,19 @@ describe('DopesheetEditor property groups', () => {
     expect(screen.getByRole('spinbutton', { name: /x position value at playhead/i })).toBeTruthy()
   })
 
+  it('nests lane group headers and property rows beneath their owning layer', () => {
+    renderEditor({
+      presentation: 'lanes',
+      propertyColumnWidth: 420,
+    })
+
+    const groupHeader = screen.getByText('Transform').closest('div.group')
+    const propertyRow = screen.getByText('X Position').closest('div.group')
+
+    expect(groupHeader).toHaveClass('pl-6', 'before:left-3')
+    expect(propertyRow).toHaveClass('pl-9', 'before:left-3')
+  })
+
   it('keeps visibility toggles when selecting a different active row in graph mode', () => {
     renderEditor({
       keyframesByProperty: {


### PR DESCRIPTION
## Summary

- add an outer nesting level for Motion lane group headers
- indent grouped property rows beneath their owning section
- preserve the existing value-control and timeline alignment
- add focused coverage for the lane hierarchy classes

## Why

Expanded Motion property content previously started too close to the same left edge as its parent layer, so the layer, section headers, and property rows read as a flatter list. The restrained inset and guide now communicate the parent → section → property hierarchy without changing interaction behavior.

## Validation

- `npx vp check --no-fmt src/features/keyframes/components/dopesheet-editor/index.tsx src/features/keyframes/components/dopesheet-editor/property-groups-ui.test.tsx src/features/editor/components/compose-workspace/compositing-timeline.test.tsx`
- 143 focused tests passed across the dope-sheet property-group and Motion timeline suites
- live verification in the existing Chrome session confirmed 24px section padding, 36px grouped-property padding, unchanged 620px property-column width, and collapse → expand recovery
- `git merge-tree --write-tree --messages origin/staging origin/develop` completed without conflicts