### PR TITLE
Improve keyframe range feedback and grouped trimming

### DIFF
--- a/src/features/keyframes/components/dopesheet-editor/affected-frame-range.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/affected-frame-range.test.tsx
@@ -1,15 +1,19 @@
-import { render, screen } from '@testing-library/react'
-import { beforeAll, describe, expect, it, vi } from 'vite-plus/test'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { DopesheetEditor } from './index'
 
 describe('DopesheetEditor affected frame range', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     class ResizeObserverMock {
       observe() {}
       disconnect() {}
     }
 
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('renders a pointer-transparent clipped band behind classic Edit lanes', () => {
@@ -33,5 +37,64 @@ describe('DopesheetEditor affected frame range', () => {
     expect(highlight).toHaveAttribute('data-to-frame', '100')
     expect(highlight).toHaveClass('border-foreground/[0.10]', 'bg-foreground/[0.035]')
     expect(highlight.parentElement).toHaveClass('pointer-events-none', 'overflow-hidden')
+  })
+
+  it('observes classic keyframe rows against the dopesheet scroller on first render', async () => {
+    const observedRoots: Array<Element | Document | null> = []
+
+    class IntersectionObserverMock {
+      readonly root: Element | Document | null
+      readonly rootMargin = '96px 0px'
+      readonly thresholds = [0]
+
+      constructor(
+        private readonly callback: IntersectionObserverCallback,
+        options?: IntersectionObserverInit,
+      ) {
+        this.root = options?.root ?? null
+        observedRoots.push(this.root)
+      }
+
+      observe(target: Element) {
+        this.callback(
+          [
+            {
+              isIntersecting: this.root !== null,
+              target,
+            } as IntersectionObserverEntry,
+          ],
+          this as unknown as IntersectionObserver,
+        )
+      }
+
+      disconnect() {}
+      unobserve() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return []
+      }
+    }
+
+    vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+
+    render(
+      <DopesheetEditor
+        itemId="item-1"
+        keyframesByProperty={{
+          rotation: [{ id: 'rotation-1', frame: 40, value: 90, easing: 'linear' }],
+        }}
+        frameViewport={{ startFrame: -20, endFrame: 180 }}
+        totalFrames={100}
+        presentation="classic"
+        width={640}
+        height={240}
+      />,
+    )
+
+    const scrollArea = screen.getByTestId('dopesheet-scroll-area')
+    await waitFor(() => {
+      expect(screen.getByTestId('row-keyframe-rotation-rotation-1')).toBeInTheDocument()
+    })
+    expect(observedRoots.length).toBeGreaterThan(0)
+    expect(observedRoots.every((root) => root === scrollArea)).toBe(true)
   })
 })

--- a/src/features/keyframes/components/dopesheet-editor/affected-frame-range.test.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/affected-frame-range.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vite-plus/test'
+import { DopesheetEditor } from './index'
+
+describe('DopesheetEditor affected frame range', () => {
+  beforeAll(() => {
+    class ResizeObserverMock {
+      observe() {}
+      disconnect() {}
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  it('renders a pointer-transparent clipped band behind classic Edit lanes', () => {
+    render(
+      <DopesheetEditor
+        itemId="item-1"
+        keyframesByProperty={{
+          rotation: [{ id: 'rotation-1', frame: 40, value: 90, easing: 'linear' }],
+        }}
+        frameViewport={{ startFrame: -20, endFrame: 180 }}
+        totalFrames={100}
+        affectedFrameRange={{ fromFrame: 0, toFrame: 100 }}
+        presentation="classic"
+        width={640}
+        height={240}
+      />,
+    )
+
+    const highlight = screen.getByTestId('dopesheet-affected-frame-range')
+    expect(highlight).toHaveAttribute('data-from-frame', '0')
+    expect(highlight).toHaveAttribute('data-to-frame', '100')
+    expect(highlight).toHaveClass('border-foreground/[0.10]', 'bg-foreground/[0.035]')
+    expect(highlight.parentElement).toHaveClass('pointer-events-none', 'overflow-hidden')
+  })
+})

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -766,7 +766,11 @@ const TimelineViewportCuller = memo(function TimelineViewportCuller({
   useEffect(() => {
     const node = rootRef.current
     if (!node || typeof IntersectionObserver === 'undefined') return
-    const motionScrollRoot = node.closest('[data-testid="motion-layer-scroll-area"]')
+    // Classic Edit has its own scroller. Observing against the browser viewport
+    // can report every row as hidden while the panel is opening and stay stale.
+    const scrollRoot =
+      node.closest('[data-dopesheet-scroll-viewport]') ??
+      node.closest('[data-testid="motion-layer-scroll-area"]')
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry) return
@@ -774,7 +778,7 @@ const TimelineViewportCuller = memo(function TimelineViewportCuller({
         setIsNearViewport(entry.isIntersecting)
       },
       {
-        root: motionScrollRoot,
+        root: scrollRoot,
         rootMargin: '96px 0px',
       },
     )

--- a/src/features/keyframes/components/dopesheet-editor/index.tsx
+++ b/src/features/keyframes/components/dopesheet-editor/index.tsx
@@ -137,6 +137,7 @@ import {
   PROPERTY_COLUMN_WIDTH,
   SPACIOUS_PROPERTY_COLUMN_WIDTH,
   ROW_HEIGHT,
+  RULER_HEIGHT,
   SNAP_THRESHOLD_PX,
   ZOOM_IN_FACTOR,
   ZOOM_OUT_FACTOR,
@@ -215,6 +216,8 @@ interface DopesheetEditorProps {
   itemFrom?: number
   /** Total duration in frames */
   totalFrames?: number
+  /** Optional span in the editor's frame space, subtly highlighted behind the sheet lanes. */
+  affectedFrameRange?: { fromFrame: number; toFrame: number }
   /** Stored keyframes currently parked beyond the item's visible out point. */
   trimmedKeyframeCount?: number
   /** Destructively consolidate parked keyframes to the visible item bounds. */
@@ -801,6 +804,7 @@ export const DopesheetEditor = memo(function DopesheetEditor({
   globalFrame = null,
   itemFrom = 0,
   totalFrames = 300,
+  affectedFrameRange,
   trimmedKeyframeCount = 0,
   onTrimAnimation,
   fps = 30,
@@ -1671,6 +1675,17 @@ export const DopesheetEditor = memo(function DopesheetEditor({
     (frame: number) => getFrameAxisX(frame, viewport, effectiveTimelineWidth, timelineEdgeInset),
     [effectiveTimelineWidth, timelineEdgeInset, viewport],
   )
+  const affectedFrameRangeGeometry = useMemo(() => {
+    if (!affectedFrameRange || affectedFrameRange.toFrame <= affectedFrameRange.fromFrame) {
+      return null
+    }
+    const rawLeft = frameToX(affectedFrameRange.fromFrame)
+    const rawRight = frameToX(affectedFrameRange.toFrame)
+    const left = Math.max(0, Math.min(effectiveTimelineWidth, rawLeft))
+    const right = Math.max(0, Math.min(effectiveTimelineWidth, rawRight))
+    if (right <= left) return null
+    return { left, width: right - left }
+  }, [affectedFrameRange, effectiveTimelineWidth, frameToX])
   const sharedGridFrameToX = useCallback(
     (frame: number) =>
       getFrameAxisX(
@@ -5038,6 +5053,18 @@ export const DopesheetEditor = memo(function DopesheetEditor({
       customGraphContent={graphMode === 'speed' ? speedGraphContent : undefined}
     />
   )
+  const affectedFrameRangeOverlayElement =
+    affectedFrameRange && affectedFrameRangeGeometry ? (
+      <div
+        data-testid="dopesheet-affected-frame-range"
+        data-from-frame={affectedFrameRange.fromFrame}
+        data-to-frame={affectedFrameRange.toFrame}
+        data-dopesheet-from-frame={affectedFrameRange.fromFrame}
+        data-dopesheet-to-frame={affectedFrameRange.toFrame}
+        className="absolute inset-y-0 border-x border-foreground/[0.10] bg-foreground/[0.035]"
+        style={affectedFrameRangeGeometry}
+      />
+    ) : null
 
   if (presentation === 'lanes') {
     return (
@@ -5137,6 +5164,16 @@ export const DopesheetEditor = memo(function DopesheetEditor({
           )}
           onWheel={viewportInteractionEnabled ? handleWheel : undefined}
         >
+          {affectedFrameRangeOverlayElement ? (
+            <div
+              data-motion-viewport-surface
+              data-motion-viewport-axis-width={effectiveTimelineWidth}
+              className="pointer-events-none absolute bottom-0 right-0 z-[5] overflow-hidden"
+              style={{ left: columnWidth, top: RULER_HEIGHT }}
+            >
+              {affectedFrameRangeOverlayElement}
+            </div>
+          ) : null}
           {skimPlayheadOverlayElement}
           {playheadOverlayElement}
           {rulerHeaderElement}

--- a/src/features/timeline/components/keyframe-graph-panel.tsx
+++ b/src/features/timeline/components/keyframe-graph-panel.tsx
@@ -3602,6 +3602,11 @@ export const KeyframeGraphPanel = memo(function KeyframeGraphPanel({
                   globalFrame={currentFrame}
                   itemFrom={selectedItemForEditor.from}
                   totalFrames={selectedItemForEditor.durationInFrames}
+                  affectedFrameRange={
+                    surface === 'edit'
+                      ? { fromFrame: 0, toFrame: selectedItemForEditor.durationInFrames }
+                      : undefined
+                  }
                   trimmedKeyframeCount={surface === 'edit' ? trimmedKeyframeCount : 0}
                   onTrimAnimation={surface === 'edit' ? handleTrimAnimation : undefined}
                   fps={surface === 'edit' ? editTimelineFps : canvas.fps}

--- a/src/features/timeline/components/timeline-density-overview.test.tsx
+++ b/src/features/timeline/components/timeline-density-overview.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { useEditorStore } from '@/shared/state/editor'
 import { useSelectionStore } from '@/shared/state/selection'
 import type { TimelineItem } from '@/types/timeline'
+import { useLinkedEditPreviewStore } from '../stores/linked-edit-preview-store'
 import { TimelineDensityOverview } from './timeline-density-overview'
 
 const overviewItems: TimelineItem[] = [
@@ -33,6 +34,7 @@ describe('TimelineDensityOverview', () => {
     useSelectionStore.getState().selectItems([])
     useSelectionStore.getState().setActiveTool('select')
     useEditorStore.setState({ linkedSelectionEnabled: false })
+    useLinkedEditPreviewStore.getState().clear()
     vi.stubGlobal('requestAnimationFrame', () => 1)
   })
 
@@ -70,6 +72,29 @@ describe('TimelineDensityOverview', () => {
 
     expect(buckets[0]?.style.left).toContain('--timeline-percent-per-frame')
     expect(buckets[0]?.style.width).toContain('--timeline-percent-per-frame')
+  })
+
+  it('culls density shells to linked edit preview geometry', () => {
+    useLinkedEditPreviewStore.getState().setUpdates([
+      { id: 'overview-1', durationInFrames: 12 },
+    ])
+
+    const view = render(
+      <TimelineDensityOverview
+        items={overviewItems}
+        selectedItemIds={new Set(['overview-1'])}
+        trackLocked={false}
+        trackHidden={false}
+      />,
+    )
+    const bucket = view.container.querySelector<HTMLElement>(
+      '[data-timeline-density-bucket]',
+    )
+
+    expect(bucket?.style.width).toBe(
+      'calc(12 * var(--timeline-percent-per-frame, 0%))',
+    )
+    expect(bucket?.className).toContain('ring-primary')
   })
 
   it('replays a razor click onto the promoted native clip', () => {

--- a/src/features/timeline/components/timeline-density-overview.tsx
+++ b/src/features/timeline/components/timeline-density-overview.tsx
@@ -1,5 +1,6 @@
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { flushSync } from 'react-dom'
+import { useShallow } from 'zustand/react/shallow'
 import { cn } from '@/shared/ui/cn'
 import { useEditorStore } from '@/shared/state/editor'
 import { useSelectionStore } from '@/shared/state/selection'
@@ -13,6 +14,7 @@ import {
 } from '../utils/timeline-density-overview'
 import { DENSE_TIMELINE_MAX_OVERVIEW_BUCKETS_PER_TRACK } from '../utils/timeline-dom-density'
 import { registerTimelineDensityMarqueeBucket } from '../utils/timeline-density-marquee-preview'
+import { useLinkedEditPreviewStore } from '../stores/linked-edit-preview-store'
 
 interface TimelineDensityOverviewProps {
   items: ReadonlyArray<TimelineItem>
@@ -75,13 +77,32 @@ export const TimelineDensityOverview = memo(function TimelineDensityOverview({
   trackHidden,
 }: TimelineDensityOverviewProps) {
   const overviewRef = useRef<HTMLDivElement>(null)
+  const itemIds = useMemo(() => items.map((item) => item.id), [items])
+  const previewUpdates = useLinkedEditPreviewStore(
+    useShallow(
+      useCallback(
+        (state) => itemIds.map((itemId) => state.updatesById[itemId] ?? null),
+        [itemIds],
+      ),
+    ),
+  )
+  const previewItems = useMemo(
+    () =>
+      items.flatMap((item, index) => {
+        const update = previewUpdates[index]
+        if (!update) return [item]
+        if (update.hidden) return []
+        return [{ ...item, ...update } as TimelineItem]
+      }),
+    [items, previewUpdates],
+  )
   const buckets = useMemo(
     () =>
       buildTimelineDensityBuckets(
-        items,
+        previewItems,
         DENSE_TIMELINE_MAX_OVERVIEW_BUCKETS_PER_TRACK,
       ),
-    [items],
+    [previewItems],
   )
 
   useEffect(() => {

--- a/src/features/timeline/hooks/use-timeline-trim.test.tsx
+++ b/src/features/timeline/hooks/use-timeline-trim.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { act, renderHook } from '@testing-library/react'
-import type { TimelineItem, VideoItem } from '@/types/timeline'
+import type { TextItem, TimelineItem, VideoItem } from '@/types/timeline'
 import type { Transition } from '@/types/transition'
 import { makeTimelineAudioItem, makeTimelineTrack, makeTimelineVideoItem } from '../test-helpers'
 import { resetPlaybackPreviewState } from '@/shared/state/playback-preview-test-helpers'
@@ -38,6 +38,7 @@ function setupStores() {
   useTransitionsStore.getState().setTransitions([])
   useSelectionStore.getState().setDragState(null)
   useSelectionStore.getState().setActiveSnapTarget(null)
+  useSelectionStore.getState().clearSelection()
   useRollingEditPreviewStore.getState().clearPreview()
   useRippleEditPreviewStore.getState().clearPreview()
   useTransitionBreakPreviewStore.getState().clearPreview()
@@ -249,6 +250,301 @@ describe('useTimelineTrim', () => {
 
       expect(getItem('video-1').durationInFrames).toBe(50)
       expect(getItem('audio-1').durationInFrames).toBe(50)
+    })
+
+    it('trims a mixed text and linked A/V selection as one undoable group', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 0,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const video = makeTimelineVideoItem({ id: 'video-1', linkedGroupId: 'lg-1' })
+      const audio = makeTimelineAudioItem({ id: 'audio-1', linkedGroupId: 'lg-1' })
+      useItemsStore.getState().setItems([text, video, audio])
+      useSelectionStore.getState().selectItems(['text-1', 'video-1', 'audio-1'])
+      const undoDepthBefore = useTimelineCommandStore.getState().undoStack.length
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'end')
+      moveMouse(-10)
+
+      expect(useSelectionStore.getState().dragState?.draggedItemIds).toEqual(['text-1'])
+      const previewUpdates = useLinkedEditPreviewStore.getState().updatesById
+      expect(previewUpdates['video-1']?.durationInFrames).toBe(50)
+      expect(previewUpdates['audio-1']?.durationInFrames).toBe(50)
+
+      releaseMouse()
+
+      expect(getItem('text-1').durationInFrames).toBe(50)
+      expect(getItem('video-1').durationInFrames).toBe(50)
+      expect(getItem('audio-1').durationInFrames).toBe(50)
+      expect(useTimelineCommandStore.getState().undoStack.length).toBe(undoDepthBefore + 1)
+
+      act(() => {
+        useTimelineCommandStore.getState().undo()
+      })
+      expect(getItem('text-1').durationInFrames).toBe(60)
+      expect(getItem('video-1').durationInFrames).toBe(60)
+      expect(getItem('audio-1').durationInFrames).toBe(60)
+    })
+
+    it('excludes horizontally selected clips that do not share the trim edge', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 120,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const alignedVideo = makeTimelineVideoItem({
+        id: 'video-aligned',
+        linkedGroupId: 'lg-aligned',
+        from: 100,
+        durationInFrames: 80,
+      })
+      const alignedAudio = makeTimelineAudioItem({
+        id: 'audio-aligned',
+        linkedGroupId: 'lg-aligned',
+        from: 100,
+        durationInFrames: 80,
+      })
+      const earlierVideo = makeTimelineVideoItem({
+        id: 'video-earlier',
+        linkedGroupId: 'lg-earlier',
+        from: 40,
+        durationInFrames: 60,
+      })
+      const earlierAudio = makeTimelineAudioItem({
+        id: 'audio-earlier',
+        linkedGroupId: 'lg-earlier',
+        from: 40,
+        durationInFrames: 60,
+      })
+      useItemsStore
+        .getState()
+        .setItems([text, alignedVideo, alignedAudio, earlierVideo, earlierAudio])
+      useSelectionStore
+        .getState()
+        .selectItems([
+          'text-1',
+          'video-aligned',
+          'audio-aligned',
+          'video-earlier',
+          'audio-earlier',
+        ])
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'end')
+      moveMouse(-10)
+
+      const previewUpdates = useLinkedEditPreviewStore.getState().updatesById
+      expect(previewUpdates['video-aligned']?.durationInFrames).toBe(70)
+      expect(previewUpdates['audio-aligned']?.durationInFrames).toBe(70)
+      expect(previewUpdates['video-earlier']).toBeUndefined()
+      expect(previewUpdates['audio-earlier']).toBeUndefined()
+
+      releaseMouse()
+
+      expect(getItem('text-1').durationInFrames).toBe(50)
+      expect(getItem('video-aligned').durationInFrames).toBe(70)
+      expect(getItem('audio-aligned').durationInFrames).toBe(70)
+      expect(getItem('video-earlier').durationInFrames).toBe(60)
+      expect(getItem('audio-earlier').durationInFrames).toBe(60)
+    })
+
+    it('uses the shared start edge instead of an adjacent selected clip end', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 100,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const alignedVideo = makeTimelineVideoItem({
+        id: 'video-aligned',
+        linkedGroupId: 'lg-aligned',
+        from: 100,
+        durationInFrames: 80,
+      })
+      const alignedAudio = makeTimelineAudioItem({
+        id: 'audio-aligned',
+        linkedGroupId: 'lg-aligned',
+        from: 100,
+        durationInFrames: 80,
+      })
+      const earlierVideo = makeTimelineVideoItem({
+        id: 'video-earlier',
+        linkedGroupId: 'lg-earlier',
+        from: 40,
+        durationInFrames: 60,
+      })
+      const earlierAudio = makeTimelineAudioItem({
+        id: 'audio-earlier',
+        linkedGroupId: 'lg-earlier',
+        from: 40,
+        durationInFrames: 60,
+      })
+      useItemsStore
+        .getState()
+        .setItems([text, alignedVideo, alignedAudio, earlierVideo, earlierAudio])
+      useSelectionStore
+        .getState()
+        .selectItems([
+          'text-1',
+          'video-aligned',
+          'audio-aligned',
+          'video-earlier',
+          'audio-earlier',
+        ])
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'start')
+      moveMouse(10)
+
+      const previewUpdates = useLinkedEditPreviewStore.getState().updatesById
+      expect(previewUpdates['video-aligned']).toMatchObject({
+        from: 110,
+        durationInFrames: 70,
+      })
+      expect(previewUpdates['audio-aligned']).toMatchObject({
+        from: 110,
+        durationInFrames: 70,
+      })
+      expect(previewUpdates['video-earlier']).toBeUndefined()
+      expect(previewUpdates['audio-earlier']).toBeUndefined()
+
+      releaseMouse()
+
+      expect(getItem('text-1')).toMatchObject({ from: 110, durationInFrames: 50 })
+      expect(getItem('video-aligned')).toMatchObject({ from: 110, durationInFrames: 70 })
+      expect(getItem('audio-aligned')).toMatchObject({ from: 110, durationInFrames: 70 })
+      expect(getItem('video-earlier')).toMatchObject({ from: 40, durationInFrames: 60 })
+      expect(getItem('audio-earlier')).toMatchObject({ from: 40, durationInFrames: 60 })
+    })
+
+    it('does not group a selected edge that is one frame away', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 120,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const nearVideo = makeTimelineVideoItem({
+        id: 'video-near',
+        from: 119,
+        durationInFrames: 60,
+      })
+      useItemsStore.getState().setItems([text, nearVideo])
+      useSelectionStore.getState().selectItems(['text-1', 'video-near'])
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'end')
+      moveMouse(-10)
+
+      expect(useLinkedEditPreviewStore.getState().updatesById['video-near']).toBeUndefined()
+
+      releaseMouse()
+
+      expect(getItem('text-1').durationInFrames).toBe(50)
+      expect(getItem('video-near').durationInFrames).toBe(60)
+    })
+
+    it('leaves a vertically aligned selected companion unchanged on a locked track', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 0,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const video = makeTimelineVideoItem({ id: 'video-1', linkedGroupId: 'lg-1' })
+      const audio = makeTimelineAudioItem({ id: 'audio-1', linkedGroupId: 'lg-1' })
+      useItemsStore
+        .getState()
+        .setTracks([
+          makeTimelineTrack({ id: 'track-v1', name: 'V1', kind: 'video', order: 0 }),
+          makeTimelineTrack({ id: 'track-v2', name: 'V2', kind: 'video', order: 1 }),
+          makeTimelineTrack({
+            id: 'track-a1',
+            name: 'A1',
+            kind: 'audio',
+            order: 2,
+            locked: true,
+          }),
+        ])
+      useItemsStore.getState().setItems([text, video, audio])
+      useSelectionStore.getState().selectItems(['text-1', 'video-1', 'audio-1'])
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'end')
+      moveMouse(-10)
+
+      const previewUpdates = useLinkedEditPreviewStore.getState().updatesById
+      expect(previewUpdates['video-1']?.durationInFrames).toBe(50)
+      expect(previewUpdates['audio-1']).toBeUndefined()
+
+      releaseMouse()
+
+      expect(getItem('text-1').durationInFrames).toBe(50)
+      expect(getItem('video-1').durationInFrames).toBe(50)
+      expect(getItem('audio-1').durationInFrames).toBe(60)
+    })
+
+    it('uses the tightest neighbor clamp across the vertical trim group', () => {
+      const text: TextItem = {
+        id: 'text-1',
+        type: 'text',
+        trackId: 'track-v2',
+        from: 0,
+        durationInFrames: 60,
+        label: 'CINEMA',
+        text: 'CINEMA',
+        color: '#ffffff',
+      }
+      const video = makeTimelineVideoItem({ id: 'video-1', linkedGroupId: 'lg-1' })
+      const audio = makeTimelineAudioItem({ id: 'audio-1', linkedGroupId: 'lg-1' })
+      const audioNeighbor = makeTimelineAudioItem({
+        id: 'audio-neighbor',
+        mediaId: 'media-2',
+        from: 65,
+        durationInFrames: 30,
+      })
+      useItemsStore.getState().setItems([text, video, audio, audioNeighbor])
+      useSelectionStore.getState().selectItems(['text-1', 'video-1', 'audio-1'])
+      const { result } = renderTrimHook(text)
+
+      startTrim(result, 'end')
+      moveMouse(20)
+
+      expect(result.current.trimDelta).toBe(5)
+      expect(result.current.trimConstraintLabel).toBe('neighbor limit')
+      expect(useLinkedEditPreviewStore.getState().updatesById['video-1']?.durationInFrames).toBe(65)
+      expect(useLinkedEditPreviewStore.getState().updatesById['audio-1']?.durationInFrames).toBe(65)
+
+      releaseMouse()
+
+      expect(getItem('text-1').durationInFrames).toBe(65)
+      expect(getItem('video-1').durationInFrames).toBe(65)
+      expect(getItem('audio-1').durationInFrames).toBe(65)
+      expect(getItem('audio-neighbor').from).toBe(65)
     })
   })
 

--- a/src/features/timeline/hooks/use-timeline-trim.ts
+++ b/src/features/timeline/hooks/use-timeline-trim.ts
@@ -20,7 +20,9 @@ import { useLinkedEditPreviewStore } from '../stores/linked-edit-preview-store'
 import {
   rollingTrimItems,
   rippleTrimItem,
+  trimItemEnd as trimSelectedItemEnds,
   trimItemBreakingTransition,
+  trimItemStart as trimSelectedItemStarts,
 } from '../stores/actions/item-actions'
 import {
   buildInsertedGapPreviewUpdatesForSyncLockedTracks,
@@ -30,6 +32,8 @@ import { findHandleNeighborWithTransitions } from '../utils/transition-linked-ne
 import {
   buildAttachedCaptionBoundsPreviewUpdates,
   buildSynchronizedLinkedMoveUpdates,
+  expandSelectionWithLinkedItems,
+  filterUnlockedItemIds,
   getSynchronizedLinkedCounterpartPair,
   getSynchronizedLinkedItems,
 } from '../utils/linked-items'
@@ -60,6 +64,13 @@ interface TrimState {
   isConstrained: boolean
   constraintLabel: string | null
   destroyTransitionAtHandle: boolean
+  trimmedItemIds: string[]
+}
+
+const TRIM_EDGE_ALIGNMENT_EPSILON = 1e-6
+
+function areTrimEdgesAligned(left: number, right: number): boolean {
+  return Math.abs(left - right) <= TRIM_EDGE_ALIGNMENT_EPSILON
 }
 
 /**
@@ -79,8 +90,6 @@ export function useTimelineTrim(
 ) {
   const pixelsToTime = pixelsToTimeNow
   const fps = useTimelineStore((s) => s.fps)
-  const trimItemStart = useTimelineStore((s) => s.trimItemStart)
-  const trimItemEnd = useTimelineStore((s) => s.trimItemEnd)
   const setDragState = useSelectionStore((s) => s.setDragState)
   const setActiveSnapTarget = useSelectionStore((s) => s.setActiveSnapTarget)
 
@@ -110,6 +119,7 @@ export function useTimelineTrim(
     isConstrained: false,
     constraintLabel: null,
     destroyTransitionAtHandle: false,
+    trimmedItemIds: [],
   })
 
   const trimStateRef = useRef(trimState)
@@ -184,6 +194,10 @@ export function useTimelineTrim(
       const allItems = useTimelineStore.getState().items
       const transitions = useTransitionsStore.getState().transitions
       const currentItem = getItemFromStore()
+      const normalTrimItems = trimStateRef.current.trimmedItemIds
+        .map((trimmedItemId) => allItems.find((candidate) => candidate.id === trimmedItemId))
+        .filter((candidate): candidate is TimelineItem => candidate !== undefined)
+      if (normalTrimItems.length === 0) normalTrimItems.push(currentItem)
       let neighborId: string | null = null
 
       if (isRollingEdit) {
@@ -200,7 +214,8 @@ export function useTimelineTrim(
       // During rolling edit, exclude the neighbor from snap targets.
       // During ripple edit, exclude downstream same-track items — their positions
       // are stale because they will shift by the trim amount on commit.
-      const snapExcludeIds = new Set<string>([currentItem.id])
+      const snapExcludeIds = new Set<string>(trimStateRef.current.trimmedItemIds)
+      snapExcludeIds.add(currentItem.id)
       if (neighborId) snapExcludeIds.add(neighborId)
       if (isRippleEdit) {
         // Split segments from the same origin can create self-referential
@@ -263,21 +278,32 @@ export function useTimelineTrim(
       // This ensures visual feedback matches what the store will actually commit
       let isConstrained = false
       let constraintLabel: string | null = null
-      const { clampedAmount } = clampTrimAmount(currentItem, handle!, deltaFrames, fps)
-      if (clampedAmount !== deltaFrames) {
-        isConstrained = true
-        constraintLabel = 'no handle'
-      }
-      deltaFrames = clampedAmount
+      const trimConstraintItems = isRollingEdit || isRippleEdit ? [currentItem] : normalTrimItems
+      for (const trimConstraintItem of trimConstraintItems) {
+        const { clampedAmount } = clampTrimAmount(
+          trimConstraintItem,
+          handle!,
+          deltaFrames,
+          fps,
+        )
+        if (clampedAmount !== deltaFrames) {
+          isConstrained = true
+          constraintLabel = 'no handle'
+        }
+        deltaFrames = clampedAmount
 
-      // Clamp to adjacent items on the same track (allow overlap with transition-linked clips)
-      // During ripple edit, skip adjacency clamping — downstream clips shift with the trim.
-      if (!isRippleEdit) {
+        // Clamp to adjacent items on the same track (allow overlap with transition-linked clips)
+        // During ripple edit, skip adjacency clamping — downstream clips shift with the trim.
+        if (isRippleEdit) continue
+
         const transitionLinkedIds = new Set<string>()
-        if (!trimStateRef.current.destroyTransitionAtHandle) {
+        if (
+          !trimStateRef.current.destroyTransitionAtHandle ||
+          trimConstraintItem.id !== currentItem.id
+        ) {
           for (const t of transitions) {
-            if (t.leftClipId === currentItem.id) transitionLinkedIds.add(t.rightClipId)
-            if (t.rightClipId === currentItem.id) transitionLinkedIds.add(t.leftClipId)
+            if (t.leftClipId === trimConstraintItem.id) transitionLinkedIds.add(t.rightClipId)
+            if (t.rightClipId === trimConstraintItem.id) transitionLinkedIds.add(t.leftClipId)
           }
         }
         // During rolling edit, exclude the neighbor from adjacency constraints —
@@ -286,7 +312,7 @@ export function useTimelineTrim(
           transitionLinkedIds.add(neighborId)
         }
         const adjacentClamped = clampToAdjacentItems(
-          currentItem,
+          trimConstraintItem,
           handle!,
           deltaFrames,
           allItems,
@@ -588,12 +614,9 @@ export function useTimelineTrim(
           linkedPreviewUpdates.push(...syncLockPreviewUpdates)
         }
       } else {
-        const synchronizedItems = linkedSelectionEnabled
-          ? getSynchronizedLinkedItems(allItems, currentItem.id)
-          : [currentItem]
         const captionClipBounds: Array<{ id: string; from: number; durationInFrames: number }> = []
 
-        for (const linkedItem of synchronizedItems) {
+        for (const linkedItem of normalTrimItems) {
           const previewUpdate =
             handle === 'end'
               ? applyTrimEndPreview(linkedItem, deltaFrames, fps)
@@ -679,7 +702,9 @@ export function useTimelineTrim(
             : []
 
         if (state.destroyTransitionAtHandle && state.handle) {
-          trimItemBreakingTransition(item.id, state.handle, deltaFrames, transitionIdsToRemove)
+          trimItemBreakingTransition(item.id, state.handle, deltaFrames, transitionIdsToRemove, {
+            itemIds: state.trimmedItemIds,
+          })
         } else if (state.isRippleEdit) {
           // Ripple edit: trim + shift downstream items
           rippleTrimItem(item.id, state.handle!, deltaFrames)
@@ -696,9 +721,9 @@ export function useTimelineTrim(
         } else {
           // Normal trim
           if (state.handle === 'start') {
-            trimItemStart(item.id, deltaFrames)
+            trimSelectedItemStarts(item.id, deltaFrames, { itemIds: state.trimmedItemIds })
           } else if (state.handle === 'end') {
-            trimItemEnd(item.id, deltaFrames)
+            trimSelectedItemEnds(item.id, deltaFrames, { itemIds: state.trimmedItemIds })
           }
         }
       }
@@ -735,9 +760,10 @@ export function useTimelineTrim(
         isConstrained: false,
         constraintLabel: null,
         destroyTransitionAtHandle: false,
+        trimmedItemIds: [],
       })
     }
-  }, [item.id, trimItemStart, trimItemEnd, setActiveSnapTarget, setDragState])
+  }, [item.id, setActiveSnapTarget, setDragState])
 
   // Setup and cleanup mouse event listeners
   useEffect(() => {
@@ -808,6 +834,7 @@ export function useTimelineTrim(
       const wantsRolling = forcedMode === 'rolling' || (forcedMode === null && modifierRolling)
       const wantsRipple = forcedMode === 'ripple' || (forcedMode === null && modifierRipple)
       const currentItem = getItemFromStore()
+      const allItems = useTimelineStore.getState().items
       const transitions = useTransitionsStore.getState().transitions
       let neighborId: string | null = null
 
@@ -815,7 +842,7 @@ export function useTimelineTrim(
         const neighbor = findHandleNeighborWithTransitions(
           currentItem,
           handle,
-          useTimelineStore.getState().items,
+          allItems,
           transitions,
         )
         neighborId = neighbor?.id ?? null
@@ -825,10 +852,39 @@ export function useTimelineTrim(
         }
       }
 
+      const selectedItemIds = useSelectionStore.getState().selectedItemIds
+      const baseTrimItemIds = selectedItemIds.includes(currentItem.id)
+        ? selectedItemIds
+        : [currentItem.id]
+      const expandedTrimItemIds = useEditorStore.getState().linkedSelectionEnabled
+        ? expandSelectionWithLinkedItems(allItems, baseTrimItemIds)
+        : baseTrimItemIds
+      const unlockedTrimItemIds = filterUnlockedItemIds(
+        allItems,
+        useItemsStore.getState().tracks,
+        expandedTrimItemIds,
+      )
+      const anchorTrimEdge =
+        handle === 'start' ? currentItem.from : currentItem.from + currentItem.durationInFrames
+      const verticallyAlignedTrimItemIds = unlockedTrimItemIds.filter((trimmedItemId) => {
+        if (trimmedItemId === currentItem.id) return true
+        const trimmedItem = allItems.find((candidate) => candidate.id === trimmedItemId)
+        if (!trimmedItem) return false
+        const trimmedItemEdge =
+          handle === 'start' ? trimmedItem.from : trimmedItem.from + trimmedItem.durationInFrames
+        return areTrimEdgesAligned(anchorTrimEdge, trimmedItemEdge)
+      })
+      const trimmedItemIds =
+        verticallyAlignedTrimItemIds.includes(currentItem.id)
+          ? verticallyAlignedTrimItemIds
+          : [currentItem.id]
+
       magneticSnapTargetsRef.current = getMagneticSnapTargets()
       setDragState({
         isDragging: true,
-        draggedItemIds: [item.id],
+        // The pointer gesture belongs to the anchor. Other selected items get
+        // their culled geometry from linked trim previews, not move-drag shells.
+        draggedItemIds: [currentItem.id],
         offset: { x: 0, y: 0 },
       })
       setActiveSnapTarget(null)
@@ -847,6 +903,7 @@ export function useTimelineTrim(
         isConstrained: false,
         constraintLabel: null,
         destroyTransitionAtHandle,
+        trimmedItemIds,
       })
 
       if (wantsRolling && neighborId) {

--- a/src/features/timeline/stores/actions/edit/trim-actions.ts
+++ b/src/features/timeline/stores/actions/edit/trim-actions.ts
@@ -34,6 +34,45 @@ function keepTightestDelta(requested: number, candidate: number): number {
   return requested < 0 ? Math.max(requested, candidate) : Math.min(requested, candidate)
 }
 
+interface SynchronizedTrimOptions {
+  forceLinked?: boolean
+  itemIds?: readonly string[]
+}
+
+function getSynchronizedTrimItems(
+  items: TimelineItem[],
+  anchorId: string,
+  options: SynchronizedTrimOptions,
+): TimelineItem[] {
+  const linkedSelectionEnabled = options.forceLinked === true || isLinkedSelectionEnabled()
+  const requestedIds = [
+    anchorId,
+    ...(options.itemIds ?? []).filter((itemId) => itemId !== anchorId),
+  ]
+  const synchronizedById = new Map<string, TimelineItem>()
+
+  if (options.itemIds !== undefined) {
+    const itemById = new Map(items.map((item) => [item.id, item]))
+    for (const requestedId of requestedIds) {
+      const requestedItem = itemById.get(requestedId)
+      if (requestedItem) synchronizedById.set(requestedItem.id, requestedItem)
+    }
+    return Array.from(synchronizedById.values())
+  }
+
+  for (const requestedId of requestedIds) {
+    for (const synchronizedItem of getSynchronizedLinkedItemsForEdit(
+      items,
+      requestedId,
+      linkedSelectionEnabled,
+    )) {
+      synchronizedById.set(synchronizedItem.id, synchronizedItem)
+    }
+  }
+
+  return Array.from(synchronizedById.values())
+}
+
 function clampSlideParticipantDelta(
   requestedDelta: number,
   item: TimelineItem,
@@ -142,15 +181,11 @@ function applySynchronizedTrim(
   id: string,
   handle: 'start' | 'end',
   trimAmount: number,
-  forceLinked: boolean,
+  options: SynchronizedTrimOptions,
 ): void {
   const itemsStore = useItemsStore.getState()
   const itemsBefore = itemsStore.items
-  const synchronizedItems = getSynchronizedLinkedItemsForEdit(
-    itemsBefore,
-    id,
-    forceLinked || isLinkedSelectionEnabled(),
-  )
+  const synchronizedItems = getSynchronizedTrimItems(itemsBefore, id, options)
   const anchorBefore = synchronizedItems.find((item) => item.id === id)
   if (!anchorBefore) return
 
@@ -218,28 +253,28 @@ function applySynchronizedTrim(
 export function trimItemStart(
   id: string,
   trimAmount: number,
-  options: { forceLinked?: boolean } = {},
+  options: SynchronizedTrimOptions = {},
 ): void {
   execute(
     'TRIM_ITEM_START',
     () => {
-      applySynchronizedTrim(id, 'start', trimAmount, options.forceLinked === true)
+      applySynchronizedTrim(id, 'start', trimAmount, options)
     },
-    { id, trimAmount },
+    { id, trimAmount, itemIds: options.itemIds },
   )
 }
 
 export function trimItemEnd(
   id: string,
   trimAmount: number,
-  options: { forceLinked?: boolean } = {},
+  options: SynchronizedTrimOptions = {},
 ): void {
   execute(
     'TRIM_ITEM_END',
     () => {
-      applySynchronizedTrim(id, 'end', trimAmount, options.forceLinked === true)
+      applySynchronizedTrim(id, 'end', trimAmount, options)
     },
-    { id, trimAmount },
+    { id, trimAmount, itemIds: options.itemIds },
   )
 }
 
@@ -248,6 +283,7 @@ export function trimItemBreakingTransition(
   handle: 'start' | 'end',
   trimAmount: number,
   transitionIdsToRemove: string[],
+  options: Pick<SynchronizedTrimOptions, 'itemIds'> = {},
 ): void {
   execute(
     handle === 'start' ? 'TRIM_ITEM_START' : 'TRIM_ITEM_END',
@@ -256,12 +292,13 @@ export function trimItemBreakingTransition(
         useTransitionsStore.getState()._removeTransitions(transitionIdsToRemove)
       }
 
-      applySynchronizedTrim(id, handle, trimAmount, false)
+      applySynchronizedTrim(id, handle, trimAmount, options)
     },
     {
       id,
       handle,
       trimAmount,
+      itemIds: options.itemIds,
       removedTransitionCount: transitionIdsToRemove.length,
     },
   )


### PR DESCRIPTION
## Summary

- add a muted overlay that shows the timeline region affected by a keyframe segment
- observe dopesheet rows against the correct scroll root so keyframes render immediately when the editor opens
- make grouped trims operate only on selected clips sharing the dragged vertical edge, including synchronized linked A/V preview and commit geometry
- keep dense timeline shells aligned with live linked-edit previews

## Root cause

The dopesheet observer could initialize against a stale scroll root, leaving keyframe rows unobserved until a vertical scroll forced another measurement. Group trimming previously either committed only the anchor or treated the entire multi-selection as one trim cohort, while dense overview shells continued using committed geometry during preview.

## Impact

Grouped text and A/V trims now preview and commit atomically with one shared source/neighbor clamp, while horizontally selected clips remain untouched. Locked companions and clips even one frame away are excluded. Keyframe affected ranges appear on first open without requiring a scroll.

## Validation

- `npx vp test` on 6 focused files: 86 tests passed
- `npx vp check --no-fmt` on all 8 changed files: clean
- `git diff --check origin/staging...origin/develop`: clean
- `git merge-tree --write-tree --messages origin/staging origin/develop`: clean
- live Chrome verification: a four-clip horizontal selection trimmed only `CINEMA` and the vertically aligned `kanye_pcm.mp4` video/audio pair; earlier selected A/V pairs were unchanged, and undo restored all durations