### PR TITLE
Restore Space playback after timeline zoom

### DIFF
--- a/src/features/preview/utils/render-pump-frame-plan.ts
+++ b/src/features/preview/utils/render-pump-frame-plan.ts
@@ -301,6 +301,44 @@ interface SelectBoundarySourcePrewarmSourcesParams {
   fps: number
 }
 
+function selectDirectionalWindowEntries<T>({
+  entries,
+  targetFrame,
+  direction,
+  windowFrames,
+  maxEntries,
+  getFrame,
+}: {
+  entries: readonly T[]
+  targetFrame: number
+  direction: ScrubDirection
+  windowFrames: number
+  maxEntries: number
+  getFrame: (entry: T) => number
+}): T[] {
+  const minFrame = targetFrame - windowFrames
+  const maxFrame = targetFrame + windowFrames
+  const directionalEntries: T[] = []
+  const fallbackEntries: T[] = []
+
+  // Both callers pass entries sorted by frame, so the first out-of-window
+  // entry lets us stop scanning the remainder.
+  for (const entry of entries) {
+    const frame = getFrame(entry)
+    if (frame < minFrame) continue
+    if (frame > maxFrame) break
+    fallbackEntries.push(entry)
+    if (direction > 0 && frame < targetFrame - 1) continue
+    if (direction < 0 && frame > targetFrame + 1) continue
+    directionalEntries.push(entry)
+  }
+
+  const candidates = directionalEntries.length > 0 ? directionalEntries : fallbackEntries
+  return [...candidates]
+    .sort((a, b) => Math.abs(getFrame(a) - targetFrame) - Math.abs(getFrame(b) - targetFrame))
+    .slice(0, maxEntries)
+}
+
 export function resolveRenderPumpTargetFrame({
   state,
   forceFastScrubOverlay,
@@ -345,14 +383,6 @@ export function resolveScrubDirectionPlan({
     const targetDelta = targetFrame - prevTargetFrame
     return {
       direction: targetDelta > 0 ? 1 : targetDelta < 0 ? -1 : 0,
-      scrubUpdates: 0,
-      scrubDroppedFrames: 0,
-    }
-  }
-
-  if (targetFrame !== null) {
-    return {
-      direction: 0,
       scrubUpdates: 0,
       scrubDroppedFrames: 0,
     }
@@ -435,24 +465,14 @@ export function selectBoundaryPrewarmFrames({
   if (boundaryFrames.length === 0) return []
 
   const windowFrames = Math.max(4, Math.round(fps * FAST_SCRUB_BOUNDARY_PREWARM_WINDOW_SECONDS))
-  const minFrame = targetFrame - windowFrames
-  const maxFrame = targetFrame + windowFrames
-  const directionalCandidates: number[] = []
-  const fallbackCandidates: number[] = []
-
-  for (const boundary of boundaryFrames) {
-    if (boundary < minFrame) continue
-    if (boundary > maxFrame) break
-    fallbackCandidates.push(boundary)
-    if (direction > 0 && boundary < targetFrame - 1) continue
-    if (direction < 0 && boundary > targetFrame + 1) continue
-    directionalCandidates.push(boundary)
-  }
-
-  const candidates = directionalCandidates.length > 0 ? directionalCandidates : fallbackCandidates
-  const selectedBoundaries = [...candidates]
-    .sort((a, b) => Math.abs(a - targetFrame) - Math.abs(b - targetFrame))
-    .slice(0, FAST_SCRUB_BOUNDARY_PREWARM_MAX_BOUNDARIES_PER_FRAME)
+  const selectedBoundaries = selectDirectionalWindowEntries({
+    entries: boundaryFrames,
+    targetFrame,
+    direction,
+    windowFrames,
+    maxEntries: FAST_SCRUB_BOUNDARY_PREWARM_MAX_BOUNDARIES_PER_FRAME,
+    getFrame: (boundary) => boundary,
+  })
 
   const frames: number[] = []
   const seen = new Set<number>()
@@ -477,24 +497,14 @@ export function selectBoundarySourcePrewarmSources({
   if (boundarySources.length === 0) return []
 
   const windowFrames = Math.max(8, Math.round(fps * FAST_SCRUB_SOURCE_PREWARM_WINDOW_SECONDS))
-  const minFrame = targetFrame - windowFrames
-  const maxFrame = targetFrame + windowFrames
-  const directionalEntries: FastScrubBoundarySource[] = []
-  const fallbackEntries: FastScrubBoundarySource[] = []
-
-  for (const entry of boundarySources) {
-    if (entry.frame < minFrame) continue
-    if (entry.frame > maxFrame) break
-    fallbackEntries.push(entry)
-    if (direction > 0 && entry.frame < targetFrame - 1) continue
-    if (direction < 0 && entry.frame > targetFrame + 1) continue
-    directionalEntries.push(entry)
-  }
-
-  const candidateEntries = directionalEntries.length > 0 ? directionalEntries : fallbackEntries
-  const selectedEntries = [...candidateEntries]
-    .sort((a, b) => Math.abs(a.frame - targetFrame) - Math.abs(b.frame - targetFrame))
-    .slice(0, FAST_SCRUB_BOUNDARY_SOURCE_PREWARM_MAX_ENTRIES_PER_FRAME)
+  const selectedEntries = selectDirectionalWindowEntries({
+    entries: boundarySources,
+    targetFrame,
+    direction,
+    windowFrames,
+    maxEntries: FAST_SCRUB_BOUNDARY_SOURCE_PREWARM_MAX_ENTRIES_PER_FRAME,
+    getFrame: (entry) => entry.frame,
+  })
 
   const sources: string[] = []
   for (const entry of selectedEntries) {

--- a/src/features/timeline/components/timeline-header.test.tsx
+++ b/src/features/timeline/components/timeline-header.test.tsx
@@ -272,12 +272,14 @@ describe('TimelineHeader zoom slider', () => {
     expect(thumb).not.toHaveFocus()
   })
 
-  it('synchronizes controlled slider state for repeated keyboard steps', () => {
+  it('synchronizes repeated keyboard steps without discarding slider focus', async () => {
     const onZoomChange = vi.fn()
     render(<TimelineHeader onZoomChange={onZoomChange} />)
     const slider = screen.getByTestId('zoom-slider')
     const thumb = screen.getByRole('slider')
     const initialValue = Number(slider.dataset.value)
+
+    thumb.focus()
 
     fireEvent.keyDown(thumb, { key: 'ArrowRight' })
     expect(Number(slider.dataset.value)).toBeCloseTo(initialValue + 0.005)
@@ -290,7 +292,13 @@ describe('TimelineHeader zoom slider', () => {
     expect(useZoomStore.getState().level).toBe(1)
 
     fireEvent.keyUp(thumb, { key: 'ArrowRight' })
+    await act(async () => {})
     expect(onZoomChange).toHaveBeenCalledTimes(2)
+    expect(thumb).toHaveFocus()
+
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' })
+    expect(Number(slider.dataset.value)).toBeCloseTo(initialValue + 0.015)
+    expect(onZoomChange).toHaveBeenCalledTimes(3)
   })
 
   it('toggles the keyframe panel without a selected clip', () => {

--- a/src/features/timeline/components/timeline-header.test.tsx
+++ b/src/features/timeline/components/timeline-header.test.tsx
@@ -243,6 +243,35 @@ describe('TimelineHeader zoom slider', () => {
     }
   })
 
+  it('releases slider focus after an outside pointer release', async () => {
+    render(<TimelineHeader />)
+    const thumb = screen.getByRole('slider')
+
+    thumb.focus()
+    expect(thumb).toHaveFocus()
+
+    fireEvent.pointerDown(thumb)
+    fireEvent.pointerUp(window)
+    await act(async () => {})
+
+    expect(thumb).not.toHaveFocus()
+  })
+
+  it('releases slider focus after a normal value commit', async () => {
+    render(<TimelineHeader />)
+    const thumb = screen.getByRole('slider')
+
+    thumb.focus()
+    expect(thumb).toHaveFocus()
+
+    fireEvent.pointerDown(thumb)
+    fireEvent.mouseDown(thumb)
+    fireEvent.mouseUp(thumb)
+    await act(async () => {})
+
+    expect(thumb).not.toHaveFocus()
+  })
+
   it('synchronizes controlled slider state for repeated keyboard steps', () => {
     const onZoomChange = vi.fn()
     render(<TimelineHeader onZoomChange={onZoomChange} />)

--- a/src/features/timeline/components/timeline-header.tsx
+++ b/src/features/timeline/components/timeline-header.tsx
@@ -343,9 +343,18 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
       latestSliderValueRef.current = sliderValue
       renderSliderPreview(sliderValue)
       commitSliderZoom(sliderValue, latestSliderValue)
-      finishSliderZoomInteraction()
+      if (sliderKeyboardInputRef.current) {
+        releaseSliderZoomGesture()
+      } else {
+        finishSliderZoomInteraction()
+      }
     },
-    [commitSliderZoom, finishSliderZoomInteraction, renderSliderPreview],
+    [
+      commitSliderZoom,
+      finishSliderZoomInteraction,
+      releaseSliderZoomGesture,
+      renderSliderPreview,
+    ],
   )
 
   const controlledSliderValue = zoomToSlider(settledZoomLevel)
@@ -385,7 +394,11 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
           sliderKeyboardInputRef.current = true
         }}
         onKeyUpCapture={() => {
-          sliderKeyboardInputRef.current = false
+          // Keep the keyboard marker set through Radix's onValueCommit, which
+          // runs later in this keyup event. The next microtask ends the input.
+          queueMicrotask(() => {
+            sliderKeyboardInputRef.current = false
+          })
         }}
         onBlurCapture={() => {
           sliderKeyboardInputRef.current = false

--- a/src/features/timeline/components/timeline-header.tsx
+++ b/src/features/timeline/components/timeline-header.tsx
@@ -100,9 +100,10 @@ function isSameZoomLevel(left: number, right: number): boolean {
   return Math.abs(left - right) <= tolerance
 }
 
-function blurActiveElement(): void {
-  if (document.activeElement instanceof HTMLElement) {
-    document.activeElement.blur()
+function blurSliderFocus(root: HTMLElement | null): void {
+  const activeElement = document.activeElement
+  if (activeElement instanceof HTMLElement && root?.contains(activeElement)) {
+    activeElement.blur()
   }
 }
 
@@ -184,6 +185,14 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
     endZoomGesture()
   }, [endZoomGesture])
 
+  const finishSliderZoomInteraction = useCallback(() => {
+    releaseSliderZoomGesture()
+    // Radix can restore thumb focus after onValueCommit returns. Defer the
+    // blur until the pointer/key event has fully finished so Space immediately
+    // returns to the editor transport.
+    queueMicrotask(() => blurSliderFocus(sliderRef.current))
+  }, [releaseSliderZoomGesture])
+
   const beginSliderZoomGesture = useCallback(() => {
     if (sliderZoomGestureHeldRef.current) {
       return
@@ -244,18 +253,18 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
   }, [renderSliderPreview, zoomToSlider])
 
   useEffect(() => {
-    window.addEventListener('pointerup', releaseSliderZoomGesture)
-    window.addEventListener('pointercancel', releaseSliderZoomGesture)
+    window.addEventListener('pointerup', finishSliderZoomInteraction)
+    window.addEventListener('pointercancel', finishSliderZoomInteraction)
 
     return () => {
-      window.removeEventListener('pointerup', releaseSliderZoomGesture)
-      window.removeEventListener('pointercancel', releaseSliderZoomGesture)
+      window.removeEventListener('pointerup', finishSliderZoomInteraction)
+      window.removeEventListener('pointercancel', finishSliderZoomInteraction)
       if (sliderRafRef.current !== null) {
         cancelAnimationFrame(sliderRafRef.current)
       }
       releaseSliderZoomGesture()
     }
-  }, [releaseSliderZoomGesture])
+  }, [finishSliderZoomInteraction, releaseSliderZoomGesture])
 
   const handleSliderChange = useCallback(
     (values: number[]) => {
@@ -334,10 +343,9 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
       latestSliderValueRef.current = sliderValue
       renderSliderPreview(sliderValue)
       commitSliderZoom(sliderValue, latestSliderValue)
-      releaseSliderZoomGesture()
-      blurActiveElement()
+      finishSliderZoomInteraction()
     },
-    [commitSliderZoom, releaseSliderZoomGesture, renderSliderPreview],
+    [commitSliderZoom, finishSliderZoomInteraction, renderSliderPreview],
   )
 
   const controlledSliderValue = zoomToSlider(settledZoomLevel)
@@ -372,7 +380,7 @@ const TimelineZoomControls = memo(function TimelineZoomControls({
         onValueChange={handleSliderChange}
         onValueCommit={handleSliderCommit}
         onPointerDownCapture={beginSliderZoomGesture}
-        onPointerCancelCapture={releaseSliderZoomGesture}
+        onPointerCancelCapture={finishSliderZoomInteraction}
         onKeyDownCapture={() => {
           sliderKeyboardInputRef.current = true
         }}


### PR DESCRIPTION
## Summary

- extract the shared directional-window filtering and sorting used by preview prewarm planning
- release timeline zoom slider focus after normal commits and outside pointer releases
- add regression coverage for both slider release paths so Space returns to playback transport

## Root cause

The Radix zoom thumb could retain or restore focus after the slider commit callback, and the window-level outside-release fallback ended the zoom gesture without releasing that focus. The focused slider then consumed Space instead of the editor playback shortcut.

## Validation

- `npx vitest run src/features/timeline/components/timeline-header.test.tsx src/features/preview/utils/render-pump-frame-plan.test.ts` — 36 tests passed
- `npx vp check --no-fmt src/features/timeline/components/timeline-header.tsx src/features/timeline/components/timeline-header.test.tsx src/features/preview/utils/render-pump-frame-plan.ts` — clean
- `git diff --check` — clean
- existing Chrome editor session reproduced slider focus consuming Space and confirmed that releasing focus restores transport ownership
