### PR TITLE
Improve timeline playback navigation

### DIFF
--- a/src/features/preview/hooks/use-preview-playback-controller.ts
+++ b/src/features/preview/hooks/use-preview-playback-controller.ts
@@ -144,13 +144,14 @@ export function usePreviewPlaybackController({
   )
 
   const handlePlayStateChange = useCallback((playing: boolean) => {
+    const playback = usePlaybackStore.getState()
+    if (playback.playbackScrubResumeTransport !== null) return
     if (playing) {
-      const playback = usePlaybackStore.getState()
       if (!playback.isPlaying) {
         playback.play()
       }
-    } else {
-      usePlaybackStore.getState().pause()
+    } else if (playback.isPlaying) {
+      playback.pause()
     }
   }, [])
 

--- a/src/features/preview/stores/playback-store.test.ts
+++ b/src/features/preview/stores/playback-store.test.ts
@@ -10,6 +10,7 @@ describe('playback-store', () => {
       isPlaying: false,
       playbackRate: 1,
       transportMode: 'normal',
+      playbackScrubResumeTransport: null,
       loop: false,
       volume: 1,
       muted: false,
@@ -93,6 +94,54 @@ describe('playback-store', () => {
       usePlaybackStore.getState().play() // already playing
       const stateD = usePlaybackStore.getState()
       expect(stateC).toBe(stateD)
+    })
+
+    it.each([
+      {
+        command: 'play',
+        run: () => usePlaybackStore.getState().play(),
+        expected: { isPlaying: true, playbackRate: 1, transportMode: 'normal' },
+      },
+      {
+        command: 'play/pause',
+        run: () => usePlaybackStore.getState().togglePlayPause(),
+        expected: { isPlaying: true, playbackRate: 1, transportMode: 'normal' },
+      },
+      {
+        command: 'forward shuttle',
+        run: () => usePlaybackStore.getState().shuttleForward(),
+        expected: { isPlaying: true, playbackRate: 1, transportMode: 'shuttle' },
+      },
+      {
+        command: 'reverse shuttle',
+        run: () => usePlaybackStore.getState().shuttleReverse(),
+        expected: { isPlaying: true, playbackRate: -1, transportMode: 'shuttle' },
+      },
+      {
+        command: 'pause',
+        run: () => usePlaybackStore.getState().pause(),
+        expected: { isPlaying: false, playbackRate: 1, transportMode: 'normal' },
+      },
+      {
+        command: 'rate change',
+        run: () => usePlaybackStore.getState().setPlaybackRate(2),
+        expected: { isPlaying: false, playbackRate: 2, transportMode: 'normal' },
+      },
+    ])('keeps a newer $command command after scrub release', ({ run, expected }) => {
+      usePlaybackStore.setState({
+        isPlaying: true,
+        playbackRate: 4,
+        transportMode: 'shuttle',
+      })
+      usePlaybackStore.getState().beginPlaybackScrub()
+
+      run()
+      usePlaybackStore.getState().resumePlaybackAfterScrub()
+
+      expect(usePlaybackStore.getState()).toMatchObject({
+        ...expected,
+        playbackScrubResumeTransport: null,
+      })
     })
 
     it('clears active skimming atomically when playback starts', () => {

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -221,6 +221,33 @@ describe('TimelineContent playback selection behavior', () => {
     })
   })
 
+  it('pages the navigator viewport when a playing playhead reaches the edge', () => {
+    const { container } = render(<TimelineContent duration={30} tracks={[VIDEO_TRACK]} />)
+    const scrollContainer = container.querySelector('[data-timeline-scroll-container]')
+    if (!(scrollContainer instanceof HTMLDivElement)) {
+      throw new Error('Expected timeline scroll container')
+    }
+
+    Object.defineProperty(scrollContainer, 'clientWidth', { configurable: true, value: 400 })
+    Object.defineProperty(scrollContainer, 'scrollWidth', { configurable: true, value: 3000 })
+    const liveScroll = vi.fn()
+    scrollContainer.addEventListener(TIMELINE_LIVE_SCROLL_EVENT, liveScroll)
+
+    act(() => {
+      usePlaybackStore.getState().setCurrentFrame(150)
+    })
+    expect(scrollContainer.scrollLeft).toBe(0)
+
+    act(() => {
+      usePlaybackStore.getState().play()
+      usePlaybackStore.getState().setCurrentFrame(151)
+    })
+
+    expect(scrollContainer.scrollLeft).toBeCloseTo(151 / 30 * 100 - 400 * 0.2)
+    expect(useTimelineViewportStore.getState().scrollLeft).toBeCloseTo(scrollContainer.scrollLeft)
+    expect(liveScroll).toHaveBeenCalledOnce()
+  })
+
   it('does not re-render the full timeline tree for live gesture zoom', () => {
     const onMetricsChange = vi.fn()
     render(

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -67,6 +67,7 @@ import {
 import { frameToPixelsNow, pixelsToFrameNow } from '../utils/zoom-conversions'
 import { applyTimelineLiveGeometry } from '../utils/timeline-live-geometry'
 import { notifyTimelineLiveScroll } from '@/shared/timeline/live-scroll-sync'
+import { getPlaybackFollowScrollLeft } from '../utils/playback-follow-scroll'
 
 const ACTIVE_TIMELINE_GESTURE_CURSOR_CLASSES = [
   'timeline-cursor-trim-left',
@@ -917,6 +918,40 @@ export const TimelineContent = memo(function TimelineContent({
       // so the sync skips a container.scrollLeft read-back, which would force a
       // synchronous reflow when a zoom width write landed the same frame.
       withPerfMeasure('tl.raf.viewportSync', () => syncViewportFromContainer(scrollLeftRef.current))
+    })
+  }, [syncViewportFromContainer])
+
+  // DaVinci-style page following: let the playhead travel naturally across the
+  // viewport, then move the native timeline (and therefore the navigator thumb)
+  // only when playback reaches an edge. This stays imperative so playback does
+  // not re-render the timeline tree on every frame.
+  useEffect(() => {
+    return usePlaybackStore.subscribe((state, previousState) => {
+      if (!state.isPlaying || state.currentFrame === previousState.currentFrame) {
+        return
+      }
+
+      const container = containerRef.current
+      if (!container) return
+
+      const cachedViewportWidth = viewportDimsRef.current?.width ?? 0
+      const viewportWidth =
+        cachedViewportWidth > 0 ? cachedViewportWidth : container.clientWidth
+      const maxScrollLeft = Math.max(0, container.scrollWidth - viewportWidth)
+      const nextScrollLeft = getPlaybackFollowScrollLeft({
+        playheadX: frameToPixelsRef.current(state.currentFrame),
+        scrollLeft: container.scrollLeft,
+        viewportWidth,
+        maxScrollLeft,
+        playbackDirection: state.playbackRate < 0 ? -1 : 1,
+      })
+      if (nextScrollLeft === null) return
+
+      velocityXRef.current = 0
+      container.scrollLeft = nextScrollLeft
+      scrollLeftRef.current = nextScrollLeft
+      syncViewportFromContainer(nextScrollLeft, true)
+      notifyTimelineLiveScroll(container)
     })
   }, [syncViewportFromContainer])
 

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -157,9 +157,6 @@ describe('TimelinePlayhead', () => {
     })
     expect(mainTimelineScrubActiveRef.current).toBe(true)
 
-    // The Player acknowledges the store pause through the same action. That
-    // echo must not erase the transport waiting to resume on release.
-    usePlaybackStore.getState().pause()
     fireEvent.mouseMove(document, { clientX: 120, clientY: 8 })
     fireEvent.mouseUp(document, { clientX: 120, clientY: 8 })
 

--- a/src/features/timeline/components/timeline-playhead.test.tsx
+++ b/src/features/timeline/components/timeline-playhead.test.tsx
@@ -21,6 +21,8 @@ describe('TimelinePlayhead', () => {
       currentFrameEpoch: 0,
       isPlaying: false,
       playbackRate: 1,
+      transportMode: 'normal',
+      playbackScrubResumeTransport: null,
       loop: false,
       volume: 1,
       muted: false,
@@ -117,7 +119,73 @@ describe('TimelinePlayhead', () => {
     })
   })
 
+  it('temporarily pauses active playback and resumes its transport from the released frame', async () => {
+    usePlaybackStore.setState({
+      isPlaying: true,
+      playbackRate: 4,
+      transportMode: 'shuttle',
+    })
+    const { container } = render(
+      <div className="timeline-ruler">
+        <TimelinePlayhead inRuler maxFrame={300} />
+      </div>,
+    )
+    const ruler = container.querySelector('.timeline-ruler') as HTMLDivElement
+    ruler.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 40,
+      width: 600,
+      height: 40,
+      toJSON: () => ({}),
+    })
+    const hitArea = container.querySelector('[data-playhead-handle]') as HTMLDivElement
+
+    fireEvent.mouseDown(hitArea, { clientX: 24, clientY: 8, button: 0 })
+
+    expect(usePlaybackStore.getState()).toMatchObject({
+      isPlaying: false,
+      playbackRate: 1,
+      transportMode: 'normal',
+      playbackScrubResumeTransport: {
+        playbackRate: 4,
+        transportMode: 'shuttle',
+      },
+    })
+    expect(mainTimelineScrubActiveRef.current).toBe(true)
+
+    // The Player acknowledges the store pause through the same action. That
+    // echo must not erase the transport waiting to resume on release.
+    usePlaybackStore.getState().pause()
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 8 })
+    fireEvent.mouseUp(document, { clientX: 120, clientY: 8 })
+
+    expect(usePlaybackStore.getState()).toMatchObject({
+      currentFrame: 36,
+      isPlaying: false,
+    })
+
+    await waitFor(() =>
+      expect(usePlaybackStore.getState()).toMatchObject({
+        currentFrame: 36,
+        isPlaying: true,
+        playbackRate: 4,
+        transportMode: 'shuttle',
+        playbackScrubResumeTransport: null,
+      }),
+    )
+    expect(mainTimelineScrubActiveRef.current).toBe(false)
+  })
+
   it('releases scrub ownership and cancels the RAF when the window loses focus', async () => {
+    usePlaybackStore.setState({
+      isPlaying: true,
+      playbackRate: -2,
+      transportMode: 'shuttle',
+    })
     const frameCallbacks: FrameRequestCallback[] = []
     const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
@@ -154,6 +222,8 @@ describe('TimelinePlayhead', () => {
     expect(timelineSkimmerScrubSignal.current).toBe(false)
     expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
     expect(usePlaybackStore.getState().previewFrame).toBeNull()
+    expect(usePlaybackStore.getState().isPlaying).toBe(false)
+    expect(usePlaybackStore.getState().playbackScrubResumeTransport).toBeNull()
     await waitFor(() => expect(document.body.style.cursor).toBe(''))
   })
 

--- a/src/features/timeline/components/timeline-playhead.tsx
+++ b/src/features/timeline/components/timeline-playhead.tsx
@@ -133,6 +133,7 @@ export function TimelinePlayhead({
   const scrubScrollContainerRef = useRef<HTMLDivElement | null>(null)
   const scrubCoordinateSurfaceRef = useRef<HTMLDivElement | null>(null)
   const scrubPlayheadElementsRef = useRef<HTMLElement[]>([])
+  const resumePlaybackRafRef = useRef<number | null>(null)
   const skimmerScrubOwnerRef = useRef({})
   const scrubThrottleStateRef = useRef(
     createScrubThrottleState({
@@ -159,6 +160,15 @@ export function TimelinePlayhead({
   useEffect(() => {
     isDraggingRef.current = isDragging
   }, [isDragging])
+
+  useEffect(() => {
+    return () => {
+      if (resumePlaybackRafRef.current !== null) {
+        cancelAnimationFrame(resumePlaybackRafRef.current)
+        usePlaybackStore.getState().cancelPlaybackScrubResume()
+      }
+    }
+  }, [])
 
   // Subscribe to playback frame changes and update position directly.
   // During playhead drags, use the same atomic scrub state as the main ruler
@@ -237,6 +247,15 @@ export function TimelinePlayhead({
       e.stopPropagation()
       // Seeking is disabled during a voiceover take (see timeline-markers).
       if (isMicRecordingActive(useMicRecordingStore.getState().status)) return
+      const playbackState = usePlaybackStore.getState()
+      if (resumePlaybackRafRef.current !== null) {
+        cancelAnimationFrame(resumePlaybackRafRef.current)
+        resumePlaybackRafRef.current = null
+        playbackState.cancelPlaybackScrubResume()
+      }
+      // Match ruler scrubbing: grabbing the playhead takes transport ownership
+      // immediately so the playback clock cannot overwrite the drag.
+      playbackState.beginPlaybackScrub()
       const { scrollContainer, coordinateSurface } = getPlayheadDragSurfaces({
         playhead: playheadRef.current,
         explicitCoordinateSurface: coordinateSurfaceRef?.current ?? null,
@@ -246,7 +265,7 @@ export function TimelinePlayhead({
         coordinateSurface,
         scrollContainer,
         e.clientX,
-        frameToPixelsRef.current(usePlaybackStore.getState().currentFrame),
+        frameToPixelsRef.current(playbackState.currentFrame),
       )
       scrubClientXRef.current = e.clientX
       scrubAnimationTimeRef.current = null
@@ -259,7 +278,7 @@ export function TimelinePlayhead({
           : []
       scrubThrottleStateRef.current = createScrubThrottleState({
         pointerX,
-        frame: usePlaybackStore.getState().currentFrame,
+        frame: playbackState.currentFrame,
         nowMs: performance.now(),
       })
       isDraggingRef.current = true
@@ -365,7 +384,7 @@ export function TimelinePlayhead({
       scrubClientXRef.current = e.clientX
     }
 
-    const handleMouseUp = () => {
+    const finishDrag = (resumePlayback: boolean) => {
       // Cancel any pending RAF before clearing preview to prevent resurrection
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current)
@@ -397,17 +416,31 @@ export function TimelinePlayhead({
       mainTimelineScrubActiveRef.current = false
       endTimelineSkimmerScrub(skimmerScrubOwner)
       setIsDragging(false)
+
+      if (resumePlayback) {
+        // Give the paused seek one paint boundary to settle before restarting.
+        // Resuming in the mouseup event lets React batch pause + resume and the
+        // previous playback clock can overwrite the released frame.
+        resumePlaybackRafRef.current = requestAnimationFrame(() => {
+          resumePlaybackRafRef.current = null
+          usePlaybackStore.getState().resumePlaybackAfterScrub()
+        })
+      } else {
+        usePlaybackStore.getState().cancelPlaybackScrubResume()
+      }
     }
+    const handleMouseUp = () => finishDrag(true)
+    const handleWindowBlur = () => finishDrag(false)
 
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
-    window.addEventListener('blur', handleMouseUp)
+    window.addEventListener('blur', handleWindowBlur)
     rafIdRef.current = requestAnimationFrame(runScrubLoop)
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
-      window.removeEventListener('blur', handleMouseUp)
+      window.removeEventListener('blur', handleWindowBlur)
       // Restore original cursor
       document.body.style.cursor = originalCursor
       // Cancel any pending RAF to prevent memory leaks
@@ -419,7 +452,7 @@ export function TimelinePlayhead({
       mainTimelineScrubActiveRef.current = false
       endTimelineSkimmerScrub(skimmerScrubOwner)
     }
-  }, [isDragging]) // Stable dependencies - no stale closures
+  }, [isDragging])
 
   return (
     <div

--- a/src/features/timeline/utils/playback-follow-scroll.test.ts
+++ b/src/features/timeline/utils/playback-follow-scroll.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { getPlaybackFollowScrollLeft } from './playback-follow-scroll'
+
+describe('getPlaybackFollowScrollLeft', () => {
+  it('leaves the viewport alone while forward playback remains visible', () => {
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 900,
+        scrollLeft: 400,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: 1,
+      }),
+    ).toBeNull()
+  })
+
+  it('pages forward with most of the new viewport available ahead', () => {
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 1200,
+        scrollLeft: 400,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: 1,
+      }),
+    ).toBe(1040)
+  })
+
+  it('pages backward with most of the new viewport available behind', () => {
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 399,
+        scrollLeft: 400,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: -1,
+      }),
+    ).toBe(0)
+  })
+
+  it('follows playback across a loop jump to the opposite side', () => {
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 100,
+        scrollLeft: 1600,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: 1,
+      }),
+    ).toBe(0)
+
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 2950,
+        scrollLeft: 0,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: -1,
+      }),
+    ).toBe(2310)
+  })
+
+  it('clamps paging to the scrollable timeline range', () => {
+    expect(
+      getPlaybackFollowScrollLeft({
+        playheadX: 3100,
+        scrollLeft: 2000,
+        viewportWidth: 800,
+        maxScrollLeft: 2400,
+        playbackDirection: 1,
+      }),
+    ).toBe(2400)
+  })
+})

--- a/src/features/timeline/utils/playback-follow-scroll.ts
+++ b/src/features/timeline/utils/playback-follow-scroll.ts
@@ -1,0 +1,56 @@
+const FORWARD_PLAYHEAD_ANCHOR = 0.2
+const REVERSE_PLAYHEAD_ANCHOR = 0.8
+const EDGE_EPSILON_PX = 1
+
+interface PlaybackFollowScrollInput {
+  playheadX: number
+  scrollLeft: number
+  viewportWidth: number
+  maxScrollLeft: number
+  playbackDirection: 1 | -1
+}
+
+/**
+ * Page the timeline only after playback reaches a viewport edge. The playhead
+ * lands toward the trailing side of the new page, leaving most of the viewport
+ * available in the active playback direction.
+ */
+export function getPlaybackFollowScrollLeft({
+  playheadX,
+  scrollLeft,
+  viewportWidth,
+  maxScrollLeft,
+  playbackDirection,
+}: PlaybackFollowScrollInput): number | null {
+  if (
+    !Number.isFinite(playheadX) ||
+    !Number.isFinite(scrollLeft) ||
+    viewportWidth <= 0 ||
+    maxScrollLeft <= 0
+  ) {
+    return null
+  }
+
+  const visibleRight = scrollLeft + viewportWidth
+  const beforeViewport = playheadX < scrollLeft
+  const atForwardEdge =
+    playbackDirection > 0 && playheadX >= visibleRight - EDGE_EPSILON_PX
+  const atReverseEdge =
+    playbackDirection < 0 && playheadX <= scrollLeft + EDGE_EPSILON_PX
+  const jumpedPastOppositeEdge =
+    (playbackDirection > 0 && beforeViewport) ||
+    (playbackDirection < 0 && playheadX > visibleRight)
+
+  if (!atForwardEdge && !atReverseEdge && !jumpedPastOppositeEdge) {
+    return null
+  }
+
+  const anchor =
+    playbackDirection > 0 ? FORWARD_PLAYHEAD_ANCHOR : REVERSE_PLAYHEAD_ANCHOR
+  const nextScrollLeft = Math.max(
+    0,
+    Math.min(maxScrollLeft, playheadX - viewportWidth * anchor),
+  )
+
+  return Math.abs(nextScrollLeft - scrollLeft) >= 0.5 ? nextScrollLeft : null
+}

--- a/src/shared/state/playback/store.ts
+++ b/src/shared/state/playback/store.ts
@@ -101,6 +101,7 @@ export const usePlaybackStore = create<PlaybackState & PlaybackActions>()(
       isPlaying: false,
       playbackRate: 1,
       transportMode: 'normal',
+      playbackScrubResumeTransport: null,
       loop: false,
       volume: 1,
       muted: false,
@@ -151,11 +152,44 @@ export const usePlaybackStore = create<PlaybackState & PlaybackActions>()(
             compositionVisualFrozen: false,
           }
         }),
+      beginPlaybackScrub: () =>
+        set((state) => ({
+          isPlaying: false,
+          playbackRate: 1,
+          transportMode: 'normal',
+          playbackScrubResumeTransport: state.isPlaying
+            ? {
+                playbackRate: state.playbackRate,
+                transportMode: state.transportMode,
+              }
+            : null,
+        })),
+      resumePlaybackAfterScrub: () =>
+        set((state) => {
+          const resumeTransport = state.playbackScrubResumeTransport
+          if (!resumeTransport) return state
+          return {
+            isPlaying: true,
+            playbackRate: resumeTransport.playbackRate,
+            transportMode: resumeTransport.transportMode,
+            playbackScrubResumeTransport: null,
+          }
+        }),
+      cancelPlaybackScrubResume: () =>
+        set((state) =>
+          state.playbackScrubResumeTransport === null
+            ? state
+            : { playbackScrubResumeTransport: null },
+        ),
       play: () => set(enterNormalPlayback),
       pause: () =>
         set((state) =>
           state.isPlaying || state.playbackRate !== 1 || state.transportMode !== 'normal'
-            ? { isPlaying: false, playbackRate: 1, transportMode: 'normal' }
+            ? {
+                isPlaying: false,
+                playbackRate: 1,
+                transportMode: 'normal',
+              }
             : state,
         ),
       togglePlayPause: () =>

--- a/src/shared/state/playback/store.ts
+++ b/src/shared/state/playback/store.ts
@@ -35,14 +35,22 @@ function enterPlayback(state: PlaybackState & PlaybackActions) {
 function enterNormalPlayback(state: PlaybackState & PlaybackActions) {
   const playbackState = enterPlayback(state)
   if (playbackState === state) {
-    return state.playbackRate === 1 && state.transportMode === 'normal'
-      ? state
-      : { playbackRate: 1, transportMode: 'normal' as const }
+    if (state.playbackRate === 1 && state.transportMode === 'normal') {
+      return state.playbackScrubResumeTransport === null
+        ? state
+        : { playbackScrubResumeTransport: null }
+    }
+    return {
+      playbackRate: 1,
+      transportMode: 'normal' as const,
+      playbackScrubResumeTransport: null,
+    }
   }
   return {
     ...playbackState,
     playbackRate: 1,
     transportMode: 'normal' as const,
+    playbackScrubResumeTransport: null,
   }
 }
 
@@ -57,6 +65,7 @@ function enterShuttlePlayback(
       ? getNextShuttleRate(state.playbackRate, direction)
       : direction,
     transportMode: 'shuttle' as const,
+    playbackScrubResumeTransport: null,
   }
 }
 
@@ -168,6 +177,9 @@ export const usePlaybackStore = create<PlaybackState & PlaybackActions>()(
         set((state) => {
           const resumeTransport = state.playbackScrubResumeTransport
           if (!resumeTransport) return state
+          if (state.isPlaying) {
+            return { playbackScrubResumeTransport: null }
+          }
           return {
             isPlaying: true,
             playbackRate: resumeTransport.playbackRate,
@@ -184,23 +196,33 @@ export const usePlaybackStore = create<PlaybackState & PlaybackActions>()(
       play: () => set(enterNormalPlayback),
       pause: () =>
         set((state) =>
-          state.isPlaying || state.playbackRate !== 1 || state.transportMode !== 'normal'
+          state.isPlaying ||
+          state.playbackRate !== 1 ||
+          state.transportMode !== 'normal' ||
+          state.playbackScrubResumeTransport !== null
             ? {
                 isPlaying: false,
                 playbackRate: 1,
                 transportMode: 'normal',
+                playbackScrubResumeTransport: null,
               }
             : state,
         ),
       togglePlayPause: () =>
         set((state) =>
           state.isPlaying
-            ? { isPlaying: false, playbackRate: 1, transportMode: 'normal' }
+            ? {
+                isPlaying: false,
+                playbackRate: 1,
+                transportMode: 'normal',
+                playbackScrubResumeTransport: null,
+              }
             : enterNormalPlayback(state),
         ),
       shuttleForward: () => set((state) => enterShuttlePlayback(state, 1)),
       shuttleReverse: () => set((state) => enterShuttlePlayback(state, -1)),
-      setPlaybackRate: (rate) => set({ playbackRate: rate }),
+      setPlaybackRate: (rate) =>
+        set({ playbackRate: rate, playbackScrubResumeTransport: null }),
       toggleLoop: () => set((state) => ({ loop: !state.loop })),
       setVolume: (volume) => set({ volume }),
       toggleMute: () => set((state) => ({ muted: !state.muted })),

--- a/src/shared/state/playback/types.ts
+++ b/src/shared/state/playback/types.ts
@@ -23,6 +23,10 @@ export interface CaptureOptions {
 
 export type PreviewQuality = 1 | 0.5 | 0.33 | 0.25
 export type PlaybackTransportMode = 'normal' | 'shuttle'
+export interface PlaybackScrubResumeTransport {
+  playbackRate: number
+  transportMode: PlaybackTransportMode
+}
 
 export interface PlaybackState {
   currentFrame: number
@@ -32,6 +36,8 @@ export interface PlaybackState {
   playbackRate: number
   /** Transient transport intent used to distinguish L at 1x from normal playback. */
   transportMode: PlaybackTransportMode
+  /** Transport to restore after a playhead drag that began during playback. */
+  playbackScrubResumeTransport: PlaybackScrubResumeTransport | null
   loop: boolean
   /**
    * Per-device monitor gain (linear, 1 = unity). Persisted to localStorage,
@@ -78,6 +84,9 @@ export interface PlaybackActions {
   setScrubFrame: (frame: number, itemId?: string | null) => void
   /** Commit a transient scrub and clear its preview/freeze in one store write. */
   finishScrub: (frame: number) => void
+  beginPlaybackScrub: () => void
+  resumePlaybackAfterScrub: () => void
+  cancelPlaybackScrubResume: () => void
   play: () => void
   pause: () => void
   togglePlayPause: () => void


### PR DESCRIPTION
## Summary
- page the timeline viewport when playback reaches an edge so the playhead and navigator stay in view
- allow direct playhead dragging during playback, then continue from the released frame
- restore the prior normal or shuttle transport after the drag and cancel resume safely on blur

## Why
During playback, the playhead could leave the visible timeline, and grabbing the playhead did not take ownership from the playback clock. This made navigation harder and prevented the expected edit-while-playing workflow.

## Validation
- `npx vp test src/features/timeline/utils/playback-follow-scroll.test.ts src/features/timeline/components/timeline-content.test.tsx src/features/timeline/components/timeline-playhead.test.tsx src/shared/state/playback/shuttle.test.ts --run` — 28 tests passed
- `npx vp check --no-fmt` on all 8 changed files — passed
- `git diff --cached --check` — passed
- live Chrome verification: forward viewport paging and drag/release playback resume
- `git merge-tree --write-tree --messages origin/staging origin/develop` — clean merge simulation