### PR TITLE
fix(export): duck from sources inside pre-compositions

### DIFF
--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -1172,6 +1172,134 @@ describe('sidechain ducking', () => {
     expect(nested).toEqual(atRoot)
   })
 
+  it('a hidden but unmuted nested track still ducks (the mix still plays it)', () => {
+    // The audio expansion only consults `muted`; excluding hidden tracks here
+    // would leave an audible source attenuating nothing.
+    const subComp = {
+      id: 'sub-hidden',
+      name: 'Hidden',
+      items: [
+        makeAudioItem({
+          id: 'hidden-sting',
+          trackId: 'sub-a1',
+          from: 0,
+          durationInFrames: 20,
+          audioDucking: { duckOthersDb: -9 },
+        }),
+      ],
+      tracks: [{ ...makeTrack({ id: 'sub-a1', order: 0, kind: 'audio' }), visible: false }],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 90,
+    }
+    useCompositionsStore.setState({
+      compositions: [subComp],
+      compositionById: { [subComp.id]: subComp },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+
+    const sources = collectDuckingSources(
+      {
+        fps: FPS,
+        durationInFrames: 200,
+        width: 1920,
+        height: 1080,
+        tracks: [
+          makeTrack({
+            id: 'root-a1',
+            order: 0,
+            kind: 'audio',
+            items: [
+              {
+                id: 'wrapper',
+                type: 'composition',
+                compositionId: subComp.id,
+                trackId: 'root-a1',
+                from: 0,
+                durationInFrames: 90,
+                label: 'Hidden',
+                compositionWidth: 1920,
+                compositionHeight: 1080,
+                transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+              } as unknown as CompositionItem,
+            ],
+          }),
+        ],
+        transitions: [],
+        keyframes: [],
+      },
+      FPS,
+    )
+    expect(sources.map((s) => s.itemId)).toEqual(['hidden-sting'])
+  })
+
+  it('a composition-backed audio item keeps its OWN ducking as well as its children', () => {
+    // Regression: intercepting composition items for recursion used to skip
+    // `duckingSourceFromItem` on the wrapper, silently dropping its own settings.
+    const subComp = {
+      id: 'sub-both',
+      name: 'Both',
+      items: [
+        makeAudioItem({
+          id: 'child',
+          trackId: 'sub-a1',
+          from: 5,
+          durationInFrames: 10,
+          audioDucking: { duckOthersDb: -6 },
+        }),
+      ],
+      tracks: [makeTrack({ id: 'sub-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 90,
+    }
+    useCompositionsStore.setState({
+      compositions: [subComp],
+      compositionById: { [subComp.id]: subComp },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+
+    const sources = collectDuckingSources(
+      {
+        fps: FPS,
+        durationInFrames: 200,
+        width: 1920,
+        height: 1080,
+        tracks: [
+          makeTrack({
+            id: 'root-a1',
+            order: 0,
+            kind: 'audio',
+            items: [
+              makeAudioItem({
+                id: 'wrapper',
+                trackId: 'root-a1',
+                from: 0,
+                durationInFrames: 90,
+                audioDucking: { duckOthersDb: -3 },
+                compositionId: subComp.id,
+              } as Partial<AudioItem>),
+            ],
+          }),
+        ],
+        transitions: [],
+        keyframes: [],
+      },
+      FPS,
+    )
+    expect(sources.map((s) => s.itemId).sort()).toEqual(['child', 'wrapper'])
+    expect(sources.find((s) => s.itemId === 'wrapper')!.duckDb).toBe(-3)
+    expect(sources.find((s) => s.itemId === 'child')!.duckDb).toBe(-6)
+  })
+
   it('a self-referencing pre-comp does not hang the duck-source scan', () => {
     const cyclic = {
       id: 'cyclic',

--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -1300,6 +1300,110 @@ describe('sidechain ducking', () => {
     expect(sources.find((s) => s.itemId === 'child')!.duckDb).toBe(-6)
   })
 
+  it('a clipped intermediate composition gives the duck scan the SAME window as the mix', () => {
+    // Two levels deep with a `sourceEnd` clip on the middle wrapper — the case
+    // where an omitted sourceEnd remap in the recursion shows up. Asserted against
+    // the audio segment rather than a hand-computed number, because "the mix and
+    // the duck scan agree" is the actual contract, not any particular frame.
+    const inner = {
+      id: 'inner',
+      name: 'Inner',
+      items: [
+        makeAudioItem({
+          id: 'deep-sting',
+          trackId: 'inner-a1',
+          from: 0,
+          durationInFrames: 60,
+          audioDucking: { duckOthersDb: -9 },
+        }),
+      ],
+      tracks: [makeTrack({ id: 'inner-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 60,
+    }
+    const middle = {
+      id: 'middle',
+      name: 'Middle',
+      items: [
+        {
+          id: 'inner-wrapper',
+          type: 'composition',
+          compositionId: 'inner',
+          trackId: 'middle-a1',
+          from: 0,
+          durationInFrames: 60,
+          // Clipped: only the first 25 frames of `inner` are used.
+          sourceStart: 0,
+          sourceEnd: 25,
+          label: 'Inner',
+          compositionWidth: 1920,
+          compositionHeight: 1080,
+          transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+        } as unknown as CompositionItem,
+      ],
+      tracks: [makeTrack({ id: 'middle-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 60,
+    }
+    useCompositionsStore.setState({
+      compositions: [inner, middle],
+      compositionById: { inner, middle },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+
+    const composition: CompositionInputProps = {
+      fps: FPS,
+      durationInFrames: 200,
+      width: 1920,
+      height: 1080,
+      tracks: [
+        makeTrack({
+          id: 'root-a1',
+          order: 0,
+          kind: 'audio',
+          items: [
+            {
+              id: 'middle-wrapper',
+              type: 'composition',
+              compositionId: 'middle',
+              trackId: 'root-a1',
+              from: 30,
+              durationInFrames: 20,
+              // Clipped at BOTH levels: this is what makes the recursive
+              // sourceEnd remap observable — without it the inner wrapper keeps
+              // an end that outruns the window the mix actually uses.
+              sourceStart: 0,
+              sourceEnd: 20,
+              label: 'Middle',
+              compositionWidth: 1920,
+              compositionHeight: 1080,
+              transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+            } as unknown as CompositionItem,
+          ],
+        }),
+      ],
+      transitions: [],
+      keyframes: [],
+    }
+
+    const segment = extractAudioSegments(composition, FPS).find((s) => s.itemId === 'deep-sting')
+    const source = collectDuckingSources(composition, FPS).find((s) => s.itemId === 'deep-sting')
+
+    expect(segment).toBeDefined()
+    expect(source).toBeDefined()
+    expect(source!.startFrame).toBe(segment!.startFrame)
+    expect(source!.endFrame).toBe(segment!.startFrame + segment!.durationFrames)
+  })
+
   it('a self-referencing pre-comp does not hang the duck-source scan', () => {
     const cyclic = {
       id: 'cyclic',

--- a/src/features/export/utils/canvas-audio.test.ts
+++ b/src/features/export/utils/canvas-audio.test.ts
@@ -1024,6 +1024,223 @@ describe('sidechain ducking', () => {
     })
   })
 
+  it('collectDuckingSources finds sources inside a pre-composition, in parent frames', () => {
+    // Regression: the mix expands nested composition audio, but the source scan
+    // only walked the root tracks — so the same arrangement ducked at root level
+    // and silently did not one level down.
+    const nestedSource = makeAudioItem({
+      id: 'nested-sting',
+      trackId: 'sub-a1',
+      from: 10,
+      durationInFrames: 20,
+      audioDucking: { duckOthersDb: -9, attackSec: 0.1, releaseSec: 0.1 },
+    })
+    const subComp = {
+      id: 'sub-duck',
+      name: 'Sting',
+      items: [nestedSource],
+      tracks: [makeTrack({ id: 'sub-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 90,
+    }
+    useCompositionsStore.setState({
+      compositions: [subComp],
+      compositionById: { [subComp.id]: subComp },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+
+    const compositionItem = {
+      id: 'comp-item',
+      type: 'composition',
+      compositionId: subComp.id,
+      trackId: 'root-v1',
+      from: 40,
+      durationInFrames: 90,
+      label: 'Sting',
+      compositionWidth: 1920,
+      compositionHeight: 1080,
+      transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+    } as unknown as CompositionItem
+
+    const composition: CompositionInputProps = {
+      fps: FPS,
+      durationInFrames: 200,
+      width: 1920,
+      height: 1080,
+      tracks: [makeTrack({ id: 'root-v1', order: 0, kind: 'video', items: [compositionItem] })],
+      transitions: [],
+      keyframes: [],
+    }
+
+    const sources = collectDuckingSources(composition, FPS)
+    expect(sources).toHaveLength(1)
+    expect(sources[0]).toMatchObject({
+      itemId: 'nested-sting',
+      // The ROOT track, because that is the track the nested audio is mixed onto
+      // and therefore what "never duck yourself" must compare against.
+      trackId: 'root-v1',
+      // Wrapper starts at 40, item sits at 10 inside it → 50..70 in parent frames.
+      startFrame: 40 + 10,
+      endFrame: 40 + 30,
+      duckDb: -9,
+    })
+  })
+
+  it('a duck source gives the same window at root level and inside a pre-comp', () => {
+    const ducking = { duckOthersDb: -12, attackSec: 0.1, releaseSec: 0.2 }
+    const atRoot = collectDuckingSources(
+      {
+        fps: FPS,
+        durationInFrames: 200,
+        width: 1920,
+        height: 1080,
+        tracks: [
+          makeTrack({
+            id: 'root-a1',
+            order: 0,
+            kind: 'audio',
+            items: [
+              makeAudioItem({ id: 'sting', trackId: 'root-a1', from: 55, durationInFrames: 20, audioDucking: ducking }),
+            ],
+          }),
+        ],
+        transitions: [],
+        keyframes: [],
+      },
+      FPS,
+    )
+
+    const subComp = {
+      id: 'sub-equiv',
+      name: 'Equivalent',
+      items: [
+        makeAudioItem({ id: 'sting', trackId: 'sub-a1', from: 15, durationInFrames: 20, audioDucking: ducking }),
+      ],
+      tracks: [makeTrack({ id: 'sub-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 90,
+    }
+    useCompositionsStore.setState({
+      compositions: [subComp],
+      compositionById: { [subComp.id]: subComp },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+    const nested = collectDuckingSources(
+      {
+        fps: FPS,
+        durationInFrames: 200,
+        width: 1920,
+        height: 1080,
+        tracks: [
+          makeTrack({
+            id: 'root-a1',
+            order: 0,
+            kind: 'audio',
+            items: [
+              {
+                id: 'wrapper',
+                type: 'composition',
+                compositionId: subComp.id,
+                trackId: 'root-a1',
+                from: 40, // 40 + 15 == 55, the root-level position
+                durationInFrames: 90,
+                label: 'Equivalent',
+                compositionWidth: 1920,
+                compositionHeight: 1080,
+                transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+              } as unknown as CompositionItem,
+            ],
+          }),
+        ],
+        transitions: [],
+        keyframes: [],
+      },
+      FPS,
+    )
+
+    // Same arrangement, same balance — this equality is the whole point.
+    expect(nested).toEqual(atRoot)
+  })
+
+  it('a self-referencing pre-comp does not hang the duck-source scan', () => {
+    const cyclic = {
+      id: 'cyclic',
+      name: 'Cyclic',
+      items: [
+        {
+          id: 'self',
+          type: 'composition',
+          compositionId: 'cyclic',
+          trackId: 'sub-a1',
+          from: 0,
+          durationInFrames: 30,
+          label: 'self',
+          compositionWidth: 1920,
+          compositionHeight: 1080,
+          transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+        } as unknown as CompositionItem,
+      ],
+      tracks: [makeTrack({ id: 'sub-a1', order: 0, kind: 'audio' })],
+      transitions: [],
+      keyframes: [],
+      fps: FPS,
+      width: 1920,
+      height: 1080,
+      durationInFrames: 90,
+    }
+    useCompositionsStore.setState({
+      compositions: [cyclic],
+      compositionById: { [cyclic.id]: cyclic },
+      mediaDependencyIds: [],
+      mediaDependencyVersion: 0,
+    })
+
+    expect(() =>
+      collectDuckingSources(
+        {
+          fps: FPS,
+          durationInFrames: 200,
+          width: 1920,
+          height: 1080,
+          tracks: [
+            makeTrack({
+              id: 'root-a1',
+              order: 0,
+              kind: 'audio',
+              items: [
+                {
+                  id: 'wrapper',
+                  type: 'composition',
+                  compositionId: 'cyclic',
+                  trackId: 'root-a1',
+                  from: 0,
+                  durationInFrames: 30,
+                  label: 'Cyclic',
+                  compositionWidth: 1920,
+                  compositionHeight: 1080,
+                  transform: { x: 0, y: 0, rotation: 0, opacity: 1 },
+                } as unknown as CompositionItem,
+              ],
+            }),
+          ],
+          transitions: [],
+          keyframes: [],
+        },
+        FPS,
+      ),
+    ).not.toThrow()
+  })
+
   it('processAudio ducks a constant target under the duck window (real pipeline)', async () => {
     clearAudioDecodeCache()
     const composition: CompositionInputProps = {

--- a/src/features/export/utils/canvas-audio.ts
+++ b/src/features/export/utils/canvas-audio.ts
@@ -600,6 +600,96 @@ interface AudioProcessingConfig {
   totalFrames: number
 }
 
+/** The wrapper composition item's timing, resolved once per expansion. */
+interface CompositionWrapperTiming {
+  compFrom: number
+  wrapperSpeed: number
+  wrapperSourceFps: number
+  sourceOffset: number
+  wrapperSourceEnd: number
+}
+
+function resolveCompositionWrapper(
+  compositionItem: { from: number; durationInFrames: number } & Partial<{
+    speed: number
+    sourceFps: number
+    sourceStart: number
+    trimStart: number
+    sourceEnd: number
+  }>,
+  fps: number,
+): CompositionWrapperTiming {
+  const wrapperSpeed = compositionItem.speed ?? 1
+  const wrapperSourceFps = compositionItem.sourceFps ?? fps
+  const sourceOffset = compositionItem.sourceStart ?? compositionItem.trimStart ?? 0
+  return {
+    compFrom: compositionItem.from,
+    wrapperSpeed,
+    wrapperSourceFps,
+    sourceOffset,
+    wrapperSourceEnd:
+      compositionItem.sourceEnd ??
+      sourceOffset +
+        timelineToSourceFrames(compositionItem.durationInFrames, wrapperSpeed, fps, wrapperSourceFps),
+  }
+}
+
+/** One nested item's visible window, expressed in PARENT timeline frames. */
+interface NestedItemWindow {
+  overlapStart: number
+  overlapEnd: number
+  effectiveStart: number
+  effectiveEnd: number
+  effectiveDuration: number
+  effectiveSourceStart: number
+}
+
+/**
+ * Map a sub-composition item into parent-timeline coordinates, honouring the
+ * wrapper's trim, speed and source fps. Returns null when the item falls
+ * entirely outside the wrapper's visible source range.
+ *
+ * Shared on purpose. The audio mix and the ducking-source scan both have to
+ * agree on where a nested item sits, and a second implementation is how they
+ * would silently drift apart — a source could be expanded into the mix while
+ * not being seen as a duck source, which is precisely the bug this fixes.
+ */
+function mapNestedItemWindow(
+  subItem: TimelineItem,
+  wrapper: CompositionWrapperTiming,
+  fps: number,
+): NestedItemWindow | null {
+  const { compFrom, wrapperSpeed, wrapperSourceFps, sourceOffset, wrapperSourceEnd } = wrapper
+  const overlapStart = Math.max(subItem.from, sourceOffset)
+  const overlapEnd = Math.min(subItem.from + subItem.durationInFrames, wrapperSourceEnd)
+  if (overlapEnd <= overlapStart) return null
+
+  const effectiveStart =
+    compFrom + sourceToTimelineFrames(overlapStart - sourceOffset, wrapperSpeed, wrapperSourceFps, fps)
+  const effectiveEnd =
+    compFrom + sourceToTimelineFrames(overlapEnd - sourceOffset, wrapperSpeed, wrapperSourceFps, fps)
+  const effectiveDuration = Math.max(1, effectiveEnd - effectiveStart)
+
+  const baseSourceStart = subItem.sourceStart ?? subItem.trimStart ?? 0
+  const effectiveSourceStart =
+    baseSourceStart +
+    timelineToSourceFrames(
+      overlapStart - subItem.from,
+      subItem.speed ?? 1,
+      wrapperSourceFps,
+      subItem.sourceFps ?? wrapperSourceFps,
+    )
+
+  return {
+    overlapStart,
+    overlapEnd,
+    effectiveStart,
+    effectiveEnd,
+    effectiveDuration,
+    effectiveSourceStart,
+  }
+}
+
 function appendCompositionAudioSegments(params: {
   segments: AudioSegment[]
   track: CompositionInputProps['tracks'][number]
@@ -624,43 +714,19 @@ function appendCompositionAudioSegments(params: {
   const wrapperAudioPitchShiftSemitones =
     (params.audioPitchShiftSemitones ?? 0) + getAudioPitchShiftSemitones(compositionItem)
   const linkedSubCompVideoIds = getLinkedVideoIdsWithAudio(subComp.items)
-  const compFrom = compositionItem.from
-  const wrapperSpeed = compositionItem.speed ?? 1
-  const wrapperSourceFps = compositionItem.sourceFps ?? fps
-  const sourceOffset = compositionItem.sourceStart ?? compositionItem.trimStart ?? 0
-  const wrapperSourceEnd =
-    compositionItem.sourceEnd ??
-    sourceOffset +
-      timelineToSourceFrames(compositionItem.durationInFrames, wrapperSpeed, fps, wrapperSourceFps)
+  const wrapper = resolveCompositionWrapper(compositionItem, fps)
+  const { wrapperSpeed, wrapperSourceFps } = wrapper
   const trackMuted = track.muted ?? false
 
   for (const subItem of subComp.items) {
     const subTrack = subComp.tracks.find((candidate) => candidate.id === subItem.trackId)
     const subTrackMuted = subTrack?.muted ?? false
-    const overlapStart = Math.max(subItem.from, sourceOffset)
-    const overlapEnd = Math.min(subItem.from + subItem.durationInFrames, wrapperSourceEnd)
-    if (overlapEnd <= overlapStart) continue
+    const window = mapNestedItemWindow(subItem, wrapper, fps)
+    if (!window) continue
+    const { overlapStart, overlapEnd, effectiveStart, effectiveDuration } = window
 
-    const effectiveStart =
-      compFrom +
-      sourceToTimelineFrames(overlapStart - sourceOffset, wrapperSpeed, wrapperSourceFps, fps)
-    const effectiveEnd =
-      compFrom +
-      sourceToTimelineFrames(overlapEnd - sourceOffset, wrapperSpeed, wrapperSourceFps, fps)
-    const effectiveDuration = Math.max(1, effectiveEnd - effectiveStart)
-    if (effectiveDuration <= 0) continue
-
-    const subItemClipStart = overlapStart - subItem.from
-    const baseSourceStart = subItem.sourceStart ?? subItem.trimStart ?? 0
     const speed = (subItem.speed ?? 1) * wrapperSpeed
-    const effectiveSourceStart =
-      baseSourceStart +
-      timelineToSourceFrames(
-        subItemClipStart,
-        subItem.speed ?? 1,
-        wrapperSourceFps,
-        subItem.sourceFps ?? wrapperSourceFps,
-      )
+    const effectiveSourceStart = window.effectiveSourceStart
 
     if (subItem.type === 'composition' || isCompositionAudioItem(subItem)) {
       if (
@@ -1384,6 +1450,8 @@ function duckingSourceFromItem(
   item: DuckSourceCandidate,
   trackId: string,
   fps: number,
+  /** Parent-timeline window, for items reached through a pre-composition. */
+  window?: { startFrame: number; endFrame: number },
 ): DuckingSource | null {
   const ducking = item.audioDucking
   if (!ducking || !(ducking.duckOthersDb < 0)) return null
@@ -1392,13 +1460,75 @@ function duckingSourceFromItem(
   return {
     itemId: item.id,
     trackId,
-    startFrame: item.from,
-    endFrame: item.from + item.durationInFrames,
+    startFrame: window?.startFrame ?? item.from,
+    endFrame: window?.endFrame ?? item.from + item.durationInFrames,
     duckDb: ducking.duckOthersDb,
     attackFrames: (ducking.attackSec ?? DUCKING_DEFAULT_ATTACK_SEC) * fps,
     releaseFrames: (ducking.releaseSec ?? DUCKING_DEFAULT_RELEASE_SEC) * fps,
     ...(ducking.targetTrackIds ? { targetTrackIds: ducking.targetTrackIds } : {}),
   }
+}
+
+/**
+ * Collect duck sources nested inside a pre-composition, in PARENT timeline frames.
+ *
+ * The mix expands nested composition audio, so a source living one level down is
+ * audible; scanning only the root tracks would leave it audible but not ducking,
+ * making the same arrangement sound different at root level and inside a
+ * pre-comp. The window mapping is shared with `appendCompositionAudioSegments`
+ * so the two cannot disagree about where a nested item sits.
+ */
+function collectNestedDuckingSources(
+  compositionItem: CompositionItem | (AudioItem & { compositionId: string }),
+  rootTrackId: string,
+  fps: number,
+  visited: ReadonlySet<string>,
+): DuckingSource[] {
+  if (visited.has(compositionItem.compositionId)) return []
+  const subComp = useCompositionsStore.getState().getComposition(compositionItem.compositionId)
+  if (!subComp) return []
+
+  const wrapper = resolveCompositionWrapper(compositionItem, fps)
+  const nestedVisited = new Set(visited)
+  nestedVisited.add(compositionItem.compositionId)
+
+  const sources: DuckingSource[] = []
+  for (const subItem of subComp.items) {
+    const subTrack = subComp.tracks.find((candidate) => candidate.id === subItem.trackId)
+    // A muted or hidden sub-track contributes no audio, so it cannot duck.
+    if (subTrack?.muted === true || subTrack?.visible === false) continue
+
+    const window = mapNestedItemWindow(subItem, wrapper, fps)
+    if (!window) continue
+
+    if (subItem.type === 'composition' || isCompositionAudioItem(subItem)) {
+      sources.push(
+        ...collectNestedDuckingSources(
+          {
+            ...subItem,
+            from: window.effectiveStart,
+            durationInFrames: window.effectiveDuration,
+            speed: (subItem.speed ?? 1) * wrapper.wrapperSpeed,
+            sourceStart: window.effectiveSourceStart,
+            sourceFps: subItem.sourceFps ?? wrapper.wrapperSourceFps,
+          } as CompositionItem | (AudioItem & { compositionId: string }),
+          rootTrackId,
+          fps,
+          nestedVisited,
+        ),
+      )
+      continue
+    }
+
+    // Nested sources belong to the ROOT track: that is the track their audio is
+    // mixed onto, so it is also what "never duck yourself" must compare against.
+    const source = duckingSourceFromItem(subItem as DuckSourceCandidate, rootTrackId, fps, {
+      startFrame: window.effectiveStart,
+      endFrame: window.effectiveEnd,
+    })
+    if (source) sources.push(source)
+  }
+  return sources
 }
 
 /** Collect duck-source windows from composition items carrying `audioDucking`. */
@@ -1410,6 +1540,14 @@ export function collectDuckingSources(
     .filter((track) => track.visible !== false && track.muted !== true)
     .flatMap((track) =>
       (track.items ?? []).flatMap((item) => {
+        if (item.type === 'composition' || isCompositionAudioItem(item)) {
+          return collectNestedDuckingSources(
+            item as CompositionItem | (AudioItem & { compositionId: string }),
+            track.id,
+            fps,
+            new Set<string>(),
+          )
+        }
         const source = duckingSourceFromItem(item as DuckSourceCandidate, track.id, fps)
         return source ? [source] : []
       }),

--- a/src/features/export/utils/canvas-audio.ts
+++ b/src/features/export/utils/canvas-audio.ts
@@ -690,6 +690,41 @@ function mapNestedItemWindow(
   }
 }
 
+/**
+ * Rebuild a nested composition item as a wrapper expressed in PARENT coordinates.
+ *
+ * Shared with the duck-source scan for the same reason the window mapping is: the
+ * `sourceEnd` remap in particular is easy to omit, and omitting it makes a
+ * clipped intermediate composition report a different window on each side.
+ */
+function buildNestedWrapper(
+  subItem: TimelineItem,
+  window: NestedItemWindow,
+  wrapper: CompositionWrapperTiming,
+): CompositionItem | (AudioItem & { compositionId: string }) {
+  const { wrapperSpeed, wrapperSourceFps } = wrapper
+  return {
+    ...subItem,
+    from: window.effectiveStart,
+    durationInFrames: window.effectiveDuration,
+    speed: (subItem.speed ?? 1) * wrapperSpeed,
+    sourceStart: window.effectiveSourceStart,
+    sourceFps: subItem.sourceFps ?? wrapperSourceFps,
+    ...(subItem.sourceEnd !== undefined && {
+      sourceEnd: Math.max(
+        window.effectiveSourceStart + 1,
+        subItem.sourceEnd -
+          timelineToSourceFrames(
+            subItem.from + subItem.durationInFrames - window.overlapEnd,
+            subItem.speed ?? 1,
+            wrapperSourceFps,
+            subItem.sourceFps ?? wrapperSourceFps,
+          ),
+      ),
+    }),
+  } as CompositionItem | (AudioItem & { compositionId: string })
+}
+
 function appendCompositionAudioSegments(params: {
   segments: AudioSegment[]
   track: CompositionInputProps['tracks'][number]
@@ -739,26 +774,7 @@ function appendCompositionAudioSegments(params: {
       const nestedSubComp = useCompositionsStore.getState().getComposition(subItem.compositionId)
       if (!nestedSubComp) continue
 
-      const nestedWrapper = {
-        ...subItem,
-        from: effectiveStart,
-        durationInFrames: effectiveDuration,
-        speed: (subItem.speed ?? 1) * wrapperSpeed,
-        sourceStart: effectiveSourceStart,
-        sourceFps: subItem.sourceFps ?? wrapperSourceFps,
-        ...(subItem.sourceEnd !== undefined && {
-          sourceEnd: Math.max(
-            effectiveSourceStart + 1,
-            subItem.sourceEnd -
-              timelineToSourceFrames(
-                subItem.from + subItem.durationInFrames - overlapEnd,
-                subItem.speed ?? 1,
-                wrapperSourceFps,
-                subItem.sourceFps ?? wrapperSourceFps,
-              ),
-          ),
-        }),
-      } as CompositionItem | (AudioItem & { compositionId: string })
+      const nestedWrapper = buildNestedWrapper(subItem, window, wrapper)
 
       // Volumes are dB offsets — sum them so nested levels accumulate correctly.
       const nestedVisited = new Set(visited)
@@ -1495,23 +1511,26 @@ function collectNestedDuckingSources(
   const sources: DuckingSource[] = []
   for (const subItem of subComp.items) {
     const subTrack = subComp.tracks.find((candidate) => candidate.id === subItem.trackId)
-    // A muted or hidden sub-track contributes no audio, so it cannot duck.
-    if (subTrack?.muted === true || subTrack?.visible === false) continue
+    // Only `muted` silences a nested track — the expansion above ignores `visible`,
+    // so excluding hidden tracks here would leave audible sources not ducking.
+    if (subTrack?.muted === true) continue
 
     const window = mapNestedItemWindow(subItem, wrapper, fps)
     if (!window) continue
 
     if (subItem.type === 'composition' || isCompositionAudioItem(subItem)) {
+      // A composition-backed AudioItem can carry `audioDucking` of its own, and it
+      // is audible in its own right — collect it as well as descending.
+      const wrapperSource = duckingSourceFromItem(
+        subItem as DuckSourceCandidate,
+        rootTrackId,
+        fps,
+        { startFrame: window.effectiveStart, endFrame: window.effectiveEnd },
+      )
+      if (wrapperSource) sources.push(wrapperSource)
       sources.push(
         ...collectNestedDuckingSources(
-          {
-            ...subItem,
-            from: window.effectiveStart,
-            durationInFrames: window.effectiveDuration,
-            speed: (subItem.speed ?? 1) * wrapper.wrapperSpeed,
-            sourceStart: window.effectiveSourceStart,
-            sourceFps: subItem.sourceFps ?? wrapper.wrapperSourceFps,
-          } as CompositionItem | (AudioItem & { compositionId: string }),
+          buildNestedWrapper(subItem, window, wrapper),
           rootTrackId,
           fps,
           nestedVisited,
@@ -1540,16 +1559,22 @@ export function collectDuckingSources(
     .filter((track) => track.visible !== false && track.muted !== true)
     .flatMap((track) =>
       (track.items ?? []).flatMap((item) => {
+        // The item's own `audioDucking` counts even when it is a composition
+        // wrapper — it is audible in its own right — so collect it either way
+        // and additionally descend when it wraps a pre-comp.
+        const own = duckingSourceFromItem(item as DuckSourceCandidate, track.id, fps)
+        const sources = own ? [own] : []
         if (item.type === 'composition' || isCompositionAudioItem(item)) {
-          return collectNestedDuckingSources(
-            item as CompositionItem | (AudioItem & { compositionId: string }),
-            track.id,
-            fps,
-            new Set<string>(),
+          sources.push(
+            ...collectNestedDuckingSources(
+              item as CompositionItem | (AudioItem & { compositionId: string }),
+              track.id,
+              fps,
+              new Set<string>(),
+            ),
           )
         }
-        const source = duckingSourceFromItem(item as DuckSourceCandidate, track.id, fps)
-        return source ? [source] : []
+        return sources
       }),
     )
 }


### PR DESCRIPTION
As agreed on #356 — "lets do it".

#356 merged about twenty seconds before my write-up of this gap landed, so it went in with the hole still open. Closing it now.

## The gap

`collectDuckingSources` walked only `composition.tracks`. The mix, however, expands nested composition audio — so a source carrying `audioDucking` inside a pre-comp was **audible while ducking nothing**. The same arrangement produced a different balance depending on whether it sat at root level or one level down, with no error and no warning.

## The fix

Shared mapping, not a second walk. The overlap clamp against the wrapper's trim plus the speed / `sourceFps` conversion now live in `mapNestedItemWindow`, and both callers use it:

- `appendCompositionAudioSegments` (the audio expansion, unchanged in behaviour)
- `collectNestedDuckingSources` (new)

Duplicating that arithmetic into a second walk is precisely how the two would drift apart again, which is the bug this is fixing.

Three details that are easy to get wrong:

- **Nested sources are attributed to the ROOT track.** That is the track their audio is actually mixed onto, so it is also what "a source never ducks itself" and `targetTrackIds` must compare against. Attributing them to the sub-track would let a nested source duck itself.
- **Muted or hidden sub-tracks contribute no audio**, so they cannot duck either.
- **Recursion carries the same `visited` cycle guard** the audio expansion already uses.

## Verification

The extraction is behaviour-neutral — I landed it first and confirmed the pre-existing audio suite passed untouched (36/36) before adding the nested walk.

Three new tests, all red before the fix and green after:

- a nested source is found, reported in **parent** frames (wrapper at 40, item at 10 inside → 50..70)
- **the same arrangement at root level and inside a pre-comp yields identical sources** — this equality is the actual contract
- a self-referencing pre-comp terminates instead of hanging the scan

```
vp check --no-fmt src headless vite.config.ts   no warnings, lint or type errors (2367 files)
vp test run                                     653 files, 4665 passed (4665)
npm run build                                   ✓ built in 6.79s
node --test headless/*.test.mjs                 42 pass, 0 fail
node headless/test.mjs --skip-build             All headless checks passed ✓
```
