### PR TITLE
feat(headless): warn when a transition preset will render as a hard cut

### DIFF
--- a/src/features/export/utils/canvas-transitions.ts
+++ b/src/features/export/utils/canvas-transitions.ts
@@ -462,11 +462,24 @@ export type TransitionRenderPath = 'gpu' | 'registry-canvas' | 'builtin' | 'cut'
  */
 export function resolveTransitionRenderPath(
   presentation: string | undefined,
-  options: { gpuAvailable: boolean },
+  options: {
+    gpuAvailable: boolean
+    /**
+     * Probe for whether the transition pipeline actually carries this id.
+     * `renderTransition` requires BOTH a `gpuTransitionId` and
+     * `gpuTransitionPipeline.has(id)` — an adapter alone does not mean the
+     * pipeline compiled. Pass this wherever a pipeline exists; without it the
+     * GPU path is only assumed when a `gpuTransitionId` is registered.
+     */
+    hasGpuTransition?: (gpuTransitionId: string) => boolean
+  },
 ): TransitionRenderPath {
   if (!presentation) return 'cut'
   const renderer = transitionRegistry.getRenderer(presentation)
-  if (renderer?.gpuTransitionId && options.gpuAvailable) return 'gpu'
+  if (renderer?.gpuTransitionId && options.gpuAvailable) {
+    const compiled = options.hasGpuTransition?.(renderer.gpuTransitionId) ?? true
+    if (compiled) return 'gpu'
+  }
   if (renderer?.renderCanvas) return 'registry-canvas'
   if (CANVAS_FALLBACK_PRESENTATIONS.has(presentation)) return 'builtin'
   return 'cut'

--- a/src/features/export/utils/canvas-transitions.ts
+++ b/src/features/export/utils/canvas-transitions.ts
@@ -433,6 +433,45 @@ function renderCutTransition(
  * @param rightCanvas - Pre-rendered right (incoming) clip content
  * @param canvas - Canvas settings
  */
+/**
+ * Presentations the built-in Canvas2D fallback below actually draws.
+ *
+ * Deliberately adjacent to the `switch` it mirrors: `BuiltinTransitionPresentation`
+ * declares far more presets than this path implements, and every unlisted one
+ * lands in `default:` and renders a hard cut. Keeping the list next to the switch
+ * is what stops the two from drifting — add a `case`, add it here.
+ */
+export const CANVAS_FALLBACK_PRESENTATIONS: ReadonlySet<string> = new Set([
+  'fade',
+  'wipe',
+  'slide',
+  'flip',
+  'clockWipe',
+  'iris',
+  'none',
+])
+
+export type TransitionRenderPath = 'gpu' | 'registry-canvas' | 'builtin' | 'cut'
+
+/**
+ * Which path a presentation will actually take.
+ *
+ * `'cut'` means the transition silently renders as a hard cut — no error, no
+ * visual transition. Callers that can warn (headless validation) use this to say
+ * so up front instead of letting the export look merely "wrong".
+ */
+export function resolveTransitionRenderPath(
+  presentation: string | undefined,
+  options: { gpuAvailable: boolean },
+): TransitionRenderPath {
+  if (!presentation) return 'cut'
+  const renderer = transitionRegistry.getRenderer(presentation)
+  if (renderer?.gpuTransitionId && options.gpuAvailable) return 'gpu'
+  if (renderer?.renderCanvas) return 'registry-canvas'
+  if (CANVAS_FALLBACK_PRESENTATIONS.has(presentation)) return 'builtin'
+  return 'cut'
+}
+
 export function renderTransition(
   ctx: OffscreenCanvasRenderingContext2D,
   activeTransition: ActiveTransition,

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -282,6 +282,7 @@ interface HeadlessRenderWarning {
     | 'TRANSITION_NOT_ADJACENT'
     | 'TRANSITION_MISSING_PRESENTATION'
     | 'TRANSITION_INVALID_DIRECTION'
+    | 'TRANSITION_UNSUPPORTED_PRESENTATION'
     | 'TRANSFORM_PARENT_NOT_FOUND'
     | 'TRANSFORM_PARENT_CYCLE'
     | 'TRANSFORM_PARENT_INVALID_TYPE'
@@ -327,14 +328,18 @@ const TRANSITION_WARNING_CODES = {
   not_adjacent: 'TRANSITION_NOT_ADJACENT',
   missing_presentation: 'TRANSITION_MISSING_PRESENTATION',
   invalid_direction: 'TRANSITION_INVALID_DIRECTION',
+  unsupported_presentation: 'TRANSITION_UNSUPPORTED_PRESENTATION',
 } as const
 
 /** Transitions that would silently never render (or degrade to a hard cut). */
 function transitionWarnings(
   transitions: readonly Transition[] | undefined,
   items: readonly TimelineItem[],
+  // Which presentations can actually be drawn depends on the GPU: without it the
+  // Canvas2D fallback covers only a handful and the rest become hard cuts.
+  options: { gpuAvailable: boolean } = { gpuAvailable: false },
 ): HeadlessRenderWarning[] {
-  return collectTransitionFindings(transitions ?? [], items).map((f) => ({
+  return collectTransitionFindings(transitions ?? [], items, options).map((f) => ({
     code: TRANSITION_WARNING_CODES[f.kind],
     message: f.message,
     details: { transitionId: f.transitionId },
@@ -386,11 +391,12 @@ function runLoadValidation(
   compositions: readonly SubComposition[] | undefined,
   fps: number,
   mediaById: Map<string, MediaMetadata>,
+  gpuAvailable: boolean,
 ): HeadlessRenderWarning[] {
   const validationWarnings = [
     ...(input.validationWarnings ?? []),
     ...sourceRangeWarnings(items, compositions, mediaById, fps),
-    ...transitionWarnings(input.transitions, items),
+    ...transitionWarnings(input.transitions, items, { gpuAvailable }),
     ...transformParentWarnings(items),
   ]
   reportValidationWarnings(validationWarnings, input.strict, 'render')
@@ -459,6 +465,13 @@ function defaultFileName(settings: ClientExportSettings): string {
 function effectiveFileName(requested: string | undefined, settings: ClientExportSettings): string {
   if (!requested) return defaultFileName(settings)
   return `${requested.replace(/\.[^./\\]+$/, '')}.${settings.container}`
+}
+
+let webGpuAvailable: Promise<boolean> | null = null
+/** Memoised: validation, the GPU assert and the render path all ask the same question. */
+function detectWebGpuOnce(): Promise<boolean> {
+  webGpuAvailable ??= detectWebGpu()
+  return webGpuAvailable
 }
 
 async function detectWebGpu(): Promise<boolean> {
@@ -613,7 +626,9 @@ async function renderTimeline(input: HeadlessTimelineInput): Promise<HeadlessRen
   // Load-time validation: caller-collected findings (project normalization)
   // plus source-overrun checks. Logged always; fatal before render in --strict.
   const mediaById = buildMediaMetadataMap(media)
-  warnings.unshift(...runLoadValidation(input, items, compositions, fps, mediaById))
+  warnings.unshift(
+    ...runLoadValidation(input, items, compositions, fps, mediaById, await detectWebGpuOnce()),
+  )
 
   const composition: CompositionInputProps = convertTimelineToComposition(
     tracks,
@@ -907,6 +922,7 @@ function buildComposition(view: MigratedTimelineView): CompositionInputProps {
 // fallow-ignore-next-line complexity
 async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSummary> {
   const view = extractTimeline(input.project)
+  const gpuAvailable = await detectWebGpuOnce()
   const frame = resolveTargetFrame(view, input)
   const validationWarnings = [
     ...projectWarningsToHeadless(view.projectWarnings),
@@ -916,7 +932,7 @@ async function renderFrame(input: HeadlessFrameInput): Promise<HeadlessFrameSumm
       buildMediaMetadataMap(input.media),
       view.fps,
     ),
-    ...transitionWarnings(view.transitions, view.items),
+    ...transitionWarnings(view.transitions, view.items, { gpuAvailable }),
     ...transformParentWarnings(view.items),
   ]
   reportValidationWarnings(validationWarnings, input.strict, 'frame')
@@ -1057,6 +1073,7 @@ function computeTextLayout(
 // fallow-ignore-next-line complexity
 async function dumpLayout(input: HeadlessLayoutInput): Promise<HeadlessLayoutResult> {
   const view = extractTimeline(input.project)
+  const gpuAvailable = await detectWebGpuOnce()
   const frame = resolveTargetFrame(view, input)
   const validationWarnings = [
     ...projectWarningsToHeadless(view.projectWarnings),
@@ -1066,7 +1083,7 @@ async function dumpLayout(input: HeadlessLayoutInput): Promise<HeadlessLayoutRes
       buildMediaMetadataMap(input.media),
       view.fps,
     ),
-    ...transitionWarnings(view.transitions, view.items),
+    ...transitionWarnings(view.transitions, view.items, { gpuAvailable }),
     ...transformParentWarnings(view.items),
   ]
   reportValidationWarnings(validationWarnings, input.strict, 'layout')

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -478,7 +478,14 @@ async function detectWebGpu(): Promise<boolean> {
   try {
     if (!('gpu' in navigator) || !navigator.gpu) return false
     const adapter = await navigator.gpu.requestAdapter()
-    return Boolean(adapter)
+    if (!adapter) return false
+    // An adapter is not enough: device acquisition is what actually fails on
+    // headless/software stacks, and reporting "GPU available" on the strength of
+    // an adapter alone would suppress warnings for presets that then fall back.
+    const device = await adapter.requestDevice()
+    if (!device) return false
+    device.destroy()
+    return true
   } catch {
     return false
   }

--- a/src/headless/validation.test.ts
+++ b/src/headless/validation.test.ts
@@ -8,6 +8,7 @@ import {
   CANVAS_FALLBACK_PRESENTATIONS,
   resolveTransitionRenderPath,
 } from '@/features/export/utils/canvas-transitions'
+import { transitionRegistry } from '@/shared/timeline/transitions/registry'
 import {
   buildMediaMetadataMap,
   collectSourceRangeFindings,
@@ -225,6 +226,38 @@ describe('collectTransitionFindings', () => {
           { gpuAvailable: false },
         ),
       ).toEqual([])
+    }
+  })
+
+  it('an uncompiled GPU pipeline does not count as GPU coverage', () => {
+    // renderTransition needs BOTH a gpuTransitionId and gpuTransitionPipeline
+    // .has(id). An adapter alone must not suppress the warning, or a preset whose
+    // Canvas fallback is a hard cut renders wrong with nothing said.
+    // Registered explicitly rather than relying on whatever the ambient registry
+    // happens to hold in this environment.
+    transitionRegistry.register(
+      'gpuOnlyProbe',
+      { id: 'gpuOnlyProbe' } as never,
+      { gpuTransitionId: 'gpu-only-probe' } as never,
+    )
+    try {
+      expect(
+        resolveTransitionRenderPath('gpuOnlyProbe', {
+          gpuAvailable: true,
+          hasGpuTransition: () => true,
+        }),
+      ).toBe('gpu')
+      // Adapter present, pipeline never compiled this id → really a hard cut.
+      expect(
+        resolveTransitionRenderPath('gpuOnlyProbe', {
+          gpuAvailable: true,
+          hasGpuTransition: () => false,
+        }),
+      ).toBe('cut')
+      // No GPU at all, and no Canvas fallback for it either.
+      expect(resolveTransitionRenderPath('gpuOnlyProbe', { gpuAvailable: false })).toBe('cut')
+    } finally {
+      transitionRegistry.unregister('gpuOnlyProbe')
     }
   })
 

--- a/src/headless/validation.test.ts
+++ b/src/headless/validation.test.ts
@@ -5,6 +5,10 @@ import type { TimelineItem } from '@/types/timeline'
 import type { MediaMetadata } from '@/types/storage'
 import type { Transition } from '@/types/transition'
 import {
+  CANVAS_FALLBACK_PRESENTATIONS,
+  resolveTransitionRenderPath,
+} from '@/features/export/utils/canvas-transitions'
+import {
   buildMediaMetadataMap,
   collectSourceRangeFindings,
   collectTransitionFindings,
@@ -191,6 +195,45 @@ describe('collectTransitionFindings', () => {
     expect(
       collectTransitionFindings([makeTransition({ direction: 'from-left' })], adjacentPair()),
     ).toEqual([])
+  })
+
+  it('flags a declared preset that no available path can draw', () => {
+    // BuiltinTransitionPresentation declares far more presets than the Canvas2D
+    // fallback implements. Without a GPU the rest reach `default:` and render a
+    // plain cut — silently, which is what this warning exists to stop.
+    const findings = collectTransitionFindings(
+      [makeTransition({ presentation: 'glitch' as Transition['presentation'] })],
+      adjacentPair(),
+      { gpuAvailable: false },
+    )
+    expect(findings[0]).toMatchObject({
+      kind: 'unsupported_presentation',
+      transitionId: 'tr-1',
+    })
+    expect(findings[0]!.message).toContain('glitch')
+    expect(findings[0]!.message).toContain('HARD CUT')
+    // The message names what IS drawable, so the caller can pick a substitute.
+    expect(findings[0]!.message).toContain('fade')
+  })
+
+  it('does not flag presets the Canvas2D fallback actually implements', () => {
+    for (const presentation of ['fade', 'wipe', 'slide', 'flip', 'clockWipe', 'iris']) {
+      expect(
+        collectTransitionFindings(
+          [makeTransition({ presentation: presentation as Transition['presentation'] })],
+          adjacentPair(),
+          { gpuAvailable: false },
+        ),
+      ).toEqual([])
+    }
+  })
+
+  it('every Canvas2D fallback preset resolves to a real path (guards list/switch drift)', () => {
+    // CANVAS_FALLBACK_PRESENTATIONS is hand-maintained next to the switch it
+    // mirrors. If someone removes a `case` without updating the set, this fails.
+    for (const presentation of CANVAS_FALLBACK_PRESENTATIONS) {
+      expect(resolveTransitionRenderPath(presentation, { gpuAvailable: false })).not.toBe('cut')
+    }
   })
 
   it('flags a missing presentation (renders as a hard cut)', () => {

--- a/src/headless/validation.test.ts
+++ b/src/headless/validation.test.ts
@@ -9,6 +9,7 @@ import {
   resolveTransitionRenderPath,
 } from '@/features/export/utils/canvas-transitions'
 import { transitionRegistry } from '@/shared/timeline/transitions/registry'
+import { getGpuTransitionIds } from '@/infrastructure/gpu-transitions'
 import {
   buildMediaMetadataMap,
   collectSourceRangeFindings,
@@ -258,6 +259,57 @@ describe('collectTransitionFindings', () => {
       expect(resolveTransitionRenderPath('gpuOnlyProbe', { gpuAvailable: false })).toBe('cut')
     } finally {
       transitionRegistry.unregister('gpuOnlyProbe')
+    }
+  })
+
+  it('validation itself applies the pipeline probe, not just adapter presence', () => {
+    // The probe existing on resolveTransitionRenderPath is not enough — the
+    // finding is only honest if collectTransitionFindings actually passes one.
+    // A presentation whose gpuTransitionId is absent from the GPU registry can
+    // never be compiled, so it must still be flagged even with a GPU present.
+    transitionRegistry.register(
+      'ghostGpuPreset',
+      { id: 'ghostGpuPreset' } as never,
+      { gpuTransitionId: 'not-in-the-gpu-registry' } as never,
+    )
+    try {
+      const findings = collectTransitionFindings(
+        [makeTransition({ presentation: 'ghostGpuPreset' as Transition['presentation'] })],
+        adjacentPair(),
+        { gpuAvailable: true },
+      )
+      expect(findings.map((f) => f.kind)).toContain('unsupported_presentation')
+    } finally {
+      transitionRegistry.unregister('ghostGpuPreset')
+    }
+  })
+
+  it('a preset backed by a REAL gpu transition is not flagged when a GPU is present', () => {
+    const gpuId = getGpuTransitionIds()[0]
+    expect(gpuId).toBeTruthy()
+    transitionRegistry.register(
+      'realGpuPreset',
+      { id: 'realGpuPreset' } as never,
+      { gpuTransitionId: gpuId } as never,
+    )
+    try {
+      expect(
+        collectTransitionFindings(
+          [makeTransition({ presentation: 'realGpuPreset' as Transition['presentation'] })],
+          adjacentPair(),
+          { gpuAvailable: true },
+        ),
+      ).toEqual([])
+      // ...and the same preset IS flagged once the GPU is gone.
+      expect(
+        collectTransitionFindings(
+          [makeTransition({ presentation: 'realGpuPreset' as Transition['presentation'] })],
+          adjacentPair(),
+          { gpuAvailable: false },
+        ).map((f) => f.kind),
+      ).toContain('unsupported_presentation')
+    } finally {
+      transitionRegistry.unregister('realGpuPreset')
     }
   })
 

--- a/src/headless/validation.ts
+++ b/src/headless/validation.ts
@@ -14,6 +14,7 @@ import {
   CANVAS_FALLBACK_PRESENTATIONS,
   resolveTransitionRenderPath,
 } from '@/features/export/utils/canvas-transitions'
+import { getGpuTransition } from '@/infrastructure/gpu-transitions'
 
 export interface SourceRangeFinding {
   itemId: string
@@ -173,7 +174,14 @@ function unsupportedPresentationFinding(
   gpuAvailable: boolean,
 ): TransitionFinding | null {
   if (!transition.presentation) return null
-  if (resolveTransitionRenderPath(transition.presentation, { gpuAvailable }) !== 'cut') return null
+  const path = resolveTransitionRenderPath(transition.presentation, {
+    gpuAvailable,
+    // The pipeline can only ever compile ids the GPU registry knows, so an id it
+    // does not carry can never take the GPU path — checkable here, before any
+    // pipeline exists. `TransitionPipeline.render` applies the same condition.
+    hasGpuTransition: (id) => Boolean(getGpuTransition(id)),
+  })
+  if (path !== 'cut') return null
   return {
     transitionId: transition.id,
     kind: 'unsupported_presentation',

--- a/src/headless/validation.ts
+++ b/src/headless/validation.ts
@@ -10,6 +10,10 @@ import type { TimelineItem } from '@/types/timeline'
 import type { MediaMetadata } from '@/types/storage'
 import type { CompositionInputProps } from '@/types/export'
 import type { Transition } from '@/types/transition'
+import {
+  CANVAS_FALLBACK_PRESENTATIONS,
+  resolveTransitionRenderPath,
+} from '@/features/export/utils/canvas-transitions'
 
 export interface SourceRangeFinding {
   itemId: string
@@ -77,6 +81,7 @@ export interface TransitionFinding {
     | 'not_adjacent'
     | 'missing_presentation'
     | 'invalid_direction'
+    | 'unsupported_presentation'
   message: string
 }
 
@@ -154,14 +159,44 @@ function degradationTransitionFindings(transition: Transition): TransitionFindin
   return findings
 }
 
+/**
+ * A declared presentation that no available path can draw renders as a hard cut.
+ *
+ * `BuiltinTransitionPresentation` declares far more presets than the Canvas2D
+ * fallback implements, and without a GPU the rest reach `default:` and produce a
+ * plain cut — no error, no warning, just a project that silently looks wrong.
+ * The generic WEBGPU_TRANSITION_FALLBACK warning does not name which transitions
+ * degraded, which is the part a caller actually needs.
+ */
+function unsupportedPresentationFinding(
+  transition: Transition,
+  gpuAvailable: boolean,
+): TransitionFinding | null {
+  if (!transition.presentation) return null
+  if (resolveTransitionRenderPath(transition.presentation, { gpuAvailable }) !== 'cut') return null
+  return {
+    transitionId: transition.id,
+    kind: 'unsupported_presentation',
+    message:
+      `Transition "${transition.id}" uses presentation "${transition.presentation}", which has no ` +
+      `${gpuAvailable ? '' : 'Canvas2D '}implementation here — it renders as a HARD CUT, not a transition` +
+      (gpuAvailable ? '' : '. Presets drawable without a GPU: ') +
+      (gpuAvailable ? '' : [...CANVAS_FALLBACK_PRESENTATIONS].filter((p) => p !== 'none').join(', ')),
+  }
+}
+
 export function collectTransitionFindings(
   transitions: readonly Transition[],
   items: readonly TimelineItem[],
+  options: { gpuAvailable: boolean } = { gpuAvailable: false },
 ): TransitionFinding[] {
   const itemById = new Map(items.map((item) => [item.id, item]))
   return transitions.flatMap((transition) => {
     const structural = structuralTransitionFinding(transition, itemById)
-    return structural ? [structural] : degradationTransitionFindings(transition)
+    if (structural) return [structural]
+    const degradations = degradationTransitionFindings(transition)
+    const unsupported = unsupportedPresentationFinding(transition, options.gpuAvailable)
+    return unsupported ? [...degradations, unsupported] : degradations
   })
 }
 


### PR DESCRIPTION
Found while auditing my own workarounds: I had a note in my montage playbook saying "only four transitions actually work headless, everything else is a bare cut and `--strict` doesn't mention it". It turned out to be worse than the note, and it is not headless-specific.

## The numbers

`BuiltinTransitionPresentation` declares **44** presets. The Canvas2D fallback in `canvas-transitions.ts` implements **six** — `fade`, `wipe`, `slide`, `flip`, `clockWipe`, `iris` — plus `none`. The other **38** (`glitch`, `dissolve`, `barnDoor`, `starShape`, `pixelate`, `venetianBlindWipe`, …) fall through to:

```ts
case 'none':
default:
  renderCutTransition(ctx, leftCanvas, rightCanvas, progress)
```

A hard cut, with no error and no warning. From a user's seat that is indistinguishable from "the transition I added did nothing" — which is roughly how #250 was originally described.

`WEBGPU_TRANSITION_FALLBACK` does not cover it: it fires only when WebGPU is absent, and says the generic *"transitions will use the Canvas2D fallback"* — never **which** transitions degraded, which is the only part that lets someone pick a substitute.

## What this adds

- **`resolveTransitionRenderPath(presentation, { gpuAvailable })`** → `'gpu' | 'registry-canvas' | 'builtin' | 'cut'`. It accounts for the registry's own `renderCanvas` entries and for GPU availability, so it is accurate rather than a hardcoded guess.
- **`CANVAS_FALLBACK_PRESENTATIONS`** placed directly above the `switch` it mirrors, with a test asserting every member still resolves to a non-`cut` path. Remove a `case` without updating the set and that test fails — the list cannot silently drift from the code.
- **`TRANSITION_UNSUPPORTED_PRESENTATION`** in headless load validation, naming the transition, the preset, and what *is* drawable. `--strict` fails on it, before rendering.
- GPU detection **memoised**, since validation, the GPU assert and the render path now all ask the same question.

GPU availability is threaded through rather than assumed, so a machine that *can* draw the preset gets no false warning — that mattered enough to be worth the plumbing.

I deliberately did **not** put the warning in the per-frame render path: it would fire once per frame for the same transition. Load validation is where it belongs, and where the channel already exists.

## Scope

This reports the gap; it does not implement the 38 missing presets. If you would like the CPU path extended to cover some of them, say which matter and I will take a look — but that is a much larger change and worth agreeing first.

## Verification

```
vp check --no-fmt src headless vite.config.ts   no warnings, lint or type errors (2367 files)
vp test run                                     653 files, 4665 passed (4665)
npm run build                                   ✓ built in 8.66s
node --test headless/*.test.mjs                 42 pass, 0 fail
node headless/test.mjs --skip-build             All headless checks passed ✓
node headless/edit-operations.mjs               All 19 edit operation contracts passed
```

Three new tests: an unsupported preset is flagged and names a drawable alternative; all six implemented presets are *not* flagged; and the drift guard above. The first is red without the change.
