### PR TITLE
(fix): preserve effects during shape drags

### DIFF
--- a/src/features/preview/hooks/use-preview-playback-controller.ts
+++ b/src/features/preview/hooks/use-preview-playback-controller.ts
@@ -48,6 +48,7 @@ export function usePreviewPlaybackController({
   const [adaptiveQualityCap, setAdaptiveQualityCap] = useState<PreviewQuality>(1)
 
   usePreviewRuntimeGuards({
+    forceFastScrubOverlay,
     isGizmoInteractingRef,
     preferPlayerForDomGizmoRef,
     setAdaptiveQualityCap,

--- a/src/features/preview/hooks/use-preview-runtime-guards.ts
+++ b/src/features/preview/hooks/use-preview-runtime-guards.ts
@@ -7,6 +7,7 @@ import { useGizmoStore } from '../stores/gizmo-store'
 import { shouldPreferDomPlayerForGizmo } from '../utils/gizmo-preview-presentation'
 
 interface UsePreviewRuntimeGuardsParams {
+  forceFastScrubOverlay: boolean
   isGizmoInteractingRef: MutableRefObject<boolean>
   preferPlayerForDomGizmoRef: MutableRefObject<boolean>
   setAdaptiveQualityCap: Dispatch<SetStateAction<PreviewQuality>>
@@ -25,6 +26,7 @@ function clearPreviewFramePreservingViewedFrame() {
 }
 
 export function usePreviewRuntimeGuards({
+  forceFastScrubOverlay,
   isGizmoInteractingRef,
   preferPlayerForDomGizmoRef,
   setAdaptiveQualityCap,
@@ -42,7 +44,8 @@ export function usePreviewRuntimeGuards({
       const isInteracting = activeGizmo !== null
       isGizmoInteractingRef.current = isInteracting
       preferPlayerForDomGizmoRef.current =
-        isInteracting && shouldPreferDomPlayerForGizmo(false, activeGizmo?.itemType)
+        isInteracting &&
+        shouldPreferDomPlayerForGizmo(forceFastScrubOverlay, activeGizmo?.itemType)
 
       if (isInteracting && !wasInteracting) {
         // Clear stale hover-scrub state without rerendering the large preview
@@ -54,7 +57,7 @@ export function usePreviewRuntimeGuards({
 
     syncGizmoState(useGizmoStore.getState())
     return useGizmoStore.subscribe(syncGizmoState)
-  }, [isGizmoInteractingRef, preferPlayerForDomGizmoRef])
+  }, [forceFastScrubOverlay, isGizmoInteractingRef, preferPlayerForDomGizmoRef])
 
   useEffect(() => {
     if (!ADAPTIVE_PREVIEW_QUALITY_ENABLED) {

--- a/src/features/preview/utils/gizmo-preview-presentation.test.ts
+++ b/src/features/preview/utils/gizmo-preview-presentation.test.ts
@@ -9,9 +9,12 @@ describe('shouldPreferDomPlayerForGizmo', () => {
     },
   )
 
-  it('keeps an effected underlay rendered while a shape transform is previewed', () => {
-    expect(shouldPreferDomPlayerForGizmo(true, 'shape')).toBe(false)
-  })
+  it.each(['text', 'shape'] as const)(
+    'keeps an effected underlay rendered while a %s transform is previewed',
+    (itemType) => {
+      expect(shouldPreferDomPlayerForGizmo(true, itemType)).toBe(false)
+    },
+  )
 
   it('does not change presentation for media gizmos', () => {
     expect(shouldPreferDomPlayerForGizmo(false, 'video')).toBe(false)

--- a/src/features/preview/utils/gizmo-preview-presentation.test.ts
+++ b/src/features/preview/utils/gizmo-preview-presentation.test.ts
@@ -9,8 +9,8 @@ describe('shouldPreferDomPlayerForGizmo', () => {
     },
   )
 
-  it('keeps vector drags on the DOM path when effects force the resting overlay', () => {
-    expect(shouldPreferDomPlayerForGizmo(true, 'shape')).toBe(true)
+  it('keeps an effected underlay rendered while a shape transform is previewed', () => {
+    expect(shouldPreferDomPlayerForGizmo(true, 'shape')).toBe(false)
   })
 
   it('does not change presentation for media gizmos', () => {

--- a/src/features/preview/utils/gizmo-preview-presentation.ts
+++ b/src/features/preview/utils/gizmo-preview-presentation.ts
@@ -6,13 +6,12 @@ import type { TimelineItem } from '@/types/timeline'
  * canvas for every pointer update. Forced rendered effects keep canvas ownership.
  */
 export function shouldPreferDomPlayerForGizmo(
-  _forceRenderedOverlay: boolean,
+  forceRenderedOverlay: boolean,
   itemType: TimelineItem['type'] | null | undefined,
 ): boolean {
-  // A continuous GPU overlay may be enabled because the project contains an
-  // effect somewhere else on the timeline. Re-compositing the full frame for
-  // every vector pointer sample makes direct manipulation visibly heavy.
-  // Shape/text content already has a live DOM presentation, so let it own the
-  // interaction and restore the high-fidelity overlay on release.
-  return itemType === 'text' || itemType === 'shape'
+  // Shape/text content has a responsive live DOM presentation, but that path
+  // cannot show effects belonging to any other visible layer. Keep the
+  // composited canvas in charge when rendered content is active; otherwise use
+  // the lightweight DOM path for direct manipulation.
+  return !forceRenderedOverlay && (itemType === 'text' || itemType === 'shape')
 }


### PR DESCRIPTION
## Summary

- keep the composited preview canvas active while rendered effects are required during shape transforms
- preserve effects on video layers beneath a dragged Solid
- retain the lightweight DOM transform path for effect-free previews

## Verification

- reproduced and verified in the existing Chrome editor session across multiple mid-drag samples and release
- confirmed the underlay effect remains visible and the Solid/gizmo stay aligned
- `npx vp test src/features/preview/utils/gizmo-preview-presentation.test.ts src/features/preview/hooks/use-gpu-effects-overlay.test.ts --run`
- `npx vp check --no-fmt` on the six affected preview files
- `git diff --check`
- clean `git merge-tree` simulation against `origin/staging`