### PR TITLE
fix(export): populate the transition registry on the export path (recovers 38 presets in worker + headless exports)

### DIFF
--- a/src/features/export/utils/canvas-item-renderer/transition.ts
+++ b/src/features/export/utils/canvas-item-renderer/transition.ts
@@ -5,6 +5,10 @@
 
 import type { TimelineItem } from '@/types/timeline'
 import { hasCornerPin } from '@/features/export/deps/composition-runtime'
+// Side-effect: populate the registry. Without it every consumer that does not
+// happen to load the editor UI (the headless harness, workers) silently falls
+// back to the built-in switch, turning 38 declared presets into hard cuts.
+import '@/shared/timeline/transitions'
 import { transitionRegistry } from '@/shared/timeline/transitions/registry'
 import type { GpuTexturePool } from '@/infrastructure/gpu-compositor'
 import {

--- a/src/features/export/utils/canvas-transitions.ts
+++ b/src/features/export/utils/canvas-transitions.ts
@@ -7,6 +7,10 @@
 
 import type { Transition, WipeDirection, SlideDirection, FlipDirection } from '@/types/transition'
 import type { TimelineItem } from '@/types/timeline'
+// Side-effect: populate the registry. Without it every consumer that does not
+// happen to load the editor UI (the headless harness, workers) silently falls
+// back to the built-in switch, turning 38 declared presets into hard cuts.
+import '@/shared/timeline/transitions'
 import { transitionRegistry } from '@/shared/timeline/transitions/registry'
 import { createLogger } from '@/shared/logging/logger'
 import type { TransitionPipeline } from '@/infrastructure/gpu-transitions'

--- a/src/headless/validation.test.ts
+++ b/src/headless/validation.test.ts
@@ -199,12 +199,17 @@ describe('collectTransitionFindings', () => {
     ).toEqual([])
   })
 
-  it('flags a declared preset that no available path can draw', () => {
-    // BuiltinTransitionPresentation declares far more presets than the Canvas2D
-    // fallback implements. Without a GPU the rest reach `default:` and render a
-    // plain cut — silently, which is what this warning exists to stop.
+  it('flags a presentation that no available path can draw', () => {
+    // `TransitionPresentation` is widened to string so custom registry entries
+    // work, which means an id with no registry entry and no built-in branch is
+    // reachable — and renders a plain cut, silently. That is what this warns on.
+    //
+    // Note this deliberately uses an unregistered id rather than a declared
+    // preset: since the export path now pulls in the built-in renderers, every
+    // declared preset resolves to a real path. Using e.g. 'glitch' here would
+    // pass only while the registry happened to be empty.
     const findings = collectTransitionFindings(
-      [makeTransition({ presentation: 'glitch' as Transition['presentation'] })],
+      [makeTransition({ presentation: 'notARegisteredPreset' as Transition['presentation'] })],
       adjacentPair(),
       { gpuAvailable: false },
     )
@@ -212,10 +217,29 @@ describe('collectTransitionFindings', () => {
       kind: 'unsupported_presentation',
       transitionId: 'tr-1',
     })
-    expect(findings[0]!.message).toContain('glitch')
+    expect(findings[0]!.message).toContain('notARegisteredPreset')
     expect(findings[0]!.message).toContain('HARD CUT')
     // The message names what IS drawable, so the caller can pick a substitute.
     expect(findings[0]!.message).toContain('fade')
+  })
+
+  it('every preset the product offers is drawable by the export path', () => {
+    // The regression this guards: the export path reads the transition registry,
+    // but nothing on that path used to populate it. Any consumer that did not
+    // happen to load the editor UI — the headless harness above all — fell back
+    // to the built-in switch, turning most declared presets into hard cuts.
+    // Verified end-to-end on real media: 6/44 drew a transition before, 44/44 after.
+    //
+    // Importing only `./validation` here is the point: it reaches the registry
+    // through the export path alone, with no editor module in the graph. Drop the
+    // side-effect import from canvas-transitions and this list stops being empty.
+    const offered = transitionRegistry.getDefinitions().map((definition) => definition.id)
+    expect(offered.length).toBeGreaterThan(6)
+
+    const notDrawable = offered.filter(
+      (id) => resolveTransitionRenderPath(id, { gpuAvailable: false }) === 'cut',
+    )
+    expect(notDrawable).toEqual([])
   })
 
   it('does not flag presets the Canvas2D fallback actually implements', () => {


### PR DESCRIPTION
Follow-up to #358 — you said the 38 missing presets would need evaluating for full compatibility and invited me to look. I did, and the answer turned out to be much better than expected: **they are not missing.** They all have working Canvas2D renderers. The export path just never registers them.

## Root cause

`registerBuiltinTransitions()` runs as a side effect of importing the `@/shared/timeline/transitions` barrel. Nothing on the export path imports it — `canvas-transitions.ts` and `canvas-item-renderer/transition.ts` both import `./registry` **directly**, so they read a registry nobody filled. `getRenderer()` returns `undefined` for everything, execution falls to:

```ts
case 'none':
default:
  renderCutTransition(ctx, leftCanvas, rightCanvas, progress)
```

In the editor **preview** this is masked, because editor modules (`transitions-panel.tsx`, `transition-ui-config.ts`, `transition-preview.tsx`) import the barrel and fill the registry on the main thread.

Export does not get that. `export-render.worker.ts` runs in a worker with its own module graph — it pulls in `renderComposition` and nothing that reaches the barrel — and `runRender` uses the worker as the primary path, falling back to the main thread only after a worker error. So this is not a headless-only bug: **the app's normal export is affected too.** The headless harness is simply where it is easiest to observe, since it mounts no editor UI at all.

## The fix

Both registry readers now import the barrel for its side effect. The guarantee belongs to the code that depends on it, instead of to whoever happened to be loaded first.

- Registration is already idempotent (`registered` flag in `register-builtins.ts`).
- The renderers do not import the export path, so there is no cycle — build is clean.
- Two lines of production code.

## Measured, on real media

Not inferred from the source: two adjacent 1280×720 image clips (red → blue) with a 20-frame transition, rendered through `headless/render.mjs`, frames extracted from the resulting mp4 with ffmpeg.

One caveat on that fixture, found while checking a review point: flat-colour sources understate any effect that depends on image detail — pixelating a solid red is a no-op. Re-run on textured sources (`testsrc`/`testsrc2`), `pixelate` goes from 5/30 unique frames to **30/30**, `glitch` to 29/30, `blurDissolve` to 30/30. The counts below are the conservative flat-colour ones.

| | presets drawing a transition | hard cut |
|---|---|---|
| before | **6 / 44** | 38 |
| after | **44 / 44** | 0 |

Unique frames across the 30-frame render window, which is the giveaway — a hard cut has exactly two:

| preset | before | after |
|---|---|---|
| `fade` (already worked — but changes, see below) | 20 / 30 | 20 / 30 |
| `heartShape` | 2 / 30 | 13 / 30 |
| `barnDoor` | 2 / 30 | 20 / 30 |
| `venetianBlindWipe` | 2 / 30 | 20 / 30 |

`TRANSITION_UNSUPPORTED_PRESENTATION` (the warning from #358) fires 38 times before and 0 times after — it was reporting this accurately all along.

## Before / after

Top row = before, bottom row = after. Frames at 25%, 50% and 75% through the transition. Before, every preset jumps red → blue with nothing in between.

**venetianBlindWipe**
![venetianBlindWipe](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/venetianBlindWipe.png)

**heartShape**
![heartShape](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/heartShape.png)

**barnDoor**
![barnDoor](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/barnDoor.png)

**split**
![split](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/split.png)

**glitch**
![glitch](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/glitch.png)

**dissolve**
![dissolve](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/dissolve.png)

**fade** — see the correction below: this one **does** change.
![fade](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/changed-fade.png)

(Images live on a separate `proofs` branch of my fork so they stay out of this diff.)

## Correction — one preset changes appearance

I originally wrote that `fade` was identical before and after. **That was wrong**, and review caught it.

Populating the registry means `renderer.renderCanvas` now takes precedence over the built-in branch for presets that have both. Measured across 3 frames each:

| preset | PSNR | mean luma delta | what actually differs |
|---|---|---|---|
| `fade` | 8.8 dB | **38.77** | the whole frame — equal-power crossfade → dip through black |
| `iris` | 17.3 dB | 1.37 | the aperture edge only (feathered instead of hard) |
| `clockWipe` | 19.1 dB | 0.93 | the sweep edge only |
| `wipe` | **inf** | **0** | nothing — byte-identical |

Amplified difference map (white = differs, black = identical; `fade` top-left, `clockWipe` top-right, `iris` bottom-left, `wipe` bottom-right):

![difference map](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/diffmap.png)

`clockWipe` keeps its sweep and `iris` keeps its circle — same geometry and timing, only a softened boundary. **`fade` is the only preset whose appearance materially changes.**

Why I still think this is the right direction rather than a regression: the registry `fade` is deliberate (`description: "Dip through black between clips"`), and the editor preview resolves through the registry, so **the bottom row is what the preview has always shown**. The built-in branch was only ever reached where the registry is empty.

Which is not only headless. `export-render.worker.ts` has its own module graph and never reaches the transitions barrel, and `runRender` uses the worker as the primary path. Bundle evidence, same build both ways:

```
without the fix:  heartShape only in  transition-ui-config-*.js        (editor chunk)
                  NOT in              canvas-render-orchestrator-*.js
with the fix:     heartShape in       canvas-render-orchestrator-*.js
```

So `fade` already renders differently in the preview than in a worker export today. This PR makes preview, worker export and headless agree.

**Your call, and I will do either:** land as-is, or — if the equal-power crossfade is the look you want (it preserves alpha for soft crop and masks, which the dip version does not) — change `renderers/basic.ts` instead, so preview and every export path get it together. What I would avoid is putting the built-in branch back ahead of the registry, since that re-splits behaviour between paths, which is the underlying bug.

## Test

One new test, and it is aimed at the wiring rather than at the renderers:

```ts
const offered = transitionRegistry.getDefinitions().map((d) => d.id)
expect(offered.length).toBeGreaterThan(6)
const notDrawable = offered.filter(
  (id) => resolveTransitionRenderPath(id, { gpuAvailable: false }) === 'cut',
)
expect(notDrawable).toEqual([])
```

The point is what the test file imports: only `./validation`, which reaches the registry through the export path alone with no editor module in the graph. Remove the side-effect import and it fails immediately — verified, the registry drops to 0 definitions.

Asserting against `getDefinitions()` rather than a hardcoded list ties the check to what the product actually offers in its UI: anything registered for users to pick must be drawable by export.

## One existing test changes

The `flags a declared preset that no available path can draw` case I added in #358 used `'glitch'`, and passed only because the registry was empty in the node environment — the "right answer for the wrong reason" I flagged in that PR. With the registry populated, `glitch` is correctly supported, so the test now uses an unregistered id, which is the case that genuinely cannot be drawn. (`TransitionPresentation` is widened to `string` for custom registry entries, so that case is reachable.)

## Verification

```
vp check --no-fmt src headless vite.config.ts   no warnings, lint or type errors (2367 files)
vp test run                                     653 files, 4675 passed (4675)
npm run build                                   ✓ built in 7.56s
node --test headless/*.test.mjs                 42 pass, 0 fail
node headless/test.mjs --skip-build             All headless checks passed ✓
node headless/edit-operations.mjs               All 19 edit operation contracts passed
check:boundaries / deps-contracts / legacy-lib-imports / deps-wrapper-health   all PASS
```

## Scope note

This is the whole of the "38 missing presets" question — there is nothing left to implement for them on the CPU path. What it does **not** touch is the GPU path: presets with a `gpuTransitionId` still need a compiled pipeline, which `resolveTransitionRenderPath` already accounts for. If you want, the natural next step is deciding whether headless should attempt WebGPU at all, but that is a separate conversation.
