### PR TITLE
Fix Solid transform preview alignment

### DIFF
--- a/src/features/export/utils/canvas-item-renderer.shape-rotation.test.ts
+++ b/src/features/export/utils/canvas-item-renderer.shape-rotation.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import type { ShapeItem } from '@/types/timeline'
+import {
+  createItemRenderContext,
+  createItemTransform,
+  createMockCanvasContext,
+} from './canvas-item-renderer-test-helpers'
+
+const renderShapeMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./canvas-shapes', () => ({
+  renderShape: renderShapeMock,
+}))
+
+import { renderItem } from './canvas-item-renderer'
+
+const solid: ShapeItem = {
+  id: 'solid-1',
+  type: 'shape',
+  trackId: 'track-1',
+  from: 0,
+  durationInFrames: 60,
+  label: 'Non-square Solid',
+  shapeType: 'rectangle',
+  fillColor: '#ffffff',
+  transform: { x: 0, y: 0, width: 320, height: 140 },
+}
+
+describe('canvas item renderer shape rotation', () => {
+  beforeEach(() => {
+    renderShapeMock.mockReset()
+  })
+
+  it.each([30, 90])('applies a %s degree shape rotation exactly once', async (rotation) => {
+    const ctx = createMockCanvasContext()
+
+    await renderItem(
+      ctx,
+      solid,
+      createItemTransform({ width: 320, height: 140, rotation }),
+      0,
+      createItemRenderContext(),
+    )
+
+    expect(ctx.rotate).toHaveBeenCalledOnce()
+    expect(ctx.rotate).toHaveBeenCalledWith((rotation * Math.PI) / 180)
+    expect(renderShapeMock).toHaveBeenCalledOnce()
+    expect(renderShapeMock.mock.calls[0]?.[2]).toMatchObject({
+      width: 320,
+      height: 140,
+      rotation: 0,
+    })
+  })
+})

--- a/src/features/export/utils/canvas-item-renderer/render-item.ts
+++ b/src/features/export/utils/canvas-item-renderer/render-item.ts
@@ -222,10 +222,20 @@ async function renderItemContent(
       renderSubtitleSegmentItem(ctx, effectiveItem as SubtitleSegmentItem, transform, frame, rctx)
       break
     case 'shape':
-      renderShape(ctx, effectiveItem as ShapeItem, resolveItemTransform(transform), {
-        width: rctx.canvasSettings.width,
-        height: rctx.canvasSettings.height,
-      })
+      renderShape(
+        ctx,
+        effectiveItem as ShapeItem,
+        {
+          ...resolveItemTransform(transform),
+          // The item renderer already rotated the canvas context above. Keep the
+          // standalone renderShape rotation contract without applying it twice here.
+          rotation: 0,
+        },
+        {
+          width: rctx.canvasSettings.width,
+          height: rctx.canvasSettings.height,
+        },
+      )
       break
     case 'composition':
       await renderCompositionItem(

--- a/src/features/preview/components/transform-gizmo.tsx
+++ b/src/features/preview/components/transform-gizmo.tsx
@@ -25,6 +25,7 @@ import { expandTextTransformForPreview } from '../utils/text-layout'
 import { calculateMediaCropLayout, resolveCropSettings } from '@/shared/utils/media-crop'
 import { calculateCropFromDrag, type CropEdge } from '../utils/crop-gizmo'
 import { attachWindowAnchorInteraction } from '../utils/anchor-gizmo'
+import { prepareScaleStartTransform } from '../utils/transform-calculations'
 
 interface TransformGizmoProps {
   item: TimelineItem
@@ -322,12 +323,18 @@ export function TransformGizmo({
       e.stopPropagation()
       e.preventDefault()
       const point = toCanvasPoint(e)
-      const startTransformSnapshot = { ...currentTransform }
+      const scaleStartTransform = prepareScaleStartTransform(
+        currentTransform,
+        item,
+        itemKeyframes,
+        itemPreview?.transform,
+      )
+      const startTransformSnapshot = { ...scaleStartTransform }
       const interactionId = startScale(
         item.id,
         handle,
         point,
-        currentTransform,
+        scaleStartTransform,
         item.type,
         item.transform?.aspectRatioLocked,
         strokeWidth,
@@ -352,9 +359,9 @@ export function TransformGizmo({
       })
     },
     [
-      item.id,
-      item.type,
-      item.transform?.aspectRatioLocked,
+      item,
+      itemKeyframes,
+      itemPreview?.transform,
       currentTransform,
       toCanvasPoint,
       startScale,

--- a/src/features/preview/utils/transform-calculations.test.ts
+++ b/src/features/preview/utils/transform-calculations.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+import type { ShapeItem } from '@/types/timeline'
+import type { ItemKeyframes } from '@/types/keyframe'
+import type { Transform } from '../types/gizmo'
+import { useGizmoStore } from '../stores/gizmo-store'
+import { prepareScaleStartTransform } from './transform-calculations'
+
+const currentTransform: Transform = {
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 100,
+  anchorX: 100,
+  anchorY: 50,
+  rotation: 0,
+  opacity: 1,
+}
+
+function createShape(transform: ShapeItem['transform']): ShapeItem {
+  return {
+    id: 'shape-1',
+    type: 'shape',
+    trackId: 'track-1',
+    from: 0,
+    durationInFrames: 60,
+    label: 'Solid',
+    shapeType: 'rectangle',
+    fillColor: '#ffffff',
+    transform,
+  }
+}
+
+describe('scale preview anchor semantics', () => {
+  afterEach(() => {
+    useGizmoStore.getState().cancelInteraction()
+  })
+
+  it('keeps an implicit anchor centered throughout preview and commit', () => {
+    const start = prepareScaleStartTransform(
+      currentTransform,
+      createShape({ x: 0, y: 0, width: 200, height: 100 }),
+      undefined,
+      undefined,
+    )
+
+    useGizmoStore.getState().setCanvasSize(1920, 1080)
+    useGizmoStore.getState().startScale('shape-1', 'se', { x: 1060, y: 590 }, start, 'shape', false)
+    useGizmoStore.getState().updateInteraction({ x: 1160, y: 640 }, true)
+
+    const preview = useGizmoStore.getState().previewTransform!
+    expect(preview.anchorX).toBeUndefined()
+    expect(preview.anchorY).toBeUndefined()
+    expect(preview.anchorX ?? preview.width / 2).toBe(preview.width / 2)
+    expect(preview.anchorY ?? preview.height / 2).toBe(preview.height / 2)
+
+    const committed = useGizmoStore.getState().endInteraction()
+    expect(committed?.anchorX).toBeUndefined()
+    expect(committed?.anchorY).toBeUndefined()
+  })
+
+  it('preserves explicit and animated anchor axes', () => {
+    const item = createShape({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      anchorX: 24,
+    })
+    const keyframes: ItemKeyframes = {
+      itemId: item.id,
+      properties: [
+        {
+          property: 'anchorY',
+          keyframes: [{ id: 'anchor-y', frame: 0, value: 36, easing: 'linear' }],
+        },
+      ],
+    }
+
+    expect(
+      prepareScaleStartTransform(
+        { ...currentTransform, anchorX: 24, anchorY: 36 },
+        item,
+        keyframes,
+        undefined,
+      ),
+    ).toMatchObject({ anchorX: 24, anchorY: 36 })
+  })
+})

--- a/src/features/preview/utils/transform-calculations.ts
+++ b/src/features/preview/utils/transform-calculations.ts
@@ -1,7 +1,70 @@
 import type { GizmoState, GizmoHandle, Transform, Point } from '../types/gizmo'
+import type { TimelineItem } from '@/types/timeline'
+import type { ItemKeyframes } from '@/types/keyframe'
 import { rotatePoint, getAngleFromCenter, getTransformAnchor } from './coordinate-transform'
 
 const MIN_SIZE = 20
+
+function hasAnimatedAnchorAxis(
+  item: TimelineItem,
+  itemKeyframes: ItemKeyframes | undefined,
+  axis: 'anchorX' | 'anchorY',
+): boolean {
+  if (
+    itemKeyframes?.properties.some(
+      (property) => property.property === axis && property.keyframes.length > 0,
+    ) ||
+    itemKeyframes?.vectorProperties?.some(
+      (property) => property.property === 'anchor' && property.keyframes.length > 0,
+    )
+  ) {
+    return true
+  }
+
+  const controlsAxis = (property: string): boolean => property === axis || property === 'anchor'
+  if (
+    itemKeyframes?.propertyLinks?.some(
+      (link) => link.enabled && controlsAxis(link.targetProperty),
+    ) ||
+    itemKeyframes?.expressions?.some(
+      (expression) => expression.enabled && controlsAxis(expression.targetProperty),
+    )
+  ) {
+    return true
+  }
+
+  return (
+    item.motionLayers?.some(
+      (layer) =>
+        layer.enabled &&
+        layer.tracks.some((track) => track.property === axis && track.keyframes.length > 0),
+    ) ?? false
+  )
+}
+
+/**
+ * Resolved transforms contain concrete center anchors even when the authored
+ * transform intentionally omits them. Keep those axes implicit during scale
+ * previews so the visible anchor follows the changing box center.
+ */
+export function prepareScaleStartTransform(
+  currentTransform: Transform,
+  item: TimelineItem,
+  itemKeyframes: ItemKeyframes | undefined,
+  propertiesPreview: Partial<Transform> | undefined,
+): Transform {
+  const result = { ...currentTransform }
+
+  for (const axis of ['anchorX', 'anchorY'] as const) {
+    const isExplicit =
+      item.transform?.[axis] !== undefined ||
+      propertiesPreview?.[axis] !== undefined ||
+      hasAnimatedAnchorAxis(item, itemKeyframes, axis)
+    if (!isExplicit) result[axis] = undefined
+  }
+
+  return result
+}
 
 /**
  * Calculate new transform based on current gizmo interaction.

--- a/src/runtime/composition-runtime/utils/frame-scene.test.ts
+++ b/src/runtime/composition-runtime/utils/frame-scene.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 import {
+  applyTransformOverride,
   createFrameCompositionSceneCache,
   resolveActiveShapeMasksAtFrame,
   resolveFrameCompositionScene,
@@ -9,6 +10,38 @@ import { resolveCompositionRenderPlan } from './scene-assembly'
 import { createTransformParentBinding } from '@/shared/utils/transform-parenting'
 
 describe('frame scene', () => {
+  it('recenters implicit preview anchors while retaining explicit anchors', () => {
+    const base = {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      anchorX: 100,
+      anchorY: 50,
+      rotation: 35,
+      opacity: 1,
+      cornerRadius: 0,
+    }
+
+    expect(
+      applyTransformOverride(base, {
+        width: 320,
+        height: 180,
+        anchorX: undefined,
+        anchorY: undefined,
+      }),
+    ).toMatchObject({ width: 320, height: 180, anchorX: 160, anchorY: 90 })
+
+    expect(
+      applyTransformOverride(base, {
+        width: 320,
+        height: 180,
+        anchorX: 24,
+        anchorY: 36,
+      }),
+    ).toMatchObject({ width: 320, height: 180, anchorX: 24, anchorY: 36 })
+  })
+
   function createMaskRenderPlan() {
     return resolveCompositionRenderPlan({
       tracks: [

--- a/src/runtime/composition-runtime/utils/frame-scene.ts
+++ b/src/runtime/composition-runtime/utils/frame-scene.ts
@@ -54,11 +54,23 @@ export function applyTransformOverride(
 ): ResolvedTransform {
   if (!override) return baseTransform
 
+  const hasAnchorX = Object.prototype.hasOwnProperty.call(override, 'anchorX')
+  const hasAnchorY = Object.prototype.hasOwnProperty.call(override, 'anchorY')
+
   return {
     ...baseTransform,
     ...override,
-    anchorX: override.anchorX ?? baseTransform.anchorX,
-    anchorY: override.anchorY ?? baseTransform.anchorY,
+    // An explicitly present undefined anchor is the gizmo's signal that this
+    // axis is authored implicitly. Recenter it against the preview dimensions
+    // instead of retaining the resolved center from drag start.
+    anchorX:
+      hasAnchorX && override.anchorX === undefined
+        ? (override.width ?? baseTransform.width) / 2
+        : (override.anchorX ?? baseTransform.anchorX),
+    anchorY:
+      hasAnchorY && override.anchorY === undefined
+        ? (override.height ?? baseTransform.height) / 2
+        : (override.anchorY ?? baseTransform.anchorY),
     opacity: override.opacity ?? baseTransform.opacity,
     cornerRadius: override.cornerRadius ?? baseTransform.cornerRadius,
   }


### PR DESCRIPTION
## Summary

- keep implicit Solid anchors centered throughout live and rotated resize previews
- preserve explicit, keyed, linked, expressed, and animated anchor behavior
- apply canvas shape rotation exactly once in the fast preview path
- add focused regressions for anchor ownership, rotated scaling, and non-square shape rotation

## Root causes

Resolved center anchors were being copied into scale interactions as if they were explicitly authored, and the runtime retained the drag-start anchor when preview dimensions changed. Separately, the canvas item renderer rotated both the drawing context and the shape path.

## User impact

Solid anchors, resize handles, gizmos, and rendered shapes now stay aligned during resize and rotation-slider gestures, including nonzero-rotation scaling.

## Validation

- 14 focused tests across four suites
- focused static check on all seven changed files
- live Chrome verification at 35°, 56°, and 75°, including repeated on-canvas resize releases