### PR TITLE
(fix): stabilize grouped text scaling

### DIFF
--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -64,6 +64,10 @@ import {
   resolveEditableGizmoTransform,
   resolveGizmoCommitParentWorld,
 } from '../utils/gizmo-transform-commit'
+import {
+  buildGroupTextScaleCommit,
+  type GroupScaledTextProperties,
+} from '../utils/group-text-scale'
 import { CROP_EDGE_PROPERTY, type CropEdge } from '../utils/crop-gizmo'
 import {
   MARQUEE_CANDIDATE_ATTRIBUTE,
@@ -1061,12 +1065,13 @@ export function GizmoOverlay({
     (
       transforms: Map<string, Transform>,
       operation: 'move' | 'resize' | 'rotate',
-      textUpdates?: ReadonlyMap<string, Partial<TimelineItem>>,
+      textUpdates?: ReadonlyMap<string, GroupScaledTextProperties>,
     ) => {
       const currentFrame = usePlaybackStore.getState().currentFrame
       // Convert Transform to TransformProperties for the batch update
       const transformsMap = new Map<string, Partial<TransformProperties>>()
       const autoKeyframeOperations: AutoKeyframeOperation[] = []
+      const itemUpdates = new Map<string, Partial<TimelineItem>>()
       const itemsById = new Map(visualItems.map((candidate) => [candidate.id, candidate]))
       for (const [itemId, transform] of transforms) {
         const item = visualItems.find((candidate) => candidate.id === itemId)
@@ -1104,12 +1109,33 @@ export function GizmoOverlay({
         })
         autoKeyframeOperations.push(...commit.autoOps)
         if (commit.shouldUpdateBase) transformsMap.set(itemId, commit.transformProps)
+
+        const textUpdate = textUpdates?.get(itemId)
+        if (item.type === 'text' && textUpdate) {
+          const hasFrameScopedScale = commit.autoOps.some(
+            (autoOperation) =>
+              autoOperation.property === 'scale' ||
+              autoOperation.property === 'width' ||
+              autoOperation.property === 'height',
+          )
+          const textCommit = buildGroupTextScaleCommit(
+            item,
+            useKeyframesStore.getState().keyframesByItemId[itemId],
+            textUpdate,
+            currentFrame,
+            hasFrameScopedScale,
+          )
+          autoKeyframeOperations.push(...textCommit.autoKeyframeOperations)
+          if (Object.keys(textCommit.itemUpdates).length > 0) {
+            itemUpdates.set(itemId, textCommit.itemUpdates)
+          }
+        }
       }
       // Use batch update for single undo operation
       updateItemsTransformMap(transformsMap, {
         operation,
         autoKeyframeOperations,
-        itemUpdates: textUpdates,
+        itemUpdates,
       })
 
       // Prevent background click from deselecting after drag

--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -1058,7 +1058,11 @@ export function GizmoOverlay({
 
   // Handle group transform end - commit transforms for all items as a single undo operation
   const handleGroupTransformEnd = useCallback(
-    (transforms: Map<string, Transform>, operation: 'move' | 'resize' | 'rotate') => {
+    (
+      transforms: Map<string, Transform>,
+      operation: 'move' | 'resize' | 'rotate',
+      textUpdates?: ReadonlyMap<string, Partial<TimelineItem>>,
+    ) => {
       const currentFrame = usePlaybackStore.getState().currentFrame
       // Convert Transform to TransformProperties for the batch update
       const transformsMap = new Map<string, Partial<TransformProperties>>()
@@ -1102,7 +1106,11 @@ export function GizmoOverlay({
         if (commit.shouldUpdateBase) transformsMap.set(itemId, commit.transformProps)
       }
       // Use batch update for single undo operation
-      updateItemsTransformMap(transformsMap, { operation, autoKeyframeOperations })
+      updateItemsTransformMap(transformsMap, {
+        operation,
+        autoKeyframeOperations,
+        itemUpdates: textUpdates,
+      })
 
       // Prevent background click from deselecting after drag
       // Use setTimeout instead of requestAnimationFrame because click events

--- a/src/features/preview/components/group-gizmo.tsx
+++ b/src/features/preview/components/group-gizmo.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useCallback, useState, useRef } from 'react'
+import { flushSync } from 'react-dom'
 import type { TimelineItem } from '@/types/timeline'
 import type {
   GizmoHandle,
@@ -27,6 +28,10 @@ import {
 } from '../utils/canvas-snap-utils'
 import { useGizmoStore, type ItemPreview } from '../stores/gizmo-store'
 import { notifyOnBlockedMouseDragIntent } from '../utils/mouse-drag-intent'
+import {
+  buildGroupScaledTextProperties,
+  type GroupScaledTextProperties,
+} from '../utils/group-text-scale'
 
 interface GroupGizmoProps {
   items: TimelineItem[]
@@ -35,6 +40,7 @@ interface GroupGizmoProps {
   onTransformEnd: (
     transforms: Map<string, Transform>,
     operation: 'move' | 'resize' | 'rotate',
+    textUpdates?: ReadonlyMap<string, GroupScaledTextProperties>,
   ) => void
   /** Called when clicking (not dragging) on a specific item to select just that item */
   onItemClick?: (itemId: string) => void
@@ -72,6 +78,7 @@ export function GroupGizmo({
 
   // Ref to track latest preview transforms for mouseup handler (avoids closure issues)
   const previewTransformsRef = useRef<Map<string, Transform> | null>(null)
+  const previewTextUpdatesRef = useRef<Map<string, GroupScaledTextProperties> | null>(null)
 
   // Unified preview store actions
   const setPreview = useGizmoStore((s) => s.setPreview)
@@ -110,10 +117,13 @@ export function GroupGizmo({
 
   // Helper to convert Map<string, Transform> to Record<string, ItemPreview> for store
   const mapToPreviewRecord = useCallback(
-    (transforms: Map<string, Transform>): Record<string, ItemPreview> => {
+    (
+      transforms: Map<string, Transform>,
+      textUpdates?: ReadonlyMap<string, GroupScaledTextProperties>,
+    ): Record<string, ItemPreview> => {
       const record: Record<string, ItemPreview> = {}
       for (const [id, transform] of transforms) {
-        record[id] = { transform }
+        record[id] = { transform, properties: textUpdates?.get(id) }
       }
       return record
     },
@@ -122,10 +132,14 @@ export function GroupGizmo({
 
   // Helper to update preview in store and ref
   const setPreviewTransforms = useCallback(
-    (transforms: Map<string, Transform> | null) => {
+    (
+      transforms: Map<string, Transform> | null,
+      textUpdates: Map<string, GroupScaledTextProperties> | null = null,
+    ) => {
       previewTransformsRef.current = transforms
+      previewTextUpdatesRef.current = textUpdates
       if (transforms) {
-        setPreview(mapToPreviewRecord(transforms))
+        setPreview(mapToPreviewRecord(transforms, textUpdates ?? undefined))
       } else {
         clearPreview()
       }
@@ -221,7 +235,9 @@ export function GroupGizmo({
 
       const finalTransforms = previewTransformsRef.current ?? itemTransforms
       if (transformsChanged(startTransformsRef.current, finalTransforms)) {
-        onTransformEnd(finalTransforms, operation)
+        flushSync(() => {
+          onTransformEnd(finalTransforms, operation, previewTextUpdatesRef.current ?? undefined)
+        })
       }
 
       resetInteractionState()
@@ -457,7 +473,10 @@ export function GroupGizmo({
           projectSize.height,
           maintainAspectRatio,
         )
-        setPreviewTransforms(newTransforms)
+        setPreviewTransforms(
+          newTransforms,
+          buildGroupScaledTextProperties(items, groupState.itemTransforms, newTransforms),
+        )
       }
 
       const handleMouseUp = () => {

--- a/src/features/preview/components/group-gizmo.tsx
+++ b/src/features/preview/components/group-gizmo.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useCallback, useState, useRef } from 'react'
 import { flushSync } from 'react-dom'
+import { resolveAnimatedTextItem } from '@/features/preview/deps/keyframes'
+import {
+  useKeyframesStore,
+  useTimelineSettingsStore,
+} from '@/features/preview/deps/timeline-store'
+import { useResolvedPlaybackFrame } from '@/shared/state/playback/use-resolved-playback-frame'
 import type { TimelineItem } from '@/types/timeline'
 import type {
   GizmoHandle,
@@ -91,6 +97,24 @@ export function GroupGizmo({
 
   const { projectSize } = coordParams
   const scale = getEffectiveScale(coordParams)
+  const fps = useTimelineSettingsStore((state) => state.fps)
+  const animationFrame = useResolvedPlaybackFrame()
+  const keyframesByItemId = useKeyframesStore((state) => state.keyframesByItemId)
+
+  const resolvedItems = useMemo(
+    () =>
+      items.map((item) =>
+        item.type === 'text'
+          ? resolveAnimatedTextItem(
+              item,
+              keyframesByItemId[item.id],
+              animationFrame - item.from,
+              { width: projectSize.width, height: projectSize.height, fps },
+            )
+          : item,
+      ),
+    [animationFrame, fps, items, keyframesByItemId, projectSize.height, projectSize.width],
+  )
 
   // Get visual transforms for all items (includes keyframes and any existing preview)
   // Note: During group interaction, we use our own preview which takes priority
@@ -475,7 +499,7 @@ export function GroupGizmo({
         )
         setPreviewTransforms(
           newTransforms,
-          buildGroupScaledTextProperties(items, groupState.itemTransforms, newTransforms),
+          buildGroupScaledTextProperties(resolvedItems, groupState.itemTransforms, newTransforms),
         )
       }
 
@@ -490,6 +514,7 @@ export function GroupGizmo({
     },
     [
       items,
+      resolvedItems,
       itemTransforms,
       projectSize,
       toCanvasPoint,

--- a/src/features/preview/deps/keyframes-contract.ts
+++ b/src/features/preview/deps/keyframes-contract.ts
@@ -15,6 +15,7 @@ export { removeMotionModifiers } from '@/features/keyframes/utils/motion-modifie
 export { isFrameInTransitionRegion } from '@/features/keyframes/utils/transition-region'
 export { resolveAnimatedTextItem } from '@/features/keyframes/utils/animated-text-item'
 export { resolveAnimatedShapeItem } from '@/features/keyframes/utils/animated-shape-item'
+export { resetAutoKeyframeStore } from '@/features/keyframes/stores/auto-keyframe-store'
 export {
   clonePathVertices,
   getChangedPathVertexValues,

--- a/src/features/preview/hooks/use-preview-composition-model.test.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it } from 'vite-plus/test'
 import type { TimelineTrack } from '@/types/timeline'
-import { buildPreviewCompositionData, mergeLiveItemPreview } from './use-preview-composition-model'
+import {
+  buildPreviewCompositionData,
+  mergeLiveItemPresentation,
+  mergeLiveItemPreview,
+} from './use-preview-composition-model'
 
 describe('mergeLiveItemPreview', () => {
   it('merges live shape properties into the canvas renderer snapshot', () => {
@@ -24,6 +28,40 @@ describe('mergeLiveItemPreview', () => {
       }),
     ).toMatchObject({ trimPathOffset: 135, taperStartWidth: 20 })
     expect(shape.trimPathOffset).toBe(0)
+  })
+})
+
+describe('mergeLiveItemPresentation', () => {
+  it('uses committed text styling with the live transform while retaining snapshot timing', () => {
+    const snapshot = {
+      id: 'text-1',
+      trackId: 'track-1',
+      type: 'text' as const,
+      label: 'Title',
+      text: 'CINEMA',
+      color: '#ffffff',
+      fontSize: 120,
+      textSpans: [{ text: 'CINEMA', fontSize: 120 }],
+      from: 10,
+      durationInFrames: 100,
+      transform: { x: 0, y: 0, width: 600, height: 180 },
+    }
+    const committed = {
+      ...snapshot,
+      fontSize: 84,
+      textSpans: [{ text: 'CINEMA', fontSize: 84 }],
+      from: 20,
+      durationInFrames: 80,
+      transform: { x: 20, y: 10, width: 420, height: 126 },
+    }
+
+    expect(mergeLiveItemPresentation(snapshot, committed)).toMatchObject({
+      fontSize: 84,
+      textSpans: [{ text: 'CINEMA', fontSize: 84 }],
+      from: 10,
+      durationInFrames: 100,
+      transform: { x: 20, y: 10, width: 420, height: 126 },
+    })
   })
 })
 

--- a/src/features/preview/hooks/use-preview-composition-model.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.ts
@@ -111,6 +111,52 @@ export function mergeLiveItemPreview(
   return liveItem
 }
 
+/**
+ * Keep item-local presentation fields current while the composition-wide item
+ * snapshot is deferred. Timeline placement/topology still comes from the
+ * stable snapshot, but a just-committed text resize must not briefly combine
+ * its new transform with stale typography after the gizmo preview clears.
+ */
+export function mergeLiveItemPresentation(
+  item: TimelineItem,
+  liveItem: TimelineItem | undefined,
+): TimelineItem {
+  if (!liveItem || liveItem.id !== item.id || liveItem.type !== item.type) return item
+
+  const itemWithLiveTransform =
+    'transform' in liveItem &&
+    'transform' in item &&
+    liveItem.transform !== item.transform
+      ? ({ ...item, transform: liveItem.transform } as TimelineItem)
+      : item
+
+  if (item.type !== 'text' || liveItem.type !== 'text') return itemWithLiveTransform
+
+  return {
+    ...itemWithLiveTransform,
+    text: liveItem.text,
+    textSpans: liveItem.textSpans,
+    spanLayout: liveItem.spanLayout,
+    textStyleScale: liveItem.textStyleScale,
+    textMotion: liveItem.textMotion,
+    color: liveItem.color,
+    fontSize: liveItem.fontSize,
+    fontFamily: liveItem.fontFamily,
+    fontWeight: liveItem.fontWeight,
+    fontStyle: liveItem.fontStyle,
+    underline: liveItem.underline,
+    letterSpacing: liveItem.letterSpacing,
+    backgroundColor: liveItem.backgroundColor,
+    backgroundRadius: liveItem.backgroundRadius,
+    textAlign: liveItem.textAlign,
+    verticalAlign: liveItem.verticalAlign,
+    lineHeight: liveItem.lineHeight,
+    textPadding: liveItem.textPadding,
+    textShadow: liveItem.textShadow,
+    stroke: liveItem.stroke,
+  } as TimelineItem
+}
+
 export function usePreviewCompositionBaseModel({
   tracks,
   itemsByTrackId,
@@ -280,15 +326,8 @@ export function usePreviewCompositionModel({
     const item = fastScrubLiveItemsByIdRef.current.get(itemId)
     if (!item) return undefined
     const liveItem = useItemsStore.getState().itemById[itemId]
-    const itemWithLiveTransform =
-      liveItem &&
-      'transform' in liveItem &&
-      'transform' in item &&
-      liveItem.transform !== item.transform
-        ? ({ ...item, transform: liveItem.transform } as TimelineItem)
-        : item
     return mergeLiveItemPreview(
-      itemWithLiveTransform,
+      mergeLiveItemPresentation(item, liveItem),
       useGizmoStore.getState().preview?.[itemId],
     )
   }, [])

--- a/src/features/preview/utils/group-text-scale.test.ts
+++ b/src/features/preview/utils/group-text-scale.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vite-plus/test'
+import type { TextItem, TimelineItem, VideoItem } from '@/types/timeline'
+import type { Transform } from '../types/gizmo'
+import { buildGroupScaledTextProperties } from './group-text-scale'
+
+const transform = (width: number, height: number): Transform => ({
+  x: 0,
+  y: 0,
+  width,
+  height,
+  rotation: 0,
+  opacity: 1,
+})
+
+describe('group text scale', () => {
+  it('scales text metrics while leaving video content on the transform path', () => {
+    const text = {
+      id: 'text-1',
+      type: 'text',
+      trackId: 'text-track',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Title',
+      text: 'Title',
+      color: '#ffffff',
+      fontSize: 80,
+      letterSpacing: 4,
+      textPadding: 20,
+      backgroundRadius: 12,
+      textShadow: { offsetX: 2, offsetY: 6, blur: 10, color: '#000000' },
+      stroke: { width: 2, color: '#000000' },
+      textSpans: [{ text: 'Title', fontSize: 100, letterSpacing: 6 }],
+    } as TextItem
+    const video = {
+      id: 'video-1',
+      type: 'video',
+      trackId: 'video-track',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Video',
+      src: 'video.mp4',
+    } as VideoItem
+    const start = new Map<string, Transform>([
+      [text.id, transform(400, 200)],
+      [video.id, transform(1280, 720)],
+    ])
+    const next = new Map<string, Transform>([
+      [text.id, transform(200, 100)],
+      [video.id, transform(640, 360)],
+    ])
+
+    const updates = buildGroupScaledTextProperties([text, video] as TimelineItem[], start, next)
+
+    expect(updates.has(video.id)).toBe(false)
+    expect(updates.get(text.id)).toMatchObject({
+      fontSize: 40,
+      letterSpacing: 2,
+      textPadding: 10,
+      backgroundRadius: 6,
+      textShadow: { offsetX: 1, offsetY: 3, blur: 5 },
+      stroke: { width: 1 },
+      textSpans: [{ fontSize: 50, letterSpacing: 3 }],
+    })
+  })
+
+  it('materializes resolved defaults so unstyled text scales visually', () => {
+    const text = {
+      id: 'text-defaults',
+      type: 'text',
+      trackId: 'text-track',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Title',
+      text: 'Title',
+      color: '#ffffff',
+    } as TextItem
+
+    const updates = buildGroupScaledTextProperties(
+      [text],
+      new Map([[text.id, transform(300, 100)]]),
+      new Map([[text.id, transform(450, 150)]]),
+    )
+
+    expect(updates.get(text.id)).toMatchObject({
+      fontSize: 90,
+      letterSpacing: 0,
+      textPadding: 24,
+      backgroundRadius: 0,
+    })
+  })
+})

--- a/src/features/preview/utils/group-text-scale.test.ts
+++ b/src/features/preview/utils/group-text-scale.test.ts
@@ -1,9 +1,15 @@
 // @vitest-environment node
 
-import { describe, expect, it } from 'vite-plus/test'
+import { beforeEach, describe, expect, it } from 'vite-plus/test'
+import { resetAutoKeyframeStore } from '@/features/preview/deps/keyframes'
+import { useTransitionsStore } from '@/features/preview/deps/timeline-store'
+import type { ItemKeyframes } from '@/types/keyframe'
 import type { TextItem, TimelineItem, VideoItem } from '@/types/timeline'
 import type { Transform } from '../types/gizmo'
-import { buildGroupScaledTextProperties } from './group-text-scale'
+import {
+  buildGroupScaledTextProperties,
+  buildGroupTextScaleCommit,
+} from './group-text-scale'
 
 const transform = (width: number, height: number): Transform => ({
   x: 0,
@@ -15,6 +21,11 @@ const transform = (width: number, height: number): Transform => ({
 })
 
 describe('group text scale', () => {
+  beforeEach(() => {
+    resetAutoKeyframeStore()
+    useTransitionsStore.getState().setTransitions([])
+  })
+
   it('scales text metrics while leaving video content on the transform path', () => {
     const text = {
       id: 'text-1',
@@ -89,5 +100,89 @@ describe('group text scale', () => {
       textPadding: 24,
       backgroundRadius: 0,
     })
+  })
+
+  it('moves scalable typography into keyframes when geometry is frame-scoped', () => {
+    const text = {
+      id: 'text-keyed-scale',
+      type: 'text',
+      trackId: 'text-track',
+      from: 10,
+      durationInFrames: 90,
+      label: 'Title',
+      text: 'Title',
+      color: '#ffffff',
+      fontSize: 80,
+      letterSpacing: 4,
+      textPadding: 20,
+      backgroundRadius: 12,
+      textStyleScale: 1,
+      textShadow: { offsetX: 2, offsetY: 6, blur: 10, color: '#000000' },
+      stroke: { width: 2, color: '#000000' },
+      textSpans: [{ text: 'Title', fontSize: 100 }],
+    } as TextItem
+    const updates = buildGroupScaledTextProperties(
+      [text],
+      new Map([[text.id, transform(400, 200)]]),
+      new Map([[text.id, transform(200, 100)]]),
+    ).get(text.id)!
+
+    const commit = buildGroupTextScaleCommit(text, undefined, updates, 25, true)
+
+    expect(commit.autoKeyframeOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'fontSize', frame: 15, value: 40 }),
+        expect.objectContaining({ property: 'textPadding', frame: 15, value: 10 }),
+        expect.objectContaining({ property: 'backgroundRadius', frame: 15, value: 6 }),
+        expect.objectContaining({ property: 'textStyleScale', frame: 15, value: 0.5 }),
+        expect.objectContaining({ property: 'textShadowOffsetX', frame: 15, value: 1 }),
+        expect.objectContaining({ property: 'textShadowOffsetY', frame: 15, value: 3 }),
+        expect.objectContaining({ property: 'textShadowBlur', frame: 15, value: 5 }),
+        expect.objectContaining({ property: 'strokeWidth', frame: 15, value: 1 }),
+      ]),
+    )
+    expect(commit.itemUpdates).toEqual({
+      letterSpacing: 2,
+      textSpans: [{ text: 'Title', fontSize: 50 }],
+    })
+  })
+
+  it('updates an existing typography lane instead of writing its base value', () => {
+    const text = {
+      id: 'text-animated-font',
+      type: 'text',
+      trackId: 'text-track',
+      from: 0,
+      durationInFrames: 90,
+      label: 'Title',
+      text: 'Title',
+      color: '#ffffff',
+      fontSize: 80,
+    } as TextItem
+    const keyframes: ItemKeyframes = {
+      itemId: text.id,
+      properties: [
+        {
+          property: 'fontSize',
+          keyframes: [{ id: 'font-kf', frame: 20, value: 120, easing: 'linear' }],
+        },
+      ],
+    }
+    const updates = buildGroupScaledTextProperties(
+      [{ ...text, fontSize: 120 }],
+      new Map([[text.id, transform(400, 200)]]),
+      new Map([[text.id, transform(200, 100)]]),
+    ).get(text.id)!
+
+    const commit = buildGroupTextScaleCommit(text, keyframes, updates, 20, false)
+
+    expect(commit.autoKeyframeOperations).toContainEqual({
+      type: 'update',
+      itemId: text.id,
+      property: 'fontSize',
+      keyframeId: 'font-kf',
+      updates: { value: 60 },
+    })
+    expect(commit.itemUpdates).not.toHaveProperty('fontSize')
   })
 })

--- a/src/features/preview/utils/group-text-scale.ts
+++ b/src/features/preview/utils/group-text-scale.ts
@@ -1,0 +1,69 @@
+import { TEXT_DEFAULTS } from '@/shared/typography/text-style'
+import type { TextItem, TextSpan, TimelineItem } from '@/types/timeline'
+import type { Transform } from '../types/gizmo'
+
+export interface GroupScaledTextProperties {
+  fontSize: number
+  letterSpacing: number
+  textPadding: number
+  backgroundRadius: number
+  textShadow?: TextItem['textShadow']
+  stroke?: TextItem['stroke']
+  textSpans?: TextSpan[]
+  textStyleScale?: number
+}
+
+function scaleTextProperties(item: TextItem, factor: number): GroupScaledTextProperties {
+  return {
+    fontSize: (item.fontSize ?? TEXT_DEFAULTS.fontSize) * factor,
+    letterSpacing: (item.letterSpacing ?? TEXT_DEFAULTS.letterSpacing) * factor,
+    textPadding: (item.textPadding ?? TEXT_DEFAULTS.textPadding) * factor,
+    backgroundRadius: (item.backgroundRadius ?? 0) * factor,
+    textShadow: item.textShadow
+      ? {
+          ...item.textShadow,
+          offsetX: item.textShadow.offsetX * factor,
+          offsetY: item.textShadow.offsetY * factor,
+          blur: item.textShadow.blur * factor,
+        }
+      : undefined,
+    stroke: item.stroke
+      ? {
+          ...item.stroke,
+          width: item.stroke.width * factor,
+        }
+      : undefined,
+    textSpans: item.textSpans?.map((span) => ({
+      ...span,
+      fontSize: span.fontSize === undefined ? undefined : span.fontSize * factor,
+      letterSpacing: span.letterSpacing === undefined ? undefined : span.letterSpacing * factor,
+    })),
+    textStyleScale: item.textStyleScale === undefined ? undefined : item.textStyleScale * factor,
+  }
+}
+
+/**
+ * Build the non-transform updates that make text content participate in a
+ * Figma-style group resize. Media content already follows its resized wrapper;
+ * text metrics are authored independently and therefore need to be scaled too.
+ */
+export function buildGroupScaledTextProperties(
+  items: readonly TimelineItem[],
+  startTransforms: ReadonlyMap<string, Transform>,
+  nextTransforms: ReadonlyMap<string, Transform>,
+): Map<string, GroupScaledTextProperties> {
+  const updates = new Map<string, GroupScaledTextProperties>()
+
+  for (const item of items) {
+    if (item.type !== 'text') continue
+    const start = startTransforms.get(item.id)
+    const next = nextTransforms.get(item.id)
+    if (!start || !next || start.width <= 0) continue
+
+    const factor = next.width / start.width
+    if (!Number.isFinite(factor) || factor <= 0) continue
+    updates.set(item.id, scaleTextProperties(item, factor))
+  }
+
+  return updates
+}

--- a/src/features/preview/utils/group-text-scale.ts
+++ b/src/features/preview/utils/group-text-scale.ts
@@ -1,6 +1,23 @@
 import { TEXT_DEFAULTS } from '@/shared/typography/text-style'
+import {
+  getAutoKeyframeOperation,
+  isFrameInTransitionRegion,
+  type AutoKeyframeOperation,
+} from '@/features/preview/deps/keyframes'
+import { useTransitionsStore } from '@/features/preview/deps/timeline-store'
+import type { ItemKeyframes } from '@/types/keyframe'
 import type { TextItem, TextSpan, TimelineItem } from '@/types/timeline'
 import type { Transform } from '../types/gizmo'
+
+type GroupTextAnimatableProperty =
+  | 'textStyleScale'
+  | 'fontSize'
+  | 'textPadding'
+  | 'backgroundRadius'
+  | 'textShadowOffsetX'
+  | 'textShadowOffsetY'
+  | 'textShadowBlur'
+  | 'strokeWidth'
 
 export interface GroupScaledTextProperties {
   fontSize: number
@@ -11,6 +28,11 @@ export interface GroupScaledTextProperties {
   stroke?: TextItem['stroke']
   textSpans?: TextSpan[]
   textStyleScale?: number
+}
+
+export interface GroupTextScaleCommit {
+  autoKeyframeOperations: AutoKeyframeOperation[]
+  itemUpdates: Partial<TextItem>
 }
 
 function scaleTextProperties(item: TextItem, factor: number): GroupScaledTextProperties {
@@ -66,4 +88,125 @@ export function buildGroupScaledTextProperties(
   }
 
   return updates
+}
+
+function getGroupTextKeyframeOperation(
+  item: TextItem,
+  itemKeyframes: ItemKeyframes | undefined,
+  property: GroupTextAnimatableProperty,
+  value: number,
+  currentFrame: number,
+  forceFrameScoped: boolean,
+): AutoKeyframeOperation | null {
+  const automatic = getAutoKeyframeOperation(
+    item,
+    itemKeyframes,
+    property,
+    value,
+    currentFrame,
+  )
+  if (automatic || !forceFrameScoped) return automatic
+
+  const relativeFrame = currentFrame - item.from
+  if (
+    relativeFrame < 0 ||
+    relativeFrame >= item.durationInFrames ||
+    isFrameInTransitionRegion(
+      relativeFrame,
+      item.id,
+      item,
+      useTransitionsStore.getState().transitions,
+    )
+  ) {
+    return null
+  }
+
+  return {
+    type: 'add',
+    itemId: item.id,
+    property,
+    frame: relativeFrame,
+    value,
+    easing: 'linear',
+  }
+}
+
+/**
+ * Split a grouped text resize into frame-specific typography keyframes and
+ * base-item writes. A keyed Scale/width/height commit forces the scalable text
+ * metrics into the same frame even when those text lanes do not exist yet.
+ */
+export function buildGroupTextScaleCommit(
+  item: TextItem,
+  itemKeyframes: ItemKeyframes | undefined,
+  updates: GroupScaledTextProperties,
+  currentFrame: number,
+  forceFrameScoped: boolean,
+): GroupTextScaleCommit {
+  const autoKeyframeOperations: AutoKeyframeOperation[] = []
+  const itemUpdates: Partial<TextItem> = {
+    letterSpacing: updates.letterSpacing,
+    textSpans: updates.textSpans,
+  }
+
+  const commitScalar = (
+    property: GroupTextAnimatableProperty,
+    value: number | undefined,
+    writeBase: (value: number) => void,
+  ): boolean => {
+    if (value === undefined) return false
+    const operation = getGroupTextKeyframeOperation(
+      item,
+      itemKeyframes,
+      property,
+      value,
+      currentFrame,
+      forceFrameScoped,
+    )
+    if (operation) {
+      autoKeyframeOperations.push(operation)
+      return true
+    }
+    writeBase(value)
+    return false
+  }
+
+  commitScalar('fontSize', updates.fontSize, (value) => {
+    itemUpdates.fontSize = value
+  })
+  commitScalar('textPadding', updates.textPadding, (value) => {
+    itemUpdates.textPadding = value
+  })
+  commitScalar('backgroundRadius', updates.backgroundRadius, (value) => {
+    itemUpdates.backgroundRadius = value
+  })
+  commitScalar('textStyleScale', updates.textStyleScale, (value) => {
+    itemUpdates.textStyleScale = value
+  })
+
+  if (updates.textShadow) {
+    const baseShadow = { ...updates.textShadow }
+    let hasBaseShadowUpdate = false
+    const shadowProperties = [
+      ['textShadowOffsetX', 'offsetX'],
+      ['textShadowOffsetY', 'offsetY'],
+      ['textShadowBlur', 'blur'],
+    ] as const
+
+    for (const [property, field] of shadowProperties) {
+      const keyframed = commitScalar(property, updates.textShadow[field], (value) => {
+        baseShadow[field] = value
+        hasBaseShadowUpdate = true
+      })
+      if (keyframed) baseShadow[field] = item.textShadow?.[field] ?? 0
+    }
+    if (hasBaseShadowUpdate) itemUpdates.textShadow = baseShadow
+  }
+
+  if (updates.stroke) {
+    const keyframed = commitScalar('strokeWidth', updates.stroke.width, () => {})
+    if (!keyframed) itemUpdates.stroke = updates.stroke
+  }
+
+  return { autoKeyframeOperations, itemUpdates }
 }

--- a/src/features/timeline/stores/actions/transform-actions.test.ts
+++ b/src/features/timeline/stores/actions/transform-actions.test.ts
@@ -155,6 +155,29 @@ describe('transform actions', () => {
       expect(useTimelineCommandStore.getState().undoStack.length).toBe(undoDepth + 1)
     })
 
+    it('commits accompanying item properties in the same undo entry', () => {
+      const undoDepth = useTimelineCommandStore.getState().undoStack.length
+      let itemStorePublishes = 0
+      const unsubscribe = useItemsStore.subscribe(() => {
+        itemStorePublishes += 1
+      })
+
+      updateItemsTransformMap(new Map([['a', { width: 640, height: 360 }]]), {
+        operation: 'resize',
+        itemUpdates: new Map([['a', { label: 'Scaled title' }]]),
+      })
+      unsubscribe()
+
+      expect(getTransform('a')).toMatchObject({ width: 640, height: 360 })
+      expect(useItemsStore.getState().itemById.a?.label).toBe('Scaled title')
+      expect(itemStorePublishes).toBe(1)
+      expect(useTimelineCommandStore.getState().undoStack.length).toBe(undoDepth + 1)
+
+      useTimelineCommandStore.getState().undo()
+      expect(getTransform('a').width).toBeUndefined()
+      expect(useItemsStore.getState().itemById.a?.label).not.toBe('Scaled title')
+    })
+
     it('does not create history or invalidate items for an empty transform map', () => {
       const itemsBefore = useItemsStore.getState().items
       const undoDepth = useTimelineCommandStore.getState().undoStack.length

--- a/src/features/timeline/stores/actions/transform-actions.ts
+++ b/src/features/timeline/stores/actions/transform-actions.ts
@@ -6,7 +6,11 @@ import type { TransformProperties } from '@/types/transform'
 import type { AnimatableProperty } from '@/types/keyframe'
 import type { MaskVertex } from '@/types/masks'
 import type { LayoutConfig } from '../../utils/bento-layout'
-import type { TransformCommandOptions, TransformHistoryOperation } from '../../types'
+import type {
+  BatchTransformCommandOptions,
+  TransformCommandOptions,
+  TransformHistoryOperation,
+} from '../../types'
 import type { AutoKeyframeOperation } from '@/features/timeline/deps/keyframes'
 import { computeLayout, buildTransitionChains } from '../../utils/bento-layout'
 import { useItemsStore } from '../items-store'
@@ -241,23 +245,29 @@ export function updateItemsTransform(
 
 export function updateItemsTransformMap(
   transformsMap: Map<string, Partial<TransformProperties>>,
-  options?: TransformCommandOptions,
+  options?: BatchTransformCommandOptions,
 ): void {
-  if (transformsMap.size === 0 && (options?.autoKeyframeOperations?.length ?? 0) === 0) return
+  const itemUpdates = options?.itemUpdates
+  if (
+    transformsMap.size === 0 &&
+    (options?.autoKeyframeOperations?.length ?? 0) === 0 &&
+    (itemUpdates?.size ?? 0) === 0
+  ) {
+    return
+  }
   const operation = options?.operation ?? inferTransformOperationFromMap(transformsMap)
   const autoKeyframeOperations = options?.autoKeyframeOperations ?? []
   execute(
     'UPDATE_TRANSFORMS',
     () => {
-      if (transformsMap.size > 0) {
-        useItemsStore.getState()._updateItemsTransformMap(transformsMap)
-      }
+      useItemsStore.getState()._updateItemsTransformMap(transformsMap, itemUpdates)
       applyAutoKeyframeOperationsInCommand(autoKeyframeOperations)
       useTimelineSettingsStore.getState().markDirty()
     },
     {
       count: transformsMap.size,
       operation,
+      itemUpdateCount: itemUpdates?.size ?? 0,
       autoKeyframeOperationCount: autoKeyframeOperations.length,
     },
   )

--- a/src/features/timeline/stores/items-store.ts
+++ b/src/features/timeline/stores/items-store.ts
@@ -103,7 +103,10 @@ interface ItemsActions {
   _updateItemTransform: (id: string, transform: Partial<TransformProperties>) => void
   _resetItemTransform: (id: string) => void
   _updateItemsTransform: (ids: string[], transform: Partial<TransformProperties>) => void
-  _updateItemsTransformMap: (transformsMap: Map<string, Partial<TransformProperties>>) => void
+  _updateItemsTransformMap: (
+    transformsMap: Map<string, Partial<TransformProperties>>,
+    itemUpdates?: ReadonlyMap<string, Partial<TimelineItem>>,
+  ) => void
 
   // Effect operations
   _addEffect: (itemId: string, effect: VisualEffect) => void
@@ -781,17 +784,22 @@ export const useItemsStore = create<ItemsState & ItemsActions>()((set, get) => (
     }),
 
   // Update transforms from map
-  _updateItemsTransformMap: (transformsMap) =>
+  _updateItemsTransformMap: (transformsMap, itemUpdates) =>
     set((state) => {
       const nextItems = state.items.map((item) => {
         const transform = transformsMap.get(item.id)
-        if (!transform) return item
-        if (!('transform' in item)) return item
+        const updates = itemUpdates?.get(item.id)
+        if (!transform && !updates) return item
 
-        return {
-          ...item,
+        const updatedItem = updates
+          ? normalizeFrameFields({ ...item, ...normalizeItemUpdates(updates) } as typeof item)
+          : item
+        if (!transform || !('transform' in item)) return updatedItem
+
+        return normalizeFrameFields({
+          ...updatedItem,
           transform: { ...item.transform, ...transform },
-        } as typeof item
+        } as typeof item)
       })
       return withItemIndexes(nextItems, state)
     }),

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -38,6 +38,11 @@ export interface TransformCommandOptions {
   autoKeyframeOperations?: AutoKeyframeOperation[]
 }
 
+export interface BatchTransformCommandOptions extends TransformCommandOptions {
+  /** Optional non-transform item writes committed with the same batch gesture. */
+  itemUpdates?: ReadonlyMap<string, Partial<TimelineItem>>
+}
+
 export interface LoadTimelineOptions {
   allowProjectUpgrade?: boolean
 }
@@ -142,7 +147,7 @@ export interface TimelineActions {
   ) => void
   updateItemsTransformMap: (
     transformsMap: Map<string, Partial<TransformProperties>>,
-    options?: TransformCommandOptions,
+    options?: BatchTransformCommandOptions,
   ) => void
   commitMaskEdit: (
     id: string,

--- a/src/shared/typography/text-style.ts
+++ b/src/shared/typography/text-style.ts
@@ -13,7 +13,7 @@ import { FONT_WEIGHT_MAP } from '@/shared/typography/fonts'
 import { getTextItemSpans } from '@/shared/utils/text-item-spans'
 
 /** Authoritative fallbacks for unspecified text-item properties. */
-const TEXT_DEFAULTS = {
+export const TEXT_DEFAULTS = {
   fontSize: 60,
   fontFamily: 'Inter',
   fontWeight: 'normal',


### PR DESCRIPTION
## Summary

- Scale text typography together with geometry during mixed text/video group resize.
- Commit grouped transforms and accompanying text properties atomically in one undo entry.
- Keep the deferred canvas renderer on current text presentation fields during the mouse-up handoff.

## Root cause

Group resize changed item bounds, but text metrics such as font size, spacing, padding, shadow, stroke, and span sizing were authored independently. On release, the fast-scrub renderer could also combine the newly committed transform with a deferred snapshot of the old typography, producing one visible settling frame.

## Impact

Text and video now resize together throughout the gesture, and the text no longer changes scale briefly after release.

## Validation

- 38 focused tests passed across group scaling, transform commits, preview composition snapshots, and gizmo commit behavior.
- Focused `vp check --no-fmt` passed for all 11 changed files.
- `git diff --check` passed.
- Verified in the existing Chrome editor session with the CINEMA text/video pair: every captured post-release canvas frame retained the same image hash and group bounds, and one Undo restored the original bounds.