### PR TITLE
Promote Vite lazy-import recovery and corner-radius docs to staging

### DIFF
--- a/src/app/vite-preload-recovery.test.ts
+++ b/src/app/vite-preload-recovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  claimDevVitePreloadRecovery,
+  DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS,
+} from './vite-preload-recovery'
+
+function createStorage(initialValue: string | null = null) {
+  let value = initialValue
+  return {
+    getItem: () => value,
+    setItem: (_key: string, nextValue: string) => {
+      value = nextValue
+    },
+  }
+}
+
+describe('claimDevVitePreloadRecovery', () => {
+  it('allows one recovery and suppresses an immediate reload loop', () => {
+    const storage = createStorage()
+    const now = 1_000_000
+
+    expect(claimDevVitePreloadRecovery(storage, now)).toBe(true)
+    expect(claimDevVitePreloadRecovery(storage, now + 1)).toBe(false)
+    expect(
+      claimDevVitePreloadRecovery(storage, now + DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS),
+    ).toBe(true)
+  })
+
+  it('recovers when session storage is unavailable', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('blocked')
+      },
+    }
+
+    expect(claimDevVitePreloadRecovery(storage)).toBe(true)
+  })
+})

--- a/src/app/vite-preload-recovery.test.ts
+++ b/src/app/vite-preload-recovery.test.ts
@@ -1,42 +1,35 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import {
-  claimDevVitePreloadRecovery,
-  DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS,
-} from './vite-preload-recovery'
+import { recoverDevVitePreload } from './vite-preload-recovery'
 
-function createStorage(initialValue: string | null = null) {
-  let value = initialValue
-  return {
-    getItem: () => value,
-    setItem: (_key: string, nextValue: string) => {
-      value = nextValue
-    },
-  }
-}
+describe('recoverDevVitePreload', () => {
+  it('reloads after the project saves successfully', async () => {
+    const reload = vi.fn()
+    const onSaveFailure = vi.fn()
 
-describe('claimDevVitePreloadRecovery', () => {
-  it('allows one recovery and suppresses an immediate reload loop', () => {
-    const storage = createStorage()
-    const now = 1_000_000
-
-    expect(claimDevVitePreloadRecovery(storage, now)).toBe(true)
-    expect(claimDevVitePreloadRecovery(storage, now + 1)).toBe(false)
-    expect(
-      claimDevVitePreloadRecovery(storage, now + DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS),
-    ).toBe(true)
+    await expect(
+      recoverDevVitePreload({
+        save: async () => true,
+        reload,
+        onSaveFailure,
+      }),
+    ).resolves.toBe(true)
+    expect(reload).toHaveBeenCalledOnce()
+    expect(onSaveFailure).not.toHaveBeenCalled()
   })
 
-  it('recovers when session storage is unavailable', () => {
-    const storage = {
-      getItem: () => {
-        throw new Error('blocked')
-      },
-      setItem: () => {
-        throw new Error('blocked')
-      },
-    }
+  it('reports a save failure without navigating', async () => {
+    const reload = vi.fn()
+    const onSaveFailure = vi.fn()
 
-    expect(claimDevVitePreloadRecovery(storage)).toBe(true)
+    await expect(
+      recoverDevVitePreload({
+        save: async () => false,
+        reload,
+        onSaveFailure,
+      }),
+    ).resolves.toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+    expect(onSaveFailure).toHaveBeenCalledOnce()
   })
 })

--- a/src/app/vite-preload-recovery.ts
+++ b/src/app/vite-preload-recovery.ts
@@ -1,30 +1,20 @@
-export const DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS = 10_000
+interface RecoverDevVitePreloadOptions {
+  save: () => Promise<boolean>
+  reload: () => void
+  onSaveFailure: () => void | Promise<void>
+}
 
-const DEV_VITE_PRELOAD_RECOVERY_KEY = 'freecut-dev-vite-preload-recovery-at'
-
-type StorageLike = Pick<Storage, 'getItem' | 'setItem'>
-
-/**
- * Claim a single development reload after Vite invalidates optimized dependency URLs.
- * Session storage prevents a broken dev server from trapping the editor in a reload loop;
- * storage failures still allow the current page's in-memory guard to recover once.
- */
-export function claimDevVitePreloadRecovery(
-  storage: StorageLike,
-  now = Date.now(),
-): boolean {
-  try {
-    const lastRecoveryAt = Number(storage.getItem(DEV_VITE_PRELOAD_RECOVERY_KEY))
-    if (
-      Number.isFinite(lastRecoveryAt) &&
-      lastRecoveryAt > 0 &&
-      now - lastRecoveryAt < DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS
-    ) {
-      return false
-    }
-    storage.setItem(DEV_VITE_PRELOAD_RECOVERY_KEY, String(now))
-  } catch {
-    // Restricted storage should not disable recovery; the caller also keeps an in-memory guard.
+/** Save before navigating so stale-module recovery never discards editor changes. */
+export async function recoverDevVitePreload({
+  save,
+  reload,
+  onSaveFailure,
+}: RecoverDevVitePreloadOptions): Promise<boolean> {
+  if (!(await save())) {
+    await onSaveFailure()
+    return false
   }
+
+  reload()
   return true
 }

--- a/src/app/vite-preload-recovery.ts
+++ b/src/app/vite-preload-recovery.ts
@@ -1,0 +1,30 @@
+export const DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS = 10_000
+
+const DEV_VITE_PRELOAD_RECOVERY_KEY = 'freecut-dev-vite-preload-recovery-at'
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'>
+
+/**
+ * Claim a single development reload after Vite invalidates optimized dependency URLs.
+ * Session storage prevents a broken dev server from trapping the editor in a reload loop;
+ * storage failures still allow the current page's in-memory guard to recover once.
+ */
+export function claimDevVitePreloadRecovery(
+  storage: StorageLike,
+  now = Date.now(),
+): boolean {
+  try {
+    const lastRecoveryAt = Number(storage.getItem(DEV_VITE_PRELOAD_RECOVERY_KEY))
+    if (
+      Number.isFinite(lastRecoveryAt) &&
+      lastRecoveryAt > 0 &&
+      now - lastRecoveryAt < DEV_VITE_PRELOAD_RECOVERY_COOLDOWN_MS
+    ) {
+      return false
+    }
+    storage.setItem(DEV_VITE_PRELOAD_RECOVERY_KEY, String(now))
+  } catch {
+    // Restricted storage should not disable recovery; the caller also keeps an in-memory guard.
+  }
+  return true
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { i18n, i18nReady } from './i18n'
 import { App } from './app'
-import { claimDevVitePreloadRecovery } from './app/vite-preload-recovery'
+import { recoverDevVitePreload } from './app/vite-preload-recovery'
 import { createLogger } from '@/shared/logging/logger'
 import {
   getEditorProjectIdFromPathname,
@@ -32,18 +32,30 @@ function getCurrentProjectId(): string | undefined {
   return getEditorProjectIdFromPathname(window.location.pathname)
 }
 
-async function saveCurrentProjectBeforeReload() {
+async function saveCurrentProjectBeforeReload(): Promise<boolean> {
   const projectId = getCurrentProjectId()
 
   if (!projectId) {
-    return
+    return true
   }
 
   try {
     const { useTimelineStore } = await import('@/features/timeline/stores/timeline-store-facade')
     await useTimelineStore.getState().saveTimeline(projectId)
+    return true
   } catch (e) {
     log.error('Failed to save before reload:', e)
+    return false
+  }
+}
+
+async function showSaveBeforeReloadFailedToast() {
+  window.dispatchEvent(new Event('freecut:ensure-toaster'))
+  try {
+    const { toast } = await import('sonner')
+    toast.error(i18n.t('editor.editor.projectSaveFailed'))
+  } catch (error) {
+    log.warn('Failed to show save-before-reload error:', error)
   }
 }
 
@@ -81,8 +93,11 @@ async function showUpdateAvailableToast(
     action: {
       label: i18n.t('appShell.saveAndReload'),
       onClick: async () => {
+        if (!(await saveCurrentProjectBeforeReload())) {
+          toast.error(i18n.t('editor.editor.projectSaveFailed'))
+          return
+        }
         rememberAcceptedAppUpdate(updateSignature)
-        await saveCurrentProjectBeforeReload()
         applyUpdate()
       },
     },
@@ -234,14 +249,18 @@ window.addEventListener('error', (event) => {
 // the toast when the live entry-script hash actually differs from ours. A transient
 // failure leaves the signature unchanged, so it stays silent and the user can retry.
 window.addEventListener('vite:preloadError', (event) => {
-  if (
-    import.meta.env.DEV &&
-    !devVitePreloadRecoveryInFlight &&
-    claimDevVitePreloadRecovery(window.sessionStorage)
-  ) {
-    devVitePreloadRecoveryInFlight = true
+  if (import.meta.env.DEV) {
     event.preventDefault()
-    void saveCurrentProjectBeforeReload().finally(reloadCurrentLocationWithUpdateCacheBust)
+    if (devVitePreloadRecoveryInFlight) return
+
+    devVitePreloadRecoveryInFlight = true
+    void recoverDevVitePreload({
+      save: saveCurrentProjectBeforeReload,
+      reload: reloadCurrentLocationWithUpdateCacheBust,
+      onSaveFailure: showSaveBeforeReloadFailedToast,
+    }).then((didReload) => {
+      if (!didReload) devVitePreloadRecoveryInFlight = false
+    })
     return
   }
   void checkForAppShellUpdate()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { i18n, i18nReady } from './i18n'
 import { App } from './app'
+import { claimDevVitePreloadRecovery } from './app/vite-preload-recovery'
 import { createLogger } from '@/shared/logging/logger'
 import {
   getEditorProjectIdFromPathname,
@@ -15,6 +16,7 @@ const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000
 const ACCEPTED_APP_UPDATE_SIGNATURE_KEY = 'freecut-accepted-app-update-signature'
 
 let updateToastVisible = false
+let devVitePreloadRecoveryInFlight = false
 
 // Debug utilities are editor-heavy; keep them out of the production startup graph.
 if (import.meta.env.DEV) {
@@ -231,7 +233,17 @@ window.addEventListener('error', (event) => {
 // against the server: checkForAppShellUpdate re-fetches the app shell and only surfaces
 // the toast when the live entry-script hash actually differs from ours. A transient
 // failure leaves the signature unchanged, so it stays silent and the user can retry.
-window.addEventListener('vite:preloadError', () => {
+window.addEventListener('vite:preloadError', (event) => {
+  if (
+    import.meta.env.DEV &&
+    !devVitePreloadRecoveryInFlight &&
+    claimDevVitePreloadRecovery(window.sessionStorage)
+  ) {
+    devVitePreloadRecoveryInFlight = true
+    event.preventDefault()
+    void saveCurrentProjectBeforeReload().finally(reloadCurrentLocationWithUpdateCacheBust)
+    return
+  }
   void checkForAppShellUpdate()
 })
 

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -349,7 +349,14 @@ export type ShapeItem = BaseTimelineItem &
     type: 'shape'
     shapeType: ShapeType
     // Shape-specific
-    cornerRadius?: number // Rect, Triangle, Star, Polygon
+    /**
+     * Corner rounding baked into the shape's PATH geometry (Rect, Triangle,
+     * Star, Polygon) — the stroke follows the rounded outline. Not the same
+     * property as `transform.cornerRadius`, which clips an item's rendered
+     * bounding box: setting THAT on a shape clips the box straight through
+     * the stroke instead of rounding the outline. Round a shape here.
+     */
+    cornerRadius?: number
     direction?: 'up' | 'down' | 'left' | 'right' // Triangle only
     points?: number // Star (5 default), Polygon (6 default)
     innerRadius?: number // Star only (ratio 0-1 of outer)

--- a/src/types/transform.ts
+++ b/src/types/transform.ts
@@ -24,7 +24,12 @@ export interface TransformProperties {
   flipVertical?: boolean
   /** Opacity from 0 (transparent) to 1 (opaque). Default: 1 */
   opacity?: number
-  /** Border radius in pixels. Default: 0 */
+  /**
+   * Border radius in pixels, applied by CLIPPING the item's rendered bounding
+   * box (video/image content). Default: 0. For shape items use
+   * `ShapeItem.cornerRadius` instead — that one rounds the path geometry
+   * itself; clipping a shape's box here cuts through its stroke.
+   */
   cornerRadius?: number
   /** UI state: aspect ratio lock for resize operations. Default: true */
   aspectRatioLocked?: boolean

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -321,6 +321,7 @@ export default defineConfig({
       'react/jsx-runtime',
       'react/jsx-dev-runtime',
       '@radix-ui/react-tooltip',
+      '@tanstack/react-virtual',
       'lucide-react',
     ],
   },


### PR DESCRIPTION
## Summary

- prebundle the lazy subtitle virtualizer dependency so Vite does not invalidate optimized module URLs when the subtitle panel first opens
- recover development preload failures by saving and reloading once, with reload-loop protection and focused tests
- include the already-reviewed clarification for the two corner-radius property types

## Why

The subtitle properties panel could encounter a Vite `Outdated Optimize Dep` response after discovering `@tanstack/react-virtual` mid-session. React then retained the rejected lazy import until the editor was manually reloaded. The recovery path now prevents the stale module state while protecting unsaved project work.

## User impact

Opening subtitle properties during development no longer leaves the panel trapped behind an error boundary. If Vite still invalidates a lazy module, FreeCut saves the project and performs one cache-busted recovery reload instead of looping.

## Validation

- focused Vite preload recovery tests passed
- scoped static checks passed
- production build passed
- live Chrome verification returned HTTP 200 for the subtitle source and optimized dependency, resolved the exact `SubtitleSection` import, and remained error-free
- `develop` into `staging` merge simulation completed without conflicts