### PR TITLE
Fix intermittent custom-audio preview silence

### DIFF
--- a/src/runtime/composition-runtime/utils/audio-decode-cache.test.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-cache.test.ts
@@ -9,7 +9,13 @@ const decodedPreviewAudioMocks = vi.hoisted(() => ({
 }))
 
 const mediaDbMocks = vi.hoisted(() => ({
-  getMedia: vi.fn(async () => null),
+  getMedia: vi.fn<
+    (_id: string) => Promise<{
+      mimeType: string
+      codec?: string
+      audioCodec?: string
+    } | null>
+  >(async () => null),
 }))
 
 const ac3Mocks = vi.hoisted(() => ({
@@ -29,12 +35,26 @@ const previewAudioConformMocks = vi.hoisted(() => ({
 }))
 
 const mediabunnyMocks = vi.hoisted(() => {
-  let pendingBuffer: Promise<{ buffer: AudioBuffer; timestamp: number; duration: number }> | null =
-    null
+  type MockAudioSample = {
+    numberOfFrames: number
+    numberOfChannels: number
+    sampleRate: number
+    timestamp: number
+    duration: number
+    copyTo: (
+      destination: Float32Array,
+      options: { planeIndex: number; format: 'f32-planar' },
+    ) => void
+    close: () => void
+  }
+
+  let pendingSamplePromise: Promise<MockAudioSample | null> | null = null
   let pendingSamples: Array<{
     numberOfFrames: number
     numberOfChannels: number
     sampleRate: number
+    timestamp: number
+    duration: number
     copyTo: (
       destination: Float32Array,
       options: { planeIndex: number; format: 'f32-planar' },
@@ -71,34 +91,29 @@ const mediabunnyMocks = vi.hoisted(() => {
     }
   }
 
-  class AudioBufferSink {
-    constructor(track: unknown) {
-      void track
-      stats.sinkConstructed += 1
-    }
-    async getBuffer(startTime: number) {
-      void startTime
-      if (!pendingBuffer) {
-        throw new Error('No pending buffer configured')
-      }
-      return pendingBuffer
-    }
-    buffers(startTime: number, endTime: number) {
-      stats.bufferRangeStarts.push(startTime)
-      void endTime
-      return (async function* emptyBuffers() {
-        yield* []
-      })()
-    }
-  }
-
   class AudioSampleSink {
     constructor(track: unknown) {
       void track
       stats.sampleSinkConstructed += 1
     }
-    samples() {
-      const samples = pendingSamples
+    async getSample(startTime: number) {
+      if (pendingSamplePromise) {
+        return pendingSamplePromise
+      }
+      return (
+        pendingSamples.find(
+          (sample) =>
+            sample.timestamp <= startTime && sample.timestamp + sample.duration > startTime,
+        ) ??
+        pendingSamples.find((sample) => sample.timestamp >= startTime) ??
+        null
+      )
+    }
+    samples(startTime = 0, endTime = Number.POSITIVE_INFINITY) {
+      stats.bufferRangeStarts.push(startTime)
+      const samples = pendingSamples.filter(
+        (sample) => sample.timestamp >= startTime && sample.timestamp < endTime,
+      )
       return (async function* yieldSamples() {
         for (const sample of samples) {
           yield sample
@@ -112,18 +127,14 @@ const mediabunnyMocks = vi.hoisted(() => {
     Input,
     UrlSource,
     BlobSource,
-    AudioBufferSink,
     AudioSampleSink,
-    __setPendingBuffer(
-      promise: Promise<{ buffer: AudioBuffer; timestamp: number; duration: number }>,
-    ) {
-      pendingBuffer = promise
-    },
     __setPendingSamples(
       samples: Array<{
         numberOfFrames: number
         numberOfChannels: number
         sampleRate: number
+        timestamp: number
+        duration: number
         copyTo: (
           destination: Float32Array,
           options: { planeIndex: number; format: 'f32-planar' },
@@ -133,8 +144,11 @@ const mediabunnyMocks = vi.hoisted(() => {
     ) {
       pendingSamples = samples
     },
+    __setPendingSamplePromise(promise: Promise<MockAudioSample | null>) {
+      pendingSamplePromise = promise
+    },
     __reset() {
-      pendingBuffer = null
+      pendingSamplePromise = null
       pendingSamples = []
       stats.inputConstructed = 0
       stats.sinkConstructed = 0
@@ -160,18 +174,6 @@ import {
   startPreviewAudioConform,
 } from './audio-decode-cache'
 
-function makeAudioBuffer(duration: number, sampleRate = 22050): AudioBuffer {
-  const length = Math.max(1, Math.round(duration * sampleRate))
-  const channels = [new Float32Array(length), new Float32Array(length)]
-  return {
-    duration,
-    numberOfChannels: 2,
-    length,
-    sampleRate,
-    getChannelData: (channel: number) => channels[channel] ?? channels[0]!,
-  } as unknown as AudioBuffer
-}
-
 function makeInt16Buffer(length: number): ArrayBuffer {
   return new Int16Array(length).buffer
 }
@@ -184,11 +186,13 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
-function makeSample(frameCount: number, sampleRate = 22050) {
+function makeSample(frameCount: number, sampleRate = 22050, timestamp = 0) {
   return {
     numberOfFrames: frameCount,
     numberOfChannels: 2,
     sampleRate,
+    timestamp,
+    duration: frameCount / sampleRate,
     copyTo(destination: Float32Array, options: { planeIndex: number; format: 'f32-planar' }) {
       void options
       destination.fill(options.planeIndex === 0 ? 0.25 : -0.25)
@@ -224,6 +228,11 @@ describe('audio-decode-cache targeted slice reuse', () => {
   beforeEach(() => {
     clearPreviewAudioCache()
     mediabunnyMocks.__reset()
+    mediaDbMocks.getMedia.mockReset()
+    mediaDbMocks.getMedia.mockResolvedValue(null)
+    ac3Mocks.ensureAc3DecoderRegistered.mockClear()
+    ac3Mocks.isAc3AudioCodec.mockReset()
+    ac3Mocks.isAc3AudioCodec.mockReturnValue(false)
     previewAudioConformMocks.persistPreviewAudioConform.mockClear()
     decodedPreviewAudioMocks.saveDecodedPreviewAudio.mockClear()
     decodedPreviewAudioMocks.getDecodedPreviewAudio.mockReset()
@@ -231,13 +240,7 @@ describe('audio-decode-cache targeted slice reuse', () => {
   })
 
   it('reuses a completed targeted slice for the same playback request', async () => {
-    mediabunnyMocks.__setPendingBuffer(
-      Promise.resolve({
-        buffer: makeAudioBuffer(2),
-        timestamp: 0,
-        duration: 2,
-      }),
-    )
+    mediabunnyMocks.__setPendingSamples([makeSample(2 * 22050)])
 
     const firstSlice = await getOrDecodeAudioSliceForPlayback('media-1', 'blob://audio', {
       minReadySeconds: 2,
@@ -253,18 +256,13 @@ describe('audio-decode-cache targeted slice reuse', () => {
 
     expect(firstSlice.buffer).toBe(secondSlice.buffer)
     expect(mediabunnyMocks.__stats.inputConstructed).toBe(1)
-    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(1)
+    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(0)
+    expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(1)
     expect(mediabunnyMocks.__stats.bufferRangeStarts).toEqual([2])
   })
 
   it('continues an incomplete targeted slice after the initial decoded buffer', async () => {
-    mediabunnyMocks.__setPendingBuffer(
-      Promise.resolve({
-        buffer: makeAudioBuffer(1),
-        timestamp: 0,
-        duration: 1,
-      }),
-    )
+    mediabunnyMocks.__setPendingSamples([makeSample(22050)])
 
     await getOrDecodeAudioSliceForPlayback('media-range', 'blob://audio', {
       minReadySeconds: 2,
@@ -275,9 +273,28 @@ describe('audio-decode-cache targeted slice reuse', () => {
     expect(mediabunnyMocks.__stats.bufferRangeStarts).toEqual([1])
   })
 
+  it('decodes a custom-codec playback window without falling back to a full decode', async () => {
+    mediaDbMocks.getMedia.mockResolvedValueOnce({ mimeType: 'audio/ac3', codec: 'ac-3' })
+    ac3Mocks.isAc3AudioCodec.mockReturnValue(true)
+    mediabunnyMocks.__setPendingSamples([makeSample(22050, 22050, 25)])
+
+    const slice = await getOrDecodeAudioSliceForPlayback('media-ac3', 'blob://audio', {
+      minReadySeconds: 1,
+      targetTimeSeconds: 25,
+      waitTimeoutMs: 0,
+    })
+
+    expect(slice.startTime).toBe(25)
+    expect(slice.buffer.duration).toBe(1)
+    expect(slice.isComplete).toBe(false)
+    expect(ac3Mocks.ensureAc3DecoderRegistered).toHaveBeenCalledTimes(1)
+    expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(1)
+    expect(mediabunnyMocks.__stats.bufferRangeStarts).toEqual([])
+  })
+
   it('shares an in-flight targeted slice decode for duplicate startup requests', async () => {
-    const deferred = createDeferred<{ buffer: AudioBuffer; timestamp: number; duration: number }>()
-    mediabunnyMocks.__setPendingBuffer(deferred.promise)
+    const deferred = createDeferred<ReturnType<typeof makeSample>>()
+    mediabunnyMocks.__setPendingSamplePromise(deferred.promise)
 
     const firstPromise = getOrDecodeAudioSliceForPlayback('media-2', 'blob://audio', {
       minReadySeconds: 2,
@@ -290,22 +307,18 @@ describe('audio-decode-cache targeted slice reuse', () => {
       waitTimeoutMs: 0,
     })
 
-    deferred.resolve({
-      buffer: makeAudioBuffer(2),
-      timestamp: 0,
-      duration: 2,
-    })
+    deferred.resolve(makeSample(2 * 22050))
 
     const [firstSlice, secondSlice] = await Promise.all([firstPromise, secondPromise])
 
     expect(firstSlice.buffer).toBe(secondSlice.buffer)
     expect(mediabunnyMocks.__stats.inputConstructed).toBe(1)
-    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(1)
+    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(0)
+    expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(1)
   })
 
   it('reuses a nearby in-flight targeted slice request while playback advances', async () => {
-    const deferred = createDeferred<{ buffer: AudioBuffer; timestamp: number; duration: number }>()
-    mediabunnyMocks.__setPendingBuffer(deferred.promise)
+    mediabunnyMocks.__setPendingSamples([makeSample(3 * 22050)])
 
     const firstPromise = getOrDecodeAudioSliceForPlayback('media-3', 'blob://audio', {
       minReadySeconds: 3,
@@ -318,17 +331,12 @@ describe('audio-decode-cache targeted slice reuse', () => {
       waitTimeoutMs: 0,
     })
 
-    deferred.resolve({
-      buffer: makeAudioBuffer(3),
-      timestamp: 0,
-      duration: 3,
-    })
-
     const [firstSlice, secondSlice] = await Promise.all([firstPromise, secondPromise])
 
     expect(firstSlice.buffer).toBe(secondSlice.buffer)
     expect(mediabunnyMocks.__stats.inputConstructed).toBe(1)
-    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(1)
+    expect(mediabunnyMocks.__stats.sinkConstructed).toBe(0)
+    expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(1)
   })
 
   it('rebuilds an immediate partial slice from persisted bins around the target time', async () => {

--- a/src/runtime/composition-runtime/utils/audio-decode-cache.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-cache.ts
@@ -109,6 +109,51 @@ export interface PlaybackAudioSlice {
   isComplete: boolean
 }
 
+interface DecodeAudioSampleData {
+  numberOfFrames?: number
+  numberOfChannels?: number
+  sampleRate?: number
+  timestamp?: number
+  duration?: number
+  copyTo: (
+    destination: Float32Array,
+    options: { planeIndex: number; format: 'f32-planar' },
+  ) => void
+  close: () => void
+}
+
+function extractDecodeSampleStereoChunk(sample: DecodeAudioSampleData): {
+  left: Float32Array
+  right: Float32Array
+  frameCount: number
+} | null {
+  const frameCount = Math.max(0, sample.numberOfFrames ?? 0)
+  const channelCount = Math.max(1, sample.numberOfChannels ?? 1)
+  if (frameCount === 0) {
+    return null
+  }
+
+  const channels: Float32Array[] = []
+  for (let c = 0; c < channelCount; c++) {
+    const channelData = new Float32Array(frameCount)
+    sample.copyTo(channelData, { planeIndex: c, format: 'f32-planar' })
+    channels.push(channelData)
+  }
+  const { left, right } = downmixToStereo(channels, frameCount)
+  return { left, right, frameCount }
+}
+
+function getDecodeSampleEndTime(sample: DecodeAudioSampleData): number | null {
+  if (
+    !Number.isFinite(sample.timestamp) ||
+    !Number.isFinite(sample.duration) ||
+    Number(sample.duration) <= 0
+  ) {
+    return null
+  }
+  return Number(sample.timestamp) + Number(sample.duration)
+}
+
 function getPlaybackSliceCoverageEnd(slice: PlaybackAudioSlice): number {
   return slice.startTime + slice.buffer.duration
 }
@@ -376,7 +421,11 @@ async function decodeAudioWindow(
 
       const safeStartTime = Math.max(0, startTime)
       const targetCoverageEndTime = safeStartTime + Math.max(0.5, durationSeconds)
-      const sink = new mb.AudioBufferSink(audioTrack)
+      // Use AudioSampleSink here as well as in the proven full-decode path.
+      // AudioBufferSink can fail for custom codecs even after their decoder is
+      // registered, which used to turn a small playback-window request into a
+      // slow full decode and leave transport advancing without audio.
+      const sink = new mb.AudioSampleSink(audioTrack)
 
       let sliceStartTime: number | null = null
       let coverageEndTime = safeStartTime
@@ -386,59 +435,64 @@ async function decodeAudioWindow(
       const rightChunks: Float32Array[] = []
       const seenBufferKeys = new Set<string>()
 
-      const appendWrappedBuffer = (wrappedBuffer: {
-        buffer: AudioBuffer
-        timestamp: number
-        duration: number
-      }) => {
-        const audioBuffer = wrappedBuffer.buffer
-        const frameCount = audioBuffer.length
-        const channelCount = Math.max(1, audioBuffer.numberOfChannels)
-        if (frameCount === 0) {
+      const appendSample = (sample: DecodeAudioSampleData) => {
+        const chunk = extractDecodeSampleStereoChunk(sample)
+        if (!chunk) {
           return
         }
 
-        const dedupeKey = `${wrappedBuffer.timestamp}:${wrappedBuffer.duration}`
+        const timestamp = Number.isFinite(sample.timestamp)
+          ? Number(sample.timestamp)
+          : coverageEndTime
+        const duration =
+          Number.isFinite(sample.duration) && Number(sample.duration) > 0
+            ? Number(sample.duration)
+            : chunk.frameCount / Math.max(1, sample.sampleRate ?? sampleRate)
+
+        const dedupeKey = `${timestamp}:${duration}`
         if (seenBufferKeys.has(dedupeKey)) {
           return
         }
         seenBufferKeys.add(dedupeKey)
 
         if (sliceStartTime === null) {
-          sliceStartTime = wrappedBuffer.timestamp
+          sliceStartTime = timestamp
         }
-        coverageEndTime = Math.max(
-          coverageEndTime,
-          wrappedBuffer.timestamp + wrappedBuffer.duration,
-        )
-        if (audioBuffer.sampleRate > 0) {
-          sampleRate = audioBuffer.sampleRate
+        coverageEndTime = Math.max(coverageEndTime, timestamp + duration)
+        if (sample.sampleRate && sample.sampleRate > 0) {
+          sampleRate = sample.sampleRate
         }
 
-        const channels: Float32Array[] = []
-        for (let c = 0; c < channelCount; c++) {
-          channels.push(audioBuffer.getChannelData(c))
-        }
-        const { left, right } = downmixToStereo(channels, frameCount)
-        leftChunks.push(left)
-        rightChunks.push(right)
-        totalFrames += frameCount
+        leftChunks.push(chunk.left)
+        rightChunks.push(chunk.right)
+        totalFrames += chunk.frameCount
       }
 
-      const initialWrappedBuffer = await sink.getBuffer(safeStartTime)
-      if (initialWrappedBuffer) {
-        appendWrappedBuffer(initialWrappedBuffer)
+      const initialSample = (await sink.getSample(safeStartTime)) as DecodeAudioSampleData | null
+      let initialSampleEndTime: number | null = null
+      if (initialSample) {
+        try {
+          appendSample(initialSample)
+          initialSampleEndTime = getDecodeSampleEndTime(initialSample)
+        } finally {
+          initialSample.close()
+        }
       }
 
-      const iteratorStartTime = initialWrappedBuffer
-        ? Math.max(
-            safeStartTime,
-            initialWrappedBuffer.timestamp + initialWrappedBuffer.duration,
-          )
-        : safeStartTime
+      const iteratorStartTime =
+        initialSampleEndTime === null
+          ? safeStartTime
+          : Math.max(safeStartTime, initialSampleEndTime)
       if (coverageEndTime < targetCoverageEndTime) {
-        for await (const wrappedBuffer of sink.buffers(iteratorStartTime, targetCoverageEndTime)) {
-          appendWrappedBuffer(wrappedBuffer)
+        for await (const sample of sink.samples(
+          iteratorStartTime,
+          targetCoverageEndTime,
+        ) as AsyncIterable<DecodeAudioSampleData>) {
+          try {
+            appendSample(sample)
+          } finally {
+            sample.close()
+          }
           if (coverageEndTime >= targetCoverageEndTime) {
             break
           }
@@ -1195,37 +1249,19 @@ async function decodeFullAudio(
 
       for await (const sample of sink.samples()) {
         try {
-          const sampleData = sample as {
-            numberOfFrames?: number
-            numberOfChannels?: number
-            sampleRate?: number
-            copyTo: (
-              destination: Float32Array,
-              options: { planeIndex: number; format: 'f32-planar' },
-            ) => void
-          }
-          const frameCount = Math.max(0, sampleData.numberOfFrames ?? 0)
-          const channelCount = Math.max(1, sampleData.numberOfChannels ?? 1)
-          if (frameCount === 0) {
+          const sampleData = sample as DecodeAudioSampleData
+          const chunk = extractDecodeSampleStereoChunk(sampleData)
+          if (!chunk) {
             continue
           }
           if (sampleData.sampleRate && sampleData.sampleRate > 0) {
             sampleRate = sampleData.sampleRate
           }
 
-          // Extract channels and downmix to stereo immediately.
-          const channels: Float32Array[] = []
-          for (let c = 0; c < channelCount; c++) {
-            const channelData = new Float32Array(frameCount)
-            sampleData.copyTo(channelData, { planeIndex: c, format: 'f32-planar' })
-            channels.push(channelData)
-          }
-          const { left, right } = downmixToStereo(channels, frameCount)
-
           // Accumulate for current bin
-          binLeftChunks.push(left)
-          binRightChunks.push(right)
-          binAccumFrames += frameCount
+          binLeftChunks.push(chunk.left)
+          binRightChunks.push(chunk.right)
+          binAccumFrames += chunk.frameCount
 
           // Flush bin when it reaches the target duration
           const binFramesAtSource = BIN_DURATION_SEC * sampleRate


### PR DESCRIPTION
## Summary

- decode targeted custom-audio playback windows through `AudioSampleSink`
- share sample extraction between targeted-window and full-file decode paths
- cover cold custom-codec playback windows without falling back to a slow full decode

## Root cause

The main-thread window fallback used `AudioBufferSink`, while the successful full decode path used `AudioSampleSink`. For custom codecs, targeted decoding could fail and escalate to a full decode while playback continued silently.

## Validation

- `npx vp check --no-fmt src/runtime/composition-runtime/utils/audio-decode-cache.ts src/runtime/composition-runtime/utils/audio-decode-cache.test.ts`
- 37 focused audio tests passed across 6 test files
- `npm run build`
- `git diff --check`
- patched production bundle loaded in the existing Chrome session; exact local-media playback remained blocked by the workspace permission prompt