### PR TITLE
docs(types): disambiguate the two cornerRadius properties

### DIFF
--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -349,7 +349,14 @@ export type ShapeItem = BaseTimelineItem &
     type: 'shape'
     shapeType: ShapeType
     // Shape-specific
-    cornerRadius?: number // Rect, Triangle, Star, Polygon
+    /**
+     * Corner rounding baked into the shape's PATH geometry (Rect, Triangle,
+     * Star, Polygon) — the stroke follows the rounded outline. Not the same
+     * property as `transform.cornerRadius`, which clips an item's rendered
+     * bounding box: setting THAT on a shape clips the box straight through
+     * the stroke instead of rounding the outline. Round a shape here.
+     */
+    cornerRadius?: number
     direction?: 'up' | 'down' | 'left' | 'right' // Triangle only
     points?: number // Star (5 default), Polygon (6 default)
     innerRadius?: number // Star only (ratio 0-1 of outer)

--- a/src/types/transform.ts
+++ b/src/types/transform.ts
@@ -24,7 +24,12 @@ export interface TransformProperties {
   flipVertical?: boolean
   /** Opacity from 0 (transparent) to 1 (opaque). Default: 1 */
   opacity?: number
-  /** Border radius in pixels. Default: 0 */
+  /**
+   * Border radius in pixels, applied by CLIPPING the item's rendered bounding
+   * box (video/image content). Default: 0. For shape items use
+   * `ShapeItem.cornerRadius` instead — that one rounds the path geometry
+   * itself; clipping a shape's box here cuts through its stroke.
+   */
   cornerRadius?: number
   /** UI state: aspect ratio lock for resize operations. Default: true */
   aspectRatioLocked?: boolean


### PR DESCRIPTION
Tiny docs-only PR. `ShapeItem.cornerRadius` rounds the shape's **path geometry** — the stroke follows the rounded outline. `transform.cornerRadius` **clips the rendered bounding box** — correct for video/image, but on a shape it cuts straight through the stroke. Confusing the two costs real debugging time (it cost us several iterations before we spotted it); this states the difference in JSDoc at both definition sites, so editors and agents surface it on hover. No behavior change — two comments only.