### PR TITLE
fix(export): stop dropping embedded video audio when a composition has no transitions

### DIFF
--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import type { CompositionInputProps } from '@/types/export'
 import type { AudioItem, CompositionItem, TimelineTrack, VideoItem } from '@/types/timeline'
+import type { Transition } from '@/types/transition'
 import { useCompositionsStore } from '@/features/export/deps/timeline-compositions'
 
 const { inputConstructor } = vi.hoisted(() => ({ inputConstructor: vi.fn() }))
@@ -232,6 +233,86 @@ describe('extractAudioSegments', () => {
       mediaDependencyIds: [],
       mediaDependencyVersion: 0,
     })
+  })
+
+  it('yields embedded video audio when the composition has no transitions', () => {
+    // Regression: buildManagedTransitionAudioSegments used to bail out on an
+    // empty `transitions`, silently dropping ALL embedded video audio (the
+    // export then produced a file with no audio track at all).
+    const video = makeVideoItem({ volume: 0 })
+    const composition: CompositionInputProps = {
+      fps: 30,
+      durationInFrames: 90,
+      width: 1920,
+      height: 1080,
+      tracks: [makeTrack({ id: 'track-v1', order: 0, kind: 'video', items: [video] })],
+      transitions: [],
+      keyframes: [],
+    }
+
+    const segments = extractAudioSegments(composition, composition.fps)
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0]).toMatchObject({
+      itemId: 'video-1',
+      type: 'video',
+      startFrame: 0,
+      durationFrames: 90,
+      muted: false,
+    })
+  })
+
+  it('is invariant to a transition between unrelated clips', () => {
+    // A transition between two OTHER clips must not change the mix segments of
+    // an uninvolved video (its existence used to resurrect/alter other audio).
+    const voice = makeVideoItem({ id: 'voice', trackId: 'track-v1', volume: 0 })
+    const docLeft = makeVideoItem({
+      id: 'doc2',
+      trackId: 'track-top',
+      from: 0,
+      durationInFrames: 45,
+      embeddedAudioMuted: true,
+    })
+    const docRight = makeVideoItem({
+      id: 'doc3',
+      trackId: 'track-top',
+      from: 45,
+      durationInFrames: 45,
+      embeddedAudioMuted: true,
+    })
+    const buildComposition = (withTransition: boolean): CompositionInputProps => ({
+      fps: 30,
+      durationInFrames: 90,
+      width: 1920,
+      height: 1080,
+      tracks: [
+        makeTrack({ id: 'track-v1', order: 0, kind: 'video', items: [voice] }),
+        makeTrack({ id: 'track-top', order: 1, kind: 'video', items: [docLeft, docRight] }),
+      ],
+      transitions: withTransition
+        ? [
+            {
+              id: 'tr-1',
+              type: 'fade',
+              presentation: 'fade',
+              timing: 'linear',
+              leftClipId: 'doc2',
+              rightClipId: 'doc3',
+              trackId: 'track-top',
+              durationInFrames: 2,
+            } as unknown as Transition,
+          ]
+        : [],
+      keyframes: [],
+    })
+
+    const without = extractAudioSegments(buildComposition(false), 30)
+    const withUnrelated = extractAudioSegments(buildComposition(true), 30)
+
+    const voiceWithout = without.filter((s) => s.itemId === 'voice')
+    const voiceWith = withUnrelated.filter((s) => s.itemId === 'voice')
+    expect(voiceWithout).toHaveLength(1)
+    expect(voiceWith).toEqual(voiceWithout)
   })
 
   it('skips root video audio when a linked audio companion exists', () => {

--- a/src/features/export/utils/canvas-audio.ts
+++ b/src/features/export/utils/canvas-audio.ts
@@ -283,7 +283,10 @@ function buildManagedTransitionAudioSegments<TItem extends TransitionAudioItem>(
   transitions: Transition[],
   fps: number,
 ): AudioSegment[] {
-  if (entriesById.size === 0 || transitions.length === 0) return []
+  // Entries that don't participate in any transition still yield plain segments below
+  // (zero extensions) — bailing out on empty `transitions` would silently drop the
+  // embedded audio of every video item in compositions without transitions.
+  if (entriesById.size === 0) return []
 
   const extensionByClipId = new Map<
     string,


### PR DESCRIPTION
Fixes the silent audio loss reported in #349. Opened against `develop` as you asked in that thread.

## The bug

A composition that has speech on a `video` item (embedded audio) and **no transitions** exports with **no audio track at all** — no error, no warning, the export still ends with "Export complete".

What made it look intermittent: export filters transitions by render range, so the *same project* is silent or audible depending on `--in`/`--duration`. Trimming the range to a stretch with no transition in it silently kills the audio.

## Root cause

`buildManagedTransitionAudioSegments` (`src/features/export/utils/canvas-audio.ts`) opened with:

```ts
if (entriesById.size === 0 || transitions.length === 0) return []
```

That function is the **only** path embedded video audio takes into the export mix, so an empty `transitions` list discarded every video item's audio rather than just skipping transition handling.

## The fix

One condition removed:

```ts
if (entriesById.size === 0) return []
```

This is safe because the function already handles non-participants: entries not referenced by any transition fall through to the plain-segment path further down with zero extensions (`before`/`after`/fades all 0). Dropping the guard doesn't add a new code path — it lets existing behaviour apply to the case where the transition list happens to be empty. An empty `transitions` list is now simply the degenerate case of "no entry participates in a transition", which was already correct.

`entriesById.size === 0` is kept, since with no entries there is genuinely nothing to emit.

## Verification

**Red/green on the new tests** — reverting just the source line makes exactly the two new tests fail and leaves the other 26 passing:

```
× yields embedded video audio when the composition has no transitions
× is invariant to a transition between unrelated clips
Tests  2 failed | 26 passed (28)
```

With the fix:

```
src/features/export/utils/canvas-audio.test.ts   28 passed (28)
src/features/export (whole feature)              32 files, 231 passed (231)
vp check --no-fmt src headless vite.config.ts    no warnings, lint or type errors (2353 files)
```

The second test is the one that guards the actual regression risk here: it builds the same project twice, once with a `fade` between two *unrelated* clips on another track and once without, and asserts an uninvolved video's segments come out identical. That pins down "the transition list only affects clips that are in a transition".

Beyond unit tests, this was found and confirmed on real renders — before the fix `ffprobe` showed no audio stream on the output; after it, an `aac` stream is present. It came out of driving ~80 minutes of production video through `headless/`.

## Notes on scope

- Two files, +85/−1. No behaviour change for compositions that *do* have transitions.
- I deliberately left the pre-existing `oxfmt` formatting drift in `canvas-audio.ts` alone (two unrelated type declarations at ~L1018 and ~L2113 that your own `vp fmt --check` already flags on `develop`). Your `pre-commit` hook auto-fixes them, so if you'd rather have that cleaned up it's a one-liner — I kept it out to keep this diff reviewable.
- Heads-up unrelated to this PR: `scripts/check-fallow-changed-health.mjs` in the pre-push hook resolves its base to `origin/staging`, so on a `develop`-based branch it grades ~104 upstream files and fails. With `--base origin/develop` it passes clean (2 changed files, 0 introduced). Might be worth making the base track the PR target.

Closes #349
