### PR TITLE
(fix): correct Motion dimming and duration persistence

### DIFF
--- a/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
+++ b/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
@@ -3603,6 +3603,55 @@ describe('CompositingTimeline', { timeout: 15_000 }, () => {
     expect(screen.getByTestId('motion-comp-end-dim')).toHaveStyle({ left: '50%' })
   })
 
+  it('dims the navigator against the full content domain', () => {
+    useItemsStore.getState().setItems([{ ...shape, durationInFrames: 240 }])
+    useTimelineStore.getState().setInPoint(30)
+    useTimelineStore.getState().setOutPoint(90)
+
+    render(<CompositingTimeline />)
+
+    const overlay = screen.getByTestId('motion-navigator-active-region-overlay')
+    const activeRegionEndDim = overlay.querySelector<HTMLElement>('[data-from-frame="90"]')
+
+    expect(overlay).toHaveClass('pointer-events-none')
+    expect(screen.getByTestId('motion-navigator-comp-end-dim')).toHaveStyle({ left: '50%' })
+    expect(activeRegionEndDim).toHaveStyle({ left: '37.5%' })
+  })
+
+  it('keeps a segment trim handle interactive under the active-region dim', () => {
+    useItemsStore.getState().setItems([{ ...shape, durationInFrames: 240 }])
+
+    render(<CompositingTimeline />)
+
+    const dim = screen.getByTestId('motion-comp-end-dim')
+    const span = screen.getByTestId(`motion-layer-span-${shape.id}`)
+    const lane = span.parentElement!
+    const endHandle = screen.getByTestId(`motion-trim-end-${shape.id}`)
+    vi.spyOn(lane, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 300,
+      bottom: 34,
+      width: 300,
+      height: 34,
+      toJSON: () => ({}),
+    })
+
+    expect(dim).toHaveStyle({ left: '50%' })
+    expect(screen.getByTestId('motion-active-region-overlay')).toHaveClass('pointer-events-none')
+
+    fireEvent.pointerDown(endHandle, { pointerId: 21, button: 0, clientX: 300 })
+    fireEvent.pointerMove(endHandle, { pointerId: 21, buttons: 1, clientX: 270 })
+    fireEvent.pointerUp(endHandle, { pointerId: 21, clientX: 270 })
+
+    expect(useItemsStore.getState().itemById[shape.id]).toMatchObject({
+      from: 0,
+      durationInFrames: 216,
+    })
+  })
+
   it('reports the authored composition duration when content overhangs at fractional fps', () => {
     useCompositionsStore.getState().updateComposition('comp-1', {
       durationInFrames: 100,

--- a/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
+++ b/src/features/editor/components/compose-workspace/compositing-timeline.test.tsx
@@ -3603,19 +3603,29 @@ describe('CompositingTimeline', { timeout: 15_000 }, () => {
     expect(screen.getByTestId('motion-comp-end-dim')).toHaveStyle({ left: '50%' })
   })
 
-  it('dims the navigator against the full content domain', () => {
+  it('dims the navigator against its inset frame axis near both edges', () => {
+    useCompositionsStore.getState().updateComposition('comp-1', {
+      durationInFrames: 240,
+    })
     useItemsStore.getState().setItems([{ ...shape, durationInFrames: 240 }])
-    useTimelineStore.getState().setInPoint(30)
-    useTimelineStore.getState().setOutPoint(90)
+    useTimelineStore.getState().setInPoint(12)
+    useTimelineStore.getState().setOutPoint(228)
 
     render(<CompositingTimeline />)
 
+    const frameAxisOverlay = screen.getByTestId('motion-navigator-frame-axis-overlay')
     const overlay = screen.getByTestId('motion-navigator-active-region-overlay')
-    const activeRegionEndDim = overlay.querySelector<HTMLElement>('[data-from-frame="90"]')
+    const activeRegionStartDim = overlay.querySelector<HTMLElement>('[data-to-frame="12"]')
+    const activeRegionEndDim = overlay.querySelector<HTMLElement>('[data-from-frame="228"]')
 
+    expect(frameAxisOverlay).toHaveStyle({
+      left: `${KEYFRAME_EDGE_INSET}px`,
+      right: `${KEYFRAME_EDGE_INSET}px`,
+    })
     expect(overlay).toHaveClass('pointer-events-none')
-    expect(screen.getByTestId('motion-navigator-comp-end-dim')).toHaveStyle({ left: '50%' })
-    expect(activeRegionEndDim).toHaveStyle({ left: '37.5%' })
+    expect(screen.getByTestId('motion-navigator-comp-end-dim')).toHaveStyle({ left: '100%' })
+    expect(activeRegionStartDim).toHaveStyle({ width: '5%' })
+    expect(activeRegionEndDim).toHaveStyle({ left: '95%' })
   })
 
   it('keeps a segment trim handle interactive under the active-region dim', () => {

--- a/src/features/editor/components/compose-workspace/compositing-timeline.tsx
+++ b/src/features/editor/components/compose-workspace/compositing-timeline.tsx
@@ -6944,7 +6944,7 @@ const CompositingTimelineCore = memo(function CompositingTimelineCore({
         />
         <div
           ref={motionTimeNavigatorRef}
-          className="min-w-0 flex-1"
+          className="relative min-w-0 flex-1"
           data-testid="motion-time-navigator"
           data-start-frame={timeViewport.startFrame}
           data-end-frame={timeViewport.endFrame}
@@ -6957,6 +6957,14 @@ const CompositingTimelineCore = memo(function CompositingTimelineCore({
             onViewportPreviewStart={prepareNavigatorMotionTimeViewportPreview}
             onViewportPreview={previewMotionTimeViewport}
           />
+          <div className="pointer-events-none absolute inset-x-2 bottom-1 top-[5px] overflow-hidden rounded-sm">
+            <MotionActiveRegionOverlay
+              viewport={{ startFrame: 0, endFrame: durationInFrames }}
+              compositionEndFrame={compositionEndFrame}
+              testId="motion-navigator-active-region-overlay"
+              compositionEndTestId="motion-navigator-comp-end-dim"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/editor/components/compose-workspace/compositing-timeline.tsx
+++ b/src/features/editor/components/compose-workspace/compositing-timeline.tsx
@@ -6958,12 +6958,18 @@ const CompositingTimelineCore = memo(function CompositingTimelineCore({
             onViewportPreview={previewMotionTimeViewport}
           />
           <div className="pointer-events-none absolute inset-x-2 bottom-1 top-[5px] overflow-hidden rounded-sm">
-            <MotionActiveRegionOverlay
-              viewport={{ startFrame: 0, endFrame: durationInFrames }}
-              compositionEndFrame={compositionEndFrame}
-              testId="motion-navigator-active-region-overlay"
-              compositionEndTestId="motion-navigator-comp-end-dim"
-            />
+            <div
+              data-testid="motion-navigator-frame-axis-overlay"
+              className="absolute inset-y-0 overflow-hidden"
+              style={{ left: KEYFRAME_EDGE_INSET, right: KEYFRAME_EDGE_INSET }}
+            >
+              <MotionActiveRegionOverlay
+                viewport={{ startFrame: 0, endFrame: durationInFrames }}
+                compositionEndFrame={compositionEndFrame}
+                testId="motion-navigator-active-region-overlay"
+                compositionEndTestId="motion-navigator-comp-end-dim"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/editor/components/compose-workspace/motion-region-overlay.tsx
+++ b/src/features/editor/components/compose-workspace/motion-region-overlay.tsx
@@ -58,9 +58,13 @@ export const MotionCompEndRulerDim = memo(function MotionCompEndRulerDim({
 export const MotionActiveRegionOverlay = memo(function MotionActiveRegionOverlay({
   viewport,
   compositionEndFrame,
+  testId = 'motion-active-region-overlay',
+  compositionEndTestId = 'motion-comp-end-dim',
 }: {
   viewport: MotionRegionViewport
   compositionEndFrame: number | null
+  testId?: string
+  compositionEndTestId?: string
 }) {
   const inPoint = useTimelineStore((s) => s.inPoint)
   const outPoint = useTimelineStore((s) => s.outPoint)
@@ -74,7 +78,7 @@ export const MotionActiveRegionOverlay = memo(function MotionActiveRegionOverlay
   return (
     <div
       aria-hidden="true"
-      data-testid="motion-active-region-overlay"
+      data-testid={testId}
       className="pointer-events-none absolute inset-0 overflow-hidden"
     >
       {hasActiveRegion ? (
@@ -98,7 +102,7 @@ export const MotionActiveRegionOverlay = memo(function MotionActiveRegionOverlay
 
       {compositionEndFrame !== null ? (
         <div
-          data-testid="motion-comp-end-dim"
+          data-testid={compositionEndTestId}
           data-from-frame={compositionEndFrame ?? 0}
           data-motion-viewport-clamp
           className="absolute inset-y-0 border-l border-border/80 bg-background/55"

--- a/src/features/timeline/stores/timeline-persistence.test.ts
+++ b/src/features/timeline/stores/timeline-persistence.test.ts
@@ -82,6 +82,52 @@ describe('timeline project hydration', () => {
     ).toEqual(['project-motion'])
   })
 
+  it('hydrates an authored Motion duration without expanding it to layer overhang', async () => {
+    const overhangingLayer = makeTimelineVideoItem({
+      id: 'overhanging-layer',
+      trackId: motionTrack.id,
+      from: 50,
+      durationInFrames: 80,
+    })
+    const project: Project = {
+      id: 'project-motion-duration',
+      name: 'Motion duration project',
+      description: '',
+      createdAt: 1,
+      updatedAt: 1,
+      duration: 10,
+      metadata: { width: 1920, height: 1080, fps: 30 },
+      timeline: {
+        tracks: [rootTrack],
+        items: [],
+        compositions: [
+          {
+            id: 'motion-comp',
+            name: 'Motion composition',
+            editorKind: 'composite-2d',
+            tracks: [motionTrack],
+            items: [overhangingLayer],
+            transitions: [],
+            keyframes: [],
+            fps: 30,
+            width: 1920,
+            height: 1080,
+            durationInFrames: 100,
+          },
+        ],
+      },
+    }
+
+    await hydrateTimelineStoresFromProject(project)
+
+    const hydratedComposition =
+      useCompositionsStore.getState().compositionById['motion-comp']
+    expect(hydratedComposition?.durationInFrames).toBe(100)
+    expect(
+      hydratedComposition?.items.map((item) => item.from + item.durationInFrames),
+    ).toEqual([130])
+  })
+
   it('preserves versioned RGBA keyframe numbers during project hydration', async () => {
     const rgbaKeyframeValue = 0x100000000 + 0x12345678
     const item = makeTimelineVideoItem({ id: 'rgba-item', trackId: rootTrack.id })

--- a/src/features/timeline/stores/timeline-persistence.ts
+++ b/src/features/timeline/stores/timeline-persistence.ts
@@ -767,7 +767,7 @@ function captureTimelinePersistenceSnapshot(): TimelinePersistenceSnapshot {
     )
     const durationInFrames =
       composition.editorKind === 'composite-2d'
-        ? Math.max(1, composition.durationInFrames, contentEnd)
+        ? Math.max(1, composition.durationInFrames)
         : contentEnd
 
     return {

--- a/src/features/timeline/stores/timeline-store-facade.test.ts
+++ b/src/features/timeline/stores/timeline-store-facade.test.ts
@@ -928,7 +928,7 @@ describe('TimelineStoreFacade', () => {
       ])
     })
 
-    it('saves held Main and live Motion edits without broadcasting Main through live stores', async () => {
+    it('saves held Main and live Motion edits with authored duration without broadcasting Main', async () => {
       indexedDbMocks.getProject.mockResolvedValue({
         id: 'project-1',
         metadata: { fps: 30, width: 1920, height: 1080 },
@@ -1118,12 +1118,19 @@ describe('TimelineStoreFacade', () => {
         items: [expect.objectContaining({ id: 'motion-base' }), expect.objectContaining({
           id: 'motion-unsaved',
         })],
-        durationInFrames: 130,
+        durationInFrames: 100,
         busAudioEq: motionBus,
         markers: motionMarkers,
         inPoint: 2,
         outPoint: 70,
       })
+      expect(
+        Math.max(
+          ...(savedTimeline.compositions
+            ?.find((composition) => composition.id === 'motion-comp')
+            ?.items.map((item) => item.from + item.durationInFrames) ?? []),
+        ),
+      ).toBe(130)
 
       expect(observedItemIds).toEqual([])
       expect(observedActiveCompositionIds).toEqual([])


### PR DESCRIPTION
## What changed

- Add a pointer-transparent active-region dim overlay to the Motion navigator, mapped across the full composition duration.
- Preserve authored `composite-2d` composition duration during save while retaining content-derived duration for sequence/compound timelines.
- Add focused regression coverage for navigator mapping, dim-covered trim-handle interaction, and composition duration save/reload with layer overhang.

## Root causes

- The viewport-mapped row overlay did not cover the navigator's separate full-domain track, leaving its handle area visually brighter.
- Save-time persistence expanded `composite-2d` duration to the longest layer end, overwriting an intentionally shorter authored duration.

## User impact

Motion timeline dimming now appears continuous without blocking segment trim handles, and edited composition durations persist after save and reload even when layers extend beyond the authored duration.

## Validation

- Focused navigator overlay and segment trim-handle tests passed.
- Focused duration save and hydration tests passed.
- Scoped `npx vp check --no-fmt` passed for all six changed files.
- `git diff --check` passed.
- Live Chrome verification confirmed navigator dim continuity, covered trim-handle dragging, and composition duration persistence through save/reload.