### PR TITLE
(fix): preserve ruler and proxy playback ownership

### DIFF
--- a/src/features/export/utils/client-render-engine.test.ts
+++ b/src/features/export/utils/client-render-engine.test.ts
@@ -6,6 +6,7 @@ import {
   collectPriorityMediaItemIds,
   collectPriorityMediaItemIdsForFrames,
   collectPriorityNestedVideoItemIds,
+  getPreviewVideoSourceCandidates,
   resolveCompositionRendererExecutionPolicy,
   resolveRenderedFrameCacheMode,
   resolveWorkerPredecodeWaitMs,
@@ -378,6 +379,42 @@ describe('collectPriorityNestedVideoItemIds', () => {
 })
 
 describe('selectPreviewVideoSource', () => {
+  it('prioritizes the canonical original URL and excludes proxies when source media is selected', () => {
+    expect(
+      getPreviewVideoSourceCandidates({
+        itemSource: 'blob:source',
+        proxySource: 'blob:proxy',
+        registeredSource: 'blob:registered-source',
+        cachedSource: 'blob:cached-source',
+        useProxyMedia: false,
+      }),
+    ).toEqual(['blob:cached-source', 'blob:registered-source', 'blob:source'])
+  })
+
+  it('drops a stale proxy item source when proxy playback is disabled', () => {
+    expect(
+      getPreviewVideoSourceCandidates({
+        itemSource: 'blob:proxy',
+        proxySource: 'blob:proxy',
+        registeredSource: 'blob:proxy',
+        cachedSource: 'blob:original',
+        useProxyMedia: false,
+      }),
+    ).toEqual(['blob:original', null, null])
+  })
+
+  it('includes cached proxies when proxy media is selected', () => {
+    expect(
+      getPreviewVideoSourceCandidates({
+        itemSource: 'blob:proxy',
+        proxySource: 'blob:proxy',
+        registeredSource: 'blob:registered-proxy',
+        cachedSource: 'blob:source',
+        useProxyMedia: true,
+      }),
+    ).toEqual(['blob:proxy', 'blob:proxy', 'blob:registered-proxy', 'blob:source'])
+  })
+
   it('selects the cached proxy when a compound item still carries its original source', () => {
     const proxyBitmap = {} as ImageBitmap
     expect(

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -195,6 +195,32 @@ export function selectPreviewVideoSource(options: {
   return candidates[0] ?? null
 }
 
+export function getPreviewVideoSourceCandidates({
+  itemSource,
+  proxySource,
+  registeredSource,
+  cachedSource,
+  useProxyMedia,
+}: {
+  itemSource?: string | null
+  proxySource?: string | null
+  registeredSource?: string | null
+  cachedSource?: string | null
+  useProxyMedia: boolean
+}): Array<string | null | undefined> {
+  if (useProxyMedia) {
+    return [proxySource, itemSource, registeredSource, cachedSource]
+  }
+
+  // blobUrlManager owns the current original-media URL and is also what the
+  // active preseek scheduler uses with proxy playback disabled. Timeline item
+  // src values can lag a proxy-mode toggle, so never let an explicit proxy URL
+  // outrank or masquerade as the original source here.
+  return [cachedSource, registeredSource, itemSource].map((candidate) =>
+    candidate === proxySource ? null : candidate,
+  )
+}
+
 // Predicate helpers (GPU-effect / animated-image classifiers) live in
 // `render-engine-predicates.ts`. `subCompositionRenderDataHasGpuEffects` is
 // re-exported so existing import sites (and its test) keep working.
@@ -1226,17 +1252,19 @@ export async function createCompositionRenderer(
           : selectExportVideoSource(item, registeredSource)
       }
       return selectPreviewVideoSource({
-        candidates: [
-          item.src,
-          item.mediaId ? resolveProxyUrl(item.mediaId) : null,
+        candidates: getPreviewVideoSourceCandidates({
+          itemSource: item.src,
+          proxySource: item.mediaId ? resolveProxyUrl(item.mediaId) : null,
           registeredSource,
-          item.mediaId ? blobUrlManager.get(item.mediaId) : null,
-        ],
+          cachedSource: item.mediaId ? blobUrlManager.get(item.mediaId) : null,
+          useProxyMedia,
+        }),
         sourceTime,
         toleranceSeconds,
         getCachedPredecodedBitmap: itemRenderContext.getCachedPredecodedBitmap,
-        getCachedActivePreviewFallbackBitmap:
-          itemRenderContext.getCachedActivePreviewFallbackBitmap,
+        getCachedActivePreviewFallbackBitmap: useProxyMedia
+          ? itemRenderContext.getCachedActivePreviewFallbackBitmap
+          : undefined,
         isActivePreviewSourceTarget: itemRenderContext.isActivePreviewSourceTarget,
       })
     },

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -1490,6 +1490,57 @@ describe('VideoPreview sync behavior', () => {
     expect(renderer.renderFrame).not.toHaveBeenCalledWith(25)
   })
 
+  it('does not publish a stale renderer after proxy mode changes during initialization', async () => {
+    usePlaybackStore.setState({ useProxy: false })
+    setMockBlobUrl('media-proxy-init-race', 'blob:source-video')
+    resolveProxyUrlMock.mockReturnValue('blob:proxy-video')
+    setSingleVideoItemAtFrame({
+      id: 'item-proxy-init-race',
+      mediaId: 'media-proxy-init-race',
+      effects: [
+        {
+          id: 'effect-proxy-init-race',
+          enabled: true,
+          effect: { type: 'gpu-effect', gpuEffectType: 'gpu-sepia', params: { amount: 0.5 } },
+        },
+      ],
+    })
+
+    const staleRenderer = createRendererDouble()
+    let resolveStaleRenderer: ((renderer: typeof staleRenderer) => void) | null = null
+    createCompositionRendererMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStaleRenderer = resolve
+        }),
+    )
+
+    renderPreviewWithScrubCanvas()
+    await waitFor(() => expect(createCompositionRendererMock).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      usePlaybackStore.getState().toggleUseProxy()
+    })
+
+    await waitFor(() => {
+      expect(createCompositionRendererMock).toHaveBeenCalledTimes(2)
+      expect(rendererMockState.instances).toHaveLength(1)
+    })
+    const currentRenderer = rendererMockState.instances[0]!
+
+    await act(async () => {
+      resolveStaleRenderer?.(staleRenderer)
+      await Promise.resolve()
+    })
+
+    expect(staleRenderer.dispose).toHaveBeenCalledOnce()
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(24)
+    })
+    await waitFor(() => expect(currentRenderer.renderFrame).toHaveBeenCalledWith(24))
+    expect(staleRenderer.renderFrame).not.toHaveBeenCalled()
+  })
+
   it('rebuilds a reversed fast-scrub renderer with the selected proxy mode', async () => {
     usePlaybackStore.setState({ useProxy: false })
     setMockBlobUrl('media-proxy-mode', 'blob:source-video')

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -905,7 +905,8 @@ describe('VideoPreview sync behavior', () => {
     blobUrlListeners.clear()
     mockBlobUrlVersion.current = 0
     resolveMediaUrlMock.mockClear()
-    resolveProxyUrlMock.mockClear()
+    resolveProxyUrlMock.mockReset()
+    resolveProxyUrlMock.mockReturnValue(null)
     createCompositionRendererMock.mockClear()
     rendererMockState.instances.length = 0
     canvasPixelReadbackEnabled = false
@@ -1487,6 +1488,66 @@ describe('VideoPreview sync behavior', () => {
     })
     expect(renderer.renderFrame).not.toHaveBeenCalledWith(24)
     expect(renderer.renderFrame).not.toHaveBeenCalledWith(25)
+  })
+
+  it('rebuilds a reversed fast-scrub renderer with the selected proxy mode', async () => {
+    usePlaybackStore.setState({ useProxy: false })
+    setMockBlobUrl('media-proxy-mode', 'blob:source-video')
+    resolveProxyUrlMock.mockReturnValue('blob:proxy-video')
+    setSingleVideoItemAtFrame({
+      id: 'item-proxy-mode',
+      mediaId: 'media-proxy-mode',
+      isReversed: true,
+      sourceStart: 0,
+      sourceEnd: 120,
+      sourceFps: 30,
+      effects: [
+        {
+          id: 'effect-proxy-mode',
+          enabled: true,
+          effect: { type: 'gpu-effect', gpuEffectType: 'gpu-sepia', params: { amount: 0.5 } },
+        },
+      ],
+    })
+
+    const { renderer } = await renderReadySingleRendererPreview(24)
+    const rendererCalls = createCompositionRendererMock.mock.calls as unknown as Array<
+      [
+        {
+          tracks: Array<{
+            items: Array<{ src?: string; audioSrc?: string; isReversed?: boolean }>
+          }>
+        },
+        unknown,
+        unknown,
+        { useProxyMedia?: boolean },
+      ]
+    >
+    const firstInput = rendererCalls[0]?.[0]
+    const firstOptions = rendererCalls[0]?.[3]
+    expect(firstInput?.tracks[0]?.items[0]).toMatchObject({
+      src: 'blob:source-video',
+      audioSrc: 'blob:source-video',
+      isReversed: true,
+    })
+    expect(firstOptions?.useProxyMedia).toBe(false)
+
+    act(() => {
+      usePlaybackStore.getState().toggleUseProxy()
+    })
+
+    await waitFor(() => {
+      expect(renderer.dispose).toHaveBeenCalledOnce()
+      expect(createCompositionRendererMock).toHaveBeenCalledTimes(2)
+    })
+    const secondInput = rendererCalls[1]?.[0]
+    const secondOptions = rendererCalls[1]?.[3]
+    expect(secondInput?.tracks[0]?.items[0]).toMatchObject({
+      src: 'blob:proxy-video',
+      audioSrc: 'blob:source-video',
+      isReversed: true,
+    })
+    expect(secondOptions?.useProxyMedia).toBe(true)
   })
 
   it('reuses the active fast-scrub renderer for committed transform updates on gpu-effect clips', async () => {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -134,6 +134,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   const [splitAfterRenderedFrame, setSplitAfterRenderedFrame] = useState<number | null>(null)
   const splitAfterRendererRef = useRef<CompositionRendererInstance | null>(null)
   const splitAfterInitPromiseRef = useRef<Promise<CompositionRendererInstance | null> | null>(null)
+  const splitAfterInitGenerationRef = useRef(0)
   const splitAfterCanvasRef = useRef<OffscreenCanvas | null>(null)
   const splitAfterRendererStructureKeyRef = useRef<string | null>(null)
   const splitAfterRenderInFlightRef = useRef(false)
@@ -407,6 +408,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   )
 
   const disposeSplitAfterRenderer = useCallback(() => {
+    splitAfterInitGenerationRef.current += 1
     splitAfterInitPromiseRef.current = null
     splitAfterRendererStructureKeyRef.current = null
     splitAfterCanvasRef.current = null
@@ -446,7 +448,9 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       if (splitAfterRendererRef.current) return splitAfterRendererRef.current
       if (splitAfterInitPromiseRef.current) return splitAfterInitPromiseRef.current
 
-      splitAfterInitPromiseRef.current = (async () => {
+      const initGeneration = splitAfterInitGenerationRef.current
+      let initPromise!: Promise<CompositionRendererInstance | null>
+      initPromise = (async () => {
         try {
           const canvas = new OffscreenCanvas(renderSize.width, renderSize.height)
           const ctx = canvas.getContext('2d')
@@ -464,6 +468,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
             getLiveKeyframes,
             renderText: !domTextScrubOverlayPlan.enabled,
           })
+          if (splitAfterInitGenerationRef.current !== initGeneration) {
+            renderer.dispose()
+            return null
+          }
 
           splitAfterCanvasRef.current = canvas
           splitAfterRendererRef.current = renderer
@@ -473,16 +481,21 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
           }
           return renderer
         } catch {
-          splitAfterCanvasRef.current = null
-          splitAfterRendererRef.current = null
-          splitAfterRendererStructureKeyRef.current = null
+          if (splitAfterInitGenerationRef.current === initGeneration) {
+            splitAfterCanvasRef.current = null
+            splitAfterRendererRef.current = null
+            splitAfterRendererStructureKeyRef.current = null
+          }
           return null
         } finally {
-          splitAfterInitPromiseRef.current = null
+          if (splitAfterInitPromiseRef.current === initPromise) {
+            splitAfterInitPromiseRef.current = null
+          }
         }
       })()
+      splitAfterInitPromiseRef.current = initPromise
 
-      return splitAfterInitPromiseRef.current
+      return initPromise
     }, [
       disposeSplitAfterRenderer,
       fastScrubInputProps,
@@ -499,6 +512,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       renderSize.width,
       useProxy,
     ])
+
+  useEffect(() => {
+    disposeSplitAfterRenderer()
+  }, [disposeSplitAfterRenderer, fastScrubRendererStructureKey])
 
   // Enter the composited path in the same render that activates the editor.
   // Waiting for the timeline-wide effect scan adds a reactive round trip that

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -382,6 +382,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
         project.width,
         project.height,
         project.backgroundColor ?? '',
+        useProxy ? 'proxy' : 'source',
         fastScrubTracksTopologyFingerprint,
         domTextScrubOverlayPlan.enabled ? 'dom-text-overlay' : 'composited-text',
         playbackTransitionFingerprint,
@@ -394,6 +395,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       project.backgroundColor,
       project.height,
       project.width,
+      useProxy,
     ],
   )
 
@@ -453,7 +455,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
           const { createCompositionRenderer } = await importCompositionRenderer()
           const renderer = await createCompositionRenderer(fastScrubInputProps, canvas, ctx, {
             mode: 'preview',
-            useProxyMedia: true,
+            useProxyMedia: useProxy,
             getPreviewTransformOverride,
             getPreviewEffectsOverride: getPreviewEffectsOverrideWithGradeApplied,
             getPreviewCornerPinOverride,
@@ -495,6 +497,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       isResolving,
       renderSize.height,
       renderSize.width,
+      useProxy,
     ])
 
   // Enter the composited path in the same render that activates the editor.
@@ -652,6 +655,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       preserveRendererAcrossOverlayRouting: shouldWarmGpuEffectsRenderer,
       domTextScrubOverlayEnabled: domTextScrubOverlayPlan.enabled,
       items,
+      useProxy,
       playerSize,
       playerRenderSize,
       renderSize,
@@ -701,6 +705,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   usePreviewRenderPump({
     fps,
     forceFastScrubOverlay,
+    useProxy,
     // Scrub decoding must use the same proxy/source URLs as the renderer.
     // Feeding unresolved project tracks here silently made the worker decode
     // full-resolution originals while the composition rendered proxies.

--- a/src/features/preview/hooks/use-preview-composition-model.test.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.test.ts
@@ -66,7 +66,7 @@ describe('mergeLiveItemPresentation', () => {
 })
 
 describe('buildPreviewCompositionData', () => {
-  it('derives playback and fast-scrub sources separately and computes boundaries', () => {
+  it('uses original media for playback and fast scrubbing when proxies are disabled', () => {
     const track: TimelineTrack = {
       id: 'track-1',
       name: 'Video',
@@ -107,12 +107,12 @@ describe('buildPreviewCompositionData', () => {
       { src: 'blob://video', startFrame: 10, endFrame: 70 },
     ])
     expect(result.scrubVideoSourceSpans).toEqual([
-      { src: 'proxy://video', startFrame: 10, endFrame: 70 },
+      { src: 'blob://video', startFrame: 10, endFrame: 70 },
     ])
     expect(result.fastScrubBoundaryFrames).toEqual([10, 70])
     expect(result.fastScrubBoundarySources).toEqual([
-      { frame: 10, srcs: ['proxy://video'] },
-      { frame: 70, srcs: ['proxy://video'] },
+      { frame: 10, srcs: ['blob://video'] },
+      { frame: 70, srcs: ['blob://video'] },
     ])
     expect(result.totalFrames).toBe(220)
     const playbackVideoItem = result.inputProps.tracks[0]?.items[0]
@@ -120,6 +120,67 @@ describe('buildPreviewCompositionData', () => {
     expect(playbackVideoItem?.type).toBe('video')
     expect(scrubVideoItem?.type).toBe('video')
     if (playbackVideoItem?.type === 'video' && scrubVideoItem?.type === 'video') {
+      expect(playbackVideoItem.src).toBe('blob://video')
+      expect(scrubVideoItem.src).toBe('blob://video')
+      expect(playbackVideoItem.audioSrc).toBe('blob://video')
+      expect(scrubVideoItem.audioSrc).toBe('blob://video')
+    }
+  })
+
+  it('uses proxy media for playback and fast scrubbing when proxies are enabled', () => {
+    const track: TimelineTrack = {
+      id: 'track-1',
+      name: 'Video',
+      height: 80,
+      locked: false,
+      visible: true,
+      muted: false,
+      solo: false,
+      order: 1,
+      items: [
+        {
+          id: 'clip-1',
+          trackId: 'track-1',
+          type: 'video',
+          mediaId: 'media-1',
+          src: '',
+          label: 'Clip',
+          from: 10,
+          durationInFrames: 60,
+        },
+      ],
+    }
+
+    const result = buildPreviewCompositionData({
+      combinedTracks: [track],
+      fps: 30,
+      items: track.items,
+      keyframes: [],
+      transitions: [],
+      resolvedUrls: new Map([['media-1', 'blob://video']]),
+      useProxy: true,
+      blobUrlVersion: 0,
+      project: { width: 1920, height: 1080, backgroundColor: '#000000' },
+      resolveProxyUrlFn: () => 'proxy://video',
+    })
+
+    expect(result.playbackVideoSourceSpans).toEqual([
+      { src: 'proxy://video', startFrame: 10, endFrame: 70 },
+    ])
+    expect(result.scrubVideoSourceSpans).toEqual([
+      { src: 'proxy://video', startFrame: 10, endFrame: 70 },
+    ])
+    expect(result.fastScrubBoundarySources).toEqual([
+      { frame: 10, srcs: ['proxy://video'] },
+      { frame: 70, srcs: ['proxy://video'] },
+    ])
+    const playbackVideoItem = result.inputProps.tracks[0]?.items[0]
+    const scrubVideoItem = result.fastScrubInputProps.tracks[0]?.items[0]
+    expect(playbackVideoItem?.type).toBe('video')
+    expect(scrubVideoItem?.type).toBe('video')
+    if (playbackVideoItem?.type === 'video' && scrubVideoItem?.type === 'video') {
+      expect(playbackVideoItem.src).toBe('proxy://video')
+      expect(scrubVideoItem.src).toBe('proxy://video')
       expect(playbackVideoItem.audioSrc).toBe('blob://video')
       expect(scrubVideoItem.audioSrc).toBe('blob://video')
     }

--- a/src/features/preview/hooks/use-preview-composition-model.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.ts
@@ -402,7 +402,7 @@ export function buildPreviewCompositionData({
       const proxyUrl =
         item.type === 'video' ? resolveProxyUrlFn(item.mediaId) || sourceUrl : sourceUrl
       const resolvedSrc = useProxy && item.type === 'video' ? proxyUrl : sourceUrl
-      const fastScrubSrc = item.type === 'video' ? proxyUrl : sourceUrl
+      const fastScrubSrc = resolvedSrc
       const hasMatchingAudioSrc = item.type !== 'video' || item.audioSrc === sourceUrl
 
       const resolvedItem =

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -69,6 +69,7 @@ import {
   collectVisibleTrackVideoSourceTimesBySrc,
   getVideoItemSourceTimeSeconds,
   resolveActivePreviewLookaheadTimestamps,
+  resolvePreviewPreseekSource,
   resolvePausedVariableSpeedPrewarmPlan,
   shouldRunJumpPreseek,
 } from '../utils/render-pump-preseek'
@@ -187,6 +188,7 @@ interface UsePreviewRenderPumpParams {
   playerRef: RefObject<PlayerRef | null>
   fps: number
   forceFastScrubOverlay: boolean
+  useProxy: boolean
   combinedTracks: TimelineTrack[]
   fastScrubBoundaryFrames: number[]
   fastScrubBoundarySources: FastScrubBoundarySource[]
@@ -270,6 +272,7 @@ export function usePreviewRenderPump({
   playerRef,
   fps,
   forceFastScrubOverlay,
+  useProxy,
   combinedTracks,
   fastScrubBoundaryFrames,
   fastScrubBoundarySources,
@@ -1516,7 +1519,12 @@ export function usePreviewRenderPump({
     const resolvePreseekItemSrc = (item: VideoItem) => {
       const proxyUrl = item.mediaId ? resolveProxyUrl(item.mediaId) : null
       const liveUrl = item.mediaId ? blobUrlManager.get(item.mediaId) : null
-      return proxyUrl ?? liveUrl ?? (item.src || null)
+      return resolvePreviewPreseekSource({
+        useProxy,
+        proxySource: proxyUrl,
+        liveSource: liveUrl,
+        itemSource: item.src,
+      })
     }
 
     function scheduleReversePlaybackPreseek(targetFrame: number) {
@@ -1565,10 +1573,12 @@ export function usePreviewRenderPump({
         return
       }
 
-      for (const [src, timestamps] of bySource) {
-        const currentTimestamp = timestamps[0]
-        if (currentTimestamp !== undefined) {
-          scheduleScrubProxyFallback(src, currentTimestamp)
+      if (useProxy) {
+        for (const [src, timestamps] of bySource) {
+          const currentTimestamp = timestamps[0]
+          if (currentTimestamp !== undefined) {
+            scheduleScrubProxyFallback(src, currentTimestamp)
+          }
         }
       }
 
@@ -1723,7 +1733,9 @@ export function usePreviewRenderPump({
         const exactTimestamp = timestamps[0]
         if (exactTimestamp === undefined) continue
         nextSourceTimes.set(src, exactTimestamp)
-        scheduleScrubProxyFallback(src, exactTimestamp)
+        if (useProxy) {
+          scheduleScrubProxyFallback(src, exactTimestamp)
+        }
 
         if (!usedDedicatedLane) {
           usedDedicatedLane = true
@@ -3001,6 +3013,7 @@ export function usePreviewRenderPump({
     fastScrubBoundarySources,
     forceFastScrubOverlay,
     fps,
+    useProxy,
     clearTransitionPlaybackSession,
     getPausedTransitionPrewarmStartFrame,
     getPinnedTransitionElementForItem,

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -276,6 +276,9 @@ export function usePreviewRendererController({
   const liveScopeCaptureInitPromiseRef = useRef<Promise<PreviewCompositionRenderer | null> | null>(
     null,
   )
+  const scrubInitGenerationRef = useRef(0)
+  const bgTransitionInitGenerationRef = useRef(0)
+  const liveScopeCaptureInitGenerationRef = useRef(0)
   const liveScopeCaptureCanvasRef = useRef<OffscreenCanvas | null>(null)
   const liveScopeCaptureCtxRef = useRef<OffscreenCanvasRenderingContext2D | null>(null)
   const liveScopeCaptureStructureKeyRef = useRef<string | null>(null)
@@ -342,6 +345,9 @@ export function usePreviewRendererController({
     // awaiting the previous renderer. The replacement pump must never tag or
     // present pixels through that stale generation's shared refs.
     scrubRenderGenerationRef.current += 1
+    scrubInitGenerationRef.current += 1
+    bgTransitionInitGenerationRef.current += 1
+    liveScopeCaptureInitGenerationRef.current += 1
     resetPlaybackStartReadiness()
     scrubInitPromiseRef.current = null
     scrubPreloadPromiseRef.current = null
@@ -443,6 +449,7 @@ export function usePreviewRendererController({
       liveScopeCaptureRendererRef.current &&
       liveScopeCaptureStructureKeyRef.current !== fastScrubRendererStructureKey
     ) {
+      liveScopeCaptureInitGenerationRef.current += 1
       try {
         liveScopeCaptureRendererRef.current.dispose()
       } catch {
@@ -456,7 +463,9 @@ export function usePreviewRendererController({
     if (liveScopeCaptureRendererRef.current) return liveScopeCaptureRendererRef.current
     if (liveScopeCaptureInitPromiseRef.current) return liveScopeCaptureInitPromiseRef.current
 
-    liveScopeCaptureInitPromiseRef.current = (async () => {
+    const initGeneration = liveScopeCaptureInitGenerationRef.current
+    let initPromise!: Promise<PreviewCompositionRenderer | null>
+    initPromise = (async () => {
       try {
         const offscreen = new OffscreenCanvas(renderSize.width, renderSize.height)
         const offscreenCtx = offscreen.getContext('2d')
@@ -477,6 +486,10 @@ export function usePreviewRendererController({
             getLiveKeyframes,
           },
         )
+        if (liveScopeCaptureInitGenerationRef.current !== initGeneration) {
+          renderer.dispose()
+          return null
+        }
         liveScopeCaptureCanvasRef.current = offscreen
         liveScopeCaptureCtxRef.current = offscreenCtx
         liveScopeCaptureRendererRef.current = renderer
@@ -487,17 +500,22 @@ export function usePreviewRendererController({
         return renderer
       } catch (error) {
         logger.warn('Failed to initialize live scope capture renderer:', error)
-        liveScopeCaptureRendererRef.current = null
-        liveScopeCaptureCanvasRef.current = null
-        liveScopeCaptureCtxRef.current = null
-        liveScopeCaptureStructureKeyRef.current = null
+        if (liveScopeCaptureInitGenerationRef.current === initGeneration) {
+          liveScopeCaptureRendererRef.current = null
+          liveScopeCaptureCanvasRef.current = null
+          liveScopeCaptureCtxRef.current = null
+          liveScopeCaptureStructureKeyRef.current = null
+        }
         return null
       } finally {
-        liveScopeCaptureInitPromiseRef.current = null
+        if (liveScopeCaptureInitPromiseRef.current === initPromise) {
+          liveScopeCaptureInitPromiseRef.current = null
+        }
       }
     })()
+    liveScopeCaptureInitPromiseRef.current = initPromise
 
-    return liveScopeCaptureInitPromiseRef.current
+    return initPromise
   }, [
     fastScrubInputProps,
     fastScrubRendererStructureKey,
@@ -526,7 +544,9 @@ export function usePreviewRendererController({
       if (bgTransitionRendererRef.current) return bgTransitionRendererRef.current
       if (bgTransitionInitPromiseRef.current) return bgTransitionInitPromiseRef.current
 
-      bgTransitionInitPromiseRef.current = (async () => {
+      const initGeneration = bgTransitionInitGenerationRef.current
+      let initPromise!: Promise<PreviewCompositionRenderer | null>
+      initPromise = (async () => {
         try {
           const canvas = new OffscreenCanvas(renderSize.width, renderSize.height)
           const ctx = canvas.getContext('2d')
@@ -543,6 +563,10 @@ export function usePreviewRendererController({
             getLiveKeyframes,
             renderText: !domTextScrubOverlayEnabled,
           })
+          if (bgTransitionInitGenerationRef.current !== initGeneration) {
+            renderer.dispose()
+            return null
+          }
           if ('warmGpuPipeline' in renderer) {
             void renderer.warmGpuPipeline()
           }
@@ -552,10 +576,13 @@ export function usePreviewRendererController({
         } catch {
           return null
         } finally {
-          bgTransitionInitPromiseRef.current = null
+          if (bgTransitionInitPromiseRef.current === initPromise) {
+            bgTransitionInitPromiseRef.current = null
+          }
         }
       })()
-      return bgTransitionInitPromiseRef.current
+      bgTransitionInitPromiseRef.current = initPromise
+      return initPromise
     }, [
       bgTransitionInitPromiseRef,
       bgTransitionRendererRef,
@@ -601,7 +628,9 @@ export function usePreviewRendererController({
         lookaheadOrigin: null,
         lookaheadReadyMs: null,
       })
-      scrubInitPromiseRef.current = (async () => {
+      const initGeneration = scrubInitGenerationRef.current
+      let initPromise!: Promise<PreviewCompositionRenderer | null>
+      initPromise = (async () => {
         try {
           const offscreen = new OffscreenCanvas(renderSize.width, renderSize.height)
           const offscreenCtx = offscreen.getContext('2d')
@@ -624,6 +653,10 @@ export function usePreviewRendererController({
               renderText: !domTextScrubOverlayEnabled,
             },
           )
+          if (scrubInitGenerationRef.current !== initGeneration) {
+            renderer.dispose()
+            return null
+          }
           scrubOffscreenCanvasRef.current = offscreen
           scrubOffscreenCtxRef.current = offscreenCtx
           scrubOffscreenRenderedFrameRef.current = null
@@ -693,20 +726,25 @@ export function usePreviewRendererController({
           ])
           return renderer
         } catch (error) {
-          markPlaybackStartReadiness({ rendererInitFailedMs: performance.now() })
           logger.warn('Failed to initialize renderer, falling back to Player seeks:', error)
-          scrubRendererRef.current = null
-          setActivePreviewScrubbingCache(null)
-          scrubOffscreenCanvasRef.current = null
-          scrubOffscreenCtxRef.current = null
-          scrubOffscreenRenderedFrameRef.current = null
+          if (scrubInitGenerationRef.current === initGeneration) {
+            markPlaybackStartReadiness({ rendererInitFailedMs: performance.now() })
+            scrubRendererRef.current = null
+            setActivePreviewScrubbingCache(null)
+            scrubOffscreenCanvasRef.current = null
+            scrubOffscreenCtxRef.current = null
+            scrubOffscreenRenderedFrameRef.current = null
+          }
           return null
         } finally {
-          scrubInitPromiseRef.current = null
+          if (scrubInitPromiseRef.current === initPromise) {
+            scrubInitPromiseRef.current = null
+          }
         }
       })()
+      scrubInitPromiseRef.current = initPromise
 
-      return scrubInitPromiseRef.current
+      return initPromise
     }, [
       disposeFastScrubRenderer,
       domTextScrubOverlayEnabled,

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -114,6 +114,7 @@ interface UsePreviewRendererControllerParams {
   preserveRendererAcrossOverlayRouting: boolean
   domTextScrubOverlayEnabled: boolean
   items: TimelineItem[]
+  useProxy: boolean
   playerSize: { width: number; height: number }
   playerRenderSize: { width: number; height: number }
   renderSize: { width: number; height: number }
@@ -192,6 +193,7 @@ export function usePreviewRendererController({
   preserveRendererAcrossOverlayRouting,
   domTextScrubOverlayEnabled,
   items,
+  useProxy,
   playerSize,
   playerRenderSize,
   renderSize,
@@ -466,7 +468,7 @@ export function usePreviewRendererController({
           offscreenCtx,
           {
             mode: 'preview',
-            useProxyMedia: true,
+            useProxyMedia: useProxy,
             getPreviewTransformOverride,
             getPreviewEffectsOverride,
             getPreviewCornerPinOverride,
@@ -508,6 +510,7 @@ export function usePreviewRendererController({
     isResolving,
     renderSize.height,
     renderSize.width,
+    useProxy,
   ])
 
   const ensureBgTransitionRenderer =
@@ -531,7 +534,7 @@ export function usePreviewRendererController({
           const { createCompositionRenderer } = await importCompositionRenderer()
           const renderer = await createCompositionRenderer(fastScrubInputProps, canvas, ctx, {
             mode: 'preview',
-            useProxyMedia: true,
+            useProxyMedia: useProxy,
             getPreviewTransformOverride,
             getPreviewEffectsOverride,
             getPreviewCornerPinOverride,
@@ -570,6 +573,7 @@ export function usePreviewRendererController({
       isResolving,
       renderSize.height,
       renderSize.width,
+      useProxy,
     ])
 
   const ensureFastScrubRenderer =
@@ -610,7 +614,7 @@ export function usePreviewRendererController({
             offscreenCtx,
             {
               mode: 'preview',
-              useProxyMedia: true,
+              useProxyMedia: useProxy,
               getPreviewTransformOverride,
               getPreviewEffectsOverride,
               getPreviewCornerPinOverride,
@@ -728,6 +732,7 @@ export function usePreviewRendererController({
       scrubRendererRef,
       scrubRendererStructureKeyRef,
       scrubRequestedFrameRef,
+      useProxy,
     ])
   ensureFastScrubRendererRef.current = ensureFastScrubRenderer
 
@@ -1778,7 +1783,9 @@ export function usePreviewRendererController({
       // ensureFastScrubRenderer() is already in flight before this idle
       // callback fires, and the pool must still warm.
       warmDecoderPrewarmWorkerPool()
-      warmScrubProxyFallback()
+      if (useProxy) {
+        warmScrubProxyFallback()
+      }
       if (scrubRendererRef.current || scrubInitPromiseRef.current) return
       void ensureFastScrubRenderer()
     }
@@ -1807,7 +1814,7 @@ export function usePreviewRendererController({
         clearTimeout(timeoutId)
       }
     }
-  }, [ensureFastScrubRenderer, isResolving, scrubInitPromiseRef, scrubRendererRef])
+  }, [ensureFastScrubRenderer, isResolving, scrubInitPromiseRef, scrubRendererRef, useProxy])
 
   useEffect(() => {
     return () => {

--- a/src/features/preview/utils/render-pump-preseek.test.ts
+++ b/src/features/preview/utils/render-pump-preseek.test.ts
@@ -25,6 +25,7 @@ import {
   collectVisibleTrackVideoSourceTimesBySrc,
   getVideoItemSourceTimeSeconds,
   mapTimelineFrameToSubCompositionFrame,
+  resolvePreviewPreseekSource,
   resolvePausedVariableSpeedPrewarmPlan,
   resolveActivePreviewLookaheadTimestamps,
   shouldRunJumpPreseek,
@@ -61,6 +62,28 @@ function makeTrack(items: VideoItem[]): TimelineTrack {
 }
 
 describe('render pump preseek helpers', () => {
+  it('keeps worker preseek on the original source when proxy playback is disabled', () => {
+    expect(
+      resolvePreviewPreseekSource({
+        useProxy: false,
+        proxySource: 'blob:proxy',
+        liveSource: 'blob:original',
+        itemSource: 'blob:stale-item-source',
+      }),
+    ).toBe('blob:original')
+  })
+
+  it('uses the proxy source when proxy playback is enabled', () => {
+    expect(
+      resolvePreviewPreseekSource({
+        useProxy: true,
+        proxySource: 'blob:proxy',
+        liveSource: 'blob:original',
+        itemSource: 'blob:stale-item-source',
+      }),
+    ).toBe('blob:proxy')
+  })
+
   it('computes source time at a timeline frame', () => {
     const item = makeVideoItem({
       from: 10,
@@ -101,6 +124,38 @@ describe('render pump preseek helpers', () => {
 
     expect(getVideoItemSourceTimeSeconds(item, 10, 30)).toBeCloseTo(179 / 60)
     expect(getVideoItemSourceTimeSeconds(item, 11, 30)).toBeCloseTo(175 / 60)
+  })
+
+  it('collects reversed playback windows from the selected proxy mode source', () => {
+    const tracks = [
+      makeTrack([
+        makeVideoItem({
+          id: 'reversed-proxy-toggle',
+          src: 'blob:stale-item-source',
+          from: 10,
+          durationInFrames: 30,
+          sourceStart: 120,
+          sourceEnd: 180,
+          sourceFps: 60,
+          speed: 1,
+          isReversed: true,
+        }),
+      ]),
+    ]
+
+    const collectForMode = (useProxy: boolean) =>
+      collectVisibleTrackVideoSourceTimesBySrc(tracks, 10, 30, {
+        resolveItemSrc: () =>
+          resolvePreviewPreseekSource({
+            useProxy,
+            proxySource: 'blob:proxy',
+            liveSource: 'blob:original',
+            itemSource: 'blob:stale-item-source',
+          }),
+      })
+
+    expectMapCloseTo(collectForMode(false), new Map([['blob:original', [179 / 60]]]))
+    expectMapCloseTo(collectForMode(true), new Map([['blob:proxy', [179 / 60]]]))
   })
 
   it('requires explicit source fps when requested', () => {

--- a/src/features/preview/utils/render-pump-preseek.ts
+++ b/src/features/preview/utils/render-pump-preseek.ts
@@ -30,6 +30,27 @@ export interface RenderPumpSourceTimeOptions {
   resolveItemSrc?: (item: VideoItem) => string | null
 }
 
+export interface PreviewPreseekSourceInput {
+  useProxy: boolean
+  proxySource?: string | null
+  liveSource?: string | null
+  itemSource?: string | null
+}
+
+/**
+ * Keep worker preseek source selection aligned with the renderer. A disabled
+ * proxy must never remain in the latency-critical decode lane or gate an
+ * original-resolution render behind the wrong source.
+ */
+export function resolvePreviewPreseekSource({
+  useProxy,
+  proxySource,
+  liveSource,
+  itemSource,
+}: PreviewPreseekSourceInput): string | null {
+  return (useProxy ? proxySource : null) ?? liveSource ?? itemSource ?? null
+}
+
 export interface PreseekSourceTarget {
   src: string
   time: number

--- a/src/features/timeline/components/timeline-content.test.tsx
+++ b/src/features/timeline/components/timeline-content.test.tsx
@@ -12,8 +12,9 @@ import { _resetViewportThrottle, useTimelineViewportStore } from '../stores/time
 import { useTimelineStore } from '../stores/timeline-store'
 import { useItemsStore } from '../stores/items-store'
 import { _resetZoomStoreForTest, useZoomStore } from '../stores/zoom-store'
-import { ZOOM_MAX, ZOOM_MIN } from '../constants'
+import { TIMELINE_RULER_HEIGHT, ZOOM_MAX, ZOOM_MIN } from '../constants'
 import { TimelineContent } from './timeline-content'
+import { getTimelineZoomInteractionShieldBounds } from '../utils/timeline-zoom-interaction-shield'
 import { TIMELINE_LIVE_SCROLL_EVENT } from '@/shared/timeline/live-scroll-sync'
 
 const perfMarkMocks = vi.hoisted(() => ({
@@ -711,6 +712,15 @@ describe('TimelineContent playback selection behavior', () => {
       deltaY: -120,
     })
     expect(zoomInteractionShield!.style.display).toBe('block')
+    expect(zoomInteractionShield).toHaveAttribute('data-marquee-ignore')
+    expect(
+      getTimelineZoomInteractionShieldBounds({ left: 0, top: 0, width: 400, height: 200 }),
+    ).toEqual({
+      left: 0,
+      top: TIMELINE_RULER_HEIGHT,
+      width: 400,
+      height: 200 - TIMELINE_RULER_HEIGHT,
+    })
     const zoomFrameCount = scheduledFrames.size
     act(() => {
       vi.advanceTimersByTime(150)

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -74,6 +74,7 @@ import { setTimelineDensityMarqueePreview } from '../utils/timeline-density-marq
 import { notifyTimelineLiveScroll } from '@/shared/timeline/live-scroll-sync'
 import { getPlaybackFollowScrollLeft } from '../utils/playback-follow-scroll'
 import { TimelineSettledContentZoomProvider } from './timeline-settled-content-zoom-provider'
+import { getTimelineZoomInteractionShieldBounds } from '../utils/timeline-zoom-interaction-shield'
 
 const ACTIVE_TIMELINE_GESTURE_CURSOR_CLASSES = [
   'timeline-cursor-trim-left',
@@ -1935,18 +1936,34 @@ export const TimelineContent = memo(function TimelineContent({
 
     const cached = viewportDimsRef.current
     const rect = cached ? null : container.getBoundingClientRect()
-    shield.style.left = `${cached?.left ?? rect?.left ?? 0}px`
-    shield.style.top = `${cached?.top ?? rect?.top ?? 0}px`
-    shield.style.width = `${cached?.width ?? rect?.width ?? container.clientWidth}px`
-    shield.style.height = `${cached?.fullHeight ?? rect?.height ?? container.clientHeight}px`
+    const shieldBounds = getTimelineZoomInteractionShieldBounds({
+      left: cached?.left ?? rect?.left ?? 0,
+      top: cached?.top ?? rect?.top ?? 0,
+      width: cached?.width ?? rect?.width ?? container.clientWidth,
+      height: cached?.fullHeight ?? rect?.height ?? container.clientHeight,
+    })
+    shield.style.left = `${shieldBounds.left}px`
+    // Keep the ruler interactive while content geometry settles. A ruler press
+    // owns transport immediately and must never land on this track-only shield.
+    shield.style.top = `${shieldBounds.top}px`
+    shield.style.width = `${shieldBounds.width}px`
+    shield.style.height = `${shieldBounds.height}px`
     shield.style.display = 'block'
   }, [])
 
   useEffect(() => {
+    const hideShieldIfSettled = (isZoomInteracting: boolean) => {
+      if (isZoomInteracting) return
+      const shield = zoomInteractionShieldRef.current
+      if (shield) shield.style.display = 'none'
+    }
+
+    // HMR or a remount can preserve an imperative `display: block` write after
+    // the zoom store has already settled. Reconcile the DOM immediately.
+    hideShieldIfSettled(useZoomStore.getState().isZoomInteracting)
     return useZoomStore.subscribe((state, previousState) => {
       if (!state.isZoomInteracting && previousState.isZoomInteracting) {
-        const shield = zoomInteractionShieldRef.current
-        if (shield) shield.style.display = 'none'
+        hideShieldIfSettled(state.isZoomInteracting)
       }
     })
   }, [])
@@ -2131,6 +2148,7 @@ export const TimelineContent = memo(function TimelineContent({
         <div
           ref={zoomInteractionShieldRef}
           data-timeline-zoom-interaction-shield
+          data-marquee-ignore
           aria-hidden="true"
           className="fixed z-50"
           style={{ display: 'none' }}

--- a/src/features/timeline/utils/timeline-zoom-interaction-shield.ts
+++ b/src/features/timeline/utils/timeline-zoom-interaction-shield.ts
@@ -1,0 +1,16 @@
+import { TIMELINE_RULER_HEIGHT } from '../constants'
+
+export function getTimelineZoomInteractionShieldBounds(bounds: {
+  left: number
+  top: number
+  width: number
+  height: number
+}) {
+  const rulerHeight = Math.min(TIMELINE_RULER_HEIGHT, bounds.height)
+  return {
+    left: bounds.left,
+    top: bounds.top + rulerHeight,
+    width: bounds.width,
+    height: Math.max(0, bounds.height - rulerHeight),
+  }
+}

--- a/src/shared/marquee/use-marquee-selection.test.tsx
+++ b/src/shared/marquee/use-marquee-selection.test.tsx
@@ -312,6 +312,39 @@ describe('useMarqueeSelection deferred commits', () => {
     expect(onSelectionChange).not.toHaveBeenCalled()
   })
 
+  it('never starts marquee from an interaction shield', () => {
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const onGestureEnd = vi.fn<(event: MouseEvent, wasActualDrag: boolean) => void>()
+    const { getByTestId } = render(
+      <MarqueeHarness onSelectionChange={onSelectionChange} onGestureEnd={onGestureEnd}>
+        <div data-marquee-ignore data-testid="interaction-shield" />
+      </MarqueeHarness>,
+    )
+    const container = getByTestId('marquee-container')
+
+    Object.defineProperties(container, {
+      clientWidth: { configurable: true, value: 200 },
+      clientHeight: { configurable: true, value: 200 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => createRect(0, 0, 200, 200),
+      },
+    })
+
+    fireEvent.mouseDown(getByTestId('interaction-shield'), {
+      button: 0,
+      clientX: 75,
+      clientY: 75,
+    })
+    fireEvent.mouseMove(document, { clientX: 140, clientY: 140 })
+    flushAnimationFrames()
+    fireEvent.mouseUp(document, { clientX: 140, clientY: 140 })
+
+    expect(container).toHaveAttribute('data-marquee-active', 'false')
+    expect(onGestureEnd).not.toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
   it('restores the committed selection when cancellation follows a throttled live commit', () => {
     vi.spyOn(performance, 'now').mockReturnValue(100)
     const onSelectionChange = vi.fn<(ids: string[]) => void>()

--- a/src/shared/marquee/use-marquee-selection.ts
+++ b/src/shared/marquee/use-marquee-selection.ts
@@ -445,6 +445,9 @@ export function useMarqueeSelection({
       target.closest('[data-composition-id]') ||
       // Don't start marquee if clicking in the timeline ruler
       target.closest('.timeline-ruler') ||
+      // Transient interaction shields may intentionally own hit testing, but
+      // they are never valid marquee origins.
+      target.closest('[data-marquee-ignore]') ||
       // Don't start marquee if clicking on the playhead handle
       target.closest('[data-playhead-handle]') ||
       // Don't start marquee if clicking on gizmo elements (handles, borders)


### PR DESCRIPTION
## Summary

- keep the transient timeline zoom shield below the ruler and exclude it from marquee ownership
- make the Proxy Playback toggle authoritative across composition sources, canvas renderers, worker preseek, and cached proxy fallbacks
- apply the selected proxy mode to reverse playback windows while keeping video audio on the original source
- add regression coverage for ruler interaction ownership, source/proxy switching, renderer recreation, and reversed media

## Root cause

The timeline zoom shield could cover the ruler while geometry settled, allowing marquee capture to compete with ruler scrubbing. Separately, the proxy toggle changed the primary playback model but fast-scrub renderers, preseek workers, and fallback caches could continue selecting proxy media after proxies were disabled.

## Impact

Ruler clicks and drags remain owned by the ruler during zoom interactions. Disabling Proxy Playback now consistently uses original video sources across paused scrubbing, rendered effects, transitions, captures, and reverse playback; enabling it restores proxy-backed preview paths.

## Validation

- 146 focused proxy, reverse-preseek, renderer, and composition tests passed
- 25 focused ruler and marquee tests passed
- targeted `vp check --no-fmt` passes on all touched source and test files
- `git diff --check` passes
- live Chrome checks confirmed ruler drag ownership and reversible Proxy Playback toggle state