### PR TITLE
feat(editor): cleaner layout + first-run guided tour

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -13,6 +13,7 @@ import { PreviewArea } from './preview-area'
 import { MotionPreviewArea, MotionTimelineDock } from './compose-workspace/compose-layout'
 import { InteractionLockRegion } from './interaction-lock-region'
 import { AudioMeterPanel } from './audio-meter-panel'
+import { GuidesTour } from './onboarding/guides-tour'
 import {
   importTimeline,
   importBentoLayoutDialog,
@@ -388,6 +389,8 @@ export const LoadedEditor = memo(function LoadedEditor({
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [bundleExportDialogOpen, setBundleExportDialogOpen] = useState(false)
   const [renderQueueOpen, setRenderQueueOpen] = useState(false)
+  // Re-open the first-run tour from the toolbar's "Show guides" item.
+  const [showGuides, setShowGuides] = useState(false)
   const renderQueueActiveCount = useRenderQueueStore(
     (s) => s.jobs.filter((j) => j.status === 'queued' || j.status === 'rendering').length,
   )
@@ -618,6 +621,11 @@ export const LoadedEditor = memo(function LoadedEditor({
     setRenderQueueOpen(true)
   }, [])
 
+  // Re-open the guided tour on demand, regardless of the hasSeenGuide flag.
+  const handleOpenGuides = useCallback(() => {
+    setShowGuides(true)
+  }, [])
+
   const handleExportBundle = useCallback(async () => {
     void preloadBundleExportDialog()
 
@@ -685,6 +693,7 @@ export const LoadedEditor = memo(function LoadedEditor({
           onExport={handleExport}
           onExportBundle={handleExportBundle}
           onOpenRenderQueue={handleOpenRenderQueue}
+          onOpenGuides={handleOpenGuides}
           renderQueueCount={renderQueueActiveCount}
         />
       </InteractionLockRegion>
@@ -779,7 +788,7 @@ export const LoadedEditor = memo(function LoadedEditor({
               <InteractionLockRegion locked={isMaskEditingActive} className="h-full">
                 <ErrorBoundary level="feature">
                   <div className="h-full flex overflow-hidden">
-                    <div className="min-w-0 flex-1">
+                    <div className="min-w-0 flex-1" data-guide-target="timeline">
                       {isMotionWorkspace ? (
                         <MotionTimelineDock project={project} />
                       ) : (
@@ -849,6 +858,11 @@ export const LoadedEditor = memo(function LoadedEditor({
 
       {/* Single global cursor-readout for IO (in/out) drags across all surfaces. */}
       <IoDragReadout />
+
+      {/* Guided tour — skips itself if already seen; "Show guides" forces it. */}
+      {!hidesDefaultSidebars && (
+        <GuidesTour force={showGuides} onComplete={() => setShowGuides(false)} />
+      )}
     </div>
   )
 })

--- a/src/features/editor/components/media-sidebar.tsx
+++ b/src/features/editor/components/media-sidebar.tsx
@@ -286,6 +286,55 @@ const TEXT_TEMPLATE_GROUPS: ReadonlyArray<{
 const DEFAULT_TEXT_TEMPLATE_LABEL = 'Text'
 const ADD_TEXT_TEMPLATE_LABEL = 'Add Text'
 
+type CategoryItem = {
+  id: import('@/config/editor-workspaces').EditorSidebarTab
+  icon: import('lucide-react').LucideIcon
+  label: string
+}
+
+/** One labeled cluster of category icons shown in the rail (Add / More). */
+function CategoryGroup({
+  label,
+  items,
+  activeTab,
+  leftSidebarOpen,
+  onSelect,
+}: {
+  label: string
+  items: CategoryItem[]
+  activeTab: string
+  leftSidebarOpen: boolean
+  onSelect: (id: import('@/config/editor-workspaces').EditorSidebarTab) => void
+}) {
+  return (
+    <div className="flex flex-shrink-0 flex-col items-center gap-1 py-1.5">
+      <span className="mb-0.5 flex-shrink-0 text-[9px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+        {label}
+      </span>
+      <div className="flex flex-col gap-1">
+        {items.map(({ id, icon: Icon, label }) => (
+          <button
+            key={id}
+            onClick={() => onSelect(id)}
+            className={`
+              w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,color] duration-150 active:scale-95
+              ${
+                activeTab === id && leftSidebarOpen
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
+              }
+            `}
+            data-tooltip={label}
+            data-tooltip-side="right"
+          >
+            <Icon className="w-4 h-4" />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export const MediaSidebar = memo(function MediaSidebar() {
   const { t } = useTranslation()
   const editorDensity = useSettingsStore((s) => s.editorDensity)
@@ -431,8 +480,7 @@ export const MediaSidebar = memo(function MediaSidebar() {
     const { tracks, fps, addItemOnNewTrack } = useTimelineStore.getState()
     const { activeTrackId, selectItems, setActiveTrack } = useSelectionStore.getState()
     const currentProject = useProjectStore.getState().currentProject
-    const activeCompositionId =
-      useCompositionNavigationStore.getState().activeCompositionId
+    const activeCompositionId = useCompositionNavigationStore.getState().activeCompositionId
     const activeComposition = activeCompositionId
       ? useCompositionsStore.getState().getComposition(activeCompositionId)
       : undefined
@@ -535,11 +583,13 @@ export const MediaSidebar = memo(function MediaSidebar() {
 
   // Category items for the vertical nav
   const categories = [
+    // Add group — the everyday insertables.
     { id: 'media' as const, icon: Film, label: t('editor.mediaSidebar.media') },
     { id: 'text' as const, icon: Type, label: t('editor.mediaSidebar.text') },
     { id: 'shapes' as const, icon: Pentagon, label: t('editor.mediaSidebar.shapes') },
-    { id: 'effects' as const, icon: Layers, label: t('editor.mediaSidebar.effects') },
     { id: 'transitions' as const, icon: Blend, label: t('editor.mediaSidebar.transitions') },
+    // More group — advanced tools surfaced behind a label so the rail reads clearly.
+    { id: 'effects' as const, icon: Layers, label: t('editor.mediaSidebar.effects') },
     { id: 'lottie' as const, icon: Sticker, label: t('lottieBrowser.tabLabel') },
     { id: 'transcript' as const, icon: Captions, label: t('transcript.tabLabel') },
     { id: 'ai' as const, icon: WandSparkles, label: t('editor.mediaSidebar.ai') },
@@ -584,6 +634,22 @@ export const MediaSidebar = memo(function MediaSidebar() {
     }, 0)
   }, [])
 
+  // Shared handler for the grouped category rail: tapping the active tab
+  // collapses the panel; any other tab opens it and (for effects) triggers the
+  // GPU preview sweep. Extracted so the Add/More groups keep one behavior.
+  const handleCategorySelect = useCallback(
+    (id: import('@/config/editor-workspaces').EditorSidebarTab) => {
+      if (activeTab === id && leftSidebarOpen) {
+        toggleLeftSidebar()
+      } else {
+        setActiveTab(id)
+        if (!leftSidebarOpen) toggleLeftSidebar()
+        if (id === 'effects') triggerPreviews()
+      }
+    },
+    [activeTab, leftSidebarOpen, toggleLeftSidebar, setActiveTab, triggerPreviews],
+  )
+
   return (
     <div className="flex h-full flex-shrink-0">
       {/* Vertical Category Bar */}
@@ -618,34 +684,26 @@ export const MediaSidebar = memo(function MediaSidebar() {
           </button>
         </div>
 
-        {/* Category Icons */}
-        <div className="flex flex-col gap-1 py-1.5">
-          {categories.map(({ id, icon: Icon, label }) => (
-            <button
-              key={id}
-              onClick={() => {
-                if (activeTab === id && leftSidebarOpen) {
-                  toggleLeftSidebar()
-                } else {
-                  setActiveTab(id)
-                  if (!leftSidebarOpen) toggleLeftSidebar()
-                  if (id === 'effects') triggerPreviews()
-                }
-              }}
-              className={`
-                w-9 h-9 rounded-lg flex items-center justify-center transition-[transform,background-color,color] duration-150 active:scale-95
-                ${
-                  activeTab === id && leftSidebarOpen
-                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
-                }
-              `}
-              data-tooltip={label}
-              data-tooltip-side="right"
-            >
-              <Icon className="w-4 h-4" />
-            </button>
-          ))}
+        {/* Category Icons — split into labeled Add / More groups so the rail
+            reads at a glance instead of an undifferentiated wall of icons. */}
+        <div
+          className="flex flex-col overflow-y-auto overflow-x-hidden"
+          data-guide-target="media-rail"
+        >
+          <CategoryGroup
+            label={t('editor.mediaSidebar.groupAdd')}
+            items={categories.slice(0, 4)}
+            activeTab={activeTab}
+            leftSidebarOpen={leftSidebarOpen}
+            onSelect={handleCategorySelect}
+          />
+          <CategoryGroup
+            label={t('editor.mediaSidebar.groupMore')}
+            items={categories.slice(4)}
+            activeTab={activeTab}
+            leftSidebarOpen={leftSidebarOpen}
+            onSelect={handleCategorySelect}
+          />
         </div>
       </div>
 

--- a/src/features/editor/components/onboarding/guides-tour.tsx
+++ b/src/features/editor/components/onboarding/guides-tour.tsx
@@ -1,0 +1,182 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { Button } from '@/components/ui/button'
+import { useSettingsStore } from '@/features/editor/deps/settings'
+import { cn } from '@/shared/ui/cn'
+
+interface GuideStep {
+  target: string
+  title: string
+  body: string
+}
+
+const TARGET_BY_STEP: Array<[string, string]> = [
+  ['workspaces', 'onboarding.step1'],
+  ['media-rail', 'onboarding.step2'],
+  ['preview', 'onboarding.step3'],
+  ['timeline', 'onboarding.step4'],
+  ['properties', 'onboarding.step5'],
+  ['export', 'onboarding.step6'],
+]
+
+/** Distance from the target edge to the tooltip (px). */
+const CARD_PAD = 16
+const CARD_MAX_WIDTH = 320
+
+/**
+ * Lightweight first-run guided tour. Renders a dimmed overlay with a spotlight
+ * on the target element and a small card with Prev / Next / Skip buttons. It
+ * never blocks editing — everything except the card/progress dots is
+ * pointer-events-none — and dismiss (Skip / Done) persists via the settings
+ * store's hasSeenGuide flag. Idempotent: returns null when already seen.
+ */
+export const GuidesTour = memo(function GuidesTour({
+  force = false,
+  onComplete,
+}: {
+  /** When true, show even if hasSeenGuide is set (used by "Show guides"). */
+  force?: boolean
+  onComplete?: () => void
+}) {
+  const { t } = useTranslation()
+  const hasSeenGuide = useSettingsStore((s) => s.hasSeenGuide)
+  const setSetting = useSettingsStore((s) => s.setSetting)
+  const prefersReducedMotion = useReducedMotion()
+
+  const steps = useMemo<GuideStep[]>(
+    () =>
+      TARGET_BY_STEP.map(([target, key]) => ({
+        target: `[data-guide-target="${target}"]`,
+        title: t(`${key}.title`),
+        body: t(`${key}.body`),
+      })),
+    // Intentionally rebuild only when the translation function changes.
+    [t],
+  )
+
+  const [index, setIndex] = useState(0)
+  const [rect, setRect] = useState<DOMRect | null>(null)
+
+  const active = force || !hasSeenGuide
+  const step = steps[Math.min(index, steps.length - 1)]
+
+  const finish = useCallback(() => {
+    setSetting('hasSeenGuide', true)
+    onComplete?.()
+  }, [setSetting, onComplete])
+
+  // Measure the target each time the step changes and on resize/scroll, so the
+  // spotlight follows the element. Falls back to a centered card if not found.
+  useEffect(() => {
+    if (!active) return
+    const measure = () => {
+      const el = document.querySelector(step?.target ?? '')
+      setRect(el ? el.getBoundingClientRect() : null)
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    document.addEventListener('scroll', measure, true)
+    return () => {
+      window.removeEventListener('resize', measure)
+      document.removeEventListener('scroll', measure, true)
+    }
+  }, [active, step?.target, index])
+
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        finish()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, finish])
+
+  if (!active || !step) return null
+
+  const cardStyle: CSSProperties = rect
+    ? {
+        top: rect.bottom + CARD_PAD,
+        left: rect.right + CARD_PAD + CARD_MAX_WIDTH > window.innerWidth ? undefined : rect.left,
+        right: rect.right + CARD_PAD + CARD_MAX_WIDTH > window.innerWidth ? CARD_PAD : undefined,
+        width: Math.max(rect.width, 240),
+      }
+    : { top: '40%', left: '50%', width: 320 }
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[100]">
+      {/* Spotlight: dim everything except the target with a huge shadow ring. */}
+      {rect && (
+        <motion.div
+          className="absolute"
+          initial={false}
+          animate={{
+            left: rect.left - 4,
+            top: rect.top - 4,
+            width: rect.width + 8,
+            height: rect.height + 8,
+          }}
+          transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.25, ease: 'easeOut' }}
+          style={{ boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)', borderRadius: 6 }}
+        />
+      )}
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          className="pointer-events-auto absolute z-10 w-60 rounded-xl border border-border bg-popover p-4 shadow-xl"
+          style={cardStyle}
+          initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.2 }}
+          role="dialog"
+          aria-label={step.title}
+        >
+          <h3 className="text-sm font-semibold text-foreground">{step.title}</h3>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <Button variant="ghost" size="sm" onClick={finish}>
+              {t('onboarding.dismiss')}
+            </Button>
+            <div className="flex items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={index === 0}
+                onClick={() => setIndex((i) => Math.max(0, i - 1))}
+              >
+                {t('onboarding.prev')}
+              </Button>
+              {index < steps.length - 1 ? (
+                <Button size="sm" onClick={() => setIndex((i) => i + 1)}>
+                  {t('onboarding.next')}
+                </Button>
+              ) : (
+                <Button size="sm" onClick={finish}>
+                  {t('onboarding.done')}
+                </Button>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+
+      {/* Progress dots */}
+      <div className="pointer-events-auto absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-background/80 px-2 py-1">
+        {steps.map((s, i) => (
+          <span
+            key={s.target}
+            className={cn(
+              'h-1.5 w-1.5 rounded-full',
+              i === index ? 'bg-primary' : 'bg-muted-foreground/40',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  )
+})

--- a/src/features/editor/components/preview-area.tsx
+++ b/src/features/editor/components/preview-area.tsx
@@ -519,6 +519,7 @@ export const PreviewArea = memo(function PreviewArea({
       className="flex-1 flex min-h-0 min-w-0 relative"
       role="region"
       aria-label="Preview area"
+      data-guide-target="preview"
     >
       {sourcePreviewMediaId && (
         <>

--- a/src/features/editor/components/properties-sidebar/index.tsx
+++ b/src/features/editor/components/properties-sidebar/index.tsx
@@ -254,6 +254,7 @@ export const PropertiesSidebar = memo(function PropertiesSidebar() {
           tracks the pointer instead of easing behind it. */}
       <motion.div
         className="panel-bg border-l border-border shrink-0 relative h-full overflow-hidden"
+        data-guide-target="properties"
         initial={false}
         animate={{ width: rightSidebarOpen ? rightSidebarWidth : 0 }}
         transition={
@@ -303,16 +304,11 @@ export const PropertiesSidebar = memo(function PropertiesSidebar() {
                 </Button>
                 <Settings2 className="w-3 h-3 shrink-0 text-muted-foreground" />
                 <h2 className="min-w-0 flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
-                  <span className="shrink-0 uppercase tracking-wide">
-                    {headerLabel}
-                  </span>
+                  <span className="shrink-0 uppercase tracking-wide">{headerLabel}</span>
                   {headerContext && (
                     <>
                       <span className="shrink-0">-</span>
-                      <span
-                        className="truncate normal-case tracking-normal"
-                        title={headerTitle}
-                      >
+                      <span className="truncate normal-case tracking-normal" title={headerTitle}>
                         {headerContext}
                       </span>
                     </>

--- a/src/features/editor/components/toolbar-more-menu.tsx
+++ b/src/features/editor/components/toolbar-more-menu.tsx
@@ -1,0 +1,116 @@
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { BookOpen, Compass, Ellipsis, Github, Keyboard, Settings, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { DiscordIcon } from '@/components/brand/discord-icon'
+import { DISCORD_INVITE_URL } from '@/config/community'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { LanguageSwitcher } from '@/shared/ui/language-switcher'
+
+interface MoreMenuProps {
+  hasUnseenWhatsNew?: boolean
+  onOpenWhatsNew: () => void
+  onOpenSettings: () => void
+  onOpenShortcuts: () => void
+  onOpenGuides?: () => void
+}
+
+/**
+ * Collapses the toolbar's secondary links (socials, docs, settings, shortcuts,
+ * language) behind a single "⋯" menu so the primary Edit actions stay front
+ * and center for new users.
+ */
+export const MoreMenu = memo(function MoreMenu({
+  hasUnseenWhatsNew = false,
+  onOpenWhatsNew,
+  onOpenSettings,
+  onOpenShortcuts,
+  onOpenGuides,
+}: MoreMenuProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            data-tooltip={t('toolbar.moreMenu')}
+            data-tooltip-side="bottom"
+            aria-label={t('toolbar.moreMenu')}
+          >
+            <Ellipsis className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+            {t('toolbar.moreMenu')}
+          </DropdownMenuLabel>
+          <DropdownMenuItem asChild className="gap-2">
+            <a
+              href="https://github.com/walterlow/freecut"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Github className="h-4 w-4" />
+              {t('toolbar.viewOnGitHub')}
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="gap-2">
+            <a href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+              <DiscordIcon className="h-4 w-4" />
+              {t('toolbar.joinDiscord')}
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="gap-2">
+            <a href="/docs" target="_blank" rel="noopener noreferrer">
+              <BookOpen className="h-4 w-4" />
+              {t('toolbar.userGuide')}
+            </a>
+          </DropdownMenuItem>
+          {onOpenGuides && (
+            <DropdownMenuItem onClick={onOpenGuides} className="gap-2">
+              <Compass className="h-4 w-4" />
+              {t('toolbar.showGuides')}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={onOpenWhatsNew} className="gap-2">
+            <span className="relative">
+              <Sparkles className="h-4 w-4" />
+              {hasUnseenWhatsNew && (
+                <span
+                  className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-primary"
+                  aria-hidden="true"
+                />
+              )}
+            </span>
+            {t('toolbar.whatsNew')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onOpenSettings} className="gap-2">
+            <Settings className="h-4 w-4" />
+            {t('toolbar.settings')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onOpenShortcuts} className="gap-2">
+            <Keyboard className="h-4 w-4" />
+            {t('toolbar.keyboardShortcuts')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <span className="text-sm text-muted-foreground">{t('language.label')}</span>
+            <LanguageSwitcher size="sm" align="end" side="bottom" />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
+})

--- a/src/features/editor/components/toolbar.tsx
+++ b/src/features/editor/components/toolbar.tsx
@@ -3,22 +3,15 @@ import { useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import {
   ArrowLeft,
-  BookOpen,
   Bug,
   ChevronDown,
   Download,
   FolderArchive,
-  Github,
-  Keyboard,
   ListVideo,
   Save,
-  Settings,
-  Sparkles,
   Video,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { DiscordIcon } from '@/components/brand/discord-icon'
-import { DISCORD_INVITE_URL } from '@/config/community'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,12 +25,12 @@ import { ProjectDebugPanel } from './project-debug-panel'
 import { SettingsDialog } from './settings-dialog'
 import { ShortcutsDialog } from './shortcuts-dialog'
 import { UnsavedChangesDialog } from './unsaved-changes-dialog'
+import { MoreMenu } from './toolbar-more-menu'
 import { WorkspaceSwitcher } from './workspace-switcher'
 import { WhatsNewDialog } from './whats-new-dialog'
 import { hasUnseenChangelog } from './whats-new-seen'
 import { EDITOR_LAYOUT_CSS_VALUES } from '@/config/editor-layout'
 import { cn } from '@/shared/ui/cn'
-import { LanguageSwitcher } from '@/shared/ui/language-switcher'
 import { useDebugStore } from '@/features/editor/stores/debug-store'
 import { useItemsStore, useTimelineStore } from '@/features/editor/deps/timeline-store'
 import { useMediaLibraryStore } from '@/features/editor/deps/media-library'
@@ -71,6 +64,8 @@ interface ToolbarProps {
   onExport?: () => void
   onExportBundle?: () => void
   onOpenRenderQueue?: () => void
+  /** Re-open the first-run guided tour from the ⋯ menu. */
+  onOpenGuides?: () => void
   /** Number of queued + rendering jobs, shown as a badge on the queue button. */
   renderQueueCount?: number
 }
@@ -82,6 +77,7 @@ export const Toolbar = memo(function Toolbar({
   onExport,
   onExportBundle,
   onOpenRenderQueue,
+  onOpenGuides,
   renderQueueCount = 0,
 }: ToolbarProps) {
   const navigate = useNavigate()
@@ -98,18 +94,15 @@ export const Toolbar = memo(function Toolbar({
   const maxItemEndFrame = useItemsStore((state) => state.maxItemEndFrame)
   const mediaDependencyIds = useItemsStore((state) => state.mediaDependencyIds)
   const brokenMediaIds = useMediaLibraryStore((state) => state.brokenMediaIds)
-  const projectSummary = useMemo(
-    () => {
-      const projectMediaIds = new Set(mediaDependencyIds)
-      return {
-        durationSeconds: project.fps > 0 ? maxItemEndFrame / project.fps : 0,
-        clipCount: itemCount,
-        mediaCount: mediaDependencyIds.length,
-        brokenMediaCount: brokenMediaIds.filter((mediaId) => projectMediaIds.has(mediaId)).length,
-      }
-    },
-    [brokenMediaIds, itemCount, maxItemEndFrame, mediaDependencyIds, project.fps],
-  )
+  const projectSummary = useMemo(() => {
+    const projectMediaIds = new Set(mediaDependencyIds)
+    return {
+      durationSeconds: project.fps > 0 ? maxItemEndFrame / project.fps : 0,
+      clipCount: itemCount,
+      mediaCount: mediaDependencyIds.length,
+      brokenMediaCount: brokenMediaIds.filter((mediaId) => projectMediaIds.has(mediaId)).length,
+    }
+  }, [brokenMediaIds, itemCount, maxItemEndFrame, mediaDependencyIds, project.fps])
 
   useEffect(() => {
     setHasUnseenWhatsNew(hasUnseenChangelog())
@@ -229,87 +222,13 @@ export const Toolbar = memo(function Toolbar({
           <DebugPopover projectId={projectId} />
         )}
 
-        {/* Socials */}
-        <Button variant="outline" size="icon" className="h-7 w-7" asChild>
-          <a
-            href="https://github.com/walterlow/freecut"
-            target="_blank"
-            rel="noopener noreferrer"
-            data-tooltip={t('toolbar.viewOnGitHub')}
-            data-tooltip-side="bottom"
-            aria-label={t('toolbar.viewOnGitHub')}
-          >
-            <Github className="h-4 w-4" />
-          </a>
-        </Button>
-        <Button variant="outline" size="icon" className="h-7 w-7" asChild>
-          <a
-            href={DISCORD_INVITE_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            data-tooltip={t('toolbar.joinDiscord')}
-            data-tooltip-side="bottom"
-            aria-label={t('toolbar.joinDiscord')}
-          >
-            <DiscordIcon className="h-4 w-4" />
-          </a>
-        </Button>
-
-        <Separator orientation="vertical" className="h-5" />
-
-        {/* Utility */}
-        <Button variant="outline" size="icon" className="h-7 w-7" asChild>
-          <a
-            href="/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            data-tooltip="User Guide"
-            data-tooltip-side="bottom"
-            aria-label="User Guide"
-          >
-            <BookOpen className="h-4 w-4" />
-          </a>
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          className="h-7 w-7 relative"
-          onClick={openWhatsNew}
-          data-tooltip={t('toolbar.whatsNew')}
-          data-tooltip-side="bottom"
-          aria-label={t('toolbar.whatsNewAria')}
-        >
-          <Sparkles className="h-4 w-4" />
-          {hasUnseenWhatsNew && (
-            <span
-              className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-primary"
-              aria-hidden="true"
-            />
-          )}
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          className="h-7 w-7"
-          onClick={() => setShowSettingsDialog(true)}
-          data-tooltip={t('toolbar.settings')}
-          data-tooltip-side="bottom"
-          aria-label={t('toolbar.settings')}
-        >
-          <Settings className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          className="h-7 w-7"
-          onClick={() => setShowShortcutsDialog(true)}
-          data-tooltip={t('toolbar.keyboardShortcuts')}
-          data-tooltip-side="bottom"
-          aria-label={t('toolbar.keyboardShortcutsAria')}
-        >
-          <Keyboard className="h-4 w-4" />
-        </Button>
-        <LanguageSwitcher size="sm" align="end" side="bottom" />
+        <MoreMenu
+          hasUnseenWhatsNew={hasUnseenWhatsNew}
+          onOpenWhatsNew={openWhatsNew}
+          onOpenSettings={() => setShowSettingsDialog(true)}
+          onOpenShortcuts={() => setShowShortcutsDialog(true)}
+          onOpenGuides={onOpenGuides}
+        />
 
         <Separator orientation="vertical" className="h-5" />
 
@@ -353,7 +272,7 @@ export const Toolbar = memo(function Toolbar({
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button size="sm" className="gap-1.5 glow-primary-sm">
+            <Button size="sm" className="gap-1.5 glow-primary-sm" data-guide-target="export">
               <Download className="h-4 w-4" />
               {t('toolbar.export')}
               <ChevronDown className="h-3 w-3" />

--- a/src/features/editor/components/workspace-switcher.tsx
+++ b/src/features/editor/components/workspace-switcher.tsx
@@ -31,6 +31,7 @@ export const WorkspaceSwitcher = memo(function WorkspaceSwitcher() {
       role="tablist"
       aria-label={t('toolbar.workspaces.label')}
       className="flex items-center gap-0.5 rounded-md bg-muted p-0.5"
+      data-guide-target="workspaces"
     >
       {WORKSPACE_ITEMS.map(({ id, icon: Icon, labelKey }) => {
         const isActive = workspace === id

--- a/src/features/media-library/components/media-grid.tsx
+++ b/src/features/media-library/components/media-grid.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2, Upload, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { createLogger } from '@/shared/logging/logger'
 
 const logger = createLogger('MediaGrid')
@@ -257,9 +258,16 @@ const MediaGridBase = memo(function MediaGridBase({
             <p className="text-sm text-muted-foreground font-light mb-4">
               {t('media.grid.emptyHint')}
             </p>
-            <span className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground mb-4">
+            <Button
+              type="button"
+              variant="default"
+              className="gap-2 mb-2"
+              onClick={handleEmptyStateClick}
+            >
+              <Upload className="w-4 h-4" />
               {t('media.grid.importButton')}
-            </span>
+            </Button>
+            <p className="text-xs text-muted-foreground/80 mb-4">{t('media.grid.dragDropHint')}</p>
             <div className="flex flex-wrap justify-center gap-2">
               {getSupportedMediaFormatLabels().map((label) => (
                 <span

--- a/src/features/settings/stores/settings-store.test.ts
+++ b/src/features/settings/stores/settings-store.test.ts
@@ -27,6 +27,11 @@ describe('settings-store', () => {
       expect(useSettingsStore.getState().snapEnabled).toBe(false)
     })
 
+    it('persists the guided-tour seen flag', () => {
+      useSettingsStore.getState().setSetting('hasSeenGuide', true)
+      expect(useSettingsStore.getState().hasSeenGuide).toBe(true)
+    })
+
     it('updates string settings', () => {
       useSettingsStore.getState().setSetting('defaultWhisperLanguage', 'en')
       expect(useSettingsStore.getState().defaultWhisperLanguage).toBe('en')

--- a/src/features/settings/stores/settings-store.ts
+++ b/src/features/settings/stores/settings-store.ts
@@ -61,6 +61,9 @@ interface AppSettings {
 
   // Keyboard shortcuts
   hotkeyOverrides: HotkeyOverrideMap
+
+  // Onboarding — whether the first-run guided tour has been shown (or skipped).
+  hasSeenGuide: boolean
 }
 
 export type CaptionSearchMode = 'keyword' | 'semantic'
@@ -168,6 +171,9 @@ const DEFAULT_SETTINGS: AppSettings = {
 
   // Keyboard shortcuts
   hotkeyOverrides: {},
+
+  // Onboarding defaults to not-yet-seen so new users get the guided tour once.
+  hasSeenGuide: false,
 }
 
 /**
@@ -289,15 +295,17 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'freecut-settings',
-      version: 2,
+      version: 3,
       // v1: auto-save now defaults on. Enable it for anyone persisted under the old
       // default (0 = disabled) so a crashed or closed tab can't lose a long edit.
-      // After this one-time bump the user's choice is sticky again (toggle in
+      // After this one-time bump the user's choice becomes sticky again (toggle in
       // Settings → General).
       // v2: Parakeet TDT is the new default ASR engine (~10x faster than Whisper base
       // with native punctuation). Upgrade anyone still on the previous default
       // ('whisper-base') so the speed win applies without manual opt-in; deliberate
       // tiny/small/large choices are preserved.
+      // v3: introduced the first-run guided tour. Existing users haven't seen it and
+      // shouldn't be pestered, so mark it as seen for anything persisted before v3.
       migrate: (persistedState, version) => {
         let state = (persistedState as Partial<AppSettings> | undefined) ?? {}
         if (version < 1 && (state.autoSaveInterval == null || state.autoSaveInterval <= 0)) {
@@ -305,6 +313,10 @@ export const useSettingsStore = create<SettingsStore>()(
         }
         if (version < 2 && state.defaultWhisperModel === 'whisper-base') {
           state = { ...state, defaultWhisperModel: 'parakeet-tdt-v3' }
+        }
+        // Existing users (pre-v3) should not get the tour — only brand-new users do.
+        if (version < 3 && state.hasSeenGuide == null) {
+          state = { ...state, hasSeenGuide: true }
         }
         return state
       },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -60,7 +60,10 @@
     "saveAria": "Projekt speichern",
     "export": "Exportieren",
     "exportVideo": "Video exportieren",
-    "downloadProjectZip": "Projekt herunterladen (.zip)"
+    "downloadProjectZip": "Projekt herunterladen (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Nicht gespeicherte Änderungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -60,7 +60,10 @@
     "saveAria": "Save project",
     "export": "Export",
     "exportVideo": "Export Video",
-    "downloadProjectZip": "Download Project (.zip)"
+    "downloadProjectZip": "Download Project (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Unsaved Changes",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -60,7 +60,10 @@
     "saveAria": "Guardar proyecto",
     "export": "Exportar",
     "exportVideo": "Exportar vídeo",
-    "downloadProjectZip": "Descargar proyecto (.zip)"
+    "downloadProjectZip": "Descargar proyecto (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Cambios sin guardar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -60,7 +60,10 @@
     "saveAria": "Enregistrer le projet",
     "export": "Exporter",
     "exportVideo": "Exporter la vidéo",
-    "downloadProjectZip": "Télécharger le projet (.zip)"
+    "downloadProjectZip": "Télécharger le projet (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Modifications non enregistrées",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -60,7 +60,10 @@
     "saveAria": "プロジェクトを保存",
     "export": "書き出し",
     "exportVideo": "動画を書き出し",
-    "downloadProjectZip": "プロジェクトをダウンロード (.zip)"
+    "downloadProjectZip": "プロジェクトをダウンロード (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "未保存の変更",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -60,7 +60,10 @@
     "saveAria": "프로젝트 저장",
     "export": "내보내기",
     "exportVideo": "동영상 내보내기",
-    "downloadProjectZip": "프로젝트 다운로드 (.zip)"
+    "downloadProjectZip": "프로젝트 다운로드 (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "저장하지 않은 변경 사항",

--- a/src/i18n/locales/partials/de/editor.json
+++ b/src/i18n/locales/partials/de/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "Eine eigene Pfadform mit dem Stiftwerkzeug zeichnen",
       "adjustmentLayer": "Einstellungsebene",
       "blankAdjustmentLayer": "Leere Einstellungsebene",
-      "presets": "Vorgaben"
+      "presets": "Vorgaben",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "Text",

--- a/src/i18n/locales/partials/de/media.json
+++ b/src/i18n/locales/partials/de/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "Medien werden vorbereitet…",
       "loadingTitle": "Medien werden geladen…",
       "importButton": "Medien importieren",
-      "folderDropUnsupported": "Ordner werden noch nicht unterstützt. Lege Mediendateien direkt ab."
+      "folderDropUnsupported": "Ordner werden noch nicht unterstützt. Lege Mediendateien direkt ab.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "Codec",

--- a/src/i18n/locales/partials/de/onboarding.json
+++ b/src/i18n/locales/partials/de/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/en/editor.json
+++ b/src/i18n/locales/partials/en/editor.json
@@ -677,6 +677,8 @@
       "speed": "Speed"
     },
     "mediaSidebar": {
+      "groupAdd": "Add",
+      "groupMore": "More",
       "media": "Media",
       "text": "Text",
       "shapes": "Shapes",

--- a/src/i18n/locales/partials/en/media.json
+++ b/src/i18n/locales/partials/en/media.json
@@ -100,6 +100,7 @@
       "loadingSubtitle": "Loading Subtitle",
       "loadingTitle": "Loading media…",
       "importButton": "Import media",
+      "dragDropHint": "or drag & drop a file anywhere to begin",
       "folderDropUnsupported": "Folders are not supported yet. Drop media files directly."
     },
     "info": {

--- a/src/i18n/locales/partials/en/onboarding.json
+++ b/src/i18n/locales/partials/en/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/es/editor.json
+++ b/src/i18n/locales/partials/es/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "Dibuja una forma de ruta personalizada con la herramienta pluma",
       "adjustmentLayer": "Capa de ajuste",
       "blankAdjustmentLayer": "Capa de ajuste en blanco",
-      "presets": "Preajustes"
+      "presets": "Preajustes",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "Texto",

--- a/src/i18n/locales/partials/es/media.json
+++ b/src/i18n/locales/partials/es/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "Preparando tus medios…",
       "loadingTitle": "Cargando medios…",
       "importButton": "Importar medios",
-      "folderDropUnsupported": "Las carpetas aún no son compatibles. Suelta archivos multimedia directamente."
+      "folderDropUnsupported": "Las carpetas aún no son compatibles. Suelta archivos multimedia directamente.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "Códec",

--- a/src/i18n/locales/partials/es/onboarding.json
+++ b/src/i18n/locales/partials/es/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/fr/editor.json
+++ b/src/i18n/locales/partials/fr/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "Dessiner une forme de tracé personnalisée avec l'outil plume",
       "adjustmentLayer": "Calque d'ajustement",
       "blankAdjustmentLayer": "Calque d'ajustement vide",
-      "presets": "Préréglages"
+      "presets": "Préréglages",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "Texte",

--- a/src/i18n/locales/partials/fr/media.json
+++ b/src/i18n/locales/partials/fr/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "Préparation de vos médias…",
       "loadingTitle": "Chargement des médias…",
       "importButton": "Importer des médias",
-      "folderDropUnsupported": "Les dossiers ne sont pas encore pris en charge. Déposez directement les fichiers multimédias."
+      "folderDropUnsupported": "Les dossiers ne sont pas encore pris en charge. Déposez directement les fichiers multimédias.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "Codec",

--- a/src/i18n/locales/partials/fr/onboarding.json
+++ b/src/i18n/locales/partials/fr/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/ja/editor.json
+++ b/src/i18n/locales/partials/ja/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "ペンツールでカスタムパス図形を描画",
       "adjustmentLayer": "調整レイヤー",
       "blankAdjustmentLayer": "空の調整レイヤー",
-      "presets": "プリセット"
+      "presets": "プリセット",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "テキスト",

--- a/src/i18n/locales/partials/ja/media.json
+++ b/src/i18n/locales/partials/ja/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "メディアを準備中…",
       "loadingTitle": "メディアを読み込み中…",
       "importButton": "メディアをインポート",
-      "folderDropUnsupported": "フォルダーはまだサポートされていません。メディアファイルを直接ドロップしてください。"
+      "folderDropUnsupported": "フォルダーはまだサポートされていません。メディアファイルを直接ドロップしてください。",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "コーデック",

--- a/src/i18n/locales/partials/ja/onboarding.json
+++ b/src/i18n/locales/partials/ja/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/ko/editor.json
+++ b/src/i18n/locales/partials/ko/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "펜 도구로 사용자 지정 경로 도형 그리기",
       "adjustmentLayer": "조정 레이어",
       "blankAdjustmentLayer": "빈 조정 레이어",
-      "presets": "프리셋"
+      "presets": "프리셋",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "텍스트",

--- a/src/i18n/locales/partials/ko/media.json
+++ b/src/i18n/locales/partials/ko/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "미디어를 준비하는 중…",
       "loadingTitle": "미디어를 불러오는 중…",
       "importButton": "미디어 가져오기",
-      "folderDropUnsupported": "폴더는 아직 지원되지 않습니다. 미디어 파일을 직접 놓으세요."
+      "folderDropUnsupported": "폴더는 아직 지원되지 않습니다. 미디어 파일을 직접 놓으세요.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "코덱",

--- a/src/i18n/locales/partials/ko/onboarding.json
+++ b/src/i18n/locales/partials/ko/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/pt-BR/editor.json
+++ b/src/i18n/locales/partials/pt-BR/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "Desenhe uma forma de caminho personalizada com a ferramenta caneta",
       "adjustmentLayer": "Camada de ajuste",
       "blankAdjustmentLayer": "Camada de ajuste em branco",
-      "presets": "Predefinições"
+      "presets": "Predefinições",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "Texto",

--- a/src/i18n/locales/partials/pt-BR/media.json
+++ b/src/i18n/locales/partials/pt-BR/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "Carregando subtitulo",
       "loadingTitle": "Carregando mídia…",
       "importButton": "Importar mídia",
-      "folderDropUnsupported": "Pastas ainda não são compatíveis. Solte arquivos de mídia diretamente."
+      "folderDropUnsupported": "Pastas ainda não são compatíveis. Solte arquivos de mídia diretamente.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "Codificador",

--- a/src/i18n/locales/partials/pt-BR/onboarding.json
+++ b/src/i18n/locales/partials/pt-BR/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/tr/editor.json
+++ b/src/i18n/locales/partials/tr/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "Kalem aracıyla özel bir yol şekli çizin",
       "adjustmentLayer": "Ayar katmanı",
       "blankAdjustmentLayer": "Boş ayar katmanı",
-      "presets": "Ön Ayarlar"
+      "presets": "Ön Ayarlar",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "Metin",

--- a/src/i18n/locales/partials/tr/media.json
+++ b/src/i18n/locales/partials/tr/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "Medya kitaplığı hazırlanıyor.",
       "loadingTitle": "Medya yükleniyor…",
       "importButton": "Medya içe aktar",
-      "folderDropUnsupported": "Klasörler henüz desteklenmiyor. Medya dosyalarını doğrudan bırakın."
+      "folderDropUnsupported": "Klasörler henüz desteklenmiyor. Medya dosyalarını doğrudan bırakın.",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "Kodek",

--- a/src/i18n/locales/partials/tr/onboarding.json
+++ b/src/i18n/locales/partials/tr/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/partials/zh/editor.json
+++ b/src/i18n/locales/partials/zh/editor.json
@@ -697,7 +697,9 @@
       "penToolHint": "使用钢笔工具绘制自定义路径形状",
       "adjustmentLayer": "调整图层",
       "blankAdjustmentLayer": "空白调整图层",
-      "presets": "预设"
+      "presets": "预设",
+      "groupAdd": "Add",
+      "groupMore": "More"
     },
     "textSection": {
       "sectionTitle": "文本",

--- a/src/i18n/locales/partials/zh/media.json
+++ b/src/i18n/locales/partials/zh/media.json
@@ -100,7 +100,8 @@
       "loadingSubtitle": "正在准备媒体…",
       "loadingTitle": "正在加载媒体…",
       "importButton": "导入媒体",
-      "folderDropUnsupported": "尚不支持文件夹。请直接拖放媒体文件。"
+      "folderDropUnsupported": "尚不支持文件夹。请直接拖放媒体文件。",
+      "dragDropHint": "or drag & drop a file anywhere to begin"
     },
     "info": {
       "codec": "编解码器",

--- a/src/i18n/locales/partials/zh/onboarding.json
+++ b/src/i18n/locales/partials/zh/onboarding.json
@@ -1,0 +1,33 @@
+{
+  "onboarding": {
+    "dismiss": "Skip tour",
+    "prev": "Back",
+    "next": "Next",
+    "done": "Done",
+    "title": "Welcome to FreeCut",
+    "step1": {
+      "title": "Workspaces",
+      "body": "Switch between Edit, Color and Motion workspaces."
+    },
+    "step2": {
+      "title": "Add media",
+      "body": "Import media, text, shapes and transitions from here."
+    },
+    "step3": {
+      "title": "Preview",
+      "body": "Watch your edit here and scrub through the timeline."
+    },
+    "step4": {
+      "title": "Timeline",
+      "body": "Drag clips, trim, split and arrange your video."
+    },
+    "step5": {
+      "title": "Properties",
+      "body": "Select a clip to tune its properties, effects and audio."
+    },
+    "step6": {
+      "title": "Export",
+      "body": "Ready when you are — export your finished video."
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -60,7 +60,10 @@
     "saveAria": "Salvar projeto",
     "export": "Exportar",
     "exportVideo": "Exportar vídeo",
-    "downloadProjectZip": "Baixar projeto (.zip)"
+    "downloadProjectZip": "Baixar projeto (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Alterações não salvas",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -60,7 +60,10 @@
     "saveAria": "Projeyi kaydet",
     "export": "Dışa Aktar",
     "exportVideo": "Videoyu Dışa Aktar",
-    "downloadProjectZip": "Projeyi İndir (.zip)"
+    "downloadProjectZip": "Projeyi İndir (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "Kaydedilmemiş Değişiklikler",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -60,7 +60,10 @@
     "saveAria": "保存项目",
     "export": "导出",
     "exportVideo": "导出视频",
-    "downloadProjectZip": "下载项目 (.zip)"
+    "downloadProjectZip": "下载项目 (.zip)",
+    "moreMenu": "More",
+    "showGuides": "Show guides",
+    "userGuide": "User Guide"
   },
   "unsavedChanges": {
     "title": "未保存的更改",


### PR DESCRIPTION
- Group left media rail into labeled ADD / More sections
- Collapse secondary toolbar links (socials/docs/settings) into a More menu
- Promote empty-state import hint to a button + drag hint
- Add dismissible guided tour (settings-store hasSeenGuide, re-openable)...