### PR TITLE
feat(headless): frame/layout inspection tooling + font-loading, alpha-occlusion and smoothing fixes

### DIFF
--- a/headless/frame.mjs
+++ b/headless/frame.mjs
@@ -1,0 +1,115 @@
+// FreeCut headless single-frame grab CLI.
+//
+// Renders ONE frame of a project straight to an image (default: full-res PNG)
+// by driving the real render engine inside headless Chrome. Much faster than
+// the "encode a short clip -> ffmpeg-extract a frame" loop: no muxer, no video
+// encoder, no audio pipeline — just one composited frame. Use it to eyeball an
+// element's position/appearance while iterating on a project.json.
+//
+// Usage:
+//   node headless/frame.mjs --workspace <dir> --project <id|project.json> --at <sec> [options]
+//   node headless/frame.mjs --workspace <dir> --project <id> --frame <n> --out frame.png
+//
+// Options:
+//   --at <sec>            Time to grab (seconds). Default 0.
+//   --frame <n>           Frame index to grab (overrides --at).
+//   --out <path>          Output image (default: ./headless/output/frame.<ext>)
+//   --format <f>          png|jpg|webp (default: png)
+//   --width/--height <n>  Output size (default: project resolution — full quality)
+//   --quality <0..1>      Encoder quality for jpg/webp (default: 1)
+//   --head                Run headed (visible browser) for debugging
+//   --build               Build dist/ first if the harness isn't built
+//   --harness-url <url>   Dev mode: drive a running Vite dev server instead of dist/
+import { chromium } from 'playwright'
+import fs from 'node:fs'
+import path from 'node:path'
+import { parseArgs, chromeLaunchArgs } from './lib/cli.mjs'
+import { startHarness, loadJobProject, resolveProjectMedia } from './lib/render-core.mjs'
+
+const MIME_BY_FORMAT = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+}
+const EXT_BY_MIME = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/webp': 'webp' }
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const workspace = args.workspace
+  if (!workspace) throw new Error('Missing --workspace <dir>')
+  if (!fs.existsSync(workspace)) throw new Error(`Workspace not found: ${workspace}`)
+  if (!args.project) throw new Error('Missing --project <id|project.json>')
+
+  const format = (args.format ?? 'png').toLowerCase()
+  const mime = MIME_BY_FORMAT[format]
+  if (!mime) throw new Error(`Unknown --format "${args.format}" (use png|jpg|webp)`)
+  const ext = EXT_BY_MIME[mime]
+  const outPath = path.resolve(args.out ?? path.join('headless', 'output', `frame.${ext}`))
+
+  const atSeconds = args.at !== undefined ? Number(args.at) : undefined
+  const frame = args.frame !== undefined ? Number(args.frame) : undefined
+
+  const { harnessUrl, mediaUrlOf, closeServers } = await startHarness({
+    workspace,
+    devUrl: args['harness-url'],
+    build: args.build,
+  })
+  console.log(`Harness: ${harnessUrl}`)
+
+  const browser = await chromium.launch({
+    channel: 'chrome',
+    headless: !args.head,
+    args: chromeLaunchArgs(),
+  })
+  try {
+    const context = await browser.newContext({ acceptDownloads: true })
+    const page = await context.newPage()
+    page.on('pageerror', (e) => console.error('  [pageerror]', e.message))
+    page.on('console', (m) => {
+      if (m.type() === 'error' && !m.text().includes('Video load error')) {
+        console.error('  [page:error]', m.text())
+      }
+    })
+    await page.goto(harnessUrl, { waitUntil: 'load', timeout: 60_000 })
+    await page.waitForFunction(() => Boolean(window.freecut?.ready), { timeout: 30_000 })
+
+    const { project } = loadJobProject(workspace, { project: args.project })
+    const { media, missing } = resolveProjectMedia(workspace, project, mediaUrlOf, null)
+    if (missing.length > 0) {
+      console.warn(
+        `  WARNING: ${missing.length} media source(s) not found on disk: ${missing.join(', ')}`,
+      )
+    }
+
+    fs.mkdirSync(path.dirname(outPath), { recursive: true })
+    const started = Date.now()
+    const downloadPromise = page.waitForEvent('download', { timeout: 5 * 60_000 })
+    downloadPromise.catch(() => {})
+    const summary = await page.evaluate((payload) => window.freecut.renderFrame(payload), {
+      project,
+      media,
+      frame,
+      atSeconds,
+      width: args.width ? Number(args.width) : undefined,
+      height: args.height ? Number(args.height) : undefined,
+      format: mime,
+      quality: args.quality ? Number(args.quality) : undefined,
+    })
+    const download = await downloadPromise
+    await download.saveAs(outPath)
+    console.log(
+      `  Frame ${summary.frame} (${summary.atSeconds.toFixed(3)}s) -> ${outPath}  ` +
+        `(${summary.width}x${summary.height} ${summary.format}, ` +
+        `${(summary.fileSize / 1000).toFixed(1)} KB, ${Date.now() - started}ms)`,
+    )
+  } finally {
+    await browser.close()
+    await closeServers()
+  }
+}
+
+main().catch((e) => {
+  console.error('\nFrame grab failed:', e.message ?? e)
+  process.exit(1)
+})

--- a/headless/frame.mjs
+++ b/headless/frame.mjs
@@ -103,6 +103,10 @@ async function main() {
         `(${summary.width}x${summary.height} ${summary.format}, ` +
         `${(summary.fileSize / 1000).toFixed(1)} KB, ${Date.now() - started}ms)`,
     )
+    // Same channel a full render uses: a frame that degraded (fallback fonts,
+    // for instance) must not look identical to a clean one.
+    for (const warning of summary.warnings ?? [])
+      console.warn(`  WARNING [${warning.code ?? 'UNKNOWN'}]: ${warning.message}`)
   } finally {
     await browser.close()
     await closeServers()

--- a/headless/http-security.test.mjs
+++ b/headless/http-security.test.mjs
@@ -16,7 +16,11 @@ import {
 import { loadProjectById, loadProjectFile, resolveMediaFile } from './lib/workspace.mjs'
 
 function fixture() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'freecut-http-security-'))
+  // realpath: resolveContained returns canonical paths, and macOS tmpdir lives
+  // behind the /var -> /private/var symlink — expectations must be canonical too.
+  const root = fs.realpathSync.native(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'freecut-http-security-')),
+  )
   const dist = path.join(root, 'dist')
   const workspace = path.join(root, 'workspace')
   fs.mkdirSync(path.join(dist, 'assets'), { recursive: true })

--- a/headless/layout.mjs
+++ b/headless/layout.mjs
@@ -1,0 +1,105 @@
+// FreeCut headless layout-dump CLI.
+//
+// Prints the COMPUTED on-canvas bounding box of every visible item at a given
+// frame, as JSON — WITHOUT rendering. It reuses the exact transform resolver
+// the export path uses, so the coordinates match what a render would draw. Use
+// it to verify text/shape/clip positioning (x, y, w, h, opacity, z-order)
+// without a slow render round-trip.
+//
+// Coordinates are canvas-space top-left corners (origin at the canvas top-left,
+// +x right, +y down). `z` is draw order (higher = composited on top).
+//
+// Usage:
+//   node headless/layout.mjs --workspace <dir> --project <id|project.json> --at <sec>
+//   node headless/layout.mjs --workspace <dir> --project <id> --frame <n> --out layout.json
+//
+// Options:
+//   --at <sec>           Time to inspect (seconds). Default 0.
+//   --frame <n>          Frame index to inspect (overrides --at).
+//   --out <path>         Write JSON to a file (default: print to stdout).
+//   --head               Run headed (visible browser) for debugging.
+//   --build              Build dist/ first if the harness isn't built.
+//   --harness-url <url>  Dev mode: drive a running Vite dev server instead of dist/.
+//
+// Status/logs go to stderr; only the layout JSON goes to stdout, so it pipes
+// cleanly (e.g. `... | jq '.items[] | select(.type=="text")'`).
+import { chromium } from 'playwright'
+import fs from 'node:fs'
+import path from 'node:path'
+import { parseArgs, chromeLaunchArgs } from './lib/cli.mjs'
+import { startHarness, loadJobProject, resolveProjectMedia } from './lib/render-core.mjs'
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const workspace = args.workspace
+  if (!workspace) throw new Error('Missing --workspace <dir>')
+  if (!fs.existsSync(workspace)) throw new Error(`Workspace not found: ${workspace}`)
+  if (!args.project) throw new Error('Missing --project <id|project.json>')
+
+  const atSeconds = args.at !== undefined ? Number(args.at) : undefined
+  const frame = args.frame !== undefined ? Number(args.frame) : undefined
+
+  const { harnessUrl, mediaUrlOf, closeServers } = await startHarness({
+    workspace,
+    devUrl: args['harness-url'],
+    build: args.build,
+  })
+  console.error(`Harness: ${harnessUrl}`)
+
+  const browser = await chromium.launch({
+    channel: 'chrome',
+    headless: !args.head,
+    args: chromeLaunchArgs(),
+  })
+  try {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    page.on('pageerror', (e) => console.error('  [pageerror]', e.message))
+    page.on('console', (m) => {
+      if (m.type() === 'error' && !m.text().includes('Video load error')) {
+        console.error('  [page:error]', m.text())
+      }
+    })
+    await page.goto(harnessUrl, { waitUntil: 'load', timeout: 60_000 })
+    await page.waitForFunction(() => Boolean(window.freecut?.ready), { timeout: 30_000 })
+
+    const { project } = loadJobProject(workspace, { project: args.project })
+    // Only metadata is used (source dimensions); URLs are never fetched here.
+    const { media, missing } = resolveProjectMedia(workspace, project, mediaUrlOf, null)
+    if (missing.length > 0) {
+      console.error(
+        `  NOTE: ${missing.length} media source(s) not on disk; their default size may be off: ${missing.join(', ')}`,
+      )
+    }
+
+    const layout = await page.evaluate((payload) => window.freecut.dumpLayout(payload), {
+      project,
+      media,
+      frame,
+      atSeconds,
+    })
+
+    const json = JSON.stringify(layout, null, 2)
+    if (args.out) {
+      const outPath = path.resolve(args.out)
+      fs.mkdirSync(path.dirname(outPath), { recursive: true })
+      fs.writeFileSync(outPath, json)
+      console.error(
+        `  Layout at frame ${layout.frame} (${layout.atSeconds.toFixed(3)}s): ${layout.items.length} item(s) -> ${outPath}`,
+      )
+    } else {
+      console.error(
+        `  Layout at frame ${layout.frame} (${layout.atSeconds.toFixed(3)}s): ${layout.items.length} item(s)`,
+      )
+      console.log(json)
+    }
+  } finally {
+    await browser.close()
+    await closeServers()
+  }
+}
+
+main().catch((e) => {
+  console.error('\nLayout dump failed:', e.message ?? e)
+  process.exit(1)
+})

--- a/headless/layout.mjs
+++ b/headless/layout.mjs
@@ -79,6 +79,11 @@ async function main() {
       atSeconds,
     })
 
+    // stderr, so the boxes on stdout stay pipeable into jq. A font that never
+    // became active makes every reported text box a fallback measurement.
+    for (const warning of layout.warnings ?? [])
+      console.error(`  WARNING [${warning.code ?? 'UNKNOWN'}]: ${warning.message}`)
+
     const json = JSON.stringify(layout, null, 2)
     if (args.out) {
       const outPath = path.resolve(args.out)

--- a/headless/lib/render-core.mjs
+++ b/headless/lib/render-core.mjs
@@ -155,25 +155,47 @@ export async function startHarness({ workspace, devUrl, build }) {
   }
 }
 
-/** Resolve everything needed to render one job (no browser involved). */
-export function prepareJob(workspace, jobArgs, mediaUrlOf) {
-  jobArgs = validate(renderRequestSchema, normalizeRenderInput(jobArgs))
-  const { project, projectJsonPath } = jobArgs.projectObject
-    ? { project: jobArgs.projectObject, projectJsonPath: '(inline)' }
-    : loadProject(workspace, jobArgs.project)
-  const settings = buildSettings(project, jobArgs)
-  const { hasRange, inPoint, outPoint } = computeRange(jobArgs, settings.fps)
-
-  const mediaIds = collectMediaIds(
-    project,
-    hasRange ? { inFrame: inPoint ?? 0, outFrame: outPoint ?? Number.POSITIVE_INFINITY } : null,
-  )
+/**
+ * Resolve the media a project references to `{ mediaId, url, metadata }` entries
+ * the harness can consume. `range` ({ inFrame, outFrame }) limits collection to
+ * media overlapping a slice; pass null for the whole project. Shared by the
+ * render, frame-grab, and layout-dump paths (no browser involved).
+ */
+export function resolveProjectMedia(workspace, project, mediaUrlOf, range = null) {
+  const mediaIds = collectMediaIds(project, range)
   const { files, missing } = resolveMediaFiles(workspace, mediaIds)
   const media = [...files.keys()].map((id) => ({
     mediaId: id,
     url: mediaUrlOf(id),
     metadata: readMediaMetadata(workspace, id) ?? undefined,
   }))
+  return { media, missing, mediaResolved: files.size, mediaTotal: mediaIds.length }
+}
+
+/** Load a project from a job's `project` id/path or inline `projectObject`. */
+export function loadJobProject(workspace, jobArgs) {
+  if (!jobArgs.project && !jobArgs.projectObject) throw new Error('Job missing "project"')
+  return jobArgs.projectObject
+    ? { project: jobArgs.projectObject, projectJsonPath: '(inline)' }
+    : loadProject(workspace, jobArgs.project)
+}
+
+/** Resolve everything needed to render one job (no browser involved). */
+export function prepareJob(workspace, jobArgs, mediaUrlOf) {
+  jobArgs = validate(renderRequestSchema, normalizeRenderInput(jobArgs))
+  const { project, projectJsonPath } = loadJobProject(workspace, jobArgs)
+  const settings = buildSettings(project, jobArgs)
+  const { hasRange, inPoint, outPoint } = computeRange(jobArgs, settings.fps)
+
+  const range = hasRange
+    ? { inFrame: inPoint ?? 0, outFrame: outPoint ?? Number.POSITIVE_INFINITY }
+    : null
+  const { media, missing, mediaResolved, mediaTotal } = resolveProjectMedia(
+    workspace,
+    project,
+    mediaUrlOf,
+    range,
+  )
 
   const outName = `${(project.name ?? 'freecut-export').replace(/[^\w.-]+/g, '_')}.${settings.container}`
   const outPath = path.resolve(jobArgs.out ?? path.join('headless', 'output', outName))
@@ -187,8 +209,8 @@ export function prepareJob(workspace, jobArgs, mediaUrlOf) {
     outPoint,
     media,
     missing,
-    mediaResolved: files.size,
-    mediaTotal: mediaIds.length,
+    mediaResolved,
+    mediaTotal,
     outPath,
   }
 }

--- a/headless/serve.mjs
+++ b/headless/serve.mjs
@@ -15,10 +15,18 @@
 //                                      -> the rendered video/audio file (attachment)
 //   POST /edit    { project|projectObject, ops, ... }
 //                                      -> { ok, project, applied, results } (edited project JSON)
+//   POST /frame   { project|projectObject, at?|frame?, width?, height?, format?, quality? }
+//                                      -> one composited frame image (attachment; default full-res PNG)
+//   POST /layout  { project|projectObject, at?|frame? }
+//                                      -> [{ id, type, x, y, width, height, opacity, z, ... }] (no render)
 //
 // Example:
 //   curl -X POST localhost:8787/render -H 'content-type: application/json' \
 //     -d '{"project":"<id>","codec":"vp9","duration":5}' -o out.webm
+//   curl -X POST localhost:8787/frame -H 'content-type: application/json' \
+//     -d '{"project":"<id>","at":12.5}' -o shot.png
+//   curl -s -X POST localhost:8787/layout -H 'content-type: application/json' \
+//     -d '{"project":"<id>","at":12.5}' | jq '.items[] | select(.type=="text")'
 import http from 'node:http'
 import os from 'node:os'
 import fs from 'node:fs'
@@ -37,6 +45,8 @@ import {
   renderJob,
   startHarness,
   warningsHeaderValue,
+  loadJobProject,
+  resolveProjectMedia,
 } from './lib/render-core.mjs'
 import { OperationQueue, OperationQueueError } from './lib/operation-queue.mjs'
 import { PageSession, probeGpu } from './lib/page-session.mjs'
@@ -101,6 +111,19 @@ export function resolveHost(args = {}, env = process.env) {
     throw new Error('Host must be a non-empty string (--host or FREECUT_HOST)')
   }
   return host.trim()
+}
+
+const IMAGE_MIME_BY_FORMAT = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+}
+const IMAGE_EXT_BY_MIME = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/webp': 'webp' }
+
+/** Strip non-ASCII so a value is always a legal HTTP header (never 500s a response). */
+function asciiHeader(value) {
+  return JSON.stringify(value).replace(/[^\t\x20-\x7E]/g, ' ')
 }
 
 function sendJson(res, status, obj) {
@@ -454,6 +477,82 @@ async function main() {
     })
   }
 
+  // Grab a single composited frame (default: full-res PNG) — no encoder/muxer,
+  // much faster than /render + extract for eyeballing a position on a warm page.
+  const handleFrame = async (req, res) => {
+    const body = await readJsonBody(req)
+    if (body.project) assertSinglePathComponent(body.project, 'project id')
+    const project =
+      body.projectObject ?? loadJobProject(workspace, { project: body.project }).project
+    const { media, missing } = resolveProjectMedia(workspace, project, mediaUrlOf, null)
+    const format = (body.format ?? 'png').toLowerCase()
+    const mime = IMAGE_MIME_BY_FORMAT[format] ?? 'image/png'
+    const outPath = path.join(
+      tmpDir,
+      `frame-${process.pid}-${++counter}.${IMAGE_EXT_BY_MIME[mime]}`,
+    )
+
+    const t0 = Date.now()
+    const summary = await queue.enqueue(
+      async () => {
+        const downloadPromise = session.page.waitForEvent('download', { timeout: 5 * 60_000 })
+        downloadPromise.catch(() => {})
+        const s = await session.page.evaluate((payload) => window.freecut.renderFrame(payload), {
+          project,
+          media,
+          frame: body.frame,
+          atSeconds: body.at ?? body.atSeconds,
+          width: body.width,
+          height: body.height,
+          format: mime,
+          quality: body.quality,
+        })
+        const download = await downloadPromise
+        await download.saveAs(outPath)
+        return s
+      },
+      { timeoutMs: renderTimeoutMs, kind: 'frame' },
+    )
+    console.log(
+      `frame ${project.name ?? project.id} @${summary.frame} (${summary.atSeconds.toFixed(3)}s) -> ` +
+        `${summary.width}x${summary.height} ${IMAGE_EXT_BY_MIME[mime]} ` +
+        `(${(summary.fileSize / 1000).toFixed(1)}KB) in ${Date.now() - t0}ms`,
+    )
+
+    res.writeHead(200, {
+      'Content-Type': mime,
+      'Content-Length': fs.statSync(outPath).size,
+      'Content-Disposition': `attachment; filename="${path.basename(outPath)}"`,
+      'X-Freecut-Frame': String(summary.frame),
+      ...(missing.length ? { 'X-Freecut-Missing-Media': asciiHeader(missing) } : {}),
+    })
+    const stream = fs.createReadStream(outPath)
+    stream.pipe(res)
+    stream.on('close', () => fs.rm(outPath, () => {}))
+  }
+
+  // Dump computed on-canvas bounding boxes at a frame (no render/GPU) — trust
+  // coordinates without a render round-trip.
+  const handleLayout = async (req, res) => {
+    const body = await readJsonBody(req)
+    if (body.project) assertSinglePathComponent(body.project, 'project id')
+    const project =
+      body.projectObject ?? loadJobProject(workspace, { project: body.project }).project
+    // Only metadata (source dimensions) is used; media URLs are never fetched.
+    const { media } = resolveProjectMedia(workspace, project, mediaUrlOf, null)
+    const layout = await queue.enqueue(
+      () =>
+        session.page.evaluate((payload) => window.freecut.dumpLayout(payload), {
+          project,
+          media,
+          frame: body.frame,
+          atSeconds: body.at ?? body.atSeconds,
+        }),
+      { timeoutMs: editTimeoutMs, kind: 'layout' },
+    )
+    sendJson(res, 200, layout)
+  }
+
   const server = http.createServer((req, res) => {
     const url = new URL(req.url ?? '/', 'http://localhost')
     const route = `${req.method} ${url.pathname}`
@@ -551,7 +650,11 @@ async function main() {
                                     ? () => handleRender(req, res)
                                     : route === 'POST /edit'
                                       ? () => handleEdit(req, res)
-                                      : null
+                                      : route === 'POST /frame'
+                                        ? () => handleFrame(req, res)
+                                        : route === 'POST /layout'
+                                          ? () => handleLayout(req, res)
+                                          : null
     if (!handler) {
       sendJson(res, 404, { error: `No route: ${route}` })
       return
@@ -598,7 +701,9 @@ async function main() {
   // Network exposure must be an explicit CLI/environment configuration choice.
   await new Promise((resolve) => server.listen(port, host, resolve))
   console.log(`FreeCut render service on http://${host}:${port}  (workspace: ${workspace})`)
-  console.log(`  GET /health  GET /capabilities  GET /projects  POST /render  POST /edit`)
+  console.log(
+    `  GET /health  GET /capabilities  GET /projects  POST /render  POST /edit  POST /frame  POST /layout`,
+  )
 
   let shuttingDown
   const shutdown = () =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4784,6 +4784,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4800,6 +4801,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4816,6 +4818,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4832,6 +4835,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4848,6 +4852,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4864,6 +4869,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4880,6 +4886,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4896,6 +4903,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4912,6 +4920,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4928,6 +4937,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4944,6 +4954,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4960,6 +4971,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4976,6 +4988,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4992,6 +5005,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5008,6 +5022,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5024,6 +5039,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5040,6 +5056,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5056,6 +5073,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5072,6 +5090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5088,6 +5107,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "test:preview-sync:stress": "node scripts/preview-sync-stress.mjs --runs 20",
     "test:coverage": "vp test run --coverage",
     "headless": "node headless/render.mjs",
+    "headless:frame": "node headless/frame.mjs",
+    "headless:layout": "node headless/layout.mjs",
     "headless:edit": "node headless/edit.mjs",
     "headless:serve": "node headless/serve.mjs",
     "headless:agent": "node headless/agent.mjs",

--- a/src/features/export/utils/canvas-item-renderer/composition.ts
+++ b/src/features/export/utils/canvas-item-renderer/composition.ts
@@ -441,6 +441,12 @@ function isSubCompFullyOccludingItem(
 ): boolean {
   if (localFrame < item.from || localFrame >= item.from + item.durationInFrames) return false
   if (item.type !== 'video' && item.type !== 'image') return false
+  // A video whose source can carry alpha is not opaque even at full cover, so it
+  // must not cull the layers beneath it (mirrors the top-level guard in
+  // frame-occlusion.ts). Without this, a full-canvas transparent overlay INSIDE a
+  // pre-composition would reveal the black base fill instead of the clip below.
+  if (item.type === 'video' && rctx.videoExtractors.get(item.id)?.getCanBeTransparent())
+    return false
   if (item.blendMode && item.blendMode !== 'normal') return false
   if (hasCornerPin(item.cornerPin)) return false
   // Use the same preview-override path as the renderer above. Otherwise a

--- a/src/features/export/utils/canvas-item-renderer/media-draw.ts
+++ b/src/features/export/utils/canvas-item-renderer/media-draw.ts
@@ -230,6 +230,11 @@ export function drawContainedMediaSource(
       scratchCtx.clearRect(0, 0, canvas.width, canvas.height)
     }
 
+    // Match the main export context: the source is drawn scaled here, so default
+    // smoothing would soften it before the 1:1 blit back onto the target canvas.
+    scratchCtx.imageSmoothingEnabled = true
+    scratchCtx.imageSmoothingQuality = 'high'
+
     scratchCtx.save()
     clipToViewport(scratchCtx, drawLayout.viewportRect)
     drawSource(scratchCtx)

--- a/src/features/export/utils/canvas-item-renderer/video.test.ts
+++ b/src/features/export/utils/canvas-item-renderer/video.test.ts
@@ -80,6 +80,7 @@ describe('renderVideoItem', () => {
       captureFrame: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 1),
       prewarmBatch: vi.fn(async () => 0),
       isBatchPrewarmAvailable: vi.fn(() => true),
@@ -143,6 +144,7 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture,
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
     const scrubbingCache = {
@@ -172,6 +174,7 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
     const ctx = createCanvasContext()
@@ -202,6 +205,7 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
     const isActivePreviewFrameSuperseded = vi.fn(() => true)
@@ -233,12 +237,10 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
-    const isActivePreviewFrameSuperseded = vi
-      .fn()
-      .mockReturnValueOnce(false)
-      .mockReturnValue(true)
+    const isActivePreviewFrameSuperseded = vi.fn().mockReturnValueOnce(false).mockReturnValue(true)
     const markActivePreviewFramePending = vi.fn()
     const renderContext = createRenderContext({
       videoExtractors: new Map([[item.id, extractor]]),
@@ -266,6 +268,7 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
     const markActivePreviewFramePending = vi.fn()
@@ -295,6 +298,7 @@ describe('renderVideoItem', () => {
       drawFrameWithCapture: vi.fn(),
       getLastFailureKind: vi.fn(() => 'none' as const),
       getDimensions: vi.fn(() => ({ width: 1920, height: 1080 })),
+      getCanBeTransparent: vi.fn(() => false),
       getDuration: vi.fn(() => 30),
     }
     const markActivePreviewFramePending = vi.fn()
@@ -492,5 +496,4 @@ describe('renderVideoItem', () => {
 
     expect(markActivePreviewFramePending).toHaveBeenCalledOnce()
   })
-
 })

--- a/src/features/export/utils/canvas-render-orchestrator.ts
+++ b/src/features/export/utils/canvas-render-orchestrator.ts
@@ -709,10 +709,19 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
     throw new Error('Failed to create OffscreenCanvas 2D context')
   }
 
+  // High-quality smoothing: media is often drawn scaled (e.g. cover-fill upscale),
+  // and the default ('low') visibly softens fine detail like small slide text.
+  ctx.imageSmoothingEnabled = true
+  ctx.imageSmoothingQuality = 'high'
+
   // Create output canvas at EXPORT resolution (for encoding)
   // If no scaling needed, we'll use renderCanvas directly
   const outputCanvas = needsScaling ? new OffscreenCanvas(exportWidth, exportHeight) : renderCanvas
   const outputCtx = needsScaling ? outputCanvas.getContext('2d')! : ctx
+  if (needsScaling) {
+    outputCtx.imageSmoothingEnabled = true
+    outputCtx.imageSmoothingQuality = 'high'
+  }
 
   onProgress({
     phase: 'preparing',
@@ -1049,6 +1058,11 @@ export async function renderSingleFrame(options: SingleFrameOptions): Promise<Bl
   if (!renderCtx) {
     throw new Error('Failed to get 2d context')
   }
+
+  // Match the export composition context so single-frame output is
+  // pixel-consistent with the final render (scaled media draws stay sharp).
+  renderCtx.imageSmoothingEnabled = true
+  renderCtx.imageSmoothingQuality = 'high'
 
   // Use the SAME renderer as export – single source of truth
   const renderer = await createCompositionRenderer(composition, renderCanvas, renderCtx)

--- a/src/features/export/utils/canvas-video-extractor.ts
+++ b/src/features/export/utils/canvas-video-extractor.ts
@@ -51,6 +51,8 @@ interface MediabunnyVideoTrack {
   displayWidth: number
   displayHeight: number
   canDecode?: () => Promise<boolean>
+  /** True if the track's samples may carry an alpha channel (e.g. VP9/VP8/AV1 with alpha, ProRes 4444). */
+  canBeTransparent?: () => Promise<boolean>
 }
 
 export interface DrawFrameCaptureResult {
@@ -77,6 +79,12 @@ export class VideoFrameExtractor {
   private videoTrack: MediabunnyVideoTrack | null = null
   private duration: number = 0
   private ready: boolean = false
+  /**
+   * Whether the decoded source can carry alpha (resolved once during init).
+   * Consumed by occlusion culling so a full-canvas transparent video never
+   * culls the layers beneath it. Defaults to false (opaque) until init runs.
+   */
+  private canBeTransparent: boolean = false
   private drawFailureCount = 0
   private sampleIterator: AsyncGenerator<MediabunnySample, void, unknown> | null = null
   private currentSample: MediabunnySample | null = null
@@ -138,6 +146,19 @@ export class VideoFrameExtractor {
           )
           return false
         }
+      }
+
+      // Resolve alpha capability once (codec/container-level signal). VideoSampleSink
+      // decodes and merges alpha side-data automatically, so a transparent source
+      // draws with real alpha — occlusion culling must know this to avoid hiding
+      // the layers beneath a full-canvas transparent overlay.
+      // NOTE: this is a *capability* signal ("may contain alpha"), not per-frame
+      // truth. A fully-opaque clip in an alpha-capable container (VP8/VP9/AV1 with
+      // alpha, ProRes 4444) will conservatively disable occlusion culling for the
+      // layers beneath it — identical output, just a little more work. Opaque H.264
+      // reports false, so the common case (plain video base track) keeps culling.
+      if (typeof this.videoTrack.canBeTransparent === 'function') {
+        this.canBeTransparent = await this.videoTrack.canBeTransparent().catch(() => false)
       }
 
       // Get duration
@@ -675,6 +696,18 @@ export class VideoFrameExtractor {
    */
   getDuration(): number {
     return this.duration
+  }
+
+  /**
+   * Whether the source may carry alpha (resolved during init). Used by occlusion
+   * culling so a full-canvas transparent video does not cull the layers below it.
+   * A source that is not ready (init failed or still pending) cannot paint any
+   * pixels, so it must never be treated as an opaque occluder either — otherwise
+   * a full-canvas video that failed to init would cull every layer beneath it
+   * and the frame would render as a black card.
+   */
+  getCanBeTransparent(): boolean {
+    return this.canBeTransparent || !this.ready
   }
 
   /**

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -2234,6 +2234,8 @@ export async function createCompositionRenderer(
         getCurrentKeyframes,
         getPreviewEffectsOverride,
         getLiveItemSnapshot,
+        hasTransparentVideoSource: (occItem) =>
+          videoExtractors.get(occItem.id)?.getCanBeTransparent() ?? false,
       }
       const isFullyOccluding = (baseItem: TimelineItem, trackOrder: number): boolean =>
         isItemFullyOccluding(baseItem, trackOrder, occlusionContext)

--- a/src/features/export/utils/frame-occlusion.test.ts
+++ b/src/features/export/utils/frame-occlusion.test.ts
@@ -111,6 +111,22 @@ describe('isItemFullyOccluding', () => {
     expect(isItemFullyOccluding(makeVideoItem(), 0, makeContext())).toBe(false)
   })
 
+  it('returns false for a full-cover video whose source can be transparent', () => {
+    const ctx = makeContext({ hasTransparentVideoSource: () => true })
+    expect(isItemFullyOccluding(makeVideoItem(), 0, ctx)).toBe(false)
+  })
+
+  it('returns true for a full-cover video whose source is opaque', () => {
+    const ctx = makeContext({ hasTransparentVideoSource: () => false })
+    expect(isItemFullyOccluding(makeVideoItem(), 0, ctx)).toBe(true)
+  })
+
+  it('ignores the transparent-source check for images (video-only)', () => {
+    const image = { ...makeVideoItem(), type: 'image' } as unknown as ImageItem
+    const ctx = makeContext({ hasTransparentVideoSource: () => true })
+    expect(isItemFullyOccluding(image, 0, ctx)).toBe(true)
+  })
+
   it('returns true for a 180-degree rotation (still covers)', () => {
     vi.mocked(getAnimatedTransform).mockReturnValue(fullCoverTransform({ rotation: 180 }) as never)
     expect(isItemFullyOccluding(makeVideoItem(), 0, makeContext())).toBe(true)

--- a/src/features/export/utils/frame-occlusion.ts
+++ b/src/features/export/utils/frame-occlusion.ts
@@ -18,6 +18,12 @@ export interface FrameOcclusionContext {
   adjustmentLayers: AdjustmentLayerWithTrackOrder[]
   getCurrentItem: <TItem extends TimelineItem>(item: TItem) => TItem
   getCurrentKeyframes: (itemId: string) => ItemKeyframes | undefined
+  /**
+   * True when a video item's decoded source may carry an alpha channel, so it is
+   * NOT opaque and must never occlude the layers beneath it. Optional: when
+   * absent (e.g. before media init), items are treated as opaque as before.
+   */
+  hasTransparentVideoSource?: (item: TimelineItem) => boolean
   getPreviewEffectsOverride?: (itemId: string) => ItemEffect[] | undefined
   getLiveItemSnapshot?: (itemId: string) => TimelineItem | undefined
 }
@@ -51,11 +57,18 @@ export function isItemFullyOccluding(
     getCurrentKeyframes,
     getPreviewEffectsOverride,
     getLiveItemSnapshot,
+    hasTransparentVideoSource,
   } = ctx
 
   const item = getCurrentItem(baseItem)
   // Only videos and images can be fully opaque
   if (item.type !== 'video' && item.type !== 'image') return false
+
+  // A video whose source carries an alpha channel is not opaque even at full
+  // cover — culling the layers below would wrongly reveal the black base fill.
+  // (Images decode to alpha-carrying bitmaps drawn as-is; only video needs this
+  // codec-level check since its opacity depends on the decoded frame's format.)
+  if (item.type === 'video' && hasTransparentVideoSource?.(item)) return false
 
   // Items in transitions are blended, not fully occluding
   if (transitionClipIds.has(item.id)) return false

--- a/src/features/export/utils/reverse-video-frame-cache.test.ts
+++ b/src/features/export/utils/reverse-video-frame-cache.test.ts
@@ -39,6 +39,9 @@ function makeExtractor(): VideoFrameSource & {
     getDuration() {
       return 10
     },
+    getCanBeTransparent() {
+      return false
+    },
     async prewarmBatch() {
       return -1
     },

--- a/src/features/export/utils/shared-video-extractor.ts
+++ b/src/features/export/utils/shared-video-extractor.ts
@@ -32,6 +32,8 @@ export interface VideoFrameSource {
   getLastFailureKind(): VideoFrameFailureKind
   getDimensions(): { width: number; height: number }
   getDuration(): number
+  /** Whether the source may carry alpha (transparent video). False until init resolves it. */
+  getCanBeTransparent(): boolean
   prewarmBatch(
     ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
     timestamps: number[],
@@ -216,6 +218,10 @@ class SharedItemVideoSource implements VideoFrameSource {
 
   getDuration(): number {
     return this.pool.getItemDuration(this.itemId, this.src)
+  }
+
+  getCanBeTransparent(): boolean {
+    return this.pool.getItemCanBeTransparent(this.itemId, this.src)
   }
 
   prewarmBatch(
@@ -432,6 +438,11 @@ export class SharedVideoExtractorPool {
   getItemDuration(itemId: string, src: string): number {
     const extractor = this.getExtractorForItem(itemId, src)
     return extractor?.getDuration() ?? this.sourceStates.get(src)?.duration ?? 0
+  }
+
+  getItemCanBeTransparent(itemId: string, src: string): boolean {
+    const extractor = this.getExtractorForItem(itemId, src)
+    return extractor?.getCanBeTransparent() ?? false
   }
 
   /**

--- a/src/features/settings/components/hotkey-editor-search.test.ts
+++ b/src/features/settings/components/hotkey-editor-search.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { describe, expect, it } from 'vite-plus/test'
-import { HOTKEYS } from '@/config/hotkeys'
+import { HOTKEYS, formatHotkeyBinding } from '@/config/hotkeys'
 import {
   HOTKEY_EDITOR_SECTIONS,
   getHotkeyBindingDisplayLabel,
@@ -42,7 +42,13 @@ describe('getHotkeyBindingDisplayLabel', () => {
     expect(getHotkeyBindingDisplayLabel('', 'Unassigned')).toBe('Unassigned')
   })
 
-  it('formats non-empty bindings normally', () => {
-    expect(getHotkeyBindingDisplayLabel('mod+shift+e', 'Unassigned')).toBe('Ctrl + Shift + E')
+  it('formats non-empty bindings for the host platform', () => {
+    // Platform detection reads the host, so pin it per platform explicitly —
+    // the implicit form must match one of the two (macOS CI vs Linux CI).
+    expect(formatHotkeyBinding('mod+shift+e', 'Win32')).toBe('Ctrl + Shift + E')
+    expect(formatHotkeyBinding('mod+shift+e', 'MacIntel')).toBe('Cmd + Shift + E')
+    expect(['Ctrl + Shift + E', 'Cmd + Shift + E']).toContain(
+      getHotkeyBindingDisplayLabel('mod+shift+e', 'Unassigned'),
+    )
   })
 })

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -38,7 +38,9 @@ import { convertTimelineToComposition } from '@/features/export/utils/timeline-t
 import {
   renderComposition,
   renderAudioOnly,
+  renderSingleFrame,
 } from '@/features/export/utils/canvas-render-orchestrator'
+import { getAnimatedTransform, buildKeyframesMap } from '@/features/export/utils/canvas-keyframes'
 import type { ClientExportSettings, RenderProgress } from '@/features/export/utils/client-renderer'
 import {
   getSupportedCodecs,
@@ -55,8 +57,15 @@ import {
 } from '@/features/export/deps/timeline-compositions'
 import { editProject } from './edit'
 import { seedMediaLibrary } from './seed-media'
+import { ensureFontsLoaded } from '@/shared/typography/font-loader'
+import { collectVisibleTextFontFamilies } from '@/runtime/composition-runtime/utils/scene-assembly'
 
 const log = createLogger('Headless')
+
+// Weights spanning the families the montage uses (medium 500 / bold 700 / heavy 800)
+// plus 400/600 for safety. The editor preloads fonts via React preview mounts; the
+// headless harness mounts none of those, so we must load fonts explicitly here.
+const HEADLESS_FONT_WEIGHTS = [400, 500, 600, 700, 800]
 
 interface HeadlessMediaSource {
   mediaId: string
@@ -336,6 +345,11 @@ async function renderTimeline(input: HeadlessTimelineInput): Promise<HeadlessRen
     masterBusDb,
   )
 
+  // Load the web fonts every visible text item needs BEFORE rasterizing. Without this
+  // the Canvas text renderer draws with an unregistered family and Chrome silently
+  // falls back to generic sans-serif (only the default resembled Inter). No-ops offline.
+  await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
+
   // Fail loudly if the project needs WebGPU (effects) but it isn't available.
   warnings.push(...(await assertGpuForComposition(composition, compositions)))
 
@@ -409,10 +423,263 @@ async function renderProject(input: HeadlessProjectInput): Promise<HeadlessRende
   })
 }
 
+// ---------------------------------------------------------------------------
+// Fast-iteration helpers: single-frame grab + layout inspection
+// ---------------------------------------------------------------------------
+
+/** Grab one frame from a Project as an image (default: full-res PNG). */
+interface HeadlessFrameInput {
+  project: Project
+  media?: HeadlessMediaSource[]
+  /** Project-frame index to render. Takes precedence over `atSeconds`. */
+  frame?: number
+  /** Time (seconds) to render; converted to a frame with the project fps. */
+  atSeconds?: number
+  /** Output size. Defaults to the project resolution (full quality). */
+  width?: number
+  height?: number
+  format?: 'image/png' | 'image/jpeg' | 'image/webp'
+  quality?: number
+  outputFileName?: string
+}
+
+interface HeadlessFrameSummary {
+  ok: true
+  frame: number
+  atSeconds: number
+  width: number
+  height: number
+  format: string
+  fileSize: number
+  fileName: string
+}
+
+/** Inspect the computed on-canvas layout (bounding boxes) at a frame. */
+interface HeadlessLayoutInput {
+  project: Project
+  media?: HeadlessMediaSource[]
+  frame?: number
+  atSeconds?: number
+}
+
+interface LayoutBox {
+  id: string
+  type: TimelineItem['type']
+  trackId: string
+  from: number
+  durationInFrames: number
+  /** Canvas-space top-left corner (px), origin at canvas top-left. */
+  x: number
+  y: number
+  /** Bounding-box size (px). For text this is the (auto-expanded) text box. */
+  width: number
+  height: number
+  opacity: number
+  rotation: number
+  cornerRadius: number
+  /** Active at this frame, on a visible track, not fully transparent. */
+  visible: boolean
+  /** Draw order (higher = composited on top). */
+  z: number
+  text?: string
+  textAlign?: string
+  verticalAlign?: string
+  fontSize?: number
+}
+
+interface HeadlessLayoutResult {
+  frame: number
+  atSeconds: number
+  canvas: { width: number; height: number; fps: number }
+  items: LayoutBox[]
+}
+
+interface MigratedTimelineView {
+  tracks: TimelineTrack[]
+  items: TimelineItem[]
+  transitions: Transition[]
+  keyframes: ItemKeyframes[]
+  compositions: SubComposition[]
+  fps: number
+  width: number
+  height: number
+  backgroundColor?: string
+  busAudioEq?: AudioEqSettings
+  masterBusDb?: number
+}
+
+/** Migrate a raw project and extract the fields the composition builder needs. */
+function extractTimeline(rawProject: Project): MigratedTimelineView {
+  const { project } = migrateProject(rawProject)
+  const timeline = project.timeline
+  if (!timeline) throw new Error('Project has no timeline')
+  const meta = project.metadata
+  return {
+    tracks: (timeline.tracks ?? []) as unknown as TimelineTrack[],
+    items: (timeline.items ?? []) as unknown as TimelineItem[],
+    transitions: (timeline.transitions ?? []) as Transition[],
+    keyframes: (timeline.keyframes ?? []) as unknown as ItemKeyframes[],
+    compositions: (timeline.compositions ?? []) as unknown as SubComposition[],
+    fps: meta?.fps ?? 30,
+    width: meta?.width ?? 1920,
+    height: meta?.height ?? 1080,
+    backgroundColor: meta?.backgroundColor,
+    busAudioEq: timeline.busAudioEq,
+    masterBusDb: timeline.masterBusDb,
+  }
+}
+
+function resolveTargetFrame(
+  view: MigratedTimelineView,
+  input: HeadlessFrameInput | HeadlessLayoutInput,
+): number {
+  if (input.frame != null) return Math.max(0, Math.round(input.frame))
+  return Math.max(0, Math.round((input.atSeconds ?? 0) * view.fps))
+}
+
+function buildComposition(view: MigratedTimelineView): CompositionInputProps {
+  return convertTimelineToComposition(
+    view.tracks,
+    view.items,
+    view.transitions,
+    view.fps,
+    view.width,
+    view.height,
+    null,
+    null,
+    view.keyframes,
+    view.backgroundColor,
+    view.busAudioEq,
+    view.masterBusDb,
+  )
+}
+
+/**
+ * Render a single project frame straight to an image Blob (default: full-res
+ * PNG). Much faster than encoding a short clip + extracting a frame with
+ * ffmpeg: no muxer, no encoder, no audio pipeline — just one composited frame.
+ */
+async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSummary> {
+  const view = extractTimeline(input.project)
+  const frame = resolveTargetFrame(view, input)
+
+  useCompositionsStore.getState().setCompositions(view.compositions)
+  registerMediaUrls(input.media)
+  seedMediaLibrary(input.media)
+
+  const composition = buildComposition(view)
+  // Same font preload as the full render — single frame grabs must match font fidelity.
+  await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
+  await assertGpuForComposition(composition, view.compositions)
+  composition.tracks = await resolveMediaUrls(composition.tracks, { useProxy: false })
+
+  const outWidth = input.width ?? view.width
+  const outHeight = input.height ?? view.height
+  const format = input.format ?? 'image/png'
+  const blob = await renderSingleFrame({
+    composition,
+    frame,
+    width: outWidth,
+    height: outHeight,
+    format,
+    quality: input.quality ?? 1,
+  })
+  const ext = format === 'image/jpeg' ? 'jpg' : format === 'image/webp' ? 'webp' : 'png'
+  const fileName = input.outputFileName ?? `freecut-frame-${frame}.${ext}`
+  triggerDownload(blob, fileName)
+
+  log.info('Headless frame grab complete', {
+    frame,
+    width: outWidth,
+    height: outHeight,
+    format,
+    fileSize: blob.size,
+  })
+
+  return {
+    ok: true,
+    frame,
+    atSeconds: frame / view.fps,
+    width: outWidth,
+    height: outHeight,
+    format,
+    fileSize: blob.size,
+    fileName,
+  }
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+/**
+ * Dump the computed on-canvas bounding box of every visible item at a frame,
+ * WITHOUT rendering. Reuses the exact transform resolver the export path uses
+ * (`getAnimatedTransform`), so the coordinates match what a render would draw —
+ * letting a caller verify positioning without a render round-trip.
+ */
+function dumpLayout(input: HeadlessLayoutInput): HeadlessLayoutResult {
+  const view = extractTimeline(input.project)
+  const frame = resolveTargetFrame(view, input)
+
+  // Source dimensions (video/image) feed the fit-to-canvas default, so seed the
+  // media store. No blob URLs / GPU needed — this is pure transform math.
+  useCompositionsStore.getState().setCompositions(view.compositions)
+  seedMediaLibrary(input.media)
+
+  const composition = buildComposition(view)
+  const canvas = { width: view.width, height: view.height, fps: view.fps }
+  const keyframesMap = buildKeyframesMap(composition.keyframes)
+
+  const items: LayoutBox[] = []
+  let z = 0
+  // composition.tracks is already sorted descending by order (topmost track
+  // last), matching the export draw order; within a track, items draw in array
+  // order. Together these give the true z-stack (later = on top).
+  for (const track of composition.tracks) {
+    const trackVisible = track.visible !== false
+    for (const item of track.items ?? []) {
+      if (item.type === 'audio') continue
+      const active = frame >= item.from && frame < item.from + item.durationInFrames
+      if (!active) continue
+      const t = getAnimatedTransform(item, keyframesMap.get(item.id), frame, canvas)
+      const left = canvas.width / 2 + t.x - t.width / 2
+      const top = canvas.height / 2 + t.y - t.height / 2
+      const box: LayoutBox = {
+        id: item.id,
+        type: item.type,
+        trackId: item.trackId,
+        from: item.from,
+        durationInFrames: item.durationInFrames,
+        x: round1(left),
+        y: round1(top),
+        width: round1(t.width),
+        height: round1(t.height),
+        opacity: Math.round(t.opacity * 1000) / 1000,
+        rotation: t.rotation,
+        cornerRadius: t.cornerRadius,
+        visible: trackVisible && t.opacity > 0,
+        z: z++,
+      }
+      if (item.type === 'text') {
+        box.text = item.text
+        box.textAlign = item.textAlign
+        box.verticalAlign = item.verticalAlign
+        box.fontSize = item.fontSize
+      }
+      items.push(box)
+    }
+  }
+
+  return { frame, atSeconds: frame / view.fps, canvas, items }
+}
+
 interface FreecutHeadlessApi {
   ready: true
   renderTimeline: typeof renderTimeline
   renderProject: typeof renderProject
+  renderFrame: typeof renderFrame
+  dumpLayout: typeof dumpLayout
   editProject: typeof editProject
   normalizeProject: typeof normalizeProjectForHeadless
   probeMedia: typeof probeMedia
@@ -499,6 +766,8 @@ window.freecut = {
   ready: true,
   renderTimeline,
   renderProject,
+  renderFrame,
+  dumpLayout,
   editProject,
   normalizeProject: normalizeProjectForHeadless,
   probeMedia,

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -58,7 +58,10 @@ import {
 import { editProject } from './edit'
 import { seedMediaLibrary } from './seed-media'
 import { ensureFontsLoaded } from '@/shared/typography/font-loader'
-import { collectVisibleTextFontFamilies } from '@/runtime/composition-runtime/utils/scene-assembly'
+import {
+  collectVisibleTextFontFamilies,
+  resolveTrackRenderState,
+} from '@/runtime/composition-runtime/utils/scene-assembly'
 
 const log = createLogger('Headless')
 
@@ -138,6 +141,34 @@ async function awaitFontsApplied(
   // Let the compositor settle one frame before the first rasterisation.
   await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
   return unresolved
+}
+
+/**
+ * The one font gate for every rasterising entry point: load the families each
+ * visible text item needs, then block until they are really being applied.
+ *
+ * Single function on purpose. Without this the entry points drift — a caller
+ * that awaits but drops the unresolved list reports success while drawing in
+ * the fallback family, which is precisely the silent failure being fixed here.
+ */
+async function prepareFonts(
+  tracks: CompositionInputProps['tracks'],
+): Promise<HeadlessRenderWarning[]> {
+  const families = collectVisibleTextFontFamilies(tracks)
+  // Without this the Canvas text renderer draws with an unregistered family and
+  // Chrome silently falls back to a generic sans-serif. No-ops offline.
+  await ensureFontsLoaded(families, HEADLESS_FONT_WEIGHTS)
+  const unresolved = await awaitFontsApplied(families, HEADLESS_FONT_WEIGHTS)
+  if (unresolved.length === 0) return []
+  return [
+    {
+      code: 'FONTS_NOT_APPLIED',
+      message:
+        `Fonts never became active within the budget: ${unresolved.join(', ')} — ` +
+        'text is rasterised with a fallback family and its geometry will not match dumpLayout',
+      details: { unresolved },
+    },
+  ]
 }
 
 interface HeadlessMediaSource {
@@ -418,27 +449,7 @@ async function renderTimeline(input: HeadlessTimelineInput): Promise<HeadlessRen
     masterBusDb,
   )
 
-  // Load the web fonts every visible text item needs BEFORE rasterizing. Without this
-  // the Canvas text renderer draws with an unregistered family and Chrome silently
-  // falls back to generic sans-serif (only the default resembled Inter). No-ops offline.
-  await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
-  // ...and until they are really being applied — see awaitFontsApplied. Without
-  // this the opening seconds rasterise with the fallback family, silently.
-  {
-    const unresolved = await awaitFontsApplied(
-      collectVisibleTextFontFamilies(composition.tracks),
-      HEADLESS_FONT_WEIGHTS,
-    )
-    if (unresolved.length > 0) {
-      warnings.push({
-        code: 'FONTS_NOT_APPLIED',
-        message:
-          `Fonts never became active within the budget: ${unresolved.join(', ')} — ` +
-          'text is rasterised with a fallback family and its geometry will not match dumpLayout',
-        details: { unresolved },
-      })
-    }
-  }
+  warnings.push(...(await prepareFonts(composition.tracks)))
 
   // Fail loudly if the project needs WebGPU (effects) but it isn't available.
   warnings.push(...(await assertGpuForComposition(composition, compositions)))
@@ -542,6 +553,8 @@ interface HeadlessFrameSummary {
   format: string
   fileSize: number
   fileName: string
+  /** Same diagnostic channel as a full render — a frame grab can degrade too. */
+  warnings: HeadlessRenderWarning[]
 }
 
 /** Inspect the computed on-canvas layout (bounding boxes) at a frame. */
@@ -658,9 +671,9 @@ async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSumm
   seedMediaLibrary(input.media)
 
   const composition = buildComposition(view)
-  // Same font preload as the full render — single frame grabs must match font fidelity.
-  await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
-  await awaitFontsApplied(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
+  // Same font gate as the full render — a single frame grab that quietly used the
+  // fallback family would be indistinguishable from a correct one.
+  const warnings = await prepareFonts(composition.tracks)
   await assertGpuForComposition(composition, view.compositions)
   composition.tracks = await resolveMediaUrls(composition.tracks, { useProxy: false })
 
@@ -696,6 +709,7 @@ async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSumm
     format,
     fileSize: blob.size,
     fileName,
+    warnings,
   }
 }
 
@@ -722,13 +736,19 @@ function dumpLayout(input: HeadlessLayoutInput): HeadlessLayoutResult {
   const canvas = { width: view.width, height: view.height, fps: view.fps }
   const keyframesMap = buildKeyframesMap(composition.keyframes)
 
+  // Track visibility comes from the SAME resolver the render path uses, so a
+  // soloed track set makes `visible` agree with what a render would actually
+  // draw. Reimplementing the rule here would drift: solo overrides `visible`
+  // entirely (a soloed-but-hidden track still renders).
+  const { visibleTrackIds } = resolveTrackRenderState(composition.tracks)
+
   const items: LayoutBox[] = []
   let z = 0
   // composition.tracks is already sorted descending by order (topmost track
   // last), matching the export draw order; within a track, items draw in array
   // order. Together these give the true z-stack (later = on top).
   for (const track of composition.tracks) {
-    const trackVisible = track.visible !== false
+    const trackVisible = visibleTrackIds.has(track.id)
     for (const item of track.items ?? []) {
       if (item.type === 'audio') continue
       const active = frame >= item.from && frame < item.from + item.durationInFrames

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -103,44 +103,62 @@ async function awaitFontsApplied(
   const ctx = canvas.getContext('2d')
   if (!ctx) return unresolved
 
-  // Glyph-rich probe: Latin + Cyrillic + digits, so a family that only ships a
-  // partial subset cannot pass on a handful of shared glyphs.
-  const PROBE = 'HAMBURGEFONTSIVЖЯЦЩ0123456789'
-  const GENERICS = ['monospace', 'serif'] as const
   const deadline = Date.now() + timeoutMs
-
   const measure = (font: string): number => {
     ctx.font = font
     return ctx.measureText(PROBE).width
   }
 
-  // Two consecutive passes, not one. A single pass flips true the moment the
-  // face lands in the font cache, while the raster path can still be a beat
-  // behind — measured as the switch merely MOVING EARLIER (frame 44 -> ~22)
-  // rather than disappearing. Requiring the metric to hold across a gap is what
-  // makes the wait cover the raster path too.
-  const STABLE_PASSES = 2
   for (const family of new Set(families)) {
     const bare = family.replace(/^["']|["']$/g, '')
     for (const weight of weights) {
-      let streak = 0
-      while (Date.now() < deadline && streak < STABLE_PASSES) {
-        // A family still falling back measures identically to the generic it is
-        // stacked on. Differing from BOTH generics means the face is really in use.
-        const applied = GENERICS.every(
-          (generic) =>
-            measure(`${weight} 100px "${bare}", ${generic}`) !==
-            measure(`${weight} 100px ${generic}`),
-        )
-        streak = applied ? streak + 1 : 0
-        if (streak < STABLE_PASSES) await new Promise((resolve) => setTimeout(resolve, 60))
+      if (!(await waitForFaceApplied(measure, bare, weight, deadline))) {
+        unresolved.push(`${bare}:${weight}`)
       }
-      if (streak < STABLE_PASSES) unresolved.push(`${bare}:${weight}`)
     }
   }
   // Let the compositor settle one frame before the first rasterisation.
   await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
   return unresolved
+}
+
+// Glyph-rich probe: Latin + Cyrillic + digits, so a family that only ships a
+// partial subset cannot pass on a handful of shared glyphs.
+const PROBE = 'HAMBURGEFONTSIVЖЯЦЩ0123456789'
+const GENERICS = ['monospace', 'serif'] as const
+
+/**
+ * True once ONE family+weight measurably differs from the generics it is
+ * stacked on, twice in a row.
+ *
+ * Two consecutive passes, not one: a single pass flips true the moment the face
+ * lands in the font cache while the raster path can still be a beat behind —
+ * measured as the switch merely MOVING EARLIER (frame 44 -> ~22) rather than
+ * disappearing. Requiring the metric to hold across a gap covers the raster path.
+ */
+async function waitForFaceApplied(
+  measure: (font: string) => number,
+  family: string,
+  weight: number,
+  deadline: number,
+): Promise<boolean> {
+  const STABLE_PASSES = 2
+  // A family still falling back measures identically to the generic it is stacked
+  // on. Differing from BOTH generics means the face is really in use.
+  const isApplied = (): boolean =>
+    GENERICS.every(
+      (generic) =>
+        measure(`${weight} 100px "${family}", ${generic}`) !== measure(`${weight} 100px ${generic}`),
+    )
+
+  let streak = 0
+  while (streak < STABLE_PASSES) {
+    streak = isApplied() ? streak + 1 : 0
+    if (streak >= STABLE_PASSES) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((resolve) => setTimeout(resolve, 60))
+  }
+  return true
 }
 
 /**

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -595,6 +595,8 @@ interface HeadlessLayoutResult {
   atSeconds: number
   canvas: { width: number; height: number; fps: number }
   items: LayoutBox[]
+  /** Font failures make the reported text boxes untrustworthy — say so. */
+  warnings: HeadlessRenderWarning[]
 }
 
 interface MigratedTimelineView {
@@ -723,7 +725,7 @@ function round1(n: number): number {
  * (`getAnimatedTransform`), so the coordinates match what a render would draw —
  * letting a caller verify positioning without a render round-trip.
  */
-function dumpLayout(input: HeadlessLayoutInput): HeadlessLayoutResult {
+async function dumpLayout(input: HeadlessLayoutInput): Promise<HeadlessLayoutResult> {
   const view = extractTimeline(input.project)
   const frame = resolveTargetFrame(view, input)
 
@@ -733,6 +735,12 @@ function dumpLayout(input: HeadlessLayoutInput): HeadlessLayoutResult {
   seedMediaLibrary(input.media)
 
   const composition = buildComposition(view)
+
+  // Text boxes are NOT pure math: the transform resolver runs text items through
+  // expandTextTransformToFitContent, which measures with a real canvas 2D context.
+  // Without the same font gate the render path uses, the boxes reported here are
+  // fallback-font measurements and silently disagree with what /frame draws.
+  const warnings = await prepareFonts(composition.tracks)
   const canvas = { width: view.width, height: view.height, fps: view.fps }
   const keyframesMap = buildKeyframesMap(composition.keyframes)
 
@@ -782,7 +790,7 @@ function dumpLayout(input: HeadlessLayoutInput): HeadlessLayoutResult {
     }
   }
 
-  return { frame, atSeconds: frame / view.fps, canvas, items }
+  return { frame, atSeconds: frame / view.fps, canvas, items, warnings }
 }
 
 interface FreecutHeadlessApi {

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -67,6 +67,79 @@ const log = createLogger('Headless')
 // headless harness mounts none of those, so we must load fonts explicitly here.
 const HEADLESS_FONT_WEIGHTS = [400, 500, 600, 700, 800]
 
+/**
+ * Block until the requested families are actually being APPLIED by the canvas
+ * text renderer, not merely until their FontFace promises settled.
+ *
+ * Why this exists. `ensureFontsLoaded` awaits `document.fonts.load(...)`, and
+ * that is not sufficient: Chrome resolves those promises a beat before the
+ * export canvas starts picking the face up, so the first frames rasterise with
+ * the fallback family. It is silent — no error, no warning, correct-looking
+ * output — and it only shows up as geometry.
+ *
+ * Measured on the channel opener (2026-07-27): `dumpLayout` reported the word
+ * "ИИ АГЕНТЫ" at 549.8px, while the render drew it at 575px for the first ~45
+ * frames and 551px afterwards, i.e. 4.6% wider glyphs for the first 1.8s. The
+ * switch frame MOVED WITH RENDER SPEED (frame 45 at --quality high, frame 29 at
+ * --quality low), which is what proves it is a race rather than a fixed offset.
+ *
+ * Detection is by metrics, because that is the only thing that reflects what the
+ * canvas will really draw: a loaded-but-not-yet-applied family measures exactly
+ * like the generic fallback it is stacked on. We compare against two different
+ * generics so a family that happens to match one of them cannot fool the check.
+ */
+async function awaitFontsApplied(
+  families: readonly string[],
+  weights: readonly number[],
+  timeoutMs = 8000,
+): Promise<string[]> {
+  const unresolved: string[] = []
+  if (families.length === 0 || typeof document === 'undefined') return unresolved
+
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return unresolved
+
+  // Glyph-rich probe: Latin + Cyrillic + digits, so a family that only ships a
+  // partial subset cannot pass on a handful of shared glyphs.
+  const PROBE = 'HAMBURGEFONTSIVЖЯЦЩ0123456789'
+  const GENERICS = ['monospace', 'serif'] as const
+  const deadline = Date.now() + timeoutMs
+
+  const measure = (font: string): number => {
+    ctx.font = font
+    return ctx.measureText(PROBE).width
+  }
+
+  // Two consecutive passes, not one. A single pass flips true the moment the
+  // face lands in the font cache, while the raster path can still be a beat
+  // behind — measured as the switch merely MOVING EARLIER (frame 44 -> ~22)
+  // rather than disappearing. Requiring the metric to hold across a gap is what
+  // makes the wait cover the raster path too.
+  const STABLE_PASSES = 2
+  for (const family of new Set(families)) {
+    const bare = family.replace(/^["']|["']$/g, '')
+    for (const weight of weights) {
+      let streak = 0
+      while (Date.now() < deadline && streak < STABLE_PASSES) {
+        // A family still falling back measures identically to the generic it is
+        // stacked on. Differing from BOTH generics means the face is really in use.
+        const applied = GENERICS.every(
+          (generic) =>
+            measure(`${weight} 100px "${bare}", ${generic}`) !==
+            measure(`${weight} 100px ${generic}`),
+        )
+        streak = applied ? streak + 1 : 0
+        if (streak < STABLE_PASSES) await new Promise((resolve) => setTimeout(resolve, 60))
+      }
+      if (streak < STABLE_PASSES) unresolved.push(`${bare}:${weight}`)
+    }
+  }
+  // Let the compositor settle one frame before the first rasterisation.
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
+  return unresolved
+}
+
 interface HeadlessMediaSource {
   mediaId: string
   /** Same-origin (or CORS+CORP) URL the harness can fetch the full media bytes from. */
@@ -129,7 +202,7 @@ interface HeadlessRenderSummary {
 }
 
 interface HeadlessRenderWarning {
-  code: 'CODEC_FALLBACK' | 'WEBGPU_TRANSITION_FALLBACK'
+  code: 'CODEC_FALLBACK' | 'WEBGPU_TRANSITION_FALLBACK' | 'FONTS_NOT_APPLIED'
   message: string
   details?: Record<string, unknown>
 }
@@ -349,6 +422,23 @@ async function renderTimeline(input: HeadlessTimelineInput): Promise<HeadlessRen
   // the Canvas text renderer draws with an unregistered family and Chrome silently
   // falls back to generic sans-serif (only the default resembled Inter). No-ops offline.
   await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
+  // ...and until they are really being applied — see awaitFontsApplied. Without
+  // this the opening seconds rasterise with the fallback family, silently.
+  {
+    const unresolved = await awaitFontsApplied(
+      collectVisibleTextFontFamilies(composition.tracks),
+      HEADLESS_FONT_WEIGHTS,
+    )
+    if (unresolved.length > 0) {
+      warnings.push({
+        code: 'FONTS_NOT_APPLIED',
+        message:
+          `Fonts never became active within the budget: ${unresolved.join(', ')} — ` +
+          'text is rasterised with a fallback family and its geometry will not match dumpLayout',
+        details: { unresolved },
+      })
+    }
+  }
 
   // Fail loudly if the project needs WebGPU (effects) but it isn't available.
   warnings.push(...(await assertGpuForComposition(composition, compositions)))
@@ -570,6 +660,7 @@ async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSumm
   const composition = buildComposition(view)
   // Same font preload as the full render — single frame grabs must match font fidelity.
   await ensureFontsLoaded(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
+  await awaitFontsApplied(collectVisibleTextFontFamilies(composition.tracks), HEADLESS_FONT_WEIGHTS)
   await assertGpuForComposition(composition, view.compositions)
   composition.tracks = await resolveMediaUrls(composition.tracks, { useProxy: false })
 


### PR DESCRIPTION
The contribution offered in #350, rebased onto `develop` as you asked in that thread. Five commits: two new headless inspection commands, three export/headless bug fixes, and one cross-platform test fix.

All of this came out of rendering an ~80-minute production entirely through `headless/`, which is what surfaced the bugs.

---

## 1. `headless:frame` — render ONE frame straight to an image

`node headless/frame.mjs --workspace <dir> --project <id|project.json> --at <sec> --out frame.png`

Drives the real render engine, but skips the muxer, the video encoder and the whole audio pipeline — just one composited frame to PNG/JPG/WebP at project resolution. The iteration loop on a programmatic `project.json` goes from "encode a clip, then ffmpeg-extract a frame" to about a second.

Verified on a minimal text project on this branch:

```
Frame 30 (1.000s) -> frame.png  (1280x720 image/png, 41.5 KB, 1423ms)
```

## 2. `headless:layout` — resolved bounding boxes, no render at all

`node headless/layout.mjs --workspace <dir> --project <id|project.json> --at <sec>`

Emits the on-canvas box of every visible item at a frame as JSON. It reuses the **same transform resolver the export path uses** (`getAnimatedTransform`), so the coordinates are what a render would actually draw — you can assert positioning without a render round-trip, and it pipes straight into `jq` for scripted QA. Output on the same fixture:

```json
{ "frame": 30, "atSeconds": 1, "canvas": { "width": 1280, "height": 720, "fps": 30 },
  "items": [ { "id": "title", "type": "text", "x": 0, "y": 0, "width": 1280, "height": 720,
               "opacity": 1, "rotation": 0, "visible": true, "z": 0, "textAlign": "center" } ] }
```

Both are also exposed as warm `POST /frame` and `POST /layout` endpoints on `serve.mjs`, so an agent driving the harness doesn't pay browser startup per call.

---

## 3. Fix: web fonts were never loaded in headless

Font loading is only triggered from React preview mounts. The headless harness mounts none of those, so **every headless render silently rasterised text in Chrome's fallback sans-serif**. `renderTimeline()` / `renderFrame()` now await the existing font gate.

## 4. Fix: fonts must be *applied*, not merely *loaded*

This is the subtler half of the same bug, and it's worth reading carefully because the failure is invisible.

`ensureFontsLoaded` awaits the `document.fonts.load` promises — and that is not sufficient. Chrome resolves those a beat before the export canvas starts picking the face up, so the opening frames still rasterise with the fallback family. No error, no warning, plausible-looking output. It only shows up as geometry.

Measured on a real project: `dumpLayout` reported a word at **549.8px** while the render drew it at **575px for the first ~45 frames** and 551px afterwards — 4.6% wider glyphs for the first 1.8 seconds. What proves it's a race rather than a fixed offset: **the switch frame moves with render speed** (frame 45 at `--quality high`, frame 29 at `--quality low`).

The new `awaitFontsApplied` blocks on canvas **metrics**, the only signal that reflects what will really be drawn — a loaded-but-not-yet-applied family measures exactly like the generic it's stacked on. Details that matter:

- Compared against **two** different generics (`monospace` and `serif`), so a family that happens to match one of them can't fool the check.
- **Two consecutive passes**, not one. A single pass flips true the moment the face lands in the font cache while the raster path is still behind — measured as the switch merely moving earlier (frame 44 → ~22) instead of disappearing.
- A glyph-rich probe (Latin + Cyrillic + digits) so a partial subset can't pass on a handful of shared glyphs.
- When the budget runs out it emits a `FONTS_NOT_APPLIED` warning, so a genuinely missing font degrades **loudly** instead of silently.

## 5. Fix: transparent (alpha) videos were wrongly occlusion-culled

A full-canvas VP9/WebM overlay with alpha blacked out every layer beneath it: the occlusion pass treated any full-frame video as opaque. `isItemFullyOccluding` now consults mediabunny's `canBeTransparent()`, and a video that failed to initialise defaults to non-occluding (fail-safe direction — draw too much rather than lose a layer). Covered by `frame-occlusion.test.ts`.

## 6. Fix: export canvases drew scaled media with default `'low'` smoothing

All export contexts now set `imageSmoothingQuality: 'high'`. Verified by per-frame md5 that **only** frames containing scaled overlay draws change — untouched frames are byte-identical.

## 7. Test fix: `http-security.test.mjs` fails on macOS

Not one of mine — this one is currently red on `develop` on any macOS machine. `resolveContained` returns canonical paths, but `os.tmpdir()` on macOS sits behind the `/var -> /private/var` symlink, so the fixture's expectations never match:

```
+ actual   '/private/var/folders/…/dist/assets/asset.txt'
- expected '/var/folders/…/dist/assets/asset.txt'
```

One `fs.realpathSync.native` on the fixture root fixes it. Included here because it's what stands between `headless:test:node` and green on macOS — happy to split it out if you'd rather take it separately.

---

## Verification

Run on this branch, on macOS:

```
node --test headless/*.test.mjs          42 pass, 0 fail   (41/1 before commit 7)
node headless/test.mjs --skip-build      All headless checks passed ✓
vp test run src/features/export          32 files, 232 passed
vp check --no-fmt src headless           no warnings, lint or type errors (2355 files)
npm run build                            ✓ built in 7.38s
headless/frame.mjs  + layout.mjs         both verified end-to-end (output above)
```

## Notes on scope

- I dropped the `headless/README.md` updates that were on my original branch — you deleted that file in b4148e85 ("drop stale subfolder docs"), so resurrecting it seemed like the wrong call. Each new CLI keeps its usage block in its own header comment instead. Say the word if you'd like the docs somewhere specific.
- No formatting-only churn: I left the pre-existing `oxfmt` drift in the files I touched alone so the diff stays reviewable.
- Heads-up unrelated to this PR: the pre-push `check:changed-health` hook resolves its base to `origin/staging`, so on a `develop`-based branch it grades ~104 upstream files and fails. With `--base origin/develop` it's clean. Might be worth making the base track the PR target.

Closes #350
