### PR TITLE
(fix): preserve ruler scrub ownership

### DIFF
--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -368,6 +368,8 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
   const { marquee } = useMediaLibraryMarquee({
     compositions,
     filteredMediaItems,
+    selectedMediaIds,
+    selectedCompositionIds,
     scrollContainerRef,
     setSelection,
   })

--- a/src/features/media-library/components/use-media-library-marquee.ts
+++ b/src/features/media-library/components/use-media-library-marquee.ts
@@ -5,6 +5,8 @@ import { useMarqueeSelection, type MarqueeItem } from '@/shared/marquee/use-marq
 interface UseMediaLibraryMarqueeParams {
   compositions: ReadonlyArray<{ id: string }>
   filteredMediaItems: MediaMetadata[]
+  selectedMediaIds: string[]
+  selectedCompositionIds: string[]
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
   setSelection: (selection: { mediaIds: string[]; compositionIds: string[] }) => void
 }
@@ -18,6 +20,8 @@ interface UseMediaLibraryMarqueeParams {
 export function useMediaLibraryMarquee({
   compositions,
   filteredMediaItems,
+  selectedMediaIds,
+  selectedCompositionIds,
   scrollContainerRef,
   setSelection,
 }: UseMediaLibraryMarqueeParams) {
@@ -115,12 +119,20 @@ export function useMediaLibraryMarquee({
     ],
     [compositions, filteredMediaItems, scrollContainerRef],
   )
+  const committedSelectionIds = useMemo(
+    () => [
+      ...selectedCompositionIds.map((id) => `composition:${id}`),
+      ...selectedMediaIds.map((id) => `media:${id}`),
+    ],
+    [selectedCompositionIds, selectedMediaIds],
+  )
 
   const { marquee } = useMarqueeSelection({
     containerRef: scrollContainerRef as React.RefObject<HTMLElement>,
     items: marqueeItems,
     enabled: marqueeItems.length > 0,
     onPreviewSelectionChange: setPreviewAssetIds,
+    committedSelectionIds,
     commitSelectionOnMouseUp: true,
     liveCommitThrottleMs: 66,
     onSelectionChange: (ids) => {

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -397,6 +397,7 @@ interface TimelineMarqueeLayerProps {
   onSelectionChange: (ids: string[]) => void
   onMarqueeActiveChange: (active: boolean) => void
   onMarqueeGestureEnd: (event: MouseEvent) => void
+  onMarqueeGestureCancel: () => void
 }
 
 const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
@@ -407,6 +408,7 @@ const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
   onSelectionChange,
   onMarqueeActiveChange,
   onMarqueeGestureEnd,
+  onMarqueeGestureCancel,
 }: TimelineMarqueeLayerProps) {
   const previewItemIdsRef = useRef<string[]>([])
 
@@ -491,6 +493,7 @@ const TimelineMarqueeLayer = memo(function TimelineMarqueeLayer({
     onSelectionChange,
     onPreviewSelectionChange: setPreviewItemIds,
     onGestureEnd: onMarqueeGestureEnd,
+    onGestureCancel: onMarqueeGestureCancel,
     enabled: itemIds.length > 0,
     threshold: 5,
     commitSelectionOnMouseUp: true,
@@ -1414,6 +1417,20 @@ export const TimelineContent = memo(function TimelineContent({
     }
   }, [])
 
+  const cancelMarqueePointerGesture = useCallback(() => {
+    const wasMarqueePointerGesture = marqueePointerDownRef.current
+    marqueePointerDownRef.current = false
+    marqueeStartPreviewFrameRef.current = null
+    marqueeReleasePreviewRef.current = null
+
+    if (!wasMarqueePointerGesture) return
+    if (marqueeReleaseRafRef.current !== null) {
+      cancelAnimationFrame(marqueeReleaseRafRef.current)
+      marqueeReleaseRafRef.current = null
+    }
+    setPreviewFrameRef.current(null)
+  }, [])
+
   useEffect(
     () => () => {
       if (marqueeReleaseRafRef.current !== null) {
@@ -2127,6 +2144,7 @@ export const TimelineContent = memo(function TimelineContent({
           onSelectionChange={handleMarqueeSelectionChange}
           onMarqueeActiveChange={handleMarqueeActiveChange}
           onMarqueeGestureEnd={finishMarqueePointerGesture}
+          onMarqueeGestureCancel={cancelMarqueePointerGesture}
         />
 
         {itemIds.length === 0 && (

--- a/src/shared/marquee/use-marquee-selection.test.tsx
+++ b/src/shared/marquee/use-marquee-selection.test.tsx
@@ -11,6 +11,8 @@ interface MarqueeHarnessProps {
   onPreviewSelectionChange?: (ids: string[]) => void
   onGestureEnd: (event: MouseEvent, wasActualDrag: boolean) => void
   onGestureCancel?: (wasActualDrag: boolean) => void
+  committedSelectionIds?: readonly string[]
+  liveCommitThrottleMs?: number
 }
 
 function createRect(left: number, top: number, right: number, bottom: number): Rect {
@@ -31,6 +33,8 @@ function MarqueeHarness({
   onPreviewSelectionChange,
   onGestureEnd,
   onGestureCancel,
+  committedSelectionIds,
+  liveCommitThrottleMs = 0,
 }: MarqueeHarnessProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const items = useMemo(
@@ -57,9 +61,11 @@ function MarqueeHarness({
     resolveItems,
     onSelectionChange,
     onPreviewSelectionChange,
+    committedSelectionIds,
     onGestureEnd,
     onGestureCancel,
     commitSelectionOnMouseUp: true,
+    liveCommitThrottleMs,
   })
 
   return (
@@ -89,6 +95,7 @@ describe('useMarqueeSelection deferred commits', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -303,6 +310,42 @@ describe('useMarqueeSelection deferred commits', () => {
     expect(onGestureCancel).toHaveBeenCalledWith(true)
     expect(onGestureEnd).not.toHaveBeenCalled()
     expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it('restores the committed selection when cancellation follows a throttled live commit', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(100)
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onGestureEnd = vi.fn<(event: MouseEvent, wasActualDrag: boolean) => void>()
+    const { getByTestId } = render(
+      <MarqueeHarness
+        committedSelectionIds={['previous-selection']}
+        liveCommitThrottleMs={66}
+        onSelectionChange={onSelectionChange}
+        onGestureEnd={onGestureEnd}
+      />,
+    )
+    const container = getByTestId('marquee-container')
+
+    Object.defineProperties(container, {
+      clientWidth: { configurable: true, value: 200 },
+      clientHeight: { configurable: true, value: 200 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => createRect(0, 0, 200, 200),
+      },
+    })
+
+    fireEvent.mouseDown(container, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 50, clientY: 50 })
+    flushAnimationFrames()
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['clip-1'])
+
+    fireEvent.blur(window)
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(['previous-selection'])
+    expect(onSelectionChange).toHaveBeenCalledTimes(2)
+    expect(onGestureEnd).not.toHaveBeenCalled()
   })
 
   it('uses a batch geometry resolver for data-driven item surfaces', () => {

--- a/src/shared/marquee/use-marquee-selection.test.tsx
+++ b/src/shared/marquee/use-marquee-selection.test.tsx
@@ -10,6 +10,7 @@ interface MarqueeHarnessProps {
   onSelectionChange: (ids: string[]) => void
   onPreviewSelectionChange?: (ids: string[]) => void
   onGestureEnd: (event: MouseEvent, wasActualDrag: boolean) => void
+  onGestureCancel?: (wasActualDrag: boolean) => void
 }
 
 function createRect(left: number, top: number, right: number, bottom: number): Rect {
@@ -29,6 +30,7 @@ function MarqueeHarness({
   onSelectionChange,
   onPreviewSelectionChange,
   onGestureEnd,
+  onGestureCancel,
 }: MarqueeHarnessProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const items = useMemo(
@@ -49,18 +51,19 @@ function MarqueeHarness({
     [useBatchResolver],
   )
 
-  useMarqueeSelection({
+  const { isActive } = useMarqueeSelection({
     containerRef: containerRef as React.RefObject<HTMLElement>,
     items,
     resolveItems,
     onSelectionChange,
     onPreviewSelectionChange,
     onGestureEnd,
+    onGestureCancel,
     commitSelectionOnMouseUp: true,
   })
 
   return (
-    <div ref={containerRef} data-testid="marquee-container">
+    <div ref={containerRef} data-marquee-active={isActive} data-testid="marquee-container">
       {children}
     </div>
   )
@@ -208,6 +211,97 @@ describe('useMarqueeSelection deferred commits', () => {
 
     expect(onGestureEnd).not.toHaveBeenCalled()
     expect(onPreviewSelectionChange).not.toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it('cancels an active drag on window blur instead of carrying it into the next gesture', () => {
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onPreviewSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onGestureEnd = vi.fn<(event: MouseEvent, wasActualDrag: boolean) => void>()
+    const onGestureCancel = vi.fn<(wasActualDrag: boolean) => void>()
+    const { getByTestId } = render(
+      <MarqueeHarness
+        onSelectionChange={onSelectionChange}
+        onPreviewSelectionChange={onPreviewSelectionChange}
+        onGestureEnd={onGestureEnd}
+        onGestureCancel={onGestureCancel}
+      >
+        <div className="timeline-ruler" data-testid="timeline-ruler" />
+      </MarqueeHarness>,
+    )
+    const container = getByTestId('marquee-container')
+
+    Object.defineProperties(container, {
+      clientWidth: { configurable: true, value: 200 },
+      clientHeight: { configurable: true, value: 200 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => createRect(0, 0, 200, 200),
+      },
+    })
+
+    fireEvent.mouseDown(container, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 50, clientY: 50 })
+    flushAnimationFrames()
+
+    expect(container).toHaveAttribute('data-marquee-active', 'true')
+
+    fireEvent.blur(window)
+
+    expect(container).toHaveAttribute('data-marquee-active', 'false')
+    expect(onGestureCancel).toHaveBeenCalledWith(true)
+    expect(onPreviewSelectionChange).toHaveBeenLastCalledWith([])
+    expect(onGestureEnd).not.toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+
+    fireEvent.mouseDown(getByTestId('timeline-ruler'), { button: 0, clientX: 75, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 50 })
+    flushAnimationFrames()
+    fireEvent.mouseUp(document, { clientX: 120, clientY: 50 })
+
+    expect(container).toHaveAttribute('data-marquee-active', 'false')
+    expect(onGestureCancel).toHaveBeenCalledTimes(1)
+    expect(onGestureEnd).not.toHaveBeenCalled()
+  })
+
+  it('drops a stale drag before an excluded surface starts a new interaction', () => {
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onGestureEnd = vi.fn<(event: MouseEvent, wasActualDrag: boolean) => void>()
+    const onGestureCancel = vi.fn<(wasActualDrag: boolean) => void>()
+    const { getByTestId } = render(
+      <MarqueeHarness
+        onSelectionChange={onSelectionChange}
+        onGestureEnd={onGestureEnd}
+        onGestureCancel={onGestureCancel}
+      >
+        <div className="timeline-ruler" data-testid="timeline-ruler" />
+      </MarqueeHarness>,
+    )
+    const container = getByTestId('marquee-container')
+
+    Object.defineProperties(container, {
+      clientWidth: { configurable: true, value: 200 },
+      clientHeight: { configurable: true, value: 200 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => createRect(0, 0, 200, 200),
+      },
+    })
+
+    fireEvent.mouseDown(container, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 50, clientY: 50 })
+    flushAnimationFrames()
+
+    expect(container).toHaveAttribute('data-marquee-active', 'true')
+
+    fireEvent.mouseDown(getByTestId('timeline-ruler'), { button: 0, clientX: 75, clientY: 5 })
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 50 })
+    flushAnimationFrames()
+    fireEvent.mouseUp(document, { clientX: 120, clientY: 50 })
+
+    expect(container).toHaveAttribute('data-marquee-active', 'false')
+    expect(onGestureCancel).toHaveBeenCalledWith(true)
+    expect(onGestureEnd).not.toHaveBeenCalled()
     expect(onSelectionChange).not.toHaveBeenCalled()
   })
 

--- a/src/shared/marquee/use-marquee-selection.ts
+++ b/src/shared/marquee/use-marquee-selection.ts
@@ -71,6 +71,9 @@ interface UseMarqueeSelectionOptions {
   /** Called when an accepted marquee pointer gesture releases. */
   onGestureEnd?: (event: MouseEvent, wasActualDrag: boolean) => void
 
+  /** Called when an accepted marquee gesture loses its release and is cancelled. */
+  onGestureCancel?: (wasActualDrag: boolean) => void
+
   /** Whether marquee selection is enabled */
   enabled?: boolean
 
@@ -178,6 +181,7 @@ export function useMarqueeSelection({
   onSelectionChange,
   onPreviewSelectionChange,
   onGestureEnd,
+  onGestureCancel,
   enabled = true,
   appendMode = false,
   threshold = 5,
@@ -348,7 +352,41 @@ export function useMarqueeSelection({
 
   // Handle mouse down - start marquee
   // Using useEffectEvent so changes to enabled, appendMode don't re-register listeners
+  const cancelGesture = useEffectEvent(() => {
+    if (!isDraggingRef.current) return
+
+    const wasActualDrag = hasMovedRef.current
+
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current)
+      rafIdRef.current = null
+    }
+    if (liveCommitTimeoutRef.current !== null) {
+      clearTimeout(liveCommitTimeoutRef.current)
+      liveCommitTimeoutRef.current = null
+    }
+
+    isDraggingRef.current = false
+    hasMovedRef.current = false
+    marqueeRef.current = { startX: 0, startY: 0, currentX: 0, currentY: 0 }
+    resolvedItemsRef.current = null
+    pendingLiveCommitIdsRef.current = null
+    lastLiveCommitTimeRef.current = 0
+
+    setIsActive(false)
+    publishSnapshot(INACTIVE_SNAPSHOT)
+
+    if (commitSelectionOnMouseUp) {
+      onPreviewSelectionChangeRef.current?.([])
+    }
+    onGestureCancel?.(wasActualDrag)
+  })
+
   const onMouseDown = useEffectEvent((e: MouseEvent) => {
+    // A previous drag may have lost its mouseup while the page was unfocused.
+    // Never let that stale gesture compete with a new interaction.
+    cancelGesture()
+
     if (!enabledRef.current || !containerRef.current || !boundsRef.current) return
 
     // Only trigger on left click
@@ -574,11 +612,21 @@ export function useMarqueeSelection({
     document.addEventListener('mousedown', onMouseDown, true)
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp, true)
+    window.addEventListener('blur', cancelGesture)
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        cancelGesture()
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
       document.removeEventListener('mousedown', onMouseDown, true)
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp, true)
+      window.removeEventListener('blur', cancelGesture)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [])
 

--- a/src/shared/marquee/use-marquee-selection.ts
+++ b/src/shared/marquee/use-marquee-selection.ts
@@ -68,6 +68,9 @@ interface UseMarqueeSelectionOptions {
   /** Optional callback for lightweight live preview updates during drag */
   onPreviewSelectionChange?: (selectedIds: string[]) => void
 
+  /** Current committed selection, used to roll back throttled live commits on cancellation. */
+  committedSelectionIds?: readonly string[]
+
   /** Called when an accepted marquee pointer gesture releases. */
   onGestureEnd?: (event: MouseEvent, wasActualDrag: boolean) => void
 
@@ -180,6 +183,7 @@ export function useMarqueeSelection({
   resolveItems,
   onSelectionChange,
   onPreviewSelectionChange,
+  committedSelectionIds,
   onGestureEnd,
   onGestureCancel,
   enabled = true,
@@ -223,6 +227,7 @@ export function useMarqueeSelection({
   const hasMovedRef = useRef(false)
   const onSelectionChangeRef = useRef(onSelectionChange)
   const onPreviewSelectionChangeRef = useRef(onPreviewSelectionChange)
+  const committedSelectionIdsRef = useRef(committedSelectionIds)
   const prevSelectedIdsRef = useRef<string[]>([])
   const rafIdRef = useRef<number | null>(null)
   const itemsRef = useRef(items)
@@ -232,6 +237,8 @@ export function useMarqueeSelection({
   const liveCommitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingLiveCommitIdsRef = useRef<string[] | null>(null)
   const lastLiveCommitTimeRef = useRef(0)
+  const gestureStartSelectionIdsRef = useRef<string[] | null>(null)
+  const hasLiveCommittedRef = useRef(false)
 
   // Keep refs up to date
   useEffect(() => {
@@ -241,6 +248,10 @@ export function useMarqueeSelection({
   useEffect(() => {
     onPreviewSelectionChangeRef.current = onPreviewSelectionChange
   }, [onPreviewSelectionChange])
+
+  useEffect(() => {
+    committedSelectionIdsRef.current = committedSelectionIds
+  }, [committedSelectionIds])
 
   useEffect(() => {
     itemsRef.current = items
@@ -270,6 +281,7 @@ export function useMarqueeSelection({
     }
     pendingLiveCommitIdsRef.current = null
     lastLiveCommitTimeRef.current = performance.now()
+    hasLiveCommittedRef.current = true
     onSelectionChangeRef.current?.(ids)
   }, [])
 
@@ -356,6 +368,9 @@ export function useMarqueeSelection({
     if (!isDraggingRef.current) return
 
     const wasActualDrag = hasMovedRef.current
+    const selectionToRestore = hasLiveCommittedRef.current
+      ? gestureStartSelectionIdsRef.current
+      : null
 
     if (rafIdRef.current !== null) {
       cancelAnimationFrame(rafIdRef.current)
@@ -372,12 +387,17 @@ export function useMarqueeSelection({
     resolvedItemsRef.current = null
     pendingLiveCommitIdsRef.current = null
     lastLiveCommitTimeRef.current = 0
+    gestureStartSelectionIdsRef.current = null
+    hasLiveCommittedRef.current = false
 
     setIsActive(false)
     publishSnapshot(INACTIVE_SNAPSHOT)
 
     if (commitSelectionOnMouseUp) {
       onPreviewSelectionChangeRef.current?.([])
+    }
+    if (selectionToRestore !== null) {
+      onSelectionChangeRef.current?.(selectionToRestore)
     }
     onGestureCancel?.(wasActualDrag)
   })
@@ -440,6 +460,10 @@ export function useMarqueeSelection({
     }
     isDraggingRef.current = true
     hasMovedRef.current = false
+    gestureStartSelectionIdsRef.current = committedSelectionIdsRef.current
+      ? [...committedSelectionIdsRef.current]
+      : null
+    hasLiveCommittedRef.current = false
     prevSelectedIdsRef.current = [] // Reset accumulated selection for new marquee
     resolvedItemsRef.current = null
     pendingLiveCommitIdsRef.current = null
@@ -589,6 +613,8 @@ export function useMarqueeSelection({
       }
       onPreviewSelectionChangeRef.current?.([])
     }
+    gestureStartSelectionIdsRef.current = null
+    hasLiveCommittedRef.current = false
   })
 
   // Cleanup RAF on unmount


### PR DESCRIPTION
## What changed

- cancel an active marquee gesture when the page loses focus or becomes hidden
- defensively clear any stale marquee before a new mouse interaction begins
- release the timeline's marquee-specific skim and preview locks when a gesture is cancelled
- add regression coverage for blur cancellation and the stale-marquee-to-ruler handoff

## Why

A marquee drag that missed its mouse-up could remain armed. The next drag on the timeline ruler then competed with that stale marquee, causing the ruler to appear to lose drag-to-scrub ownership.

## Impact

Ruler scrubbing keeps ownership after interrupted marquee gestures, the cursor and playhead settle normally on release, and post-release pointer movement no longer revives the stale interaction.

## Validation

- 23 focused tests passed across the marquee hook and timeline content
- focused static checks passed for all 3 changed files
- `git diff --check` passed
- live Chrome reproduction of the interrupted marquee → ruler drag showed no marquee during the new ruler drag, correct scrubbing, cursor cleanup, and a stable playhead after release
- `develop → staging` contains 1 commit / 3 files and the merge simulation is conflict-free