### PR TITLE
fix(transitions): make fade an equal-power crossfade on every path

### DIFF
--- a/src/infrastructure/gpu-transitions/transitions/fade.ts
+++ b/src/infrastructure/gpu-transitions/transitions/fade.ts
@@ -22,15 +22,27 @@ struct FadeParams {
 
 @fragment
 fn fadeFragment(input: VertexOutput) -> @location(0) vec4f {
-  let left = textureSample(leftTex, texSampler, input.uv);
-  let right = textureSample(rightTex, texSampler, input.uv);
   let p = clamp(params.progress, 0.0, 1.0);
 
-  let outgoingWeight = select(0.0, max(0.0, cos(p * PI)), p < 0.5);
-  let incomingWeight = select(max(0.0, -cos(p * PI)), 0.0, p < 0.5);
-  let blackWeight = 1.0 - max(outgoingWeight, incomingWeight);
-  let color = left.rgb * outgoingWeight + right.rgb * incomingWeight;
-  let alpha = clamp(left.a * outgoingWeight + right.a * incomingWeight + blackWeight, 0.0, 1.0);
+  // cos²/sin² weights summing to 1, plus a 4% scale drift — mirrors the
+  // Canvas2D fade renderer so GPU preview matches CPU export exactly.
+  let c = cos(p * PI / 2.0);
+  let outgoingWeight = c * c;
+  let incomingWeight = 1.0 - c * c;
+  let outgoingScale = 1.0 - 0.04 * p;
+  let incomingScale = 1.04 - 0.04 * p;
+
+  let outgoingUv = (input.uv - vec2f(0.5)) / outgoingScale + vec2f(0.5);
+  let incomingUv = (input.uv - vec2f(0.5)) / incomingScale + vec2f(0.5);
+  let left = textureSample(leftTex, texSampler, clamp(outgoingUv, vec2f(0.0), vec2f(1.0)));
+  let right = textureSample(rightTex, texSampler, clamp(incomingUv, vec2f(0.0), vec2f(1.0)));
+  let outgoingMask = f32(all(outgoingUv >= vec2f(0.0)) && all(outgoingUv <= vec2f(1.0)));
+  let incomingMask = f32(all(incomingUv >= vec2f(0.0)) && all(incomingUv <= vec2f(1.0)));
+
+  let wOut = outgoingWeight * outgoingMask;
+  let wIn = incomingWeight * incomingMask;
+  let color = left.rgb * wOut + right.rgb * wIn;
+  let alpha = clamp(left.a * wOut + right.a * wIn, 0.0, 1.0);
 
   return vec4f(color, alpha);
 }`,

--- a/src/shared/timeline/transitions/renderers/basic.test.ts
+++ b/src/shared/timeline/transitions/renderers/basic.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vite-plus/test'
+import { TransitionRegistry } from '../registry'
+import { registerBasicTransitions } from './basic'
+
+interface RecordedDraw {
+  source: unknown
+  alpha: number
+  composite: string
+  scale: number
+}
+
+interface RecordedFill {
+  fillStyle: string
+  composite: string
+}
+
+/**
+ * Records the draw calls `renderCanvas` makes so tests can assert on the
+ * weights and compositing without a real rasterizer.
+ */
+class RecordingContext {
+  globalAlpha = 1
+  globalCompositeOperation = 'source-over'
+  fillStyle = ''
+  draws: RecordedDraw[] = []
+  fills: RecordedFill[] = []
+
+  private scaleX = 1
+  private stack: Array<{ alpha: number; composite: string; scaleX: number }> = []
+
+  save(): void {
+    this.stack.push({
+      alpha: this.globalAlpha,
+      composite: this.globalCompositeOperation,
+      scaleX: this.scaleX,
+    })
+  }
+
+  restore(): void {
+    const state = this.stack.pop()
+    if (state) {
+      this.globalAlpha = state.alpha
+      this.globalCompositeOperation = state.composite
+      this.scaleX = state.scaleX
+    }
+  }
+
+  translate(): void {}
+
+  scale(x: number): void {
+    this.scaleX *= x
+  }
+
+  drawImage(source: unknown): void {
+    this.draws.push({
+      source,
+      alpha: this.globalAlpha,
+      composite: this.globalCompositeOperation,
+      scale: this.scaleX,
+    })
+  }
+
+  fillRect(): void {
+    this.fills.push({ fillStyle: this.fillStyle, composite: this.globalCompositeOperation })
+  }
+}
+
+function renderFadeAt(progress: number) {
+  const registry = new TransitionRegistry()
+  registerBasicTransitions(registry)
+  const renderer = registry.getRenderer('fade')
+  expect(renderer?.renderCanvas).toBeDefined()
+
+  const ctx = new RecordingContext()
+  const left = { width: 640, height: 360 }
+  const right = { width: 640, height: 360 }
+  renderer!.renderCanvas!(
+    ctx as unknown as OffscreenCanvasRenderingContext2D,
+    left as unknown as OffscreenCanvas,
+    right as unknown as OffscreenCanvas,
+    progress,
+    undefined,
+    { width: 640, height: 360 },
+  )
+
+  const drawsFor = (source: unknown) => ctx.draws.filter((draw) => draw.source === source)
+  return { ctx, left, right, drawsFor }
+}
+
+describe('fade renderCanvas (equal-power crossfade)', () => {
+  it('draws both clips at half weight at the midpoint instead of dipping to black', () => {
+    const { drawsFor, left, right } = renderFadeAt(0.5)
+
+    const outgoing = drawsFor(left)
+    const incoming = drawsFor(right)
+    expect(outgoing).toHaveLength(1)
+    expect(incoming).toHaveLength(1)
+    expect(outgoing[0]!.alpha).toBeCloseTo(0.5, 5)
+    expect(incoming[0]!.alpha).toBeCloseTo(0.5, 5)
+  })
+
+  it('weights follow the export path cos²/sin² curve, summing to 1 at every progress', () => {
+    for (const p of [0.1, 0.25, 0.5, 0.75, 0.9]) {
+      const { drawsFor, left, right } = renderFadeAt(p)
+      const c = Math.cos((p * Math.PI) / 2)
+      expect(drawsFor(left)[0]!.alpha).toBeCloseTo(c * c, 5)
+      expect(drawsFor(right)[0]!.alpha).toBeCloseTo(1 - c * c, 5)
+    }
+  })
+
+  it('shows exactly the outgoing clip at progress 0 and the incoming clip at progress 1', () => {
+    const start = renderFadeAt(0)
+    expect(start.drawsFor(start.left)[0]!.alpha).toBeCloseTo(1, 5)
+
+    const end = renderFadeAt(1)
+    expect(end.drawsFor(end.right)[0]!.alpha).toBeCloseTo(1, 5)
+    const lingeringOutgoing = end.drawsFor(end.left)
+    if (lingeringOutgoing.length > 0) {
+      expect(lingeringOutgoing[0]!.alpha).toBeCloseTo(0, 5)
+    }
+  })
+
+  it('composites the outgoing clip additively with no black underfill', () => {
+    const { ctx, drawsFor, left } = renderFadeAt(0.5)
+
+    expect(ctx.fills).toHaveLength(0)
+    expect(drawsFor(left)[0]!.composite).toBe('lighter')
+  })
+
+  it('applies the legacy 4% scale drift from the export path', () => {
+    const start = renderFadeAt(0)
+    expect(start.drawsFor(start.left)[0]!.scale).toBeCloseTo(1, 5)
+    expect(start.drawsFor(start.right)[0]!.scale).toBeCloseTo(1.04, 5)
+
+    const end = renderFadeAt(1)
+    expect(end.drawsFor(end.right)[0]!.scale).toBeCloseTo(1, 5)
+  })
+})
+
+describe('fade definition', () => {
+  it('describes a crossfade, not a dip through black', () => {
+    const registry = new TransitionRegistry()
+    registerBasicTransitions(registry)
+    const definition = registry.getDefinition('fade')
+    expect(definition?.description).not.toMatch(/dip/i)
+    expect(definition?.description).toMatch(/crossfade/i)
+  })
+})

--- a/src/shared/timeline/transitions/renderers/basic.ts
+++ b/src/shared/timeline/transitions/renderers/basic.ts
@@ -15,38 +15,52 @@ function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value))
 }
 
-function calculateFadeDipOpacity(progress: number, isOutgoing: boolean): number {
-  if (progress < 0.5) {
-    return isOutgoing ? Math.max(0, Math.cos(progress * Math.PI)) : 0
+// cos²/sin² weights — always sum to 1, preserving alpha for soft crop & masks.
+// Mirrors the export path's legacy fade (canvas-transitions.ts) so registering
+// this renderer does not change export output; the dip-through-black look
+// lives on as the `dipToColorDissolve` preset.
+function fadeWeight(progress: number, isOutgoing: boolean): number {
+  const c = Math.cos((progress * Math.PI) / 2)
+  return isOutgoing ? c * c : 1 - c * c
+}
+
+function fadeScale(progress: number, isOutgoing: boolean): number {
+  if (isOutgoing) {
+    return 1 - 0.04 * progress
   }
-  return isOutgoing ? 0 : Math.max(0, -Math.cos(progress * Math.PI))
+  return 1.04 - 0.04 * progress
+}
+
+function drawFadeParticipant(
+  ctx: OffscreenCanvasRenderingContext2D,
+  source: OffscreenCanvas,
+  width: number,
+  height: number,
+  scale: number,
+  alpha: number,
+): void {
+  ctx.save()
+  ctx.globalAlpha = alpha
+  ctx.translate(width / 2, height / 2)
+  ctx.scale(scale, scale)
+  ctx.translate(-width / 2, -height / 2)
+  ctx.drawImage(source, 0, 0)
+  ctx.restore()
 }
 
 const fadeRenderer: TransitionRenderer = {
   gpuTransitionId: 'fade',
-  renderCanvas(ctx, leftCanvas, rightCanvas, progress) {
+  renderCanvas(ctx, leftCanvas, rightCanvas, progress, _direction, canvas) {
     const p = clamp01(progress)
-    const outgoingWeight = calculateFadeDipOpacity(p, true)
-    const incomingWeight = calculateFadeDipOpacity(p, false)
-    const w = Math.max(leftCanvas.width, rightCanvas.width)
-    const h = Math.max(leftCanvas.height, rightCanvas.height)
+    const w = canvas?.width ?? Math.max(leftCanvas.width, rightCanvas.width)
+    const h = canvas?.height ?? Math.max(leftCanvas.height, rightCanvas.height)
 
     ctx.save()
     ctx.globalCompositeOperation = 'copy'
-    ctx.fillStyle = 'black'
-    ctx.fillRect(0, 0, w, h)
+    drawFadeParticipant(ctx, rightCanvas, w, h, fadeScale(p, false), fadeWeight(p, false))
 
-    if (outgoingWeight > 0) {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.globalAlpha = outgoingWeight
-      ctx.drawImage(leftCanvas, 0, 0)
-    }
-
-    if (incomingWeight > 0) {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.globalAlpha = incomingWeight
-      ctx.drawImage(rightCanvas, 0, 0)
-    }
+    ctx.globalCompositeOperation = 'lighter'
+    drawFadeParticipant(ctx, leftCanvas, w, h, fadeScale(p, true), fadeWeight(p, true))
     ctx.restore()
   },
 }
@@ -54,7 +68,7 @@ const fadeRenderer: TransitionRenderer = {
 const fadeDef: TransitionDefinition = {
   id: 'fade',
   label: 'Fade',
-  description: 'Dip through black between clips',
+  description: 'Equal-power crossfade between clips',
   category: 'basic',
   icon: 'Blend',
   hasDirection: false,


### PR DESCRIPTION
Follow-up to #359, per [your call there](https://github.com/walterlow/freecut/pull/359#issuecomment-5142205188): `fade` is now an equal-power crossfade on every path, and the dip-through-black look stays available as `dipToColorDissolve`.

## What was wrong

Before #359 the two paths disagreed about what `fade` means:

- **Export** (legacy `canvas-transitions.ts` fallback): equal-power crossfade — cos²/sin² weights summing to 1, additive compositing, a subtle 4% scale drift.
- **Preview** (GPU shader + registry Canvas renderer): dip through black.

Once #359 registered the Canvas renderers on the export path, the registry's dip renderer started overriding the legacy export fade — silently changing export output. That is the "changed output for existing CPU transitions" the review flagged.

## What this PR does

Ports the legacy export fade math into the registry renderer (`renderers/basic.ts`) and mirrors it in the WGSL shader (`gpu-transitions/transitions/fade.ts`), so CPU export, headless, CPU preview fallback and GPU preview all render the same equal-power crossfade. The definition's description is updated from "Dip through black between clips".

**Scope note:** the legacy export fade included a 4% scale drift (outgoing eases to 0.96, incoming from 1.04). I kept it deliberately — it is what `fade` exports have always looked like, and it keeps `fade` visually distinct from `dissolve` (whose cos-eased `mix` is otherwise the same curve). If you'd rather have a pure crossfade, it's a two-line removal — say the word.

## Proof (rendered, not argued)

Fixture: two textured image clips (`testsrc`/`testsrc2`), 20-frame `fade` across the cut, rendered through `headless/render.mjs` at three commits and measured with ffmpeg:

| Render | Mid-transition frame mean luma (YAVG) | PSNR vs pre-#359 export |
|---|---|---|
| pre-#359 `develop` (9ebca78c, legacy export path) | 123.30 | — |
| current `develop` (b97795eb, dip regression) | 25.02 — near-black | 16.3 dB |
| this branch | 123.30 | **47.7 dB** (codec noise; visually identical) |

Frames 5/10/15/20/25 of the render window — top: pre-#359 export, middle: current `develop`, bottom: this PR:

![fade equal-power proof](https://raw.githubusercontent.com/SomeStay07/freecut/proofs/transitions/fade-equal-power-crossfade.png)

## Tests

`renderers/basic.test.ts` (new) pins the behavior with a recording 2D context: midpoint draws both clips at 0.5 alpha instead of black, weights follow the cos²/sin² curve and sum to 1 at every progress, additive compositing with no black underfill, and the 4% scale drift. All six fail against the previous dip implementation.

Full verification: `vp check` (2368 files clean), `vp test run` (4681 tests), build, `node --test headless` (42), headless render + edit-operation contracts, and all boundary/dependency checks pass.
