### PR TITLE
Fix long-project preview churn and lag

### DIFF
--- a/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test'
 import {
+  buildContinuousPreviewOverlayIndex,
   getContinuousPreviewOverlayFrameWindow,
+  shouldForceContinuousPreviewOverlayFromIndex,
   shouldForceContinuousPreviewOverlay,
   shouldForceContinuousPreviewOverlayInWindow,
   timelineHasContinuousOverlayContent,
@@ -53,6 +55,45 @@ function createSubComposition(items: TimelineItem[]): SubComposition {
 }
 
 describe('shouldForceContinuousPreviewOverlay', () => {
+  it('indexes only rendered-overlay candidates for per-frame checks', () => {
+    const ordinaryItems = Array.from({ length: 327 }, (_, index) =>
+      createVideoItem({
+        id: `ordinary-${index}`,
+        from: index * 90,
+      }),
+    )
+    const effectedItem = createVideoItem({
+      id: 'effected',
+      from: 30_000,
+      effects: [
+        {
+          id: 'effect-1',
+          enabled: true,
+          effect: {
+            type: 'gpu-effect',
+            gpuEffectType: 'gpu-blur',
+            params: { amount: 0.5 },
+          },
+        },
+      ],
+    })
+    const index = buildContinuousPreviewOverlayIndex([...ordinaryItems, effectedItem], [])
+
+    expect(index.candidateItems.map((item) => item.id)).toEqual(['effected'])
+    expect(
+      shouldForceContinuousPreviewOverlayFromIndex(index, {
+        startFrame: 30_000,
+        endFrameExclusive: 30_001,
+      }),
+    ).toBe(true)
+    expect(
+      shouldForceContinuousPreviewOverlayFromIndex(index, {
+        startFrame: 0,
+        endFrameExclusive: 1,
+      }),
+    ).toBe(false)
+  })
+
   it('keeps numeric transition counts as a non-forcing legacy hint', () => {
     expect(shouldForceContinuousPreviewOverlay([createVideoItem()], 1, 0)).toBe(false)
   })

--- a/src/features/preview/hooks/use-gpu-effects-overlay.ts
+++ b/src/features/preview/hooks/use-gpu-effects-overlay.ts
@@ -10,7 +10,10 @@ import { useGizmoStore } from '@/features/preview/stores/gizmo-store'
 import type { ItemEffect } from '@/types/effects'
 import type { TimelineItem } from '@/types/timeline'
 import type { Transition } from '@/types/transition'
-import { resolveTransitionWindows } from '@/shared/timeline/transitions/transition-planner'
+import {
+  resolveTransitionWindows,
+  type ResolvedTransitionWindow,
+} from '@/shared/timeline/transitions/transition-planner'
 import { hasCornerPin } from '@/features/preview/deps/composition-runtime'
 import { isTextMotionActive } from '@/shared/typography/text-motion'
 
@@ -80,6 +83,12 @@ export interface ContinuousPreviewOverlayFrameWindow {
 
 interface ContinuousPreviewOverlayWindowOptions {
   forceTransitionFrames?: boolean
+  checkTransitions?: boolean
+}
+
+export interface ContinuousPreviewOverlayIndex {
+  candidateItems: TimelineItem[]
+  transitionWindows: ResolvedTransitionWindow[]
 }
 
 interface ContinuousPreviewOverlayFrameWindowInput {
@@ -143,6 +152,102 @@ function isTextMotionActiveInWindow(
     }
   }
   return false
+}
+
+export function buildContinuousPreviewOverlayIndex(
+  items: TimelineItem[],
+  transitions: Transition[],
+  previewEffectsByItemId?: ReadonlyMap<string, ItemEffect[]>,
+  compositionById?: Record<string, SubComposition>,
+): ContinuousPreviewOverlayIndex {
+  const candidateItems = items.filter((item) => {
+    const effectiveEffects = previewEffectsByItemId?.get(item.id) ?? item.effects
+    if (hasEnabledGpuEffect(effectiveEffects)) return true
+    if (hasRenderableBlendMode(item)) return true
+    if (hasCornerPin(item.cornerPin)) return true
+    if (hasTextMotionSpec(item)) return true
+    if (item.type === 'composition' && compositionById) {
+      const subComp = compositionById[item.compositionId]
+      return Boolean(subComp && subCompositionNeedsRenderedOverlayPath(subComp, compositionById))
+    }
+    return false
+  })
+  const clipsById = new Map(items.map((item) => [item.id, item]))
+
+  return {
+    candidateItems,
+    transitionWindows: resolveTransitionWindows(transitions, clipsById),
+  }
+}
+
+export function shouldForceContinuousPreviewOverlayFromIndex(
+  index: ContinuousPreviewOverlayIndex,
+  window: ContinuousPreviewOverlayFrameWindow,
+  previewEffectsByItemId?: ReadonlyMap<string, ItemEffect[]>,
+  compositionById?: Record<string, SubComposition>,
+  options: ContinuousPreviewOverlayWindowOptions = {},
+): boolean {
+  const { startFrame, endFrameExclusive } = window
+  if (
+    !Number.isFinite(startFrame) ||
+    !Number.isFinite(endFrameExclusive) ||
+    endFrameExclusive <= startFrame
+  ) {
+    return false
+  }
+
+  if (options.checkTransitions !== false) {
+    for (const transitionWindow of index.transitionWindows) {
+      if (
+        !rangesOverlap(
+          startFrame,
+          endFrameExclusive,
+          transitionWindow.startFrame,
+          transitionWindow.endFrame,
+        )
+      ) {
+        continue
+      }
+      if (options.forceTransitionFrames) return true
+      if (
+        transitionWindow.leftClip.type === 'composition' ||
+        transitionWindow.rightClip.type === 'composition' ||
+        hasCornerPin(transitionWindow.leftClip.cornerPin) ||
+        hasCornerPin(transitionWindow.rightClip.cornerPin)
+      ) {
+        return true
+      }
+    }
+  }
+
+  return index.candidateItems.some((item) => {
+    if (
+      !rangesOverlap(
+        startFrame,
+        endFrameExclusive,
+        item.from,
+        item.from + item.durationInFrames,
+      )
+    ) {
+      return false
+    }
+    const effectiveEffects = previewEffectsByItemId?.get(item.id) ?? item.effects
+    if (hasEnabledGpuEffect(effectiveEffects)) return true
+    if (hasRenderableBlendMode(item)) return true
+    if (hasCornerPin(item.cornerPin)) return true
+    if (
+      item.type === 'text' &&
+      item.textMotion !== undefined &&
+      isTextMotionActiveInWindow(item, startFrame, endFrameExclusive)
+    ) {
+      return true
+    }
+    if (item.type === 'composition' && compositionById) {
+      const subComp = compositionById[item.compositionId]
+      return Boolean(subComp && subCompositionNeedsRenderedOverlayPath(subComp, compositionById))
+    }
+    return false
+  })
 }
 
 /**
@@ -253,12 +358,7 @@ export function shouldForceContinuousPreviewOverlayInWindow(
 
   return items.some((item) => {
     if (
-      !rangesOverlap(
-        startFrame,
-        endFrameExclusive,
-        item.from,
-        item.from + item.durationInFrames,
-      )
+      !rangesOverlap(startFrame, endFrameExclusive, item.from, item.from + item.durationInFrames)
     ) {
       return false
     }
@@ -306,10 +406,49 @@ export function useGpuEffectsOverlay(fps: number) {
   }, [])
 
   useEffect(() => {
-    const check = () => {
+    let indexedItems: TimelineItem[] | null = null
+    let indexedTransitions: Transition[] | null = null
+    let indexedCompositions: Record<string, SubComposition> | null = null
+    let indexedPreview: ReturnType<typeof useGizmoStore.getState>['preview'] | undefined
+    let previewEffectsByItemId: ReadonlyMap<string, ItemEffect[]> | undefined
+    let overlayIndex: ContinuousPreviewOverlayIndex | null = null
+
+    const getOverlayIndex = () => {
       const items = useItemsStore.getState().items
       const transitions = useTransitionsStore.getState().transitions
       const compositionById = useCompositionsStore.getState().compositionById
+      const preview = useGizmoStore.getState().preview
+      if (
+        overlayIndex &&
+        indexedItems === items &&
+        indexedTransitions === transitions &&
+        indexedCompositions === compositionById &&
+        indexedPreview === preview
+      ) {
+        return { compositionById, overlayIndex, previewEffectsByItemId }
+      }
+
+      previewEffectsByItemId = preview
+        ? new Map(
+            Object.entries(preview)
+              .filter(([, itemPreview]) => Array.isArray(itemPreview.effects))
+              .map(([itemId, itemPreview]) => [itemId, itemPreview.effects!]),
+          )
+        : undefined
+      overlayIndex = buildContinuousPreviewOverlayIndex(
+        items,
+        transitions,
+        previewEffectsByItemId,
+        compositionById,
+      )
+      indexedItems = items
+      indexedTransitions = transitions
+      indexedCompositions = compositionById
+      indexedPreview = preview
+      return { compositionById, overlayIndex, previewEffectsByItemId }
+    }
+
+    const check = () => {
       const playback = usePlaybackStore.getState()
       const isPreviewing = playback.previewFrame !== null
       const frame = playback.previewFrame ?? playback.currentFrame
@@ -320,34 +459,26 @@ export function useGpuEffectsOverlay(fps: number) {
         isPreviewing,
         playbackRate: playback.playbackRate,
       })
-      const preview = useGizmoStore.getState().preview
-      const previewEffectsByItemId = preview
-        ? new Map(
-            Object.entries(preview)
-              .filter(([, itemPreview]) => Array.isArray(itemPreview.effects))
-              .map(([itemId, itemPreview]) => [itemId, itemPreview.effects!]),
-          )
-        : undefined
+      const { compositionById, overlayIndex, previewEffectsByItemId } = getOverlayIndex()
 
       setNeedsOverlay((prev) => {
         // Pre-arm shortly before rendered-only content and retain it briefly
         // after the boundary. Ordinary frames outside this bounded window stay
         // on the browser Player instead of paying the continuous render-pump cost.
         const next =
-          shouldForceContinuousPreviewOverlayInWindow(
-            items,
-            0,
+          shouldForceContinuousPreviewOverlayFromIndex(
+            overlayIndex,
             frameWindow,
             previewEffectsByItemId,
             compositionById,
+            { checkTransitions: false },
           ) ||
           // Transition pre-rendering has its own runway and buffer ownership.
           // Only route an actual transition frame here so effect lookahead does
           // not turn the pre-render runway itself into presented overlay frames.
-          shouldForceContinuousPreviewOverlay(
-            items,
-            transitions,
-            frame,
+          shouldForceContinuousPreviewOverlayFromIndex(
+            overlayIndex,
+            { startFrame: frame, endFrameExclusive: frame + 1 },
             previewEffectsByItemId,
             compositionById,
             { forceTransitionFrames: isPreviewing || playback.isPlaying },

--- a/src/runtime/composition-runtime/components/custom-decoder-audio.test.tsx
+++ b/src/runtime/composition-runtime/components/custom-decoder-audio.test.tsx
@@ -171,6 +171,7 @@ describe('CustomDecoderAudio', () => {
         'true',
       )
     })
+    expect(audioDecodeMocks.getOrDecodeAudio).not.toHaveBeenCalled()
   })
 
   it('defers pitch-preserved decoding until an active preview scrub settles', async () => {

--- a/src/runtime/composition-runtime/components/custom-decoder-audio.tsx
+++ b/src/runtime/composition-runtime/components/custom-decoder-audio.tsx
@@ -3,7 +3,7 @@ import { SoundTouchWorkletAudio } from './soundtouch-worklet-audio'
 import { CustomDecoderBufferedAudio } from './custom-decoder-buffered-audio'
 import { NativePitchCorrectedAudio } from './pitch-corrected-audio'
 import type { AudioPlaybackProps } from './audio-playback-props'
-import { getOrDecodeAudio, getOrDecodeAudioSliceForPlayback } from '../utils/audio-decode-cache'
+import { getOrDecodeAudioSliceForPlayback } from '../utils/audio-decode-cache'
 import { audioBufferToWavBlob } from '../utils/audio-buffer-wav'
 import { createReversedAudioBuffer } from '../utils/audio-buffer-utils'
 import { createLogger } from '@/shared/logging/logger'
@@ -23,8 +23,6 @@ const PARTIAL_WAV_READY_SECONDS = 2
 const PARTIAL_WAV_WAIT_TIMEOUT_MS = 6000
 const PARTIAL_WAV_EXTENSION_TRIGGER_SECONDS = 1.25
 const PARTIAL_WAV_EXTENSION_READY_SECONDS = 3
-const BACKGROUND_FULL_DECODE_DELAY_MS = 1500
-const BACKGROUND_FULL_DECODE_BACKSTOP_MS = 4000
 const REVERSE_SHUTTLE_PREROLL_SECONDS = 4
 
 interface CustomDecoderAudioProps extends AudioPlaybackProps {
@@ -244,9 +242,6 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
     if (!mediaId || !src || isPreviewScrubbing) return
 
     let cancelled = false
-    let fullDecodeStarted = false
-    let scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-    let fullDecodeTimer: ReturnType<typeof setTimeout> | null = null
     const effectiveSourceFps = sourceFps ?? 30
     const seedSourceFrames = isReverseShuttle
       ? getAudioTargetTimeSeconds(
@@ -262,52 +257,11 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
         ? reverseSourceEnd
         : trimBefore
     const clipStartTime = Math.max(0, seedSourceFrames / effectiveSourceFps)
-    const clearScheduledFullDecode = () => {
-      scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-      if (fullDecodeTimer !== null) {
-        clearTimeout(fullDecodeTimer)
-        fullDecodeTimer = null
-      }
-    }
-    const startFullDecode = () => {
-      if (cancelled || fullDecodeStarted) return
-      clearScheduledFullDecode()
-      fullDecodeStarted = true
-      getOrDecodeAudio(mediaId, src)
-        .then((buffer) => {
-          if (cancelled) return
-          setDecodedSource({
-            buffer,
-            sourceStartOffsetSec: 0,
-            coverageEndSec: Number.POSITIVE_INFINITY,
-            isComplete: true,
-          })
-          log.info('Decoded pitch source ready', { mediaId })
-        })
-        .catch((err) => {
-          if (cancelled) return
-          log.error('Failed to prepare decoded pitch source', { mediaId, err })
-        })
-    }
-    const scheduleFullDecode = (delayMs: number) => {
-      if (cancelled || fullDecodeStarted) return
-      const safeDelayMs = Math.max(0, delayMs)
-      const dueAtMs = Date.now() + safeDelayMs
-      if (fullDecodeTimer !== null && dueAtMs >= scheduledFullDecodeAtMs - 1) {
-        return
-      }
-      clearScheduledFullDecode()
-      scheduledFullDecodeAtMs = dueAtMs
-      fullDecodeTimer = setTimeout(() => {
-        fullDecodeTimer = null
-        scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-        startFullDecode()
-      }, safeDelayMs)
-    }
     setDecodedSource(null)
     pendingExtensionKeyRef.current = null
-    scheduleFullDecode(BACKGROUND_FULL_DECODE_BACKSTOP_MS)
 
+    // Keep preview audio windowed. Whole-file decoding makes long custom-codec
+    // sources retain very large Float32 buffers after the cache has evicted them.
     getOrDecodeAudioSliceForPlayback(mediaId, src, {
       minReadySeconds: PARTIAL_WAV_READY_SECONDS,
       waitTimeoutMs: PARTIAL_WAV_WAIT_TIMEOUT_MS,
@@ -328,11 +282,6 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
           }
           return nextSource
         })
-        if (slice.isComplete) {
-          clearScheduledFullDecode()
-        } else {
-          scheduleFullDecode(BACKGROUND_FULL_DECODE_DELAY_MS)
-        }
         log.info('Partial decoded pitch source ready', {
           mediaId,
           duration: slice.buffer.duration.toFixed(2),
@@ -341,12 +290,10 @@ const CustomDecoderPitchPreservedAudio: React.FC<CustomDecoderAudioProps> = ({
       .catch((err) => {
         if (cancelled) return
         log.error('Failed to prepare partial decoded pitch source', { mediaId, err })
-        startFullDecode()
       })
 
     return () => {
       cancelled = true
-      clearScheduledFullDecode()
     }
   }, [
     fps,

--- a/src/runtime/composition-runtime/components/custom-decoder-buffered-audio.test.tsx
+++ b/src/runtime/composition-runtime/components/custom-decoder-buffered-audio.test.tsx
@@ -129,7 +129,7 @@ describe('CustomDecoderBufferedAudio', () => {
     audioDecodeMocks.getOrDecodeAudio.mockReturnValue(pendingDecode)
   })
 
-  it('starts with partial decode playback and continues full decode in background', async () => {
+  it('keeps long preview audio windowed instead of starting a background full decode', async () => {
     vi.useFakeTimers()
     try {
       render(
@@ -162,11 +162,11 @@ describe('CustomDecoderBufferedAudio', () => {
       expect(audioDecodeMocks.getOrDecodeAudio).not.toHaveBeenCalled()
 
       await act(async () => {
-        vi.advanceTimersByTime(1600)
+        vi.advanceTimersByTime(10_000)
         await Promise.resolve()
       })
 
-      expect(audioDecodeMocks.getOrDecodeAudio).toHaveBeenCalledWith('media-1', 'blob:audio')
+      expect(audioDecodeMocks.getOrDecodeAudio).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }

--- a/src/runtime/composition-runtime/components/custom-decoder-buffered-audio.tsx
+++ b/src/runtime/composition-runtime/components/custom-decoder-buffered-audio.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { getAudioTargetTimeSeconds } from '../utils/video-timing'
 import {
-  getOrDecodeAudio,
   getOrDecodeAudioSliceForPlayback,
   isPreviewAudioDecodePending,
   type PlaybackAudioSlice,
@@ -32,12 +31,6 @@ const PARTIAL_BUFFER_EXTENSION_READY_SECONDS = 3
 const PARTIAL_BUFFER_REQUEST_PREROLL_SECONDS = 0.25
 const PENDING_SLICE_REUSE_HEADROOM_SECONDS = 1
 const PAUSED_SEEK_PREFETCH_DEBOUNCE_MS = 50
-const BACKGROUND_FULL_DECODE_DELAY_MS = 1500
-const BACKGROUND_FULL_DECODE_BACKSTOP_MS = 4000
-// Prefer a playable partial decode first, then upgrade to the full buffer in
-// the background. This keeps custom-decoded formats like Vorbis responsive on
-// first play after import/refresh instead of waiting for the whole file.
-const WAIT_FOR_FULL_DECODE_BEFORE_PLAYBACK = false
 
 interface CustomDecoderBufferedAudioProps extends AudioPlaybackProps {
   src: string
@@ -236,62 +229,7 @@ export const CustomDecoderBufferedAudio: React.FC<CustomDecoderBufferedAudioProp
       if (!mediaId || !src || isPreviewScrubbing) return
 
       let cancelled = false
-      let fullDecodeStarted = false
-      let scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-      let fullDecodeTimer: ReturnType<typeof setTimeout> | null = null
       const effectiveSourceFps = sourceFps ?? fps
-      const clearScheduledFullDecode = () => {
-        scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-        if (fullDecodeTimer !== null) {
-          clearTimeout(fullDecodeTimer)
-          fullDecodeTimer = null
-        }
-      }
-      const startFullDecode = () => {
-        if (cancelled || fullDecodeStarted) {
-          return
-        }
-        clearScheduledFullDecode()
-        activeSliceRequestRef.current = null
-        fullDecodeStarted = true
-        getOrDecodeAudio(mediaId, src)
-          .then((buffer) => {
-            if (!cancelled) {
-              setAudioSlice((current) => {
-                if (
-                  current?.isComplete &&
-                  current.buffer.length === buffer.length &&
-                  current.buffer.sampleRate === buffer.sampleRate
-                ) {
-                  return current
-                }
-                return { buffer, startTime: 0, isComplete: true }
-              })
-            }
-          })
-          .catch((err) => {
-            if (!cancelled) {
-              log.error('Failed to finalize buffered audio decode', { mediaId, err })
-            }
-          })
-      }
-      const scheduleFullDecode = (delayMs: number) => {
-        if (cancelled || fullDecodeStarted) {
-          return
-        }
-        const safeDelayMs = Math.max(0, delayMs)
-        const dueAtMs = Date.now() + safeDelayMs
-        if (fullDecodeTimer !== null && dueAtMs >= scheduledFullDecodeAtMs - 1) {
-          return
-        }
-        clearScheduledFullDecode()
-        scheduledFullDecodeAtMs = dueAtMs
-        fullDecodeTimer = setTimeout(() => {
-          fullDecodeTimer = null
-          scheduledFullDecodeAtMs = Number.POSITIVE_INFINITY
-          startFullDecode()
-        }, safeDelayMs)
-      }
       activeSliceRequestRef.current = null
       const decodeSeedKey = `${mediaId}:${src}:${trimBefore}:${effectiveSourceFps}:${playbackRate}`
       if (decodeSeedRef.current?.key !== decodeSeedKey) {
@@ -307,109 +245,81 @@ export const CustomDecoderBufferedAudio: React.FC<CustomDecoderBufferedAudioProp
         }
       }
       const initialTargetTime = decodeSeedRef.current.targetTime
-      if (WAIT_FOR_FULL_DECODE_BEFORE_PLAYBACK) {
-        getOrDecodeAudio(mediaId, src)
-          .then((buffer) => {
-            if (!cancelled) {
-              setAudioSlice({ buffer, startTime: 0, isComplete: true })
-              log.info('Full buffered audio ready', {
-                mediaId,
-                duration: buffer.duration.toFixed(2),
-                sampleRate: buffer.sampleRate,
-                channels: buffer.numberOfChannels,
-              })
+      // Keep preview audio windowed. A whole-file Float32 AudioBuffer for a
+      // long source can be hundreds of MiB and remains retained by component
+      // state even when the shared cache evicts it.
+      const initialSliceRequest = requestPartialSlice(
+        initialTargetTime,
+        INITIAL_PLAYABLE_BUFFER_SECONDS,
+      )
+      initialSliceRequest.promise
+        .then((slice) => {
+          if (!cancelled) {
+            if (!acceptPartialSlice(initialSliceRequest.requestId, slice)) {
+              return
             }
-          })
-          .catch((err) => {
-            if (!cancelled) {
-              log.error('Failed to decode buffered audio', { mediaId, err })
-            }
-          })
-      } else {
-        // Legacy low-latency path: start from partial bins, then upgrade to full decode.
-        scheduleFullDecode(BACKGROUND_FULL_DECODE_BACKSTOP_MS)
-        const initialSliceRequest = requestPartialSlice(
-          initialTargetTime,
-          INITIAL_PLAYABLE_BUFFER_SECONDS,
-        )
-        initialSliceRequest.promise
-          .then((slice) => {
-            if (!cancelled) {
-              if (!acceptPartialSlice(initialSliceRequest.requestId, slice)) {
-                return
-              }
-              if (slice.isComplete) {
-                clearScheduledFullDecode()
-              } else {
-                scheduleFullDecode(BACKGROUND_FULL_DECODE_DELAY_MS)
-              }
-              log.info('Initial buffered audio ready', {
-                mediaId,
-                duration: slice.buffer.duration.toFixed(2),
-                sampleRate: slice.buffer.sampleRate,
-                channels: slice.buffer.numberOfChannels,
-                startTime: slice.startTime.toFixed(2),
-              })
+            log.info('Initial buffered audio ready', {
+              mediaId,
+              duration: slice.buffer.duration.toFixed(2),
+              sampleRate: slice.buffer.sampleRate,
+              channels: slice.buffer.numberOfChannels,
+              startTime: slice.startTime.toFixed(2),
+            })
 
-              // The startup slice is intentionally small for fast first sound.
-              // If it is still tiny once ready, immediately ask for follow-up
-              // coverage so 1x playback does not outrun the initial buffer before
-              // the normal extension effect gets another turn.
-              if (
-                !slice.isComplete &&
-                slice.buffer.duration <= INITIAL_PLAYABLE_BUFFER_SECONDS + 0.5
-              ) {
-                const prefetchTargetTime = Math.max(
-                  initialTargetTime,
-                  slice.startTime +
-                    Math.max(0, slice.buffer.duration - PARTIAL_BUFFER_HEADROOM_SECONDS),
-                )
-                const prefetchSliceRequest = requestPartialSlice(
-                  prefetchTargetTime,
-                  PARTIAL_BUFFER_EXTENSION_READY_SECONDS,
-                )
-                void prefetchSliceRequest.promise
-                  .then((nextSlice) => {
-                    if (cancelled) {
-                      return
-                    }
-                    acceptPartialSlice(prefetchSliceRequest.requestId, nextSlice)
-                  })
-                  .catch((err) => {
-                    if (!cancelled) {
-                      log.warn('Failed to prefetch buffered custom decoder audio slice', {
-                        mediaId,
-                        targetTime: prefetchTargetTime,
-                        err,
-                      })
-                    }
-                  })
-                  .finally(() => {
-                    if (
-                      activeSliceRequestRef.current?.requestId === prefetchSliceRequest.requestId
-                    ) {
-                      activeSliceRequestRef.current = null
-                    }
-                  })
-              }
+            // The startup slice is intentionally small for fast first sound.
+            // If it is still tiny once ready, immediately ask for follow-up
+            // coverage so 1x playback does not outrun the initial buffer before
+            // the normal extension effect gets another turn.
+            if (
+              !slice.isComplete &&
+              slice.buffer.duration <= INITIAL_PLAYABLE_BUFFER_SECONDS + 0.5
+            ) {
+              const prefetchTargetTime = Math.max(
+                initialTargetTime,
+                slice.startTime +
+                  Math.max(0, slice.buffer.duration - PARTIAL_BUFFER_HEADROOM_SECONDS),
+              )
+              const prefetchSliceRequest = requestPartialSlice(
+                prefetchTargetTime,
+                PARTIAL_BUFFER_EXTENSION_READY_SECONDS,
+              )
+              void prefetchSliceRequest.promise
+                .then((nextSlice) => {
+                  if (cancelled) {
+                    return
+                  }
+                  acceptPartialSlice(prefetchSliceRequest.requestId, nextSlice)
+                })
+                .catch((err) => {
+                  if (!cancelled) {
+                    log.warn('Failed to prefetch buffered custom decoder audio slice', {
+                      mediaId,
+                      targetTime: prefetchTargetTime,
+                      err,
+                    })
+                  }
+                })
+                .finally(() => {
+                  if (activeSliceRequestRef.current?.requestId === prefetchSliceRequest.requestId) {
+                    activeSliceRequestRef.current = null
+                  }
+                })
             }
-          })
-          .catch((err) => {
-            if (!cancelled) {
-              log.error('Failed to decode buffered audio', { mediaId, err })
-            }
-            startFullDecode()
-          })
-          .finally(() => {
-            if (activeSliceRequestRef.current?.requestId === initialSliceRequest.requestId) {
-              activeSliceRequestRef.current = null
-            }
-          })
-      }
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            log.error('Failed to decode buffered audio slice', { mediaId, err })
+          }
+        })
+        .finally(() => {
+          if (activeSliceRequestRef.current?.requestId === initialSliceRequest.requestId) {
+            activeSliceRequestRef.current = null
+          }
+        })
 
       return () => {
         cancelled = true
-        clearScheduledFullDecode()
         activeSliceRequestRef.current = null
       }
     }, [

--- a/src/runtime/composition-runtime/components/pitch-corrected-audio.test.tsx
+++ b/src/runtime/composition-runtime/components/pitch-corrected-audio.test.tsx
@@ -273,7 +273,7 @@ describe('PitchCorrectedAudio', () => {
       expect(document.querySelector('[data-testid="pitch"]')).toHaveAttribute('data-offset', '4')
     })
 
-    expect(audioDecodeMocks.getOrDecodeAudio).toHaveBeenCalledWith('media-1', 'blob:audio')
+    expect(audioDecodeMocks.getOrDecodeAudio).not.toHaveBeenCalled()
   })
 
   it('defers decoded pitch audio until an active preview scrub settles', async () => {
@@ -313,7 +313,7 @@ describe('PitchCorrectedAudio', () => {
 
     await waitFor(() => {
       expect(audioDecodeMocks.getOrDecodeAudioSliceForPlayback).toHaveBeenCalledTimes(1)
-      expect(audioDecodeMocks.getOrDecodeAudio).toHaveBeenCalledTimes(1)
+      expect(audioDecodeMocks.getOrDecodeAudio).not.toHaveBeenCalled()
     })
   })
 

--- a/src/runtime/composition-runtime/components/pitch-corrected-audio.tsx
+++ b/src/runtime/composition-runtime/components/pitch-corrected-audio.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { createLogger } from '@/shared/logging/logger'
 import { useGizmoStore } from '@/runtime/composition-runtime/deps/stores'
 import { usePlaybackStore } from '@/runtime/composition-runtime/deps/stores'
-import { getOrDecodeAudio, getOrDecodeAudioSliceForPlayback } from '../utils/audio-decode-cache'
+import { getOrDecodeAudioSliceForPlayback } from '../utils/audio-decode-cache'
 import { audioBufferToWavBlob } from '../utils/audio-buffer-wav'
 import { createReversedAudioBuffer } from '../utils/audio-buffer-utils'
 import { getAudioTargetTimeSeconds } from '../utils/video-timing'
@@ -577,25 +577,6 @@ const DecodedPitchCorrectedAudio: React.FC<DecodedPitchCorrectedAudioProps> = Re
         .catch((error) => {
           if (!cancelled) {
             log.warn('Failed to prepare partial pitch-corrected preview buffer', {
-              mediaId,
-              error,
-            })
-          }
-        })
-
-      getOrDecodeAudio(mediaId, src)
-        .then((buffer) => {
-          if (cancelled) return
-          setDecodedSource({
-            buffer,
-            sourceStartOffsetSec: 0,
-            coverageEndSec: Number.POSITIVE_INFINITY,
-            isComplete: true,
-          })
-        })
-        .catch((error) => {
-          if (!cancelled) {
-            log.warn('Failed to prepare full pitch-corrected preview buffer', {
               mediaId,
               error,
             })

--- a/src/runtime/composition-runtime/utils/audio-decode-cache.test.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-cache.test.ts
@@ -61,11 +61,13 @@ const mediabunnyMocks = vi.hoisted(() => {
     ) => void
     close: () => void
   }> = []
+  let rejectTargetedWindows = false
   const stats = {
     inputConstructed: 0,
     sinkConstructed: 0,
     sampleSinkConstructed: 0,
     bufferRangeStarts: [] as number[],
+    sequentialSamplesCalls: 0,
   }
 
   class Input {
@@ -97,6 +99,9 @@ const mediabunnyMocks = vi.hoisted(() => {
       stats.sampleSinkConstructed += 1
     }
     async getSample(startTime: number) {
+      if (rejectTargetedWindows) {
+        throw new Error('Random-access audio decode is unsupported')
+      }
       if (pendingSamplePromise) {
         return pendingSamplePromise
       }
@@ -109,10 +114,15 @@ const mediabunnyMocks = vi.hoisted(() => {
         null
       )
     }
-    samples(startTime = 0, endTime = Number.POSITIVE_INFINITY) {
-      stats.bufferRangeStarts.push(startTime)
+    samples(startTime?: number, endTime = Number.POSITIVE_INFINITY) {
+      if (startTime === undefined) {
+        stats.sequentialSamplesCalls += 1
+      } else {
+        stats.bufferRangeStarts.push(startTime)
+      }
+      const effectiveStartTime = startTime ?? 0
       const samples = pendingSamples.filter(
-        (sample) => sample.timestamp >= startTime && sample.timestamp < endTime,
+        (sample) => sample.timestamp >= effectiveStartTime && sample.timestamp < endTime,
       )
       return (async function* yieldSamples() {
         for (const sample of samples) {
@@ -147,13 +157,18 @@ const mediabunnyMocks = vi.hoisted(() => {
     __setPendingSamplePromise(promise: Promise<MockAudioSample | null>) {
       pendingSamplePromise = promise
     },
+    __setRejectTargetedWindows(value: boolean) {
+      rejectTargetedWindows = value
+    },
     __reset() {
       pendingSamplePromise = null
       pendingSamples = []
+      rejectTargetedWindows = false
       stats.inputConstructed = 0
       stats.sinkConstructed = 0
       stats.sampleSinkConstructed = 0
       stats.bufferRangeStarts = []
+      stats.sequentialSamplesCalls = 0
     },
     __stats: stats,
   }
@@ -289,6 +304,33 @@ describe('audio-decode-cache targeted slice reuse', () => {
     expect(slice.isComplete).toBe(false)
     expect(ac3Mocks.ensureAc3DecoderRegistered).toHaveBeenCalledTimes(1)
     expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(1)
+    expect(mediabunnyMocks.__stats.bufferRangeStarts).toEqual([])
+    expect(mediabunnyMocks.__stats.sequentialSamplesCalls).toBe(0)
+  })
+
+  it('falls back to bounded sequential decoding when targeted windows are unsupported', async () => {
+    mediaDbMocks.getMedia.mockResolvedValue({ mimeType: 'audio/ac3', codec: 'ac-3' })
+    ac3Mocks.isAc3AudioCodec.mockReturnValue(true)
+    mediabunnyMocks.__setRejectTargetedWindows(true)
+    mediabunnyMocks.__setPendingSamples([
+      makeSample(22050, 22050, 0),
+      makeSample(22050, 22050, 24),
+      makeSample(22050, 22050, 25),
+      makeSample(22050, 22050, 26),
+    ])
+
+    const slice = await getOrDecodeAudioSliceForPlayback('media-sequential', 'blob://audio', {
+      minReadySeconds: 1,
+      targetTimeSeconds: 25,
+      preRollSeconds: 0,
+      waitTimeoutMs: 0,
+    })
+
+    expect(slice.startTime).toBe(25)
+    expect(slice.buffer.duration).toBe(1)
+    expect(slice.isComplete).toBe(false)
+    expect(mediabunnyMocks.__stats.sampleSinkConstructed).toBe(2)
+    expect(mediabunnyMocks.__stats.sequentialSamplesCalls).toBe(1)
     expect(mediabunnyMocks.__stats.bufferRangeStarts).toEqual([])
   })
 

--- a/src/runtime/composition-runtime/utils/audio-decode-cache.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-cache.ts
@@ -92,7 +92,6 @@ function evictIfNeeded(): void {
   }
 }
 const DEFAULT_PLAYABLE_PARTIAL_READY_SECONDS = 2
-const PLAYABLE_PARTIAL_TIMEOUT_MS = 8000
 const PLAYABLE_PARTIAL_PREROLL_SECONDS = 0.25
 const STARTUP_PLAYABLE_PARTIAL_READY_SECONDS = 1
 const PENDING_PLAYBACK_SLICE_REUSE_HEADROOM_SECONDS = 1
@@ -213,12 +212,6 @@ function rememberPlaybackSlice(mediaId: string, slice: PlaybackAudioSlice): void
 
 function binKey(mediaId: string, binIndex: number): string {
   return `${mediaId}:bin:${binIndex}`
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
 }
 
 function createInputSource(mb: Awaited<typeof import('mediabunny')>, src: PreviewAudioSource) {
@@ -531,14 +524,16 @@ async function decodeAudioWindow(
 
 /**
  * Playback-first helper for custom-decoded audio:
- * returns a partial buffer as soon as enough decoded bins are available,
- * while full decode continues in the background.
+ * returns a bounded buffer around the requested playback position. This path
+ * deliberately never starts a whole-file decode: callers retain the returned
+ * AudioBuffer, so a long source would otherwise defeat the shared cache budget.
  */
 export async function getOrDecodeAudioSliceForPlayback(
   mediaId: string,
   src: PreviewAudioSource,
   options?: {
     minReadySeconds?: number
+    /** @deprecated Retained for call-site compatibility; window decoding no longer escalates. */
     waitTimeoutMs?: number
     targetTimeSeconds?: number
     preRollSeconds?: number
@@ -558,10 +553,8 @@ export async function getOrDecodeAudioSliceForPlayback(
     1,
     options?.minReadySeconds ?? DEFAULT_PLAYABLE_PARTIAL_READY_SECONDS,
   )
-  const waitTimeoutMs = Math.max(0, options?.waitTimeoutMs ?? PLAYABLE_PARTIAL_TIMEOUT_MS)
   const targetTimeSeconds = Math.max(0, options?.targetTimeSeconds ?? 0)
   const preRollSeconds = Math.max(0, options?.preRollSeconds ?? PLAYABLE_PARTIAL_PREROLL_SECONDS)
-  const pendingFullDecodePromise = pendingDecodes.get(mediaId) ?? null
 
   const cachedPlaybackSlice = playbackSliceCache.get(mediaId)
   if (
@@ -611,17 +604,12 @@ export async function getOrDecodeAudioSliceForPlayback(
       rememberPlaybackSlice(mediaId, slice)
       return slice
     } catch (windowError) {
-      log.warn('Targeted preview audio window decode failed, falling back to full decode', {
+      log.warn('Targeted preview audio window decode failed', {
         mediaId,
         targetTimeSeconds,
         error: windowError,
       })
-    }
-
-    return {
-      buffer: await getOrDecodeAudio(mediaId, src),
-      startTime: 0,
-      isComplete: true,
+      throw windowError
     }
   })()
 
@@ -632,19 +620,6 @@ export async function getOrDecodeAudioSliceForPlayback(
   })
 
   try {
-    if (waitTimeoutMs > 0) {
-      return await Promise.race([
-        partialPromise,
-        (async () => {
-          await sleep(waitTimeoutMs)
-          return {
-            buffer: await (pendingFullDecodePromise ?? getOrDecodeAudio(mediaId, src)),
-            startTime: 0,
-            isComplete: true,
-          } satisfies PlaybackAudioSlice
-        })(),
-      ])
-    }
     return await partialPromise
   } finally {
     const pendingSlice = pendingPlaybackSliceDecodes.get(mediaId)

--- a/src/runtime/composition-runtime/utils/audio-decode-cache.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-cache.ts
@@ -108,6 +108,8 @@ export interface PlaybackAudioSlice {
   isComplete: boolean
 }
 
+type AudioWindowDecodeMode = 'targeted' | 'sequential'
+
 interface DecodeAudioSampleData {
   numberOfFrames?: number
   numberOfChannels?: number
@@ -391,6 +393,7 @@ async function decodeAudioWindow(
   src: PreviewAudioSource,
   startTime: number,
   durationSeconds: number,
+  mode: AudioWindowDecodeMode = 'targeted',
   ac3RetryAttempted: boolean = false,
 ): Promise<PlaybackAudioSlice> {
   const shouldRegisterAc3 = ac3RetryAttempted || (await shouldPreRegisterAc3Decoder(mediaId))
@@ -461,33 +464,58 @@ async function decodeAudioWindow(
         totalFrames += chunk.frameCount
       }
 
-      const initialSample = (await sink.getSample(safeStartTime)) as DecodeAudioSampleData | null
-      let initialSampleEndTime: number | null = null
-      if (initialSample) {
-        try {
-          appendSample(initialSample)
-          initialSampleEndTime = getDecodeSampleEndTime(initialSample)
-        } finally {
-          initialSample.close()
-        }
-      }
-
-      const iteratorStartTime =
-        initialSampleEndTime === null
-          ? safeStartTime
-          : Math.max(safeStartTime, initialSampleEndTime)
-      if (coverageEndTime < targetCoverageEndTime) {
-        for await (const sample of sink.samples(
-          iteratorStartTime,
-          targetCoverageEndTime,
-        ) as AsyncIterable<DecodeAudioSampleData>) {
+      if (mode === 'sequential') {
+        // A custom decoder may support only forward decoding from the start.
+        // Discard early samples and retain chunks only for the requested window.
+        for await (const sample of sink.samples() as AsyncIterable<DecodeAudioSampleData>) {
           try {
+            const sampleStartTime = Number.isFinite(sample.timestamp)
+              ? Number(sample.timestamp)
+              : null
+            const sampleEndTime = getDecodeSampleEndTime(sample)
+            if (sampleEndTime !== null && sampleEndTime <= safeStartTime) {
+              continue
+            }
+            if (sampleStartTime !== null && sampleStartTime >= targetCoverageEndTime) {
+              break
+            }
             appendSample(sample)
           } finally {
             sample.close()
           }
           if (coverageEndTime >= targetCoverageEndTime) {
             break
+          }
+        }
+      } else {
+        const initialSample = (await sink.getSample(safeStartTime)) as DecodeAudioSampleData | null
+        let initialSampleEndTime: number | null = null
+        if (initialSample) {
+          try {
+            appendSample(initialSample)
+            initialSampleEndTime = getDecodeSampleEndTime(initialSample)
+          } finally {
+            initialSample.close()
+          }
+        }
+
+        const iteratorStartTime =
+          initialSampleEndTime === null
+            ? safeStartTime
+            : Math.max(safeStartTime, initialSampleEndTime)
+        if (coverageEndTime < targetCoverageEndTime) {
+          for await (const sample of sink.samples(
+            iteratorStartTime,
+            targetCoverageEndTime,
+          ) as AsyncIterable<DecodeAudioSampleData>) {
+            try {
+              appendSample(sample)
+            } finally {
+              sample.close()
+            }
+            if (coverageEndTime >= targetCoverageEndTime) {
+              break
+            }
           }
         }
       }
@@ -513,7 +541,7 @@ async function decodeAudioWindow(
   } catch (err) {
     if (!ac3RetryAttempted && !shouldRegisterAc3) {
       try {
-        return await decodeAudioWindow(mediaId, src, startTime, durationSeconds, true)
+        return await decodeAudioWindow(mediaId, src, startTime, durationSeconds, mode, true)
       } catch {
         // Keep original error as primary failure.
       }
@@ -604,12 +632,30 @@ export async function getOrDecodeAudioSliceForPlayback(
       rememberPlaybackSlice(mediaId, slice)
       return slice
     } catch (windowError) {
-      log.warn('Targeted preview audio window decode failed', {
+      log.warn('Targeted preview audio window decode failed, retrying sequentially', {
         mediaId,
         targetTimeSeconds,
         error: windowError,
       })
-      throw windowError
+      try {
+        const slice = await decodeAudioWindowPreferWorker(
+          mediaId,
+          src,
+          partialStartTime,
+          partialDurationSeconds,
+          'sequential',
+        )
+        rememberPlaybackSlice(mediaId, slice)
+        return slice
+      } catch (sequentialError) {
+        log.warn('Sequential preview audio window decode failed', {
+          mediaId,
+          targetTimeSeconds,
+          targetedError: windowError,
+          error: sequentialError,
+        })
+        throw sequentialError
+      }
     }
   })()
 
@@ -829,6 +875,7 @@ function decodeAudioWindowViaWorker(
   src: PreviewAudioSource,
   startTime: number,
   durationSeconds: number,
+  mode: AudioWindowDecodeMode = 'targeted',
 ): Promise<PlaybackAudioSlice> {
   return new Promise<PlaybackAudioSlice>((resolve, reject) => {
     const worker = getAudioWindowWorker()
@@ -881,6 +928,7 @@ function decodeAudioWindowViaWorker(
       startTime,
       durationSeconds,
       storageSampleRate: STORAGE_SAMPLE_RATE,
+      mode,
     })
   })
 }
@@ -891,18 +939,20 @@ async function decodeAudioWindowPreferWorker(
   src: PreviewAudioSource,
   startTime: number,
   durationSeconds: number,
+  mode: AudioWindowDecodeMode = 'targeted',
 ): Promise<PlaybackAudioSlice> {
   if (canUseAudioDecodeWorker()) {
     try {
-      return await decodeAudioWindowViaWorker(mediaId, src, startTime, durationSeconds)
+      return await decodeAudioWindowViaWorker(mediaId, src, startTime, durationSeconds, mode)
     } catch (err) {
       log.warn('Worker window decode failed, falling back to main-thread window decode', {
         mediaId,
+        mode,
         err,
       })
     }
   }
-  return decodeAudioWindow(mediaId, src, startTime, durationSeconds)
+  return decodeAudioWindow(mediaId, src, startTime, durationSeconds, mode)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/composition-runtime/utils/audio-decode-worker.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-worker.ts
@@ -223,6 +223,7 @@ async function decodeWindow(
     startTime,
     durationSeconds,
     storageSampleRate,
+    mode = 'targeted',
   } = message
 
   const mb = await import('mediabunny')
@@ -286,31 +287,56 @@ async function decodeWindow(
       totalFrames += chunk.frameCount
     }
 
-    const initialSample = (await sink.getSample(safeStartTime)) as DecodeSampleData | null
-    let initialSampleEndTime: number | null = null
-    if (initialSample) {
-      try {
-        append(initialSample)
-        initialSampleEndTime = getDecodeSampleEndTime(initialSample)
-      } finally {
-        initialSample.close()
-      }
-    }
-
-    const iteratorStartTime =
-      initialSampleEndTime === null ? safeStartTime : Math.max(safeStartTime, initialSampleEndTime)
-    if (coverageEndTime < targetCoverageEndTime) {
-      for await (const sample of sink.samples(
-        iteratorStartTime,
-        targetCoverageEndTime,
-      ) as AsyncIterable<DecodeSampleData>) {
+    if (mode === 'sequential') {
+      // Some custom decoders can only advance from the beginning. Decode and
+      // discard early samples, retaining Float32 chunks only for this window.
+      for await (const sample of sink.samples() as AsyncIterable<DecodeSampleData>) {
         try {
+          const sampleStartTime = Number.isFinite(sample.timestamp)
+            ? Number(sample.timestamp)
+            : null
+          const sampleEndTime = getDecodeSampleEndTime(sample)
+          if (sampleEndTime !== null && sampleEndTime <= safeStartTime) {
+            continue
+          }
+          if (sampleStartTime !== null && sampleStartTime >= targetCoverageEndTime) {
+            break
+          }
           append(sample)
         } finally {
           sample.close()
         }
         if (coverageEndTime >= targetCoverageEndTime) {
           break
+        }
+      }
+    } else {
+      const initialSample = (await sink.getSample(safeStartTime)) as DecodeSampleData | null
+      let initialSampleEndTime: number | null = null
+      if (initialSample) {
+        try {
+          append(initialSample)
+          initialSampleEndTime = getDecodeSampleEndTime(initialSample)
+        } finally {
+          initialSample.close()
+        }
+      }
+
+      const iteratorStartTime =
+        initialSampleEndTime === null ? safeStartTime : Math.max(safeStartTime, initialSampleEndTime)
+      if (coverageEndTime < targetCoverageEndTime) {
+        for await (const sample of sink.samples(
+          iteratorStartTime,
+          targetCoverageEndTime,
+        ) as AsyncIterable<DecodeSampleData>) {
+          try {
+            append(sample)
+          } finally {
+            sample.close()
+          }
+          if (coverageEndTime >= targetCoverageEndTime) {
+            break
+          }
         }
       }
     }

--- a/src/runtime/composition-runtime/utils/audio-decode-worker.types.ts
+++ b/src/runtime/composition-runtime/utils/audio-decode-worker.types.ts
@@ -28,6 +28,8 @@ export interface AudioDecodeWindowRequest {
   startTime: number
   durationSeconds: number
   storageSampleRate: number
+  /** Targeted seeks first; sequential mode decodes forward while retaining only this window. */
+  mode?: 'targeted' | 'sequential'
 }
 
 /**


### PR DESCRIPTION
## Summary

- keep custom-decoded and pitch-corrected preview audio on bounded rolling slices
- remove delayed, timeout, and error fallbacks that escalated preview playback to a whole-file decode
- cache GPU-overlay candidate items and resolved transition windows until timeline/effect structure changes

## Root cause

Long custom-codec sources were upgraded from small playback slices to a full Float32 `AudioBuffer` shortly after playback began. For the profiled 65-minute source that retained roughly 660 MiB in the editor. The GPU-overlay routing hook also rebuilt transition maps and scanned all 328 timeline items on every playhead update.

## Impact

Long projects avoid the largest retained audio allocation during normal, pitch-shifted, reverse, and slow targeted-decode playback. Ordinary frames now evaluate only the pre-indexed overlay candidates instead of rebuilding and scanning the complete timeline each tick.

## Validation

- 59 focused tests passed across audio decode/playback and GPU overlay routing
- `vp check --no-fmt` passed for all 9 changed files
- `npm run build` passed
- the same 328-clip localhost project advanced exactly 360 frames during a 12-second playback check at 30 fps; the playhead was restored to `01:22:37:00`
- `git merge-tree --write-tree --messages origin/staging HEAD` completed without conflicts
