### PR TITLE
(perf): stabilize preview playback frame pacing

### DIFF
--- a/src/features/preview/components/gizmo-overlay.tsx
+++ b/src/features/preview/components/gizmo-overlay.tsx
@@ -266,7 +266,11 @@ export function GizmoOverlay({
   useEffect(() => {
     if (!isPlaying) {
       // When paused/skimming, sync to the effective preview frame
-      frozenFrameRef.current = getResolvedFrameForPlaybackState(usePlaybackStore.getState())
+      const nextFrame = getResolvedFrameForPlaybackState(usePlaybackStore.getState())
+      if (frozenFrameRef.current !== nextFrame) {
+        frozenFrameRef.current = nextFrame
+        setForceUpdate((n) => n + 1)
+      }
     }
   }, [getResolvedFrameForPlaybackState, isPlaying])
 
@@ -813,6 +817,7 @@ export function GizmoOverlay({
     visibleItems,
     projectSize,
     itemsWithLiveTransforms,
+    frozenFrameRef.current,
   )
 
   // Create marquee items with pre-computed bounding rects for collision detection
@@ -1484,7 +1489,8 @@ export function GizmoOverlay({
           })}
 
         {/* Transform gizmo(s) for selected items - hidden while another canvas editor is active */}
-        {isExclusiveCanvasEditorActive ? null : selectedItems.length === 1 && selectedItems[0] ? (
+        {isExclusiveCanvasEditorActive || isPlaying ? null : selectedItems.length === 1 &&
+          selectedItems[0] ? (
           <TransformGizmo
             item={selectedItems[0]}
             coordParams={coordParams}

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -2591,17 +2591,24 @@ describe('VideoPreview sync behavior', () => {
       } as unknown as TimelineItem,
     ])
 
-    // The timeline contains a gpu-effect clip, so the overlay stays warm from
-    // the start (project-level always-on) rather than switching on at the clip
-    // boundary — this is what makes the effect appear instantly on landing.
+    // A future effect must not route ordinary frame 0 through the continuous
+    // renderer. The bounded router switches only when the seek lands on it.
     const { scrubCanvas } = await renderPreviewAfterInitialSeek()
-    expect(scrubCanvas.style.visibility).toBe('visible')
+    expect(scrubCanvas.style.visibility).toBe('hidden')
 
     act(() => {
       usePlaybackStore.getState().setCurrentFrame(24)
     })
 
     await waitForSingleRendererFrame(24, scrubCanvas, { expectedDisplayedFrame: 24 })
+
+    act(() => {
+      usePlaybackStore.getState().setCurrentFrame(0)
+    })
+    await waitFor(() => {
+      expect(scrubCanvas.style.visibility).toBe('hidden')
+      expect(getDisplayedFrame()).toBeNull()
+    })
   })
 
   it('keeps corner-pinned text on the rendered overlay even when Player is already at the frame', async () => {
@@ -2639,10 +2646,10 @@ describe('VideoPreview sync behavior', () => {
 
     mockedPlayerFrame = 24
 
-    // Corner-pin is overlay-only content, so the overlay is warm from the start
-    // (project-level always-on) even though the Player already sits at the frame.
+    // Player position alone does not force the project-wide overlay; the
+    // playback store landing activates it at the corner-pinned frame.
     const { scrubCanvas } = await renderPreviewAfterInitialSeek()
-    expect(scrubCanvas.style.visibility).toBe('visible')
+    expect(scrubCanvas.style.visibility).toBe('hidden')
 
     act(() => {
       usePlaybackStore.getState().setCurrentFrame(24)

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -622,10 +622,16 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     (frame: number) => {
       const nextFrame = Math.max(0, Math.round(frame))
       latestPlayerDisplayedFrameRef.current = nextFrame
-      setPlayerDisplayedFrame((prevFrame) => (prevFrame === nextFrame ? prevFrame : nextFrame))
+      // Ordinary playback consumes this imperatively through the ref below.
+      // Mirroring every Clock tick into React state invalidates the entire
+      // VideoPreview tree (including editor overlays) even though only color
+      // comparison needs a rendered-frame state value.
+      if (comparisonEnabled) {
+        setPlayerDisplayedFrame((prevFrame) => (prevFrame === nextFrame ? prevFrame : nextFrame))
+      }
       handleFrameChange(frame)
     },
-    [handleFrameChange],
+    [comparisonEnabled, handleFrameChange],
   )
 
   const getLivePlaybackFrame = useCallback(() => {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -142,12 +142,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     playerRef,
     scrubCanvasRef,
     gpuEffectsCanvasRef,
-    scrubFrameDirtyRef,
     bypassPreviewSeekRef,
     isGizmoInteractingRef,
     preferPlayerForStyledTextScrubRef,
     adaptiveQualityStateRef,
-    scrubOffscreenCanvasRef,
     transitionSessionTraceRef,
     transitionTelemetryRef,
     transitionSessionBufferedFramesRef,
@@ -174,7 +172,6 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     proxyReadyCount,
     playerSize,
     needsOverflow,
-    playerContainerRef,
     playerContainerRect,
     backgroundRef,
     setPlayerContainerRefCallback,
@@ -191,12 +188,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     useProxyMedia: useProxy,
     blobUrlVersion,
   })
-  const showGpuEffectsOverlay = useGpuEffectsOverlay(
-    gpuEffectsCanvasRef,
-    playerContainerRef,
-    scrubOffscreenCanvasRef,
-    scrubFrameDirtyRef,
-  )
+  const {
+    needsOverlay: showGpuEffectsOverlay,
+    shouldWarmRenderer: shouldWarmGpuEffectsRenderer,
+  } = useGpuEffectsOverlay(fps)
   const isMaskEditing = useMaskEditorStore((s) => s.isEditing)
   const isCornerPinEditing = useCornerPinStore((s) => s.isEditing)
   const isPowerWindowEditing = usePowerWindowEditorStore((s) => s.isEditing)
@@ -507,6 +502,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   // makes the first neutral-EV drag look stuck until another parameter changes.
   const forceFastScrubOverlay =
     showGpuEffectsOverlay || isPowerWindowEditing || isSpatialEffectEditing
+  const previousForceFastScrubOverlayRef = useRef(forceFastScrubOverlay)
 
   // The split comparison is the only render-time branch that needs playback
   // state. Keep the selected value stable for the normal (non-split) preview
@@ -561,6 +557,29 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     pushTransitionTrace,
     ...previewRuntimeRefs.transitionSessionControllerRefs,
   })
+  useEffect(() => {
+    const wasForced = previousForceFastScrubOverlayRef.current
+    previousForceFastScrubOverlayRef.current = forceFastScrubOverlay
+    if (!wasForced || forceFastScrubOverlay) return
+
+    const playbackState = usePlaybackStore.getState()
+    if (
+      playbackState.previewFrame !== null ||
+      isPausedTransitionOverlayActive(playbackState.currentFrame, playbackState)
+    ) {
+      return
+    }
+
+    // A rendered-only item just left the routing window. Release its last
+    // bitmap immediately so an ordinary Player frame cannot remain occluded.
+    hideFastScrubOverlay()
+    setDisplayedFrame(null)
+  }, [
+    forceFastScrubOverlay,
+    hideFastScrubOverlay,
+    isPausedTransitionOverlayActive,
+    setDisplayedFrame,
+  ])
   const shouldPreferPlayerForPreview = useCallback(
     (previewFrame: number | null) => {
       const playbackState = usePlaybackStore.getState()
@@ -624,6 +643,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       fps,
       isResolving,
       forceFastScrubOverlay,
+      preserveRendererAcrossOverlayRouting: shouldWarmGpuEffectsRenderer,
       domTextScrubOverlayEnabled: domTextScrubOverlayPlan.enabled,
       items,
       playerSize,
@@ -651,6 +671,27 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       setDisplayedFrame,
       ...previewRuntimeRefs.rendererControllerRefs,
     })
+  useEffect(() => {
+    if (!shouldWarmGpuEffectsRenderer || isResolving) return
+
+    let cancelled = false
+    const warmRenderer = () => {
+      if (!cancelled) void ensureFastScrubRenderer()
+    }
+    if (typeof window.requestIdleCallback === 'function') {
+      const idleId = window.requestIdleCallback(warmRenderer, { timeout: 750 })
+      return () => {
+        cancelled = true
+        window.cancelIdleCallback(idleId)
+      }
+    }
+
+    const timeoutId = window.setTimeout(warmRenderer, 0)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeoutId)
+    }
+  }, [ensureFastScrubRenderer, isResolving, shouldWarmGpuEffectsRenderer])
   usePreviewRenderPump({
     fps,
     forceFastScrubOverlay,

--- a/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test'
 import {
+  getContinuousPreviewOverlayFrameWindow,
   shouldForceContinuousPreviewOverlay,
+  shouldForceContinuousPreviewOverlayInWindow,
   timelineHasContinuousOverlayContent,
 } from './use-gpu-effects-overlay'
 import type { TimelineItem } from '@/types/timeline'
@@ -481,6 +483,96 @@ describe('shouldForceContinuousPreviewOverlay', () => {
   })
 })
 
+describe('bounded continuous overlay routing', () => {
+  const gpuEffect = {
+    id: 'effect-window',
+    enabled: true,
+    effect: { type: 'gpu-effect' as const, gpuEffectType: 'gpu-blur', params: { amount: 0.5 } },
+  }
+
+  it('uses the exact frame while paused on an ordinary timeline', () => {
+    expect(
+      getContinuousPreviewOverlayFrameWindow({
+        frame: 500,
+        fps: 30,
+        isPlaying: false,
+        isPreviewing: false,
+        playbackRate: 1,
+      }),
+    ).toEqual({ startFrame: 500, endFrameExclusive: 501 })
+  })
+
+  it('pre-arms forward playback and retains a short post-roll', () => {
+    expect(
+      getContinuousPreviewOverlayFrameWindow({
+        frame: 500,
+        fps: 30,
+        isPlaying: true,
+        isPreviewing: false,
+        playbackRate: 1,
+      }),
+    ).toEqual({ startFrame: 497, endFrameExclusive: 509 })
+  })
+
+  it('puts the longer pre-arm window behind the playhead during reverse playback', () => {
+    expect(
+      getContinuousPreviewOverlayFrameWindow({
+        frame: 500,
+        fps: 30,
+        isPlaying: true,
+        isPreviewing: false,
+        playbackRate: -1,
+      }),
+    ).toEqual({ startFrame: 492, endFrameExclusive: 504 })
+  })
+
+  it('activates for a one-frame effect inside the lookahead without routing distant frames', () => {
+    const effected = createVideoItem({
+      from: 508,
+      durationInFrames: 1,
+      effects: [gpuEffect],
+    })
+
+    expect(
+      shouldForceContinuousPreviewOverlayInWindow(
+        [effected],
+        0,
+        { startFrame: 497, endFrameExclusive: 509 },
+      ),
+    ).toBe(true)
+    expect(
+      shouldForceContinuousPreviewOverlayInWindow(
+        [effected],
+        0,
+        { startFrame: 0, endFrameExclusive: 9 },
+      ),
+    ).toBe(false)
+  })
+
+  it('holds the rendered path across the end boundary, then releases it', () => {
+    const effected = createVideoItem({
+      from: 400,
+      durationInFrames: 100,
+      effects: [gpuEffect],
+    })
+
+    expect(
+      shouldForceContinuousPreviewOverlayInWindow(
+        [effected],
+        0,
+        { startFrame: 499, endFrameExclusive: 511 },
+      ),
+    ).toBe(true)
+    expect(
+      shouldForceContinuousPreviewOverlayInWindow(
+        [effected],
+        0,
+        { startFrame: 500, endFrameExclusive: 512 },
+      ),
+    ).toBe(false)
+  })
+})
+
 describe('timelineHasContinuousOverlayContent', () => {
   const gpuEffect = {
     id: 'effect-1',
@@ -493,8 +585,6 @@ describe('timelineHasContinuousOverlayContent', () => {
   })
 
   it('is true when any item has an enabled GPU effect, regardless of frame position', () => {
-    // The clip sits far from frame 0, yet the overlay must stay warm the whole
-    // session — this is exactly what the frame-based check misses.
     const effected = createVideoItem({ from: 500, durationInFrames: 60, effects: [gpuEffect] })
     expect(timelineHasContinuousOverlayContent([createVideoItem(), effected])).toBe(true)
   })

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -69,17 +69,90 @@ function subCompositionNeedsRenderedOverlayPath(
   })
 }
 
+const PLAYBACK_OVERLAY_LOOKAHEAD_SECONDS = 0.25
+const PLAYBACK_OVERLAY_HOLD_SECONDS = 0.1
+const SCRUB_OVERLAY_RADIUS_SECONDS = 0.08
+
+export interface ContinuousPreviewOverlayFrameWindow {
+  startFrame: number
+  endFrameExclusive: number
+}
+
+interface ContinuousPreviewOverlayWindowOptions {
+  forceTransitionFrames?: boolean
+}
+
+interface ContinuousPreviewOverlayFrameWindowInput {
+  frame: number
+  fps: number
+  isPlaying: boolean
+  isPreviewing: boolean
+  playbackRate: number
+}
+
+export function getContinuousPreviewOverlayFrameWindow({
+  frame,
+  fps,
+  isPlaying,
+  isPreviewing,
+  playbackRate,
+}: ContinuousPreviewOverlayFrameWindowInput): ContinuousPreviewOverlayFrameWindow {
+  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 30
+  const lookaheadFrames = isPlaying
+    ? Math.max(1, Math.ceil(safeFps * PLAYBACK_OVERLAY_LOOKAHEAD_SECONDS))
+    : isPreviewing
+      ? Math.max(1, Math.ceil(safeFps * SCRUB_OVERLAY_RADIUS_SECONDS))
+      : 0
+  const holdFrames = isPlaying
+    ? Math.max(1, Math.ceil(safeFps * PLAYBACK_OVERLAY_HOLD_SECONDS))
+    : isPreviewing
+      ? lookaheadFrames
+      : 0
+  const isReversePlayback = isPlaying && playbackRate < 0
+
+  return {
+    startFrame: frame - (isReversePlayback ? lookaheadFrames : holdFrames),
+    endFrameExclusive: frame + (isReversePlayback ? holdFrames : lookaheadFrames) + 1,
+  }
+}
+
+function rangesOverlap(
+  startFrame: number,
+  endFrameExclusive: number,
+  otherStartFrame: number,
+  otherEndFrameExclusive: number,
+): boolean {
+  return startFrame < otherEndFrameExclusive && endFrameExclusive > otherStartFrame
+}
+
+function isTextMotionActiveInWindow(
+  item: Extract<TimelineItem, { type: 'text' }>,
+  startFrame: number,
+  endFrameExclusive: number,
+): boolean {
+  const textMotion = item.textMotion
+  if (!textMotion) return false
+  const firstFrame = Math.max(item.from, Math.ceil(startFrame))
+  const lastFrameExclusive = Math.min(
+    item.from + item.durationInFrames,
+    Math.ceil(endFrameExclusive),
+  )
+  for (let frame = firstFrame; frame < lastFrameExclusive; frame += 1) {
+    if (isTextMotionActive(textMotion, frame - item.from, 0, item.durationInFrames)) {
+      return true
+    }
+  }
+  return false
+}
+
 /**
  * Frame-independent scan: does the timeline contain ANY content that can only
  * be shown through the GPU overlay (enabled GPU effects, non-normal blend modes,
  * corner pin, text motion) — anywhere, on any clip, at any time?
  *
- * When true, the caller keeps the overlay active for the whole session instead
- * of flipping it on per-frame as the playhead enters each such clip. The
- * per-frame flip is a reactive React-state round-trip, so effects would
- * otherwise pop in a few frames late on every skim/playback entry. Trading a
- * ~1-2ms GPU composite over non-effect clips for instant effects is worth it;
- * projects with no such content keep the fast DOM path (this returns false).
+ * This is an inventory helper only. Presentation routing must remain bounded to
+ * the playhead so one effected clip cannot force the expensive renderer across
+ * an otherwise ordinary long timeline.
  */
 export function timelineHasContinuousOverlayContent(
   items: TimelineItem[],
@@ -113,7 +186,30 @@ export function shouldForceContinuousPreviewOverlay(
   compositionById?: Record<string, SubComposition>,
   options: { forceTransitionFrames?: boolean } = {},
 ): boolean {
-  if (!Number.isFinite(frame)) {
+  return shouldForceContinuousPreviewOverlayInWindow(
+    items,
+    transitionsOrCount,
+    { startFrame: frame, endFrameExclusive: frame + 1 },
+    previewEffectsByItemId,
+    compositionById,
+    options,
+  )
+}
+
+export function shouldForceContinuousPreviewOverlayInWindow(
+  items: TimelineItem[],
+  transitionsOrCount: Transition[] | number,
+  window: ContinuousPreviewOverlayFrameWindow,
+  previewEffectsByItemId?: ReadonlyMap<string, ItemEffect[]>,
+  compositionById?: Record<string, SubComposition>,
+  options: ContinuousPreviewOverlayWindowOptions = {},
+): boolean {
+  const { startFrame, endFrameExclusive } = window
+  if (
+    !Number.isFinite(startFrame) ||
+    !Number.isFinite(endFrameExclusive) ||
+    endFrameExclusive <= startFrame
+  ) {
     return false
   }
 
@@ -123,15 +219,28 @@ export function shouldForceContinuousPreviewOverlay(
       clipMap.set(item.id, item)
     }
 
-    for (const window of resolveTransitionWindows(transitionsOrCount, clipMap)) {
-      if (frame >= window.startFrame && frame < window.endFrame) {
+    for (const transitionWindow of resolveTransitionWindows(transitionsOrCount, clipMap)) {
+      if (
+        rangesOverlap(
+          startFrame,
+          endFrameExclusive,
+          transitionWindow.startFrame,
+          transitionWindow.endFrame,
+        )
+      ) {
         if (options.forceTransitionFrames) {
           return true
         }
-        if (window.leftClip.type === 'composition' || window.rightClip.type === 'composition') {
+        if (
+          transitionWindow.leftClip.type === 'composition' ||
+          transitionWindow.rightClip.type === 'composition'
+        ) {
           return true
         }
-        if (hasCornerPin(window.leftClip.cornerPin) || hasCornerPin(window.rightClip.cornerPin)) {
+        if (
+          hasCornerPin(transitionWindow.leftClip.cornerPin) ||
+          hasCornerPin(transitionWindow.rightClip.cornerPin)
+        ) {
           return true
         }
         // Multiple transitions on different tracks can cover the same
@@ -143,7 +252,14 @@ export function shouldForceContinuousPreviewOverlay(
   }
 
   return items.some((item) => {
-    if (frame < item.from || frame >= item.from + item.durationInFrames) {
+    if (
+      !rangesOverlap(
+        startFrame,
+        endFrameExclusive,
+        item.from,
+        item.from + item.durationInFrames,
+      )
+    ) {
       return false
     }
     const effectiveEffects = previewEffectsByItemId?.get(item.id) ?? item.effects
@@ -156,7 +272,7 @@ export function shouldForceContinuousPreviewOverlay(
     if (
       item.type === 'text' &&
       item.textMotion !== undefined &&
-      isTextMotionActive(item.textMotion, frame - item.from, 0, item.durationInFrames)
+      isTextMotionActiveInWindow(item, startFrame, endFrameExclusive)
     ) {
       return true
     }
@@ -168,9 +284,26 @@ export function shouldForceContinuousPreviewOverlay(
   })
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function useGpuEffectsOverlay(..._args: unknown[]) {
+export function useGpuEffectsOverlay(fps: number) {
   const [needsOverlay, setNeedsOverlay] = useState(false)
+  const [shouldWarmRenderer, setShouldWarmRenderer] = useState(false)
+
+  useEffect(() => {
+    const checkInventory = () => {
+      const items = useItemsStore.getState().items
+      const compositionById = useCompositionsStore.getState().compositionById
+      const next = timelineHasContinuousOverlayContent(items, compositionById)
+      setShouldWarmRenderer((prev) => (prev === next ? prev : next))
+    }
+
+    checkInventory()
+    const unsubItems = useItemsStore.subscribe(checkInventory)
+    const unsubCompositions = useCompositionsStore.subscribe(checkInventory)
+    return () => {
+      unsubItems()
+      unsubCompositions()
+    }
+  }, [])
 
   useEffect(() => {
     const check = () => {
@@ -178,7 +311,15 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
       const transitions = useTransitionsStore.getState().transitions
       const compositionById = useCompositionsStore.getState().compositionById
       const playback = usePlaybackStore.getState()
+      const isPreviewing = playback.previewFrame !== null
       const frame = playback.previewFrame ?? playback.currentFrame
+      const frameWindow = getContinuousPreviewOverlayFrameWindow({
+        frame,
+        fps,
+        isPlaying: playback.isPlaying,
+        isPreviewing,
+        playbackRate: playback.playbackRate,
+      })
       const preview = useGizmoStore.getState().preview
       const previewEffectsByItemId = preview
         ? new Map(
@@ -189,29 +330,27 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
         : undefined
 
       setNeedsOverlay((prev) => {
-        // Option 1: if the timeline contains any overlay-only content anywhere,
-        // keep the overlay warm for the whole session so effects/blend/corner-pin
-        // are instant on skim + playback instead of lagging the reactive per-frame
-        // flag. Otherwise fall back to the frame-based decision (transitions etc.).
+        // Pre-arm shortly before rendered-only content and retain it briefly
+        // after the boundary. Ordinary frames outside this bounded window stay
+        // on the browser Player instead of paying the continuous render-pump cost.
         const next =
-          timelineHasContinuousOverlayContent(items, compositionById) ||
+          shouldForceContinuousPreviewOverlayInWindow(
+            items,
+            0,
+            frameWindow,
+            previewEffectsByItemId,
+            compositionById,
+          ) ||
+          // Transition pre-rendering has its own runway and buffer ownership.
+          // Only route an actual transition frame here so effect lookahead does
+          // not turn the pre-render runway itself into presented overlay frames.
           shouldForceContinuousPreviewOverlay(
             items,
             transitions,
             frame,
             previewEffectsByItemId,
             compositionById,
-            // Keep the continuous (fast-scrub) overlay forced across an active
-            // transition window during playback as well as scrubbing — not only
-            // when a participant has GPU effects/blend/corner-pin. Otherwise a
-            // plain transition can drop the continuous overlay mid-window (e.g.
-            // when an unrelated effected/composition item that happened to be
-            // keeping it on ends at the cut), switching to the buffered overlay
-            // path which can leave frames un-rendered and collapse the wipe to
-            // one clip for the rest of the transition. Forcing it for the whole
-            // window keeps every transition on the per-frame render path that
-            // already works for the transitions that look correct today.
-            { forceTransitionFrames: playback.previewFrame !== null || playback.isPlaying },
+            { forceTransitionFrames: isPreviewing || playback.isPlaying },
           )
         return prev === next ? prev : next
       })
@@ -231,7 +370,12 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
       check()
     })
     const unsubPlayback = usePlaybackStore.subscribe((state, prev) => {
-      if (state.currentFrame === prev.currentFrame && state.previewFrame === prev.previewFrame) {
+      if (
+        state.currentFrame === prev.currentFrame &&
+        state.previewFrame === prev.previewFrame &&
+        state.isPlaying === prev.isPlaying &&
+        state.playbackRate === prev.playbackRate
+      ) {
         return
       }
       check()
@@ -243,7 +387,7 @@ export function useGpuEffectsOverlay(..._args: unknown[]) {
       unsubGizmo()
       unsubPlayback()
     }
-  }, [])
+  }, [fps])
 
-  return needsOverlay
+  return { needsOverlay, shouldWarmRenderer }
 }

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -54,6 +54,7 @@ import {
   selectBoundarySourcePrewarmSources,
   shouldDropStalePausedPreviewRender,
   shouldPreservePausedTransportPresentation,
+  shouldProbePreviewSourcePixels,
   shouldRejectBlankReleasedScrubHandoff,
   shouldRejectBlankTransportHandoff,
   shouldRecoverFailedActivePreseekSchedule,
@@ -410,6 +411,9 @@ export function usePreviewRenderPump({
     const isEffectivelyBlankPreviewSource = (
       source: OffscreenCanvas | HTMLCanvasElement,
     ): boolean => {
+      if (!shouldProbePreviewSourcePixels(usePlaybackStore.getState().isPlaying)) {
+        return false
+      }
       try {
         blankProbeCanvas ??= new OffscreenCanvas(8, 8)
         const context = blankProbeCanvas.getContext('2d', { willReadFrequently: true })

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -111,6 +111,7 @@ interface UsePreviewRendererControllerParams {
   fps: number
   isResolving: boolean
   forceFastScrubOverlay: boolean
+  preserveRendererAcrossOverlayRouting: boolean
   domTextScrubOverlayEnabled: boolean
   items: TimelineItem[]
   playerSize: { width: number; height: number }
@@ -188,6 +189,7 @@ export function usePreviewRendererController({
   fps,
   isResolving,
   forceFastScrubOverlay,
+  preserveRendererAcrossOverlayRouting,
   domTextScrubOverlayEnabled,
   items,
   playerSize,
@@ -261,6 +263,11 @@ export function usePreviewRendererController({
   })
   const previousItemsRef = useRef(items)
   const previousIsResolvingRef = useRef(isResolving)
+  const forceFastScrubOverlayRef = useRef(forceFastScrubOverlay)
+  forceFastScrubOverlayRef.current = forceFastScrubOverlay
+  const overlayRoutingResetKey = preserveRendererAcrossOverlayRouting
+    ? false
+    : forceFastScrubOverlay
   const pendingPostEditWarmRequestRef = useRef<PostEditWarmRequest | null>(null)
   const postEditWarmInFlightRef = useRef(false)
   const liveScopeCaptureRendererRef = useRef<PreviewCompositionRenderer | null>(null)
@@ -839,7 +846,7 @@ export function usePreviewRendererController({
     const playbackState = usePlaybackStore.getState()
     const targetFrame = playbackState.previewFrame ?? playbackState.currentFrame
     if (
-      forceFastScrubOverlay ||
+      forceFastScrubOverlayRef.current ||
       playbackState.previewFrame !== null ||
       showFastScrubOverlayRef.current ||
       showPlaybackTransitionOverlayRef.current
@@ -857,7 +864,7 @@ export function usePreviewRendererController({
     bgTransitionRendererRef,
     disposeFastScrubRenderer,
     fastScrubRendererStructureKey,
-    forceFastScrubOverlay,
+    overlayRoutingResetKey,
     invalidateCommittedPreviewSnapshot,
     renderSize.height,
     renderSize.width,

--- a/src/features/preview/hooks/use-visual-transform.test.tsx
+++ b/src/features/preview/hooks/use-visual-transform.test.tsx
@@ -103,6 +103,12 @@ function VisualTransformsProbe({ item = ITEM }: { item?: TimelineItem }) {
   )
 }
 
+function FrozenVisualTransformsProbe({ frame }: { frame: number }) {
+  probeRenderCount += 1
+  const transforms = useVisualTransforms([ITEM], PROJECT_SIZE, undefined, frame)
+  return <div data-testid="frozen-visual-probe" data-x={String(transforms.get(ITEM.id)?.x)} />
+}
+
 function resetStores() {
   if (typeof localStorage !== 'undefined') {
     if (typeof localStorage.clear === 'function') {
@@ -201,6 +207,23 @@ describe('useVisualTransforms skimming frame resolution', () => {
 
     expect(probeRenderCount).toBe(rendersBeforeDrag)
     expect(screen.getByTestId('visual-probe')).toHaveAttribute('data-x', '110')
+  })
+
+  it('does not re-render a frozen overlay for live playback frame changes', () => {
+    render(<FrozenVisualTransformsProbe frame={10} />)
+
+    expect(screen.getByTestId('frozen-visual-probe')).toHaveAttribute('data-x', '110')
+    const rendersBeforePlayback = probeRenderCount
+
+    act(() => {
+      const playback = usePlaybackStore.getState()
+      playback.play()
+      playback.setCurrentFrame(20)
+      playback.setCurrentFrame(30)
+    })
+
+    expect(probeRenderCount).toBe(rendersBeforePlayback)
+    expect(screen.getByTestId('frozen-visual-probe')).toHaveAttribute('data-x', '110')
   })
 
   it('uses previewFrame while paused', async () => {

--- a/src/features/preview/hooks/use-visual-transform.ts
+++ b/src/features/preview/hooks/use-visual-transform.ts
@@ -39,6 +39,7 @@ export function useVisualTransforms(
   items: TimelineItem[],
   projectSize: ProjectSize,
   allItemsOverride?: TimelineItem[],
+  frameOverride?: number,
 ): Map<string, ResolvedTransform> {
   const fps = useTimelineSettingsStore((s) => s.fps)
   const allItems = useItemsStore((state) => allItemsOverride ?? state.items)
@@ -53,7 +54,14 @@ export function useVisualTransforms(
     s.activeGizmo?.mode === 'translate' ? null : s.previewTransform,
   )
   const preview = useGizmoStore((s) => s.preview)
-  const animationFrame = useResolvedPlaybackFrame()
+  // Frozen editor chrome (notably GizmoOverlay during playback) can provide
+  // its presentation frame explicitly. Keeping the external-store snapshot
+  // disabled in that mode prevents live playback ticks from re-rendering a
+  // scene-wide overlay whose controls are not being presented.
+  const resolvedPlaybackFrame = useResolvedPlaybackFrame(
+    frameOverride === undefined && items.length > 0,
+  )
+  const animationFrame = frameOverride ?? resolvedPlaybackFrame
 
   return useMemo(() => {
     const transforms = new Map<string, ResolvedTransform>()

--- a/src/features/preview/utils/render-pump-frame-plan.test.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.test.ts
@@ -13,6 +13,7 @@ import {
   selectBoundarySourcePrewarmSources,
   shouldDropStalePausedPreviewRender,
   shouldPreservePausedTransportPresentation,
+  shouldProbePreviewSourcePixels,
   shouldRejectBlankReleasedScrubHandoff,
   shouldRejectBlankTransportHandoff,
   shouldRecoverFailedActivePreseekSchedule,
@@ -32,6 +33,11 @@ function makeState(overrides: Partial<RenderPumpFrameState> = {}): RenderPumpFra
 }
 
 describe('render pump frame plan', () => {
+  it('avoids synchronous canvas pixel probes during playback', () => {
+    expect(shouldProbePreviewSourcePixels(true)).toBe(false)
+    expect(shouldProbePreviewSourcePixels(false)).toBe(true)
+  })
+
   it('routes reverse shuttle through the rendered playback overlay', () => {
     expect(
       shouldUseRenderedPlaybackOverlay(

--- a/src/features/preview/utils/render-pump-frame-plan.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.ts
@@ -110,6 +110,17 @@ export function shouldUseRenderedPlaybackOverlay(
 }
 
 /**
+ * Pixel probes are useful when a paused scrub handoff may be replacing a known
+ * good canvas with a cleared one. During playback, however, probing a WebGPU-
+ * backed canvas forces a synchronous GPU readback and can block the UI thread
+ * for several frames. Active playback relies on the renderer's aborted/pending
+ * contract instead of sampling pixels.
+ */
+export function shouldProbePreviewSourcePixels(isPlaying: boolean): boolean {
+  return !isPlaying
+}
+
+/**
  * Keeps the last valid rendered surface pinned while an exact replacement is
  * prepared. Scrubs always own this lane; continuous-overlay playback also
  * borrows it for the single play/pause handoff frame so nested composition

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -242,7 +242,11 @@ describe('TimelineContent playback selection behavior', () => {
     }
 
     Object.defineProperty(scrollContainer, 'clientWidth', { configurable: true, value: 400 })
-    Object.defineProperty(scrollContainer, 'scrollWidth', { configurable: true, value: 3000 })
+    const scrollWidthRead = vi.fn(() => 3000)
+    Object.defineProperty(scrollContainer, 'scrollWidth', {
+      configurable: true,
+      get: scrollWidthRead,
+    })
     const liveScroll = vi.fn()
     scrollContainer.addEventListener(TIMELINE_LIVE_SCROLL_EVENT, liveScroll)
 
@@ -259,6 +263,7 @@ describe('TimelineContent playback selection behavior', () => {
     expect(scrollContainer.scrollLeft).toBeCloseTo((151 / 30) * 100 - 400 * 0.2)
     expect(useTimelineViewportStore.getState().scrollLeft).toBeCloseTo(scrollContainer.scrollLeft)
     expect(liveScroll).toHaveBeenCalledOnce()
+    expect(scrollWidthRead).not.toHaveBeenCalled()
   })
 
   it('does not re-render the full timeline tree for live or settled gesture zoom', () => {

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -902,6 +902,10 @@ export const TimelineContent = memo(function TimelineContent({
   // scheduleViewportSync can hand it to syncViewportFromContainer instead of
   // reading container.scrollLeft back (a forced reflow after a width write).
   const scrollLeftRef = useRef(0)
+  // The rendered content width is derived below and changes only with content,
+  // viewport size, or settled zoom. Keep it available to playback follow-scroll
+  // without reading container.scrollWidth on every clock frame.
+  const timelineWidthRef = useRef(0)
 
   // Cached viewport box dimensions. clientWidth/clientHeight are invariant under
   // scroll and horizontal zoom (only the *content* width changes), so reading
@@ -969,10 +973,10 @@ export const TimelineContent = memo(function TimelineContent({
 
       const cachedViewportWidth = viewportDimsRef.current?.width ?? 0
       const viewportWidth = cachedViewportWidth > 0 ? cachedViewportWidth : container.clientWidth
-      const maxScrollLeft = Math.max(0, container.scrollWidth - viewportWidth)
+      const maxScrollLeft = Math.max(0, timelineWidthRef.current - viewportWidth)
       const nextScrollLeft = getPlaybackFollowScrollLeft({
         playheadX: frameToPixelsRef.current(state.currentFrame),
-        scrollLeft: container.scrollLeft,
+        scrollLeft: scrollLeftRef.current,
         viewportWidth,
         maxScrollLeft,
         playbackDirection: state.playbackRate < 0 ? -1 : 1,
@@ -1567,6 +1571,7 @@ export const TimelineContent = memo(function TimelineContent({
   }, [furthestItemEndFrame, fps, containerWidth])
 
   actualDurationRef.current = actualDuration
+  timelineWidthRef.current = timelineWidth
 
   useLayoutEffect(() => {
     const container = containerRef.current

--- a/src/features/timeline/services/filmstrip-storage.test.ts
+++ b/src/features/timeline/services/filmstrip-storage.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 const fsMocks = vi.hoisted(() => ({
   readBlob: vi.fn(),
@@ -83,11 +83,50 @@ describe('filmstripStorage', () => {
     ])
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
   it('does not revoke unrequested frame URLs during single-frame loads', async () => {
     await filmstripStorage.load('media-1')
     await filmstripStorage.loadSingleFrame('media-1', 1)
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-1')
     expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:frame-0')
+  })
+
+  it('yields while materializing persisted frame URLs', async () => {
+    const storedFrames = Array.from({ length: 5 }, (_, index) => ({
+      name: `${index}.jpg`,
+      blob: new Blob([`frame-${index}`], { type: 'image/jpeg' }),
+    }))
+    fsMocks.readJson.mockResolvedValue({
+      version: 2,
+      width: 160,
+      height: 90,
+      isComplete: true,
+      frameCount: storedFrames.length,
+    })
+    fsMocks.readDirectoryFiles.mockResolvedValue(storedFrames)
+
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5
+      return now
+    })
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+    const loaded = await filmstripStorage.load('media-yield')
+
+    expect(timeoutSpy).toHaveBeenCalledTimes(storedFrames.length - 1)
+    expect(loaded?.frames.map((frame) => frame.index)).toEqual([0, 1, 2, 3, 4])
+    expect(loaded?.frames.map((frame) => frame.url)).toEqual([
+      'blob:frame-0',
+      'blob:frame-1',
+      'blob:frame-2',
+      'blob:frame-3',
+      'blob:frame-4',
+    ])
   })
 })

--- a/src/features/timeline/services/filmstrip-storage.test.ts
+++ b/src/features/timeline/services/filmstrip-storage.test.ts
@@ -129,4 +129,102 @@ describe('filmstripStorage', () => {
       'blob:frame-4',
     ])
   })
+
+  it('does not publish a full load after a newer single-frame load', async () => {
+    let resumeFirstYield: (() => void) | undefined
+    let markFirstYieldReached: (() => void) | undefined
+    const firstYieldReached = new Promise<void>((resolve) => {
+      markFirstYieldReached = resolve
+    })
+    let yieldCount = 0
+    vi.stubGlobal('scheduler', {
+      yield: vi.fn(() => {
+        yieldCount++
+        if (yieldCount !== 1) return Promise.resolve()
+        markFirstYieldReached?.()
+        return new Promise<void>((resolve) => {
+          resumeFirstYield = resolve
+        })
+      }),
+    })
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5
+      return now
+    })
+
+    const staleLoad = filmstripStorage.load('media-single-frame-race')
+    await firstYieldReached
+    const newerFrame = await filmstripStorage.loadSingleFrame('media-single-frame-race', 1)
+    resumeFirstYield?.()
+
+    expect(await staleLoad).toBeNull()
+    expect(newerFrame?.url).toBe('blob:frame-1')
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-0')
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:frame-1')
+  })
+
+  it('does not let an older full load replace a newer full load', async () => {
+    let resumeFirstYield: (() => void) | undefined
+    let markFirstYieldReached: (() => void) | undefined
+    const firstYieldReached = new Promise<void>((resolve) => {
+      markFirstYieldReached = resolve
+    })
+    let yieldCount = 0
+    vi.stubGlobal('scheduler', {
+      yield: vi.fn(() => {
+        yieldCount++
+        if (yieldCount !== 1) return Promise.resolve()
+        markFirstYieldReached?.()
+        return new Promise<void>((resolve) => {
+          resumeFirstYield = resolve
+        })
+      }),
+    })
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5
+      return now
+    })
+
+    const staleLoad = filmstripStorage.load('media-full-load-race')
+    await firstYieldReached
+    const newerLoad = await filmstripStorage.load('media-full-load-race')
+    resumeFirstYield?.()
+
+    expect(await staleLoad).toBeNull()
+    expect(newerLoad?.frames.map((frame) => frame.url)).toEqual(['blob:frame-1', 'blob:frame-2'])
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-0')
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:frame-1')
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:frame-2')
+  })
+
+  it('does not publish a full load after its media URLs are cleared', async () => {
+    let resumeYield: (() => void) | undefined
+    let markYieldReached: (() => void) | undefined
+    const yieldReached = new Promise<void>((resolve) => {
+      markYieldReached = resolve
+    })
+    vi.stubGlobal('scheduler', {
+      yield: vi.fn(() => {
+        markYieldReached?.()
+        return new Promise<void>((resolve) => {
+          resumeYield = resolve
+        })
+      }),
+    })
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 5
+      return now
+    })
+
+    const staleLoad = filmstripStorage.load('media-clear-race')
+    await yieldReached
+    filmstripStorage.revokeUrls('media-clear-race')
+    resumeYield?.()
+
+    expect(await staleLoad).toBeNull()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:frame-0')
+  })
 })

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -37,6 +37,21 @@ const PRIMARY_FRAME_EXT = 'jpg'
 const LEGACY_FRAME_EXT = 'webp'
 const FRAME_EXTENSIONS = new Set([PRIMARY_FRAME_EXT, LEGACY_FRAME_EXT])
 const FILMSTRIP_FRAME_SCHEMA_VERSION = 2
+const FILMSTRIP_URL_CREATION_SLICE_BUDGET_MS = 4
+
+type CooperativeScheduler = {
+  yield?: () => Promise<void>
+}
+
+async function yieldToMainThread(): Promise<void> {
+  const scheduler = (globalThis as typeof globalThis & { scheduler?: CooperativeScheduler }).scheduler
+  if (scheduler?.yield) {
+    await scheduler.yield()
+    return
+  }
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
 
 function parseFrameFileNameParts(name: string): { index: number; ext: string } | null {
   const dotIndex = name.lastIndexOf('.')
@@ -302,16 +317,28 @@ class FilmstripStorage {
         .sort((a, b) => a.index - b.index)
 
       const nextUrls: Array<{ index: number; url: string }> = []
-      const frames: FilmstripFrame[] = frameFiles.map(({ index, blob }) => {
+      const frames: FilmstripFrame[] = []
+      let sliceStartedAt = performance.now()
+
+      for (const [frameIndex, { index, blob }] of frameFiles.entries()) {
         const url = URL.createObjectURL(blob)
         nextUrls.push({ index, url })
-        return {
+        frames.push({
           index,
           timestamp: index / FRAME_RATE,
           url,
           byteSize: blob.size,
+        })
+
+        const hasMoreFrames = frameIndex < frameFiles.length - 1
+        if (
+          hasMoreFrames &&
+          performance.now() - sliceStartedAt >= FILMSTRIP_URL_CREATION_SLICE_BUDGET_MS
+        ) {
+          await yieldToMainThread()
+          sliceStartedAt = performance.now()
         }
-      })
+      }
       this.replaceAllFrameUrls(mediaId, nextUrls)
 
       const existingIndices = frameFiles.map((frame) => frame.index)

--- a/src/features/timeline/services/filmstrip-storage.ts
+++ b/src/features/timeline/services/filmstrip-storage.ts
@@ -44,7 +44,8 @@ type CooperativeScheduler = {
 }
 
 async function yieldToMainThread(): Promise<void> {
-  const scheduler = (globalThis as typeof globalThis & { scheduler?: CooperativeScheduler }).scheduler
+  const scheduler = (globalThis as typeof globalThis & { scheduler?: CooperativeScheduler })
+    .scheduler
   if (scheduler?.yield) {
     await scheduler.yield()
     return
@@ -89,9 +90,42 @@ interface LoadedFilmstrip {
   existingIndices: number[]
 }
 
+interface FrameUrlOperationToken {
+  clearGeneration: number
+  mediaGeneration: number
+}
+
 class FilmstripStorage {
   private objectUrls = new Map<string, Map<number, string>>()
+  private frameUrlGenerations = new Map<string, number>()
+  private clearGeneration = 0
   private legacyInitPromise: Promise<FileSystemDirectoryHandle | null> | null = null
+
+  private beginFrameUrlOperation(mediaId: string): FrameUrlOperationToken {
+    const mediaGeneration = (this.frameUrlGenerations.get(mediaId) ?? 0) + 1
+    this.frameUrlGenerations.set(mediaId, mediaGeneration)
+    return {
+      clearGeneration: this.clearGeneration,
+      mediaGeneration,
+    }
+  }
+
+  private invalidateFrameUrlOperations(mediaId: string): void {
+    this.frameUrlGenerations.set(mediaId, (this.frameUrlGenerations.get(mediaId) ?? 0) + 1)
+  }
+
+  private ownsFrameUrlOperation(mediaId: string, token: FrameUrlOperationToken): boolean {
+    return (
+      token.clearGeneration === this.clearGeneration &&
+      token.mediaGeneration === this.frameUrlGenerations.get(mediaId)
+    )
+  }
+
+  private revokeUncommittedFrameUrls(entries: Array<{ url: string }>): void {
+    for (const { url } of entries) {
+      URL.revokeObjectURL(url)
+    }
+  }
 
   private scheduleRevoke(urls: string[]): void {
     if (urls.length === 0) return
@@ -111,6 +145,7 @@ class FilmstripStorage {
   }
 
   private setFrameUrl(mediaId: string, index: number, url: string): void {
+    this.invalidateFrameUrlOperations(mediaId)
     const urlsByIndex = this.objectUrls.get(mediaId) ?? new Map<number, string>()
     const previous = urlsByIndex.get(index)
     urlsByIndex.set(index, url)
@@ -124,7 +159,12 @@ class FilmstripStorage {
   private replaceAllFrameUrls(
     mediaId: string,
     entries: Array<{ index: number; url: string }>,
-  ): void {
+    token: FrameUrlOperationToken,
+  ): boolean {
+    if (!this.ownsFrameUrlOperation(mediaId, token)) {
+      return false
+    }
+
     const previous = this.objectUrls.get(mediaId)
     const next = new Map<number, string>()
     for (const entry of entries) {
@@ -132,7 +172,7 @@ class FilmstripStorage {
     }
     this.objectUrls.set(mediaId, next)
 
-    if (!previous) return
+    if (!previous) return true
 
     const toRevoke: string[] = []
     for (const [index, url] of previous) {
@@ -142,6 +182,7 @@ class FilmstripStorage {
       }
     }
     this.scheduleRevoke(toRevoke)
+    return true
   }
 
   private async readMetadata(mediaId: string): Promise<FilmstripMetadata | null> {
@@ -152,6 +193,7 @@ class FilmstripStorage {
     const existing = await this.readMetadata(mediaId)
     if (existing) {
       if (existing.version === FILMSTRIP_FRAME_SCHEMA_VERSION) return existing
+      this.invalidateFrameUrlOperations(mediaId)
       const staleUrls = this.objectUrls.get(mediaId)
       if (staleUrls) this.scheduleRevoke([...staleUrls.values()])
       await Promise.resolve(
@@ -286,9 +328,14 @@ class FilmstripStorage {
   }
 
   async load(mediaId: string): Promise<LoadedFilmstrip | null> {
+    const urlOperation = this.beginFrameUrlOperation(mediaId)
+    const nextUrls: Array<{ index: number; url: string }> = []
+    let urlsCommitted = false
+
     try {
       const metadata = await this.ensureWorkspaceFilmstrip(mediaId)
       if (!metadata) return null
+      if (!this.ownsFrameUrlOperation(mediaId, urlOperation)) return null
 
       // Resolve the filmstrip dir once and read all matching files via the
       // same handle iterator. readBlob-per-path would re-walk the 4-segment
@@ -316,11 +363,15 @@ class FilmstripStorage {
         .map(({ index, blob }) => ({ index, blob }))
         .sort((a, b) => a.index - b.index)
 
-      const nextUrls: Array<{ index: number; url: string }> = []
       const frames: FilmstripFrame[] = []
       let sliceStartedAt = performance.now()
 
       for (const [frameIndex, { index, blob }] of frameFiles.entries()) {
+        if (!this.ownsFrameUrlOperation(mediaId, urlOperation)) {
+          this.revokeUncommittedFrameUrls(nextUrls)
+          return null
+        }
+
         const url = URL.createObjectURL(blob)
         nextUrls.push({ index, url })
         frames.push({
@@ -339,7 +390,11 @@ class FilmstripStorage {
           sliceStartedAt = performance.now()
         }
       }
-      this.replaceAllFrameUrls(mediaId, nextUrls)
+      urlsCommitted = this.replaceAllFrameUrls(mediaId, nextUrls, urlOperation)
+      if (!urlsCommitted) {
+        this.revokeUncommittedFrameUrls(nextUrls)
+        return null
+      }
 
       const existingIndices = frameFiles.map((frame) => frame.index)
 
@@ -354,6 +409,9 @@ class FilmstripStorage {
       )
       return { metadata, frames, existingIndices }
     } catch (error) {
+      if (!urlsCommitted) {
+        this.revokeUncommittedFrameUrls(nextUrls)
+      }
       logger.warn('Failed to load filmstrip:', error)
       return null
     }
@@ -465,6 +523,7 @@ class FilmstripStorage {
   }
 
   revokeUrls(mediaId: string): void {
+    this.invalidateFrameUrlOperations(mediaId)
     const urlsByIndex = this.objectUrls.get(mediaId)
     if (!urlsByIndex) return
 
@@ -475,25 +534,35 @@ class FilmstripStorage {
   }
 
   async clearAll(): Promise<void> {
-    for (const mediaId of this.objectUrls.keys()) {
-      this.revokeUrls(mediaId)
-    }
-
-    // In v2, filmstrips live per-media under `media/<id>/cache/filmstrip/`.
-    // Enumerate media dirs and prune each one's filmstrip subtree.
+    // Invalidate loads that started before or during the clear, including
+    // media that have not published an object URL map yet.
+    this.clearGeneration++
     try {
-      const mediaEntries = await listDirectory(requireWorkspaceRoot(), ['media'])
-      for (const entry of mediaEntries) {
-        if (entry.kind !== 'directory') continue
-        await removeEntry(requireWorkspaceRoot(), filmstripDir(entry.name), {
-          recursive: true,
-        }).catch(() => undefined)
+      for (const mediaId of this.objectUrls.keys()) {
+        this.revokeUrls(mediaId)
       }
-    } catch {
-      // media dir may not exist yet — nothing to clear
-    }
 
-    await this.clearLegacyFilmstrips()
+      // In v2, filmstrips live per-media under `media/<id>/cache/filmstrip/`.
+      // Enumerate media dirs and prune each one's filmstrip subtree.
+      try {
+        const mediaEntries = await listDirectory(requireWorkspaceRoot(), ['media'])
+        for (const entry of mediaEntries) {
+          if (entry.kind !== 'directory') continue
+          await removeEntry(requireWorkspaceRoot(), filmstripDir(entry.name), {
+            recursive: true,
+          }).catch(() => undefined)
+        }
+      } catch {
+        // media dir may not exist yet — nothing to clear
+      }
+
+      await this.clearLegacyFilmstrips()
+    } finally {
+      this.clearGeneration++
+      for (const mediaId of this.objectUrls.keys()) {
+        this.revokeUrls(mediaId)
+      }
+    }
   }
 }
 

--- a/src/runtime/composition-runtime/components/custom-decoder-audio.tsx
+++ b/src/runtime/composition-runtime/components/custom-decoder-audio.tsx
@@ -42,14 +42,18 @@ interface DecodedPitchSource {
 interface DecodedPitchFallbackAudioProps extends AudioPlaybackProps {
   audioBuffer: AudioBuffer
   sourceStartOffsetSec: number
+  isComplete: boolean
+  timelineFps: number
 }
 
 const DecodedPitchFallbackAudio: React.FC<DecodedPitchFallbackAudioProps> = ({
   audioBuffer,
   sourceStartOffsetSec,
+  isComplete,
+  timelineFps,
   itemId,
   liveGainItemIds,
-  trimBefore,
+  trimBefore = 0,
   sourceFps,
   volume,
   playbackRate,
@@ -77,14 +81,35 @@ const DecodedPitchFallbackAudio: React.FC<DecodedPitchFallbackAudioProps> = ({
   volumeMultiplier,
 }) => {
   const [decodedSrc, setDecodedSrc] = useState<string | null>(null)
+  const reversedPlayback = React.useMemo(() => {
+    if (!isComplete || !isReversed) return null
+    const effectiveSourceFps = sourceFps ?? timelineFps
+    const sourceEndSeconds = (reverseSourceEnd ?? trimBefore) / effectiveSourceFps
+    return {
+      buffer: createReversedAudioBuffer(audioBuffer),
+      trimBefore: Math.max(
+        0,
+        Math.round((audioBuffer.duration - sourceEndSeconds) * effectiveSourceFps),
+      ),
+    }
+  }, [
+    audioBuffer,
+    isComplete,
+    isReversed,
+    reverseSourceEnd,
+    sourceFps,
+    timelineFps,
+    trimBefore,
+  ])
+  const fallbackBuffer = reversedPlayback?.buffer ?? audioBuffer
 
   useEffect(() => {
-    const url = URL.createObjectURL(audioBufferToWavBlob(audioBuffer))
+    const url = URL.createObjectURL(audioBufferToWavBlob(fallbackBuffer))
     setDecodedSrc(url)
     return () => {
       URL.revokeObjectURL(url)
     }
-  }, [audioBuffer])
+  }, [fallbackBuffer])
 
   if (!decodedSrc) {
     return null
@@ -95,13 +120,13 @@ const DecodedPitchFallbackAudio: React.FC<DecodedPitchFallbackAudioProps> = ({
       src={decodedSrc}
       itemId={itemId}
       liveGainItemIds={liveGainItemIds}
-      trimBefore={trimBefore}
+      trimBefore={reversedPlayback?.trimBefore ?? trimBefore}
       sourceFps={sourceFps}
-      sourceStartOffsetSec={sourceStartOffsetSec}
+      sourceStartOffsetSec={reversedPlayback ? 0 : sourceStartOffsetSec}
       volume={volume}
       playbackRate={playbackRate}
-      isReversed={isReversed}
-      reverseSourceEnd={reverseSourceEnd}
+      isReversed={isReversed && !reversedPlayback}
+      reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
       audioPitchSemitones={audioPitchSemitones}
       audioPitchCents={audioPitchCents}
       audioPitchShiftSemitones={audioPitchShiftSemitones}
@@ -425,40 +450,22 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
     trimBefore,
   ])
 
-  const reversedPlayback = React.useMemo(() => {
-    if (!decodedSource || !isReversed || !decodedSource.isComplete) {
-      return null
-    }
-    const effectiveSourceFps = sourceFps ?? fps
-    const sourceEndSeconds = (reverseSourceEnd ?? trimBefore) / effectiveSourceFps
-    const reversedTrimBefore = Math.max(
-      0,
-      Math.round((decodedSource.buffer.duration - sourceEndSeconds) * effectiveSourceFps),
-    )
-    return {
-      buffer: createReversedAudioBuffer(decodedSource.buffer),
-      trimBefore: reversedTrimBefore,
-    }
-  }, [decodedSource, fps, isReversed, reverseSourceEnd, sourceFps, trimBefore])
-
   if (!decodedSource) return null
-
-  const playbackBuffer = reversedPlayback?.buffer ?? decodedSource.buffer
-  const playbackTrimBefore = reversedPlayback?.trimBefore ?? trimBefore
-  const playbackSourceStartOffsetSec = reversedPlayback ? 0 : decodedSource.sourceStartOffsetSec
 
   const fallback = (
     <DecodedPitchFallbackAudio
-      audioBuffer={playbackBuffer}
-      sourceStartOffsetSec={playbackSourceStartOffsetSec}
+      audioBuffer={decodedSource.buffer}
+      sourceStartOffsetSec={decodedSource.sourceStartOffsetSec}
+      isComplete={decodedSource.isComplete}
+      timelineFps={fps}
       itemId={itemId}
       liveGainItemIds={liveGainItemIds}
-      trimBefore={playbackTrimBefore}
+      trimBefore={trimBefore}
       sourceFps={sourceFps}
       volume={volume}
       playbackRate={playbackRate}
-      isReversed={isReversed && !reversedPlayback}
-      reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
+      isReversed={isReversed}
+      reverseSourceEnd={reverseSourceEnd}
       audioPitchSemitones={audioPitchSemitones}
       audioPitchCents={audioPitchCents}
       audioPitchShiftSemitones={audioPitchShiftSemitones}
@@ -484,18 +491,18 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
 
   return (
     <SoundTouchWorkletAudio
-      audioBuffer={playbackBuffer}
+      audioBuffer={decodedSource.buffer}
       fallback={fallback}
       itemId={itemId}
       liveGainItemIds={liveGainItemIds}
-      trimBefore={playbackTrimBefore}
+      trimBefore={trimBefore}
       sourceFps={sourceFps}
-      sourceStartOffsetSec={playbackSourceStartOffsetSec}
+      sourceStartOffsetSec={decodedSource.sourceStartOffsetSec}
       isComplete={decodedSource.isComplete}
       volume={volume}
       playbackRate={playbackRate}
-      isReversed={isReversed && !reversedPlayback}
-      reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
+      isReversed={isReversed}
+      reverseSourceEnd={reverseSourceEnd}
       audioPitchSemitones={audioPitchSemitones}
       audioPitchCents={audioPitchCents}
       audioPitchShiftSemitones={audioPitchShiftSemitones}

--- a/src/runtime/composition-runtime/components/item-visual-wrapper.tsx
+++ b/src/runtime/composition-runtime/components/item-visual-wrapper.tsx
@@ -20,6 +20,7 @@ import { getShapePath } from '../utils/shape-path'
 import {
   useCornerPinStore,
   useGizmoStore,
+  usePlaybackStore,
 } from '@/runtime/composition-runtime/deps/stores'
 import { useItemVisualState } from './hooks/use-item-visual-state'
 import { useRuntimeItemKeyframes } from './hooks/use-runtime-item-keyframes'
@@ -38,6 +39,7 @@ import {
   useLiveTimelineItemResolver,
 } from '../contexts/live-item-transform-context'
 import { KeyframesContext } from '../contexts/keyframes-context-core'
+import { shouldRasterizeSvgMaskForFrame } from '../utils/mask-rendering-policy'
 
 interface ItemVisualWrapperProps {
   item: TimelineItem
@@ -412,8 +414,13 @@ export const ItemVisualWrapper: React.FC<ItemVisualWrapperProps> = ({
     () => useGizmoStore.subscribe(syncGizmoPresentation),
     [syncGizmoPresentation],
   )
-  const shouldRasterizeSvgMask =
-    state.maskType === 'svg-mask' && !!state.svgMaskPaths && state.maskFeather > 0
+  const isPlaying = usePlaybackStore((playback) => playback.isPlaying)
+  const shouldRasterizeSvgMask = shouldRasterizeSvgMaskForFrame({
+    maskType: state.maskType,
+    hasPaths: !!state.svgMaskPaths,
+    feather: state.maskFeather,
+    isPlaying,
+  })
   const hasCornerPinnedMask = masks.some((mask) => hasCornerPin(mask.shape.cornerPin))
 
   // Compute mask style based on mask type

--- a/src/runtime/composition-runtime/components/pitch-corrected-audio.tsx
+++ b/src/runtime/composition-runtime/components/pitch-corrected-audio.tsx
@@ -54,6 +54,8 @@ interface DecodedPitchSource {
 type DecodedPitchFallbackAudioProps = PitchCorrectedAudioProps & {
   audioBuffer: AudioBuffer
   sourceStartOffsetSec: number
+  isComplete: boolean
+  timelineFps: number
 }
 
 function shouldReplaceDecodedPitchSource(
@@ -85,17 +87,44 @@ function shouldReplaceDecodedPitchSource(
 const DecodedPitchFallbackAudio: React.FC<DecodedPitchFallbackAudioProps> = ({
   audioBuffer,
   sourceStartOffsetSec,
+  isComplete,
+  timelineFps,
+  isReversed = false,
+  reverseSourceEnd,
+  trimBefore = 0,
+  sourceFps,
   ...props
 }) => {
   const [decodedSrc, setDecodedSrc] = useState<string | null>(null)
+  const reversedPlayback = React.useMemo(() => {
+    if (!isComplete || !isReversed) return null
+    const effectiveSourceFps = sourceFps ?? timelineFps
+    const sourceEndSeconds = (reverseSourceEnd ?? trimBefore) / effectiveSourceFps
+    return {
+      buffer: createReversedAudioBuffer(audioBuffer),
+      trimBefore: Math.max(
+        0,
+        Math.round((audioBuffer.duration - sourceEndSeconds) * effectiveSourceFps),
+      ),
+    }
+  }, [
+    audioBuffer,
+    isComplete,
+    isReversed,
+    reverseSourceEnd,
+    sourceFps,
+    timelineFps,
+    trimBefore,
+  ])
+  const fallbackBuffer = reversedPlayback?.buffer ?? audioBuffer
 
   useEffect(() => {
-    const url = URL.createObjectURL(audioBufferToWavBlob(audioBuffer))
+    const url = URL.createObjectURL(audioBufferToWavBlob(fallbackBuffer))
     setDecodedSrc(url)
     return () => {
       URL.revokeObjectURL(url)
     }
-  }, [audioBuffer])
+  }, [fallbackBuffer])
 
   if (!decodedSrc) {
     return null
@@ -105,7 +134,11 @@ const DecodedPitchFallbackAudio: React.FC<DecodedPitchFallbackAudioProps> = ({
     <NativePitchCorrectedAudio
       {...props}
       src={decodedSrc}
-      sourceStartOffsetSec={sourceStartOffsetSec}
+      trimBefore={reversedPlayback?.trimBefore ?? trimBefore}
+      sourceFps={sourceFps}
+      sourceStartOffsetSec={reversedPlayback ? 0 : sourceStartOffsetSec}
+      isReversed={isReversed && !reversedPlayback}
+      reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
     />
   )
 }
@@ -679,56 +712,35 @@ const DecodedPitchCorrectedAudio: React.FC<DecodedPitchCorrectedAudioProps> = Re
       trimBefore,
     ])
 
-    const reversedPlayback = React.useMemo(() => {
-      if (!decodedSource || !isReversed || !decodedSource.isComplete) {
-        return null
-      }
-      const effectiveSourceFps = sourceFps ?? fps
-      const sourceEndSeconds = (reverseSourceEnd ?? trimBefore) / effectiveSourceFps
-      const reversedTrimBefore = Math.max(
-        0,
-        Math.round((decodedSource.buffer.duration - sourceEndSeconds) * effectiveSourceFps),
-      )
-      return {
-        buffer: createReversedAudioBuffer(decodedSource.buffer),
-        trimBefore: reversedTrimBefore,
-      }
-    }, [decodedSource, fps, isReversed, reverseSourceEnd, sourceFps, trimBefore])
-
     if (!decodedSource) {
       return nativeFallback
     }
 
-    const playbackBuffer = reversedPlayback?.buffer ?? decodedSource.buffer
-    const playbackTrimBefore = reversedPlayback?.trimBefore ?? trimBefore
-    const playbackSourceStartOffsetSec = reversedPlayback
-      ? 0
-      : sourceStartOffsetSec + decodedSource.sourceStartOffsetSec
+    const playbackSourceStartOffsetSec = sourceStartOffsetSec + decodedSource.sourceStartOffsetSec
     const decodedFallback = (
       <DecodedPitchFallbackAudio
         {...props}
         src={src}
-        audioBuffer={playbackBuffer}
-        trimBefore={playbackTrimBefore}
+        audioBuffer={decodedSource.buffer}
         sourceStartOffsetSec={playbackSourceStartOffsetSec}
-        isReversed={isReversed && !reversedPlayback}
-        reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
+        isComplete={decodedSource.isComplete}
+        timelineFps={fps}
       />
     )
 
     return (
       <SoundTouchWorkletAudio
-        audioBuffer={playbackBuffer}
+        audioBuffer={decodedSource.buffer}
         fallback={decodedFallback}
         itemId={itemId}
-        trimBefore={playbackTrimBefore}
+        trimBefore={trimBefore}
         sourceFps={sourceFps}
         sourceStartOffsetSec={playbackSourceStartOffsetSec}
         isComplete={decodedSource.isComplete}
         volume={volume}
         playbackRate={playbackRate}
-        isReversed={isReversed && !reversedPlayback}
-        reverseSourceEnd={reversedPlayback ? undefined : reverseSourceEnd}
+        isReversed={isReversed}
+        reverseSourceEnd={reverseSourceEnd}
         audioPitchSemitones={props.audioPitchSemitones}
         audioPitchCents={props.audioPitchCents}
         audioPitchShiftSemitones={props.audioPitchShiftSemitones}

--- a/src/runtime/composition-runtime/components/soundtouch-worklet-audio.test.tsx
+++ b/src/runtime/composition-runtime/components/soundtouch-worklet-audio.test.tsx
@@ -39,7 +39,7 @@ const previewGraphMocks = vi.hoisted(() => ({
 
 const soundTouchWorkletMocks = vi.hoisted(() => ({
   ensureSoundTouchPreviewWorkletLoaded: vi.fn(),
-  serializeAudioBufferForSoundTouchPreview: vi.fn(() => ({
+  prepareAudioBufferForSoundTouchPreview: vi.fn(async () => ({
     leftChannel: new Float32Array(0),
     rightChannel: new Float32Array(0),
     frameCount: 0,
@@ -60,8 +60,8 @@ vi.mock('../utils/preview-audio-graph', () => ({
 }))
 vi.mock('../utils/soundtouch-preview-worklet', () => ({
   ensureSoundTouchPreviewWorkletLoaded: soundTouchWorkletMocks.ensureSoundTouchPreviewWorkletLoaded,
-  serializeAudioBufferForSoundTouchPreview:
-    soundTouchWorkletMocks.serializeAudioBufferForSoundTouchPreview,
+  prepareAudioBufferForSoundTouchPreview:
+    soundTouchWorkletMocks.prepareAudioBufferForSoundTouchPreview,
   SOUND_TOUCH_PREVIEW_PROCESSOR_NAME: 'soundtouch-preview-processor',
 }))
 vi.mock('@/runtime/composition-runtime/deps/stores', () => ({
@@ -234,6 +234,36 @@ describe('SoundTouchWorkletAudio', () => {
         type: 'set-playing',
         playing: true,
       })
+    })
+  })
+
+  it('reads an authored reversed clip backwards without reversing its buffer on the UI thread', async () => {
+    playbackStateMocks.current = {
+      ...playbackStateMocks.current,
+      frame: 90,
+      playing: true,
+      transportPlaybackRate: 1,
+    }
+    soundTouchWorkletMocks.ensureSoundTouchPreviewWorkletLoaded.mockResolvedValue(true)
+
+    render(
+      <SoundTouchWorkletAudio
+        audioBuffer={makeAudioBuffer(12)}
+        itemId="reversed-audio-1"
+        durationInFrames={360}
+        playbackRate={1}
+        isReversed
+        reverseSourceEnd={360}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(workletNodeMocks.messages).toContainEqual(
+        expect.objectContaining({
+          type: 'seek',
+          direction: -1,
+        }),
+      )
     })
   })
 })

--- a/src/runtime/composition-runtime/components/soundtouch-worklet-audio.tsx
+++ b/src/runtime/composition-runtime/components/soundtouch-worklet-audio.tsx
@@ -16,7 +16,7 @@ import {
 } from '../utils/preview-audio-graph'
 import {
   ensureSoundTouchPreviewWorkletLoaded,
-  serializeAudioBufferForSoundTouchPreview,
+  prepareAudioBufferForSoundTouchPreview,
   SOUND_TOUCH_PREVIEW_PROCESSOR_NAME,
 } from '../utils/soundtouch-preview-worklet'
 import type { SoundTouchPreviewProcessorMessage } from '../utils/soundtouch-preview-shared'
@@ -126,8 +126,11 @@ export const SoundTouchWorkletAudio: React.FC<SoundTouchWorkletAudioProps> = Rea
     mutedRef.current = muted
     finalVolumeRef.current = finalVolume
 
-    const postMessage = (message: SoundTouchPreviewProcessorMessage): void => {
-      nodeRef.current?.port.postMessage(message)
+    const postMessage = (
+      message: SoundTouchPreviewProcessorMessage,
+      transfer: Transferable[] = [],
+    ): void => {
+      nodeRef.current?.port.postMessage(message, transfer)
     }
 
     const postSeekSeconds = (seconds: number, sampleRate: number, direction: -1 | 1 = 1): void => {
@@ -291,18 +294,33 @@ export const SoundTouchWorkletAudio: React.FC<SoundTouchWorkletAudioProps> = Rea
         return
       }
 
-      const serialized = serializeAudioBufferForSoundTouchPreview(
-        audioBuffer,
-        graph.context.sampleRate,
-      )
-      postMessage({
-        type: 'append-source',
-        startFrame: Math.max(0, Math.floor(sourceStartOffsetSec * graph.context.sampleRate)),
-        leftChannel: serialized.leftChannel.buffer as ArrayBuffer,
-        rightChannel: serialized.rightChannel.buffer as ArrayBuffer,
-        frameCount: serialized.frameCount,
-        sampleRate: serialized.sampleRate,
-      })
+      let cancelled = false
+      void prepareAudioBufferForSoundTouchPreview(audioBuffer, graph.context.sampleRate)
+        .then((serialized) => {
+          if (cancelled || nodeRef.current !== node) return
+          const leftChannel = serialized.leftChannel.buffer as ArrayBuffer
+          const rightChannel = serialized.rightChannel.buffer as ArrayBuffer
+          postMessage(
+            {
+              type: 'append-source',
+              startFrame: Math.max(0, Math.floor(sourceStartOffsetSec * graph.context.sampleRate)),
+              leftChannel,
+              rightChannel,
+              frameCount: serialized.frameCount,
+              sampleRate: serialized.sampleRate,
+            },
+            [leftChannel, rightChannel],
+          )
+        })
+        .catch((error) => {
+          if (cancelled) return
+          log.warn('Failed to prepare SoundTouch preview source', { error })
+          setFallbackRequested(true)
+        })
+
+      return () => {
+        cancelled = true
+      }
     }, [audioBuffer, nodeReady, sourceStartOffsetSec])
 
     useEffect(() => {

--- a/src/runtime/composition-runtime/compositions/main-composition.tsx
+++ b/src/runtime/composition-runtime/compositions/main-composition.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useMemo, useCallback } from 'react'
-import { AbsoluteFill, Sequence, useClock } from '@/runtime/composition-runtime/deps/player'
+import {
+  AbsoluteFill,
+  Sequence,
+  useClock,
+  useClockFrameSelector,
+} from '@/runtime/composition-runtime/deps/player'
 import { timelineToSourceFrames } from '@/runtime/composition-runtime/deps/timeline'
-import { useCurrentFrame, useVideoConfig } from '../hooks/use-player-compat'
+import { useVideoConfig } from '../hooks/use-player-compat'
 import type { CompositionInputProps } from '@/types/export'
 import type { TimelineItem } from '@/types/timeline'
 import { Item, type MaskInfo } from '../components/item'
@@ -43,7 +48,7 @@ import {
   type AudioTrackItem,
   type ShapeMaskWithTrackOrder,
 } from '../utils/scene-assembly'
-import { resolveActiveShapeMasksAtFrame } from '../utils/frame-scene'
+import { resolveActiveShapeMasksAtFrame, selectMaskRenderFrame } from '../utils/frame-scene'
 import { KeyframesContext } from '../contexts/keyframes-context-core'
 import {
   EMPTY_MASK_INFOS,
@@ -74,13 +79,24 @@ const VIDEO_CLIP_PREMOUNT_SECONDS = 2
 
 const ActiveMasksContext = React.createContext<MaskInfo[]>(EMPTY_MASK_INFOS)
 
-const FrameActiveMasksProvider: React.FC<{
+type ActiveMasksProviderProps = {
   masks: ShapeMaskWithTrackOrder[]
   canvasWidth: number
   canvasHeight: number
   children: React.ReactNode
-}> = ({ masks, canvasWidth, canvasHeight, children }) => {
-  const frame = useCurrentFrame()
+}
+
+const FrameResolvedActiveMasksProvider: React.FC<ActiveMasksProviderProps> = ({
+  masks,
+  canvasWidth,
+  canvasHeight,
+  children,
+}) => {
+  const selectRelevantMaskFrame = useCallback(
+    (frame: number) => selectMaskRenderFrame(masks, frame),
+    [masks],
+  )
+  const frame = useClockFrameSelector(selectRelevantMaskFrame)
   const { fps } = useVideoConfig()
   const keyframesCtx = React.useContext(KeyframesContext)
   const previousMasksRef = React.useRef<MaskInfo[]>(EMPTY_MASK_INFOS)
@@ -120,6 +136,23 @@ const FrameActiveMasksProvider: React.FC<{
   ])
 
   return <ActiveMasksContext.Provider value={activeMasks}>{children}</ActiveMasksContext.Provider>
+}
+
+/**
+ * Avoid subscribing the entire visual layer to the playback clock when the
+ * composition has no masks. The frame-aware provider is mounted only while
+ * masks exist, so ordinary projects keep this boundary stable during playback.
+ */
+const ActiveMasksProvider: React.FC<ActiveMasksProviderProps> = (props) => {
+  if (props.masks.length === 0) {
+    return (
+      <ActiveMasksContext.Provider value={EMPTY_MASK_INFOS}>
+        {props.children}
+      </ActiveMasksContext.Provider>
+    )
+  }
+
+  return <FrameResolvedActiveMasksProvider {...props} />
 }
 
 /**
@@ -647,7 +680,7 @@ export const MainComposition: React.FC<MainCompositionProps> = ({
 
             {/* ALL VISUAL LAYERS - videos and non-media in SINGLE wrapper for proper z-index stacking */}
             {/* This ensures items from different tracks respect z-index across all types */}
-            <FrameActiveMasksProvider
+            <ActiveMasksProvider
               masks={visibleShapeMasks}
               canvasWidth={canvasWidth}
               canvasHeight={canvasHeight}
@@ -712,7 +745,7 @@ export const MainComposition: React.FC<MainCompositionProps> = ({
                     )
                   })}
               </AbsoluteFill>
-            </FrameActiveMasksProvider>
+            </ActiveMasksProvider>
             </AbsoluteFill>
           </CompositionSpaceProvider>
         </KeyframesProvider>

--- a/src/runtime/composition-runtime/deps/player-contract.ts
+++ b/src/runtime/composition-runtime/deps/player-contract.ts
@@ -13,6 +13,10 @@ export {
 export { VideoConfigProvider } from '@/runtime/player/VideoConfigProvider'
 export { useVideoConfig } from '@/runtime/player/video-config-context'
 export { useBridgedCurrentFrame, useBridgedIsPlaying } from '@/runtime/player/clock'
-export { useClock, useClockPlaybackRate } from '@/runtime/player/clock/clock-hooks'
+export {
+  useClock,
+  useClockFrameSelector,
+  useClockPlaybackRate,
+} from '@/runtime/player/clock/clock-hooks'
 export { useVideoSourcePool } from '@/runtime/player/video/VideoSourcePoolContext'
 export { isVideoPoolAbortError } from '@/runtime/player/video/VideoSourcePool'

--- a/src/runtime/composition-runtime/utils/audio-buffer-utils.ts
+++ b/src/runtime/composition-runtime/utils/audio-buffer-utils.ts
@@ -1,4 +1,9 @@
+const reversedAudioBufferCache = new WeakMap<AudioBuffer, AudioBuffer>()
+
 export function createReversedAudioBuffer(buffer: AudioBuffer): AudioBuffer {
+  const cached = reversedAudioBufferCache.get(buffer)
+  if (cached) return cached
+
   const reversed = new AudioBuffer({
     numberOfChannels: buffer.numberOfChannels,
     length: buffer.length,
@@ -11,5 +16,6 @@ export function createReversedAudioBuffer(buffer: AudioBuffer): AudioBuffer {
       output[i] = input[input.length - 1 - i] ?? 0
     }
   }
+  reversedAudioBufferCache.set(buffer, reversed)
   return reversed
 }

--- a/src/runtime/composition-runtime/utils/frame-scene.test.ts
+++ b/src/runtime/composition-runtime/utils/frame-scene.test.ts
@@ -5,11 +5,50 @@ import {
   resolveActiveShapeMasksAtFrame,
   resolveFrameCompositionScene,
   resolveItemTransformAtFrame,
+  selectMaskRenderFrame,
 } from './frame-scene'
 import { resolveCompositionRenderPlan } from './scene-assembly'
 import { createTransformParentBinding } from '@/shared/utils/transform-parenting'
 
 describe('frame scene', () => {
+  it('keeps inactive mask clock snapshots stable between boundaries', () => {
+    const masks = [
+      {
+        id: 'mask-1',
+        type: 'shape' as const,
+        trackId: 'track-1',
+        from: 10,
+        durationInFrames: 10,
+        label: 'Mask 1',
+        shapeType: 'rectangle' as const,
+        fillColor: '#fff',
+        isMask: true,
+        transform: { x: 0, y: 0, width: 100, height: 100, rotation: 0, opacity: 1 },
+      },
+      {
+        id: 'mask-2',
+        type: 'shape' as const,
+        trackId: 'track-1',
+        from: 30,
+        durationInFrames: 10,
+        label: 'Mask 2',
+        shapeType: 'rectangle' as const,
+        fillColor: '#fff',
+        isMask: true,
+        transform: { x: 0, y: 0, width: 100, height: 100, rotation: 0, opacity: 1 },
+      },
+    ]
+
+    expect(selectMaskRenderFrame(masks, 0)).toBe(-1)
+    expect(selectMaskRenderFrame(masks, 9)).toBe(-1)
+    expect(selectMaskRenderFrame(masks, 10)).toBe(10)
+    expect(selectMaskRenderFrame(masks, 19)).toBe(19)
+    expect(selectMaskRenderFrame(masks, 20)).toBe(-2)
+    expect(selectMaskRenderFrame(masks, 29)).toBe(-2)
+    expect(selectMaskRenderFrame(masks, 30)).toBe(30)
+    expect(selectMaskRenderFrame(masks, 40)).toBe(-3)
+  })
+
   it('recenters implicit preview anchors while retaining explicit anchors', () => {
     const base = {
       x: 0,

--- a/src/runtime/composition-runtime/utils/frame-scene.ts
+++ b/src/runtime/composition-runtime/utils/frame-scene.ts
@@ -207,6 +207,30 @@ export function resolveActiveShapeMasksAtFrame(
     })
 }
 
+/**
+ * Select a stable clock snapshot while no mask is active.
+ *
+ * Active masks can animate, so their actual frame must flow through. Outside
+ * every mask range, only crossing a mask boundary can change the resolved mask
+ * set. Negative tokens distinguish those inactive regions from real frames.
+ */
+export function selectMaskRenderFrame(
+  masks: Array<ShapeItem | ShapeMaskWithTrackOrder>,
+  frame: number,
+): number {
+  let completedMaskCount = 0
+
+  for (const maskSource of masks) {
+    const mask = 'mask' in maskSource ? maskSource.mask : maskSource
+    const end = mask.from + mask.durationInFrames
+
+    if (frame >= mask.from && frame < end) return frame
+    if (frame >= end) completedMaskCount += 1
+  }
+
+  return -(completedMaskCount + 1)
+}
+
 export function resolveFrameCompositionScene({
   renderPlan,
   frame,

--- a/src/runtime/composition-runtime/utils/mask-rendering-policy.test.ts
+++ b/src/runtime/composition-runtime/utils/mask-rendering-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { shouldRasterizeSvgMaskForFrame } from './mask-rendering-policy'
+
+describe('shouldRasterizeSvgMaskForFrame', () => {
+  it('keeps the high-quality raster mask while paused', () => {
+    expect(
+      shouldRasterizeSvgMaskForFrame({
+        maskType: 'svg-mask',
+        hasPaths: true,
+        feather: 10,
+        isPlaying: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('uses the live SVG mask during playback', () => {
+    expect(
+      shouldRasterizeSvgMaskForFrame({
+        maskType: 'svg-mask',
+        hasPaths: true,
+        feather: 10,
+        isPlaying: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not rasterize hard-edge or empty masks', () => {
+    expect(
+      shouldRasterizeSvgMaskForFrame({
+        maskType: 'clip',
+        hasPaths: true,
+        feather: 10,
+        isPlaying: false,
+      }),
+    ).toBe(false)
+    expect(
+      shouldRasterizeSvgMaskForFrame({
+        maskType: 'svg-mask',
+        hasPaths: false,
+        feather: 10,
+        isPlaying: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/runtime/composition-runtime/utils/mask-rendering-policy.ts
+++ b/src/runtime/composition-runtime/utils/mask-rendering-policy.ts
@@ -1,0 +1,13 @@
+export function shouldRasterizeSvgMaskForFrame({
+  maskType,
+  hasPaths,
+  feather,
+  isPlaying,
+}: {
+  maskType: 'clip' | 'alpha' | 'svg-mask' | null
+  hasPaths: boolean
+  feather: number
+  isPlaying: boolean
+}): boolean {
+  return maskType === 'svg-mask' && hasPaths && feather > 0 && !isPlaying
+}

--- a/src/runtime/composition-runtime/utils/soundtouch-preview-worklet.test.ts
+++ b/src/runtime/composition-runtime/utils/soundtouch-preview-worklet.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
 import { describe, expect, it } from 'vite-plus/test'
-import { serializeAudioBufferForSoundTouchPreview } from './soundtouch-preview-worklet'
+import {
+  prepareAudioBufferForSoundTouchPreview,
+  serializeAudioBufferForSoundTouchPreview,
+} from './soundtouch-preview-worklet'
 
 function makeAudioBuffer(channels: Float32Array[], sampleRate: number): AudioBuffer {
   return {
@@ -37,5 +40,17 @@ describe('serializeAudioBufferForSoundTouchPreview', () => {
     expect(serialized.leftChannel.length).toBe(8)
     expect(serialized.rightChannel.length).toBe(8)
     expect(serialized.rightChannel[3]).toBeCloseTo(serialized.leftChannel[3] ?? 0, 5)
+  })
+
+  it('returns independently transferable channel copies from the prepared-source cache', async () => {
+    const buffer = makeAudioBuffer([new Float32Array([0, 1, 0, -1])], 4)
+
+    const first = await prepareAudioBufferForSoundTouchPreview(buffer, 8)
+    first.leftChannel[0] = 99
+    const second = await prepareAudioBufferForSoundTouchPreview(buffer, 8)
+
+    expect(second.frameCount).toBe(8)
+    expect(second.leftChannel[0]).toBe(0)
+    expect(second.leftChannel.buffer).not.toBe(first.leftChannel.buffer)
   })
 })

--- a/src/runtime/composition-runtime/utils/soundtouch-preview-worklet.ts
+++ b/src/runtime/composition-runtime/utils/soundtouch-preview-worklet.ts
@@ -12,6 +12,18 @@ export interface SerializedSoundTouchPreviewSource {
   sampleRate: number
 }
 
+interface PreparedSoundTouchPreviewSource {
+  leftChannel: Float32Array
+  rightChannel: Float32Array
+  frameCount: number
+  sampleRate: number
+}
+
+const preparedSourceCache = new WeakMap<
+  AudioBuffer,
+  Map<number, Promise<PreparedSoundTouchPreviewSource>>
+>()
+
 function resampleChannelLinear(
   input: Float32Array,
   targetFrames: number,
@@ -53,6 +65,76 @@ export function serializeAudioBufferForSoundTouchPreview(
     rightChannel: resampleChannelLinear(rightSource, targetFrames, ratio),
     frameCount: targetFrames,
     sampleRate: safeTargetRate,
+  }
+}
+
+async function prepareSoundTouchPreviewSource(
+  buffer: AudioBuffer,
+  targetSampleRate: number,
+): Promise<PreparedSoundTouchPreviewSource> {
+  const safeTargetRate = Math.max(1, Math.floor(targetSampleRate))
+  const cachedByRate = preparedSourceCache.get(buffer) ?? new Map()
+  preparedSourceCache.set(buffer, cachedByRate)
+
+  const cached = cachedByRate.get(safeTargetRate)
+  if (cached) return cached
+
+  const task = (async () => {
+    if (buffer.sampleRate === safeTargetRate) {
+      return {
+        leftChannel: buffer.getChannelData(0),
+        rightChannel: buffer.getChannelData(buffer.numberOfChannels > 1 ? 1 : 0),
+        frameCount: buffer.length,
+        sampleRate: buffer.sampleRate,
+      }
+    }
+
+    if (typeof OfflineAudioContext !== 'undefined') {
+      const targetFrames = Math.max(1, Math.ceil(buffer.length * (safeTargetRate / buffer.sampleRate)))
+      const context = new OfflineAudioContext(
+        Math.max(1, Math.min(2, buffer.numberOfChannels)),
+        targetFrames,
+        safeTargetRate,
+      )
+      const source = context.createBufferSource()
+      source.buffer = buffer
+      source.connect(context.destination)
+      source.start()
+      const rendered = await context.startRendering()
+      return {
+        leftChannel: rendered.getChannelData(0),
+        rightChannel: rendered.getChannelData(rendered.numberOfChannels > 1 ? 1 : 0),
+        frameCount: rendered.length,
+        sampleRate: rendered.sampleRate,
+      }
+    }
+
+    return serializeAudioBufferForSoundTouchPreview(buffer, safeTargetRate)
+  })().catch((error) => {
+    cachedByRate.delete(safeTargetRate)
+    throw error
+  })
+
+  cachedByRate.set(safeTargetRate, task)
+  return task
+}
+
+/**
+ * Prepares worklet source data without running a multi-million-sample resample
+ * loop on the UI thread. The cached prepared channels stay owned by this module;
+ * each caller receives transferable copies so posting them to the worklet does
+ * not clone the full clip again.
+ */
+export async function prepareAudioBufferForSoundTouchPreview(
+  buffer: AudioBuffer,
+  targetSampleRate: number,
+): Promise<SerializedSoundTouchPreviewSource> {
+  const prepared = await prepareSoundTouchPreviewSource(buffer, targetSampleRate)
+  return {
+    leftChannel: new Float32Array(prepared.leftChannel),
+    rightChannel: new Float32Array(prepared.rightChannel),
+    frameCount: prepared.frameCount,
+    sampleRate: prepared.sampleRate,
   }
 }
 

--- a/src/shared/state/playback/use-resolved-playback-frame.ts
+++ b/src/shared/state/playback/use-resolved-playback-frame.ts
@@ -25,15 +25,22 @@ function getResolvedPlaybackFrameSnapshot(): number {
   })
 }
 
+function getDisabledPlaybackFrameSnapshot(): number {
+  return 0
+}
+
 /**
  * Subscribe to the resolved visible frame as one scalar snapshot. Requested
  * scrub frames do not re-render gizmos while the fast overlay is still
  * presenting an older `displayedFrame`.
  */
-export function useResolvedPlaybackFrame(): number {
+export function useResolvedPlaybackFrame(enabled = true): number {
+  const getSnapshot = enabled
+    ? getResolvedPlaybackFrameSnapshot
+    : getDisabledPlaybackFrameSnapshot
   return useSyncExternalStore(
     subscribeResolvedPlaybackFrame,
-    getResolvedPlaybackFrameSnapshot,
-    getResolvedPlaybackFrameSnapshot,
+    getSnapshot,
+    getSnapshot,
   )
 }


### PR DESCRIPTION
## Summary

- isolate ordinary playback updates from preview synchronization and bound overlay routing
- skip inactive layout, transform, raster-mask, and GPU-effect work during playback
- remove audio startup stalls across native, pitch-corrected, and worklet playback paths
- cooperatively yield while materializing persisted filmstrip object URLs

## Root cause

Several preview, overlay, audio, and filmstrip paths could perform avoidable main-thread work at playback startup or on every frame. Persisted filmstrip hydration also created thousands of object URLs in one uninterrupted pass, producing a large cold-load task.

## Impact

This reduces main-thread contention during playback and keeps cold filmstrip hydration responsive. Production profiling showed no recurring object-URL work during warm playback and no long tasks after the hydration change.

## Validation

- focused preview, GPU overlay, audio, frame-scene, mask-policy, and filmstrip tests
- `npx vp check --no-fmt` on the changed TypeScript files
- `git diff --check`
- `npm run build:perf`
- production playback profiling in the existing Chrome session