### PR TITLE
fix(preview): stabilize realtime transitions and skimming

### DIFF
--- a/src/features/export/utils/canvas-item-renderer/composition.ts
+++ b/src/features/export/utils/canvas-item-renderer/composition.ts
@@ -26,6 +26,7 @@ import type { CanvasSettings, ItemRenderContext, ItemTransform, SubCompRenderDat
 import { log } from './shared'
 import { drawContainedMediaSource } from './media-draw'
 import { resolveSubCompRenderDataForInstance } from './composition-instance'
+import { getCanvasRenderScale } from '../canvas-render-scale'
 
 /**
  * Render a CompositionItem by rendering all its sub-composition items to an
@@ -84,23 +85,30 @@ export async function renderCompositionItem(
   const { canvas: subContentCanvas, ctx: subContentCtx } = rctx.canvasPool.acquire()
 
   try {
+    const renderScale = getCanvasRenderScale(rctx.canvasSettings)
+    const subRenderWidth = Math.max(2, Math.round(item.compositionWidth * renderScale.x))
+    const subRenderHeight = Math.max(2, Math.round(item.compositionHeight * renderScale.y))
     // Use the sub-composition's authored dimensions for canvas settings
     // so transforms and positioning inside the sub-composition are correct.
     // The pooled canvas may be at main canvas size, so we resize it to match.
-    subCanvas.width = item.compositionWidth
-    subCanvas.height = item.compositionHeight
-    subContentCanvas.width = item.compositionWidth
-    subContentCanvas.height = item.compositionHeight
+    subCanvas.width = subRenderWidth
+    subCanvas.height = subRenderHeight
+    subContentCanvas.width = subRenderWidth
+    subContentCanvas.height = subRenderHeight
     subCtx.clearRect(0, 0, subCanvas.width, subCanvas.height)
     subContentCtx.clearRect(0, 0, subContentCanvas.width, subContentCanvas.height)
     const subCanvasSettings: CanvasSettings = {
-      width: item.compositionWidth,
-      height: item.compositionHeight,
+      width: subRenderWidth,
+      height: subRenderHeight,
+      logicalWidth: item.compositionWidth,
+      logicalHeight: item.compositionHeight,
       fps: subData.fps,
     }
     const subMaskSettings: MaskCanvasSettings = {
-      width: item.compositionWidth,
-      height: item.compositionHeight,
+      width: subRenderWidth,
+      height: subRenderHeight,
+      logicalWidth: item.compositionWidth,
+      logicalHeight: item.compositionHeight,
       fps: subData.fps,
     }
 
@@ -222,8 +230,8 @@ export async function renderCompositionItem(
         } else if (!hasEffects) {
           const { canvas: maskedItemCanvas, ctx: maskedItemCtx } = rctx.canvasPool.acquire()
           try {
-            maskedItemCanvas.width = item.compositionWidth
-            maskedItemCanvas.height = item.compositionHeight
+            maskedItemCanvas.width = subRenderWidth
+            maskedItemCanvas.height = subRenderHeight
             maskedItemCtx.clearRect(0, 0, maskedItemCanvas.width, maskedItemCanvas.height)
             await rctx.renderItem(
               maskedItemCtx,
@@ -245,8 +253,8 @@ export async function renderCompositionItem(
           }
         } else {
           const { canvas: itemCanvas, ctx: itemCtx } = rctx.canvasPool.acquire()
-          itemCanvas.width = item.compositionWidth
-          itemCanvas.height = item.compositionHeight
+          itemCanvas.width = subRenderWidth
+          itemCanvas.height = subRenderHeight
           itemCtx.clearRect(0, 0, itemCanvas.width, itemCanvas.height)
           try {
             await rctx.renderItem(
@@ -389,6 +397,8 @@ export function getActiveSubCompMasks(
   const subMaskSettings: MaskCanvasSettings = {
     width: subCanvasSettings.width,
     height: subCanvasSettings.height,
+    logicalWidth: subCanvasSettings.logicalWidth,
+    logicalHeight: subCanvasSettings.logicalHeight,
     fps: subCanvasSettings.fps,
   }
   const activeMasks: Array<{

--- a/src/features/export/utils/canvas-item-renderer/gpu.ts
+++ b/src/features/export/utils/canvas-item-renderer/gpu.ts
@@ -30,6 +30,12 @@ import { flattenBezierPath } from '@/shared/graphics/shapes/bezier-path'
 import { resolveShapeLinearGradient } from '@/shared/graphics/shapes/linear-gradient'
 import { recordPreviewVideoSource } from '@/shared/logging/preview-scrub-performance'
 import { getAnimatedTransform } from '../canvas-keyframes'
+import {
+  getCanvasRenderScale,
+  getLogicalCanvasSize,
+  scaleShapeItemForCanvas,
+  scaleTextItemForCanvas,
+} from '../canvas-render-scale'
 import { combineEffects, getAdjustmentLayerEffects, getGpuEffectInstances } from '../canvas-effects'
 import {
   getItemRenderTimelineSpan,
@@ -619,18 +625,22 @@ async function resolveGpuMediaParticipantSource(
   if (participant.item.type === 'shape') {
     const itemKeyframes =
       rctx.getCurrentKeyframes?.(participant.item.id) ?? rctx.keyframesMap.get(participant.item.id)
-    const shape = resolveAnimatedShapeItem(
-      participant.item,
-      itemKeyframes,
-      frame - participant.item.from,
-      rctx.canvasSettings.getExpressionItem && rctx.canvasSettings.getExpressionKeyframes
-        ? {
-            globalFrame: frame,
-            canvas: rctx.canvasSettings,
-            getItem: rctx.canvasSettings.getExpressionItem,
-            getKeyframes: rctx.canvasSettings.getExpressionKeyframes,
-          }
-        : undefined,
+    const logicalCanvasSettings = getLogicalCanvasSize(rctx.canvasSettings)
+    const shape = scaleShapeItemForCanvas(
+      resolveAnimatedShapeItem(
+        participant.item,
+        itemKeyframes,
+        frame - participant.item.from,
+        rctx.canvasSettings.getExpressionItem && rctx.canvasSettings.getExpressionKeyframes
+          ? {
+              globalFrame: frame,
+              canvas: logicalCanvasSettings,
+              getItem: rctx.canvasSettings.getExpressionItem,
+              getKeyframes: rctx.canvasSettings.getExpressionKeyframes,
+            }
+          : undefined,
+      ),
+      rctx.canvasSettings,
     )
     if (getGpuShapeUnsupportedReason(shape, transform, participant.effects, rctx)) return null
     const resolvedPathVertices =
@@ -703,18 +713,46 @@ async function resolveGpuMediaParticipantSource(
   }
 
   if (participant.item.type !== 'video') return null
-  if (!rctx.useMediabunny.has(participant.item.id)) return null
-  if (rctx.mediabunnyDisabledItems.has(participant.item.id)) return null
-
-  const extractor = rctx.videoExtractors.get(participant.item.id)
-  if (!extractor) return null
-
   const sourceTime = resolveVideoParticipantSourceTime(
     participant.item,
     participant.renderSpan,
     frame,
     rctx,
   )
+  const domVideo = rctx.domVideoElementProvider?.(participant.item.id) ?? null
+  const hasActiveRamp =
+    participant.renderSpan.sourceTimeRamp !== undefined &&
+    frame >= participant.renderSpan.sourceTimeRamp.rampStart &&
+    frame <= participant.renderSpan.sourceTimeRamp.rampEnd
+  const canUseSynchronizedDomVideo =
+    !hasActiveRamp || domVideo?.dataset.transitionSourceRamp === '1'
+  const domDecision = resolvePreviewDomVideoDrawDecision({
+    domVideo: canUseSynchronizedDomVideo ? domVideo : null,
+    sourceTime,
+    speed: domVideo?.playbackRate ?? participant.item.speed ?? 1,
+    isRenderingTransition: true,
+  })
+  if (domVideo && domDecision.shouldDraw) {
+    recordPreviewVideoSource({
+      frame,
+      itemId: participant.item.id,
+      path: 'dom-video',
+      sourceTime,
+    })
+    return {
+      kind: 'media',
+      item: participant.item,
+      source: domVideo,
+      sourceWidth: domVideo.videoWidth,
+      sourceHeight: domVideo.videoHeight,
+    }
+  }
+  if (!rctx.useMediabunny.has(participant.item.id)) return null
+  if (rctx.mediabunnyDisabledItems.has(participant.item.id)) return null
+
+  const extractor = rctx.videoExtractors.get(participant.item.id)
+  if (!extractor) return null
+
   const captured = await extractor.captureFrame(sourceTime)
   if (!captured.success || !captured.frame) return null
   const sourceWidth =
@@ -742,10 +780,18 @@ function resolveGpuTextParticipantSource(
   const relativeFrame = frame - participant.item.from
   const itemKeyframes =
     rctx.getCurrentKeyframes?.(participant.item.id) ?? rctx.keyframesMap.get(participant.item.id)
-  const resolvedTextItem = {
-    ...resolveAnimatedTextItem(participant.item, itemKeyframes, relativeFrame, rctx.canvasSettings),
-    cornerPin: participant.item.cornerPin,
-  }
+  const resolvedTextItem = scaleTextItemForCanvas(
+    {
+      ...resolveAnimatedTextItem(
+        participant.item,
+        itemKeyframes,
+        relativeFrame,
+        getLogicalCanvasSize(rctx.canvasSettings),
+      ),
+      cornerPin: participant.item.cornerPin,
+    },
+    rctx.canvasSettings,
+  )
   const baseTransform = resolveItemTransform(participant.transform)
   const resolvedTransform = expandTextTransformToFitContent(resolvedTextItem, baseTransform)
   const textureTransform = hasCornerPin(resolvedTextItem.cornerPin)
@@ -874,8 +920,9 @@ async function resolveGpuCompositionParticipantSource(
 ): Promise<ResolvedGpuMediaParticipantSource | null> {
   if (!rctx.gpuPipeline || !rctx.gpuMediaPipeline) return null
   if (rctx.gpuCompositionStack?.has(participant.item.compositionId)) return null
-  const width = Math.max(2, Math.ceil(participant.item.compositionWidth))
-  const height = Math.max(2, Math.ceil(participant.item.compositionHeight))
+  const renderScale = getCanvasRenderScale(rctx.canvasSettings)
+  const width = Math.max(2, Math.ceil(participant.item.compositionWidth * renderScale.x))
+  const height = Math.max(2, Math.ceil(participant.item.compositionHeight * renderScale.y))
   const gpuCompositionStack = new Set(rctx.gpuCompositionStack)
   gpuCompositionStack.add(participant.item.compositionId)
   const directTexture = await renderGpuSubCompChildrenToTexture(
@@ -930,7 +977,13 @@ async function renderGpuSubCompChildrenToTexture(
     rctx,
   )
 
-  const subCanvasSettings = { width, height, fps: subData.fps }
+  const subCanvasSettings = {
+    width,
+    height,
+    logicalWidth: participant.item.compositionWidth,
+    logicalHeight: participant.item.compositionHeight,
+    fps: subData.fps,
+  }
   const subRctx = createSubCompositionRenderContext(rctx, subData, subCanvasSettings)
   const occlusionCutoffOrder = findSubCompOcclusionCutoffOrder(
     subData,

--- a/src/features/export/utils/canvas-item-renderer/render-item.ts
+++ b/src/features/export/utils/canvas-item-renderer/render-item.ts
@@ -41,6 +41,12 @@ import { getTextRasterCacheKey, renderSubtitleSegmentItem, renderTextItem } from
 import { isTextMotionActive } from '@/shared/typography/text-motion'
 import { renderCompositionItem } from './composition'
 import type { CornerPinWarpCacheEntry } from './types'
+import {
+  getLogicalCanvasSize,
+  scaleShapeItemForCanvas,
+  scaleSubtitleItemForCanvas,
+  scaleTextItemForCanvas,
+} from '../canvas-render-scale'
 
 /** Total RAM budget for the preview corner-pin warp cache. */
 const CORNER_PIN_WARP_CACHE_MAX_BYTES = 256_000_000 // ~256MB
@@ -73,24 +79,43 @@ export async function renderItem(
   preCornerPinMasks: EffectSourceMask[] = [],
 ): Promise<void> {
   const itemKeyframes = rctx.getCurrentKeyframes?.(item.id) ?? rctx.keyframesMap.get(item.id)
+  const logicalCanvasSettings = getLogicalCanvasSize(rctx.canvasSettings)
   const shapeExpressionContext =
     rctx.canvasSettings.getExpressionItem && rctx.canvasSettings.getExpressionKeyframes
       ? {
           globalFrame: frame,
-          canvas: rctx.canvasSettings,
+          canvas: logicalCanvasSettings,
           getItem: rctx.canvasSettings.getExpressionItem,
           getKeyframes: rctx.canvasSettings.getExpressionKeyframes,
         }
       : undefined
   const animatedTextItem =
     item.type === 'text'
-      ? {
-          ...resolveAnimatedTextItem(item, itemKeyframes, frame - item.from, rctx.canvasSettings),
-          cornerPin: item.cornerPin,
-        }
+      ? scaleTextItemForCanvas(
+          {
+            ...resolveAnimatedTextItem(
+              item,
+              itemKeyframes,
+              frame - item.from,
+              logicalCanvasSettings,
+            ),
+            cornerPin: item.cornerPin,
+          },
+          rctx.canvasSettings,
+        )
       : item.type === 'shape'
-        ? resolveAnimatedShapeItem(item, itemKeyframes, frame - item.from, shapeExpressionContext)
-        : item
+        ? scaleShapeItemForCanvas(
+            resolveAnimatedShapeItem(
+              item,
+              itemKeyframes,
+              frame - item.from,
+              shapeExpressionContext,
+            ),
+            rctx.canvasSettings,
+          )
+        : item.type === 'subtitle'
+          ? scaleSubtitleItemForCanvas(item, rctx.canvasSettings)
+          : item
   const frameResolvedItem = applyAnimatedCropToItem(animatedTextItem, frame, rctx, renderSpan)
   const resolvedTransform = resolveItemTransform(transform)
   const frameResolvedTransform =

--- a/src/features/export/utils/canvas-item-renderer/transition.ts
+++ b/src/features/export/utils/canvas-item-renderer/transition.ts
@@ -21,6 +21,7 @@ import {
 import { renderTransition, type ActiveTransition } from '../canvas-transitions'
 import { resolveAATransitionRamps, resolveTransitionRenderTimelineSpan } from '../render-span'
 import { getAnimatedTransform } from '../canvas-keyframes'
+import { scalePartialTransformForCanvas } from '../canvas-render-scale'
 import type {
   ItemRenderContext,
   ResolvedGpuMediaParticipantSource,
@@ -522,10 +523,14 @@ export function resolveTransitionParticipantRenderState<TItem extends TimelineIt
   if (rctx.renderMode === 'preview') {
     const previewOverride = rctx.getPreviewTransformOverride?.(currentClip.id)
     if (previewOverride) {
+      const scaledPreviewOverride = scalePartialTransformForCanvas(
+        previewOverride,
+        rctx.canvasSettings,
+      )
       transform = {
         ...transform,
-        ...previewOverride,
-        cornerRadius: previewOverride.cornerRadius ?? transform.cornerRadius,
+        ...scaledPreviewOverride,
+        cornerRadius: scaledPreviewOverride.cornerRadius ?? transform.cornerRadius,
       }
     }
   }

--- a/src/features/export/utils/canvas-item-renderer/types.ts
+++ b/src/features/export/utils/canvas-item-renderer/types.ts
@@ -47,6 +47,10 @@ export type { ResolvedTransform }
 export interface CanvasSettings {
   width: number
   height: number
+  /** Authored composition width when preview pixels are rendered at a lower resolution. */
+  logicalWidth?: number
+  /** Authored composition height when preview pixels are rendered at a lower resolution. */
+  logicalHeight?: number
   fps: number
   /** Same-composition sources for deterministic scalar property expressions. */
   getExpressionItem?: (itemId: string) => TimelineItem | undefined
@@ -70,7 +74,7 @@ export interface ItemTransform {
   cornerRadius: number
 }
 
-export type RenderImageSource = HTMLImageElement | ImageBitmap
+export type RenderImageSource = HTMLImageElement | HTMLVideoElement | ImageBitmap
 
 export interface WorkerLoadedImage {
   source: RenderImageSource

--- a/src/features/export/utils/canvas-item-renderer/video.test.ts
+++ b/src/features/export/utils/canvas-item-renderer/video.test.ts
@@ -496,4 +496,40 @@ describe('renderVideoItem', () => {
 
     expect(markActivePreviewFramePending).toHaveBeenCalledOnce()
   })
+
+  it('holds a paused ramp-owned transition video without blocking on its seek', async () => {
+    const target = new EventTarget()
+    const mutableVideo = Object.assign(target, {
+      currentTime: 0.6,
+      dataset: { transitionHold: '1', transitionSourceRamp: '1' },
+      paused: true,
+      readyState: 1,
+      videoHeight: 1080,
+      videoWidth: 1920,
+    })
+    const domVideo = mutableVideo as unknown as HTMLVideoElement
+    const markActivePreviewFramePending = vi.fn()
+    const ctx = createCanvasContext()
+    const renderContext = createRenderContext({
+      domVideoElementProvider: vi.fn(() => domVideo),
+      isRenderingTransition: true,
+      markActivePreviewFramePending,
+    })
+
+    await expect(
+      renderVideoItem(ctx, item, transform, 12, renderContext, 0, {
+        from: 0,
+        durationInFrames: 30,
+        sourceStart: 0,
+        sourceTimeRamp: {
+          anchor: 'start',
+          rampStart: 0,
+          rampEnd: 20,
+          slope: 0.5,
+        },
+      }),
+    ).resolves.toBe(false)
+    expect(ctx.drawImage).not.toHaveBeenCalled()
+    expect(markActivePreviewFramePending).toHaveBeenCalledOnce()
+  })
 })

--- a/src/features/export/utils/canvas-item-renderer/video.ts
+++ b/src/features/export/utils/canvas-item-renderer/video.ts
@@ -6,9 +6,8 @@
 import type { VideoItem } from '@/types/timeline'
 import {
   getItemRenderTimelineSpan,
-  getRenderTimelineSourceStart,
-  getSourceFrameRampOffset,
   isFrameInsideSourceTimeRamp,
+  resolveVideoRenderSourceTimeSeconds,
   type RenderTimelineSpan,
 } from '../render-span'
 import {
@@ -62,10 +61,7 @@ function tryDrawActivePreviewFallback(options: {
   allowOutsideActivePreview?: boolean
 }): boolean {
   const { rctx, previewRootFrame, workerSource, sourceTime, toleranceSeconds, drawBitmap } = options
-  if (
-    !options.allowOutsideActivePreview &&
-    !rctx.isActivePreviewFrameCurrent?.(previewRootFrame)
-  )
+  if (!options.allowOutsideActivePreview && !rctx.isActivePreviewFrameCurrent?.(previewRootFrame))
     return false
   const bitmap = rctx.getCachedActivePreviewFallbackBitmap?.(
     workerSource,
@@ -131,25 +127,6 @@ async function tryDrawInflightWorkerBitmap(
     sourceTime: options.sourceTime,
   })
   return true
-}
-
-function clampVideoSourceTime(
-  sourceTime: number,
-  sourceFps: number,
-  sourceDurationFrames: number | undefined,
-): number {
-  const clampedToStart = Math.max(0, sourceTime)
-  if (
-    sourceDurationFrames === undefined ||
-    !Number.isFinite(sourceDurationFrames) ||
-    sourceDurationFrames <= 0
-  ) {
-    return clampedToStart
-  }
-
-  const lastFrame = Math.max(0, sourceDurationFrames - 1)
-  const maxTime = (lastFrame + 1e-4) / sourceFps
-  return Math.min(clampedToStart, maxTime)
 }
 
 function drawTier2VideoFrame(
@@ -272,37 +249,15 @@ export async function renderVideoItem(
   let mediabunnyFailedThisFrame = false
   const effectiveRenderSpan = renderSpan ?? getItemRenderTimelineSpan(item)
 
-  // Calculate source time
-  const localFrame = frame - effectiveRenderSpan.from
-  const localTime = localFrame / fps
-  const sourceStart = getRenderTimelineSourceStart(item, effectiveRenderSpan)
   const sourceFps = item.sourceFps ?? fps
   const speed = item.speed ?? 1
-
-  // Normal: play from sourceStart forwards
-  // sourceStart is in source-native FPS frames, so divide by sourceFps (not project fps)
-  // Snap to nearest source frame boundary to avoid floating-point drift
-  // that can cause Math.floor(sourceTime * sourceFps) to land on the wrong frame.
-  const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / fps
-  const reverseSourceEnd = (item.sourceEnd ?? sourceStart + sourceFramesNeeded) - sourceFrameOffset
-  const adjustedSourceStart = sourceStart + sourceFrameOffset
-  // A-A transition ramps add extra source frames per timeline frame so left/
-  // right participants render distinct source content (otherwise their handle
-  // expansions resolve to identical frames and the transition is invisible).
-  // Ramps are scoped to the transition window and skip reversed clips.
-  const rampOffsetSourceFrames =
-    effectiveRenderSpan.sourceTimeRamp && !item.isReversed
-      ? getSourceFrameRampOffset(effectiveRenderSpan.sourceTimeRamp, frame)
-      : 0
-  const unclampedSourceTime = item.isReversed
-    ? (reverseSourceEnd - localFrame * speed * (sourceFps / fps) - 1) / sourceFps
-    : adjustedSourceStart / sourceFps + localTime * speed + rampOffsetSourceFrames / sourceFps
-  const rawSourceTime = clampVideoSourceTime(unclampedSourceTime, sourceFps, item.sourceDuration)
-  const snappedSourceFrame = Math.round(rawSourceTime * sourceFps)
-  const sourceTime =
-    Math.abs(rawSourceTime * sourceFps - snappedSourceFrame) < 1e-6
-      ? (snappedSourceFrame + 1e-4) / sourceFps
-      : rawSourceTime
+  const sourceTime = resolveVideoRenderSourceTimeSeconds(
+    item,
+    effectiveRenderSpan,
+    frame,
+    fps,
+    sourceFrameOffset,
+  )
   const tier2ToleranceSeconds = getTier2VideoFrameToleranceSeconds(sourceFps)
   const nonBlockingToleranceSeconds = rctx.nonBlockingVideoFrameToleranceSeconds
   const previewRootFrame = rctx.previewRootTimelineFrame ?? frame
@@ -405,20 +360,24 @@ export async function renderVideoItem(
   // effectiveRenderSpan (not the natural item span) and let the policy
   // function decide whether the DOM video is fresh enough, mirroring the GPU
   // transition path in gpu.ts which also passes isRenderingTransition through.
-  // A-A transition ramps render source frames offset from the DOM video
-  // element's natural playback time. Drawing from the live element would
-  // ignore the offset and show identical pixels on both transition sides,
-  // defeating the ramp. Force the decode path when a ramp is active here.
+  // A-A transition ramps can use a zero-copy DOM frame only while the preview
+  // transition session explicitly owns and synchronizes that element to the
+  // same ramped source time as this renderer.
   const hasActiveRamp =
     !!effectiveRenderSpan.sourceTimeRamp &&
     isFrameInsideSourceTimeRamp(effectiveRenderSpan.sourceTimeRamp, frame)
-  const canUseDomVideoElement =
+  const domVideoCandidate =
     isPreviewMode &&
     domVideoElementProvider &&
     sourceFrameOffset === 0 &&
-    !hasActiveRamp &&
     isFrameInsideItemTimelineSpan(effectiveRenderSpan, frame)
-  const domVideo = canUseDomVideoElement ? domVideoElementProvider(item.id) : null
+      ? domVideoElementProvider(item.id)
+      : null
+  const domVideo =
+    !hasActiveRamp || domVideoCandidate?.dataset.transitionSourceRamp === '1'
+      ? domVideoCandidate
+      : null
+  const canUseDomVideoElement = Boolean(domVideoCandidate)
   const domVideoDecisionOptions = {
     domVideo,
     sourceTime,
@@ -443,6 +402,19 @@ export async function renderVideoItem(
     }
   }
   const hasDomVideo = domVideoDecision.hasReadyDomVideo
+
+  if (
+    isPreviewMode &&
+    hasActiveRamp &&
+    domVideoCandidate?.dataset.transitionSourceRamp === '1' &&
+    !domVideoDecision.shouldDraw
+  ) {
+    // Let the browser finish the session-owned seek. Falling through to an
+    // exact main-thread decode here prevents that seek from settling and turns
+    // a one-frame hold into a 250-600ms playback freeze.
+    holdPreviewFrontBuffer()
+    return false
+  }
 
   // DEV diagnostics: record which transition participants the renderer actually
   // composites per frame. Tree-shaken from prod; no-op unless a trace is running.
@@ -1008,23 +980,5 @@ export function resolveVideoParticipantSourceTime(
   frame: number,
   rctx: ItemRenderContext,
 ): number {
-  const localFrame = frame - renderSpan.from
-  const localTime = localFrame / rctx.fps
-  const sourceStart = getRenderTimelineSourceStart(item, renderSpan)
-  const sourceFps = item.sourceFps ?? rctx.fps
-  const speed = item.speed ?? 1
-  const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / rctx.fps
-  const reverseSourceEnd = item.sourceEnd ?? sourceStart + sourceFramesNeeded
-  const rampOffsetSourceFrames =
-    renderSpan.sourceTimeRamp && !item.isReversed
-      ? getSourceFrameRampOffset(renderSpan.sourceTimeRamp, frame)
-      : 0
-  const unclampedSourceTime = item.isReversed
-    ? (reverseSourceEnd - localFrame * speed * (sourceFps / rctx.fps) - 1) / sourceFps
-    : sourceStart / sourceFps + localTime * speed + rampOffsetSourceFrames / sourceFps
-  const rawSourceTime = clampVideoSourceTime(unclampedSourceTime, sourceFps, item.sourceDuration)
-  const snappedSourceFrame = Math.round(rawSourceTime * sourceFps)
-  return Math.abs(rawSourceTime * sourceFps - snappedSourceFrame) < 1e-6
-    ? (snappedSourceFrame + 1e-4) / sourceFps
-    : rawSourceTime
+  return resolveVideoRenderSourceTimeSeconds(item, renderSpan, frame, rctx.fps)
 }

--- a/src/features/export/utils/canvas-keyframes.test.ts
+++ b/src/features/export/utils/canvas-keyframes.test.ts
@@ -47,6 +47,48 @@ describe('canvas-keyframes text sizing', () => {
   })
 })
 
+describe('canvas-keyframes logical preview space', () => {
+  it('resolves authored transforms before scaling them to preview pixels', () => {
+    const item: ShapeItem = {
+      id: 'shape-preview-scale',
+      type: 'shape',
+      shapeType: 'rectangle',
+      fillColor: '#fff',
+      trackId: 'shape-track',
+      from: 0,
+      durationInFrames: 60,
+      label: 'Shape',
+      transform: {
+        x: 320,
+        y: -180,
+        width: 960,
+        height: 540,
+        anchorX: 240,
+        anchorY: 135,
+        cornerRadius: 40,
+      },
+    }
+
+    const resolved = getAnimatedTransform(item, undefined, 0, {
+      width: 960,
+      height: 540,
+      logicalWidth: 3840,
+      logicalHeight: 2160,
+      fps: 30,
+    })
+
+    expect(resolved).toMatchObject({
+      x: 80,
+      y: -45,
+      width: 240,
+      height: 135,
+      anchorX: 60,
+      anchorY: 33.75,
+      cornerRadius: 10,
+    })
+  })
+})
+
 describe('canvas-keyframes transform parenting', () => {
   it('matches controller animation during export resolution', () => {
     const parentBase = {

--- a/src/features/export/utils/canvas-keyframes.ts
+++ b/src/features/export/utils/canvas-keyframes.ts
@@ -11,6 +11,7 @@ import type { CropSettings, ResolvedTransform } from '@/types/transform'
 import { resolveItemTransformAtFrame } from '@/features/export/deps/composition-runtime'
 import { resolveAnimatedCrop } from '@/features/export/deps/keyframes'
 import { applyRenderTimelineSpan, type RenderTimelineSpan } from './render-span'
+import { getLogicalCanvasSize, scaleResolvedTransformForCanvas } from './canvas-render-scale'
 
 function clamp01(value: number): number {
   if (value <= 0) return 0
@@ -103,6 +104,8 @@ function getVisualFadeOpacity(item: TimelineItem, frame: number, fps: number): n
 interface CanvasRenderSettings {
   width: number
   height: number
+  logicalWidth?: number
+  logicalHeight?: number
   fps: number
   getExpressionItem?: (itemId: string) => TimelineItem | undefined
   getExpressionKeyframes?: (itemId: string) => ItemKeyframes | undefined
@@ -155,10 +158,11 @@ export function getAnimatedTransform(
   renderSpan?: RenderTimelineSpan,
 ): ResolvedTransform {
   const resolvedItem = applyRenderTimelineSpan(item, renderSpan)
+  const logicalCanvas = getLogicalCanvasSize(canvas)
   const resolved = resolveItemTransformAtFrame(resolvedItem, {
     canvas: {
-      width: canvas.width,
-      height: canvas.height,
+      width: logicalCanvas.width,
+      height: logicalCanvas.height,
       fps: canvas.fps,
     },
     frame,
@@ -168,14 +172,15 @@ export function getAnimatedTransform(
     getPreviewTransform: canvas.getPreviewTransform,
   })
 
+  const scaled = scaleResolvedTransformForCanvas(resolved, canvas)
   const fadeOpacity = getVisualFadeOpacity(resolvedItem, frame, canvas.fps)
   if (fadeOpacity >= 1) {
-    return resolved
+    return scaled
   }
 
   return {
-    ...resolved,
-    opacity: resolved.opacity * fadeOpacity,
+    ...scaled,
+    opacity: scaled.opacity * fadeOpacity,
   }
 }
 
@@ -186,7 +191,7 @@ export function getAnimatedCrop(
   canvas: Pick<CanvasRenderSettings, 'width' | 'height'>,
   renderSpan?: RenderTimelineSpan,
 ): CropSettings | undefined {
-  const dimensions = getCropSourceDimensions(item, canvas)
+  const dimensions = getCropSourceDimensions(item, getLogicalCanvasSize(canvas))
   if (!dimensions) {
     return item.crop
   }

--- a/src/features/export/utils/canvas-masks.ts
+++ b/src/features/export/utils/canvas-masks.ts
@@ -17,6 +17,11 @@ import {
   rotatePath,
   resolveActiveShapeMasksAtFrame,
 } from '@/features/export/deps/composition-runtime'
+import {
+  getLogicalCanvasSize,
+  scaleResolvedTransformForCanvas,
+  scaleShapeItemForCanvas,
+} from './canvas-render-scale'
 
 interface MaskEntry {
   mask: ShapeItem
@@ -46,6 +51,8 @@ export interface MaskFrameIndex {
 export interface MaskCanvasSettings {
   width: number
   height: number
+  logicalWidth?: number
+  logicalHeight?: number
   fps: number
 }
 
@@ -161,14 +168,15 @@ export function buildPreparedMask(
   transform: ResolvedTransform,
   canvas: MaskCanvasSettings,
 ): PreparedMask {
-  const cornerPinnedBitmapMask = renderCornerPinnedMaskBitmap(mask, transform, canvas)
+  const renderedMask = scaleShapeItemForCanvas(mask, canvas)
+  const cornerPinnedBitmapMask = renderCornerPinnedMaskBitmap(renderedMask, transform, canvas)
   if (cornerPinnedBitmapMask) {
-    const maskType = mask.maskType ?? 'clip'
-    const feather = maskType === 'alpha' ? (mask.maskFeather ?? 0) : 0
+    const maskType = renderedMask.maskType ?? 'clip'
+    const feather = maskType === 'alpha' ? (renderedMask.maskFeather ?? 0) : 0
 
     return {
       bitmapMask: cornerPinnedBitmapMask,
-      inverted: mask.maskInvert ?? false,
+      inverted: renderedMask.maskInvert ?? false,
       feather,
       // The corner-pinned bitmap already carries the opacity in its alpha.
       opacity: 1,
@@ -179,7 +187,7 @@ export function buildPreparedMask(
 
   // Generate SVG path
   let svgPath = getShapePath(
-    { ...mask, pathClosed: true },
+    { ...renderedMask, pathClosed: true },
     {
       x: transform.x,
       y: transform.y,
@@ -201,16 +209,16 @@ export function buildPreparedMask(
     svgPath = rotatePath(svgPath, transform.rotation, centerX, centerY)
   }
 
-  const maskType = mask.maskType ?? 'clip'
+  const maskType = renderedMask.maskType ?? 'clip'
   // Feather only applies to alpha masks - clip masks are always hard-edged
-  const feather = maskType === 'alpha' ? (mask.maskFeather ?? 0) : 0
+  const feather = maskType === 'alpha' ? (renderedMask.maskFeather ?? 0) : 0
   const opacity =
-    (Math.max(0, Math.min(100, mask.maskOpacity ?? 100)) / 100) *
+    (Math.max(0, Math.min(100, renderedMask.maskOpacity ?? 100)) / 100) *
     Math.max(0, Math.min(1, transform.opacity))
 
   return {
     path: svgPathToPath2D(svgPath),
-    inverted: mask.maskInvert ?? false,
+    inverted: renderedMask.maskInvert ?? false,
     feather,
     opacity,
     maskType,
@@ -447,12 +455,7 @@ export function applyMasks(
         mask.opacity,
         canvas,
       )
-    } else if (
-      mask.maskType === 'clip' &&
-      mask.feather === 0 &&
-      mask.opacity === 1 &&
-      mask.path
-    ) {
+    } else if (mask.maskType === 'clip' && mask.feather === 0 && mask.opacity === 1 && mask.path) {
       // Simple clip mask
       outputCtx.save()
       applyClipMask(outputCtx, mask.path, mask.inverted, canvas)
@@ -536,7 +539,7 @@ export function getActiveMasksForFrame(
     trackOrder,
   }))
   const activeMaskShapes = resolveActiveShapeMasksAtFrame(liveMasks, {
-    canvas,
+    canvas: getLogicalCanvasSize(canvas),
     frame,
     getKeyframes: (itemId) => resolveMaskKeyframes(keyframes, itemId),
     getItem: getExpressionItem,
@@ -546,7 +549,11 @@ export function getActiveMasksForFrame(
 
   for (const mask of activeMaskShapes) {
     activeMasks.push({
-      ...buildPreparedMask(mask.shape, mask.transform, canvas),
+      ...buildPreparedMask(
+        mask.shape,
+        scaleResolvedTransformForCanvas(mask.transform, canvas),
+        canvas,
+      ),
       trackOrder: mask.trackOrder,
     })
   }

--- a/src/features/export/utils/canvas-render-scale.test.ts
+++ b/src/features/export/utils/canvas-render-scale.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vite-plus/test'
+import type { ShapeItem, SubtitleSegmentItem, TextItem } from '@/types/timeline'
+import {
+  scaleShapeItemForCanvas,
+  scaleSubtitleItemForCanvas,
+  scaleTextItemForCanvas,
+} from './canvas-render-scale'
+
+const previewCanvas = {
+  width: 960,
+  height: 540,
+  logicalWidth: 3840,
+  logicalHeight: 2160,
+}
+
+describe('canvas render scaling', () => {
+  it('scales text pixel styling without changing authored data', () => {
+    const item: TextItem = {
+      id: 'text-scale',
+      type: 'text',
+      trackId: 'text-track',
+      from: 0,
+      durationInFrames: 30,
+      label: 'Text',
+      text: 'Preview',
+      color: '#fff',
+      fontSize: 80,
+      letterSpacing: 8,
+      textPadding: 24,
+      backgroundRadius: 16,
+      textShadow: { offsetX: 8, offsetY: 4, blur: 12, color: '#000' },
+      stroke: { width: 4, color: '#000' },
+    }
+
+    const scaled = scaleTextItemForCanvas(item, previewCanvas)
+    expect(scaled).toMatchObject({
+      fontSize: 20,
+      letterSpacing: 2,
+      textPadding: 6,
+      backgroundRadius: 4,
+      textShadow: { offsetX: 2, offsetY: 1, blur: 3 },
+      stroke: { width: 1 },
+    })
+    expect(item.fontSize).toBe(80)
+  })
+
+  it('scales shape stroke, rounding, and mask feather', () => {
+    const item: ShapeItem = {
+      id: 'shape-scale',
+      type: 'shape',
+      trackId: 'shape-track',
+      from: 0,
+      durationInFrames: 30,
+      label: 'Shape',
+      shapeType: 'rectangle',
+      fillColor: '#fff',
+      strokeWidth: 12,
+      cornerRadius: 20,
+      maskFeather: 40,
+    }
+
+    expect(scaleShapeItemForCanvas(item, previewCanvas)).toMatchObject({
+      strokeWidth: 3,
+      cornerRadius: 5,
+      maskFeather: 10,
+    })
+  })
+
+  it('scales subtitle pixel styling without changing authored data', () => {
+    const item: SubtitleSegmentItem = {
+      id: 'subtitle-scale',
+      type: 'subtitle',
+      trackId: 'subtitle-track',
+      from: 0,
+      durationInFrames: 30,
+      label: 'Subtitles',
+      source: { type: 'transcript', mediaId: 'media-1', clipId: 'clip-1' },
+      cues: [{ id: 'cue-1', startSeconds: 0, endSeconds: 1, text: 'Preview' }],
+      color: '#fff',
+      fontSize: 80,
+      letterSpacing: 8,
+      textPadding: 24,
+      backgroundRadius: 16,
+      textShadow: { offsetX: 8, offsetY: 4, blur: 12, color: '#000' },
+      stroke: { width: 4, color: '#000' },
+    }
+
+    const scaled = scaleSubtitleItemForCanvas(item, previewCanvas)
+    expect(scaled).toMatchObject({
+      fontSize: 20,
+      letterSpacing: 2,
+      textPadding: 6,
+      backgroundRadius: 4,
+      textShadow: { offsetX: 2, offsetY: 1, blur: 3 },
+      stroke: { width: 1 },
+    })
+    expect(item.fontSize).toBe(80)
+  })
+})

--- a/src/features/export/utils/canvas-render-scale.ts
+++ b/src/features/export/utils/canvas-render-scale.ts
@@ -1,0 +1,130 @@
+import type { ShapeItem, SubtitleSegmentItem, TextItem } from '@/types/timeline'
+import type { ResolvedTransform } from '@/types/transform'
+
+export interface LogicalCanvasSize {
+  width: number
+  height: number
+  logicalWidth?: number
+  logicalHeight?: number
+}
+
+export interface CanvasRenderScale {
+  x: number
+  y: number
+  uniform: number
+}
+
+export function getCanvasRenderScale(canvas: LogicalCanvasSize): CanvasRenderScale {
+  const logicalWidth = Math.max(1, canvas.logicalWidth ?? canvas.width)
+  const logicalHeight = Math.max(1, canvas.logicalHeight ?? canvas.height)
+  const x = canvas.width / logicalWidth
+  const y = canvas.height / logicalHeight
+  return { x, y, uniform: Math.min(x, y) }
+}
+
+export function getLogicalCanvasSize<TCanvas extends LogicalCanvasSize>(canvas: TCanvas): TCanvas {
+  if (canvas.logicalWidth === undefined && canvas.logicalHeight === undefined) return canvas
+  return {
+    ...canvas,
+    width: canvas.logicalWidth ?? canvas.width,
+    height: canvas.logicalHeight ?? canvas.height,
+  }
+}
+
+export function scaleResolvedTransformForCanvas(
+  transform: ResolvedTransform,
+  canvas: LogicalCanvasSize,
+): ResolvedTransform {
+  const scale = getCanvasRenderScale(canvas)
+  if (scale.x === 1 && scale.y === 1) return transform
+  return {
+    ...transform,
+    x: transform.x * scale.x,
+    y: transform.y * scale.y,
+    width: transform.width * scale.x,
+    height: transform.height * scale.y,
+    anchorX: transform.anchorX * scale.x,
+    anchorY: transform.anchorY * scale.y,
+    cornerRadius: transform.cornerRadius * scale.uniform,
+  }
+}
+
+export function scalePartialTransformForCanvas(
+  transform: Partial<ResolvedTransform>,
+  canvas: LogicalCanvasSize,
+): Partial<ResolvedTransform> {
+  const scale = getCanvasRenderScale(canvas)
+  if (scale.x === 1 && scale.y === 1) return transform
+  return {
+    ...transform,
+    x: scaleOptional(transform.x, scale.x),
+    y: scaleOptional(transform.y, scale.y),
+    width: scaleOptional(transform.width, scale.x),
+    height: scaleOptional(transform.height, scale.y),
+    anchorX: scaleOptional(transform.anchorX, scale.x),
+    anchorY: scaleOptional(transform.anchorY, scale.y),
+    cornerRadius: scaleOptional(transform.cornerRadius, scale.uniform),
+  }
+}
+
+function scaleOptional(value: number | undefined, scale: number): number | undefined {
+  return value === undefined ? undefined : value * scale
+}
+
+function scaleTextStyleForCanvas<TItem extends TextItem | SubtitleSegmentItem>(
+  item: TItem,
+  canvas: LogicalCanvasSize,
+): TItem {
+  const scale = getCanvasRenderScale(canvas)
+  if (scale.x === 1 && scale.y === 1) return item
+
+  return {
+    ...item,
+    fontSize: scaleOptional(item.fontSize, scale.uniform),
+    letterSpacing: scaleOptional(item.letterSpacing, scale.uniform),
+    backgroundRadius: scaleOptional(item.backgroundRadius, scale.uniform),
+    textPadding: scaleOptional(item.textPadding, scale.uniform),
+    ...('textSpans' in item
+      ? {
+          textSpans: item.textSpans?.map((span) => ({
+            ...span,
+            fontSize: scaleOptional(span.fontSize, scale.uniform),
+            letterSpacing: scaleOptional(span.letterSpacing, scale.uniform),
+          })),
+        }
+      : {}),
+    textShadow: item.textShadow
+      ? {
+          ...item.textShadow,
+          offsetX: item.textShadow.offsetX * scale.x,
+          offsetY: item.textShadow.offsetY * scale.y,
+          blur: item.textShadow.blur * scale.uniform,
+        }
+      : item.textShadow,
+    stroke: item.stroke
+      ? { ...item.stroke, width: item.stroke.width * scale.uniform }
+      : item.stroke,
+  }
+}
+
+export function scaleTextItemForCanvas(item: TextItem, canvas: LogicalCanvasSize): TextItem {
+  return scaleTextStyleForCanvas(item, canvas)
+}
+
+export function scaleSubtitleItemForCanvas(
+  item: SubtitleSegmentItem,
+  canvas: LogicalCanvasSize,
+): SubtitleSegmentItem {
+  return scaleTextStyleForCanvas(item, canvas)
+}
+
+export function scaleShapeItemForCanvas(item: ShapeItem, canvas: LogicalCanvasSize): ShapeItem {
+  const scale = getCanvasRenderScale(canvas)
+  if (scale.uniform === 1) return item
+  return {
+    ...item,
+    strokeWidth: scaleOptional(item.strokeWidth, scale.uniform),
+    cornerRadius: scaleOptional(item.cornerRadius, scale.uniform),
+    maskFeather: scaleOptional(item.maskFeather, scale.uniform),
+  }
+}

--- a/src/features/export/utils/client-render-engine.ts
+++ b/src/features/export/utils/client-render-engine.ts
@@ -39,6 +39,7 @@ import { recordPreviewCanvasPool } from '@/shared/logging/preview-scrub-performa
 
 // Import subsystems
 import { buildKeyframesMap } from './canvas-keyframes'
+import { getLogicalCanvasSize } from './canvas-render-scale'
 import { type AdjustmentLayerWithTrackOrder } from './canvas-effects'
 import { GpuPipelineManager } from './gpu-pipeline-manager'
 import { isItemFullyOccluding, type FrameOcclusionContext } from './frame-occlusion'
@@ -711,6 +712,8 @@ export async function createCompositionRenderer(
   const canvasSettings: CanvasSettings = {
     width: canvas.width,
     height: canvas.height,
+    logicalWidth: composition.width,
+    logicalHeight: composition.height,
     fps,
     getPreviewTransform: renderMode === 'preview' ? getPreviewTransformOverride : undefined,
   }
@@ -2068,7 +2071,7 @@ export async function createCompositionRenderer(
         {
           renderPlan: getCurrentRenderPlan(),
           frame,
-          canvas: canvasSettings,
+          canvas: getLogicalCanvasSize(canvasSettings),
           getKeyframes: getCurrentKeyframes,
           getItem: canvasSettings.getExpressionItem,
           getPreviewTransform: renderMode === 'preview' ? getPreviewTransformOverride : undefined,

--- a/src/features/export/utils/render-span.ts
+++ b/src/features/export/utils/render-span.ts
@@ -1,4 +1,4 @@
-import type { CompositionItem, TimelineItem } from '@/types/timeline'
+import type { CompositionItem, TimelineItem, VideoItem } from '@/types/timeline'
 import type { ActiveTransition } from './canvas-transitions'
 import { timelineToSourceFrames } from '@/features/export/deps/timeline-frame'
 
@@ -248,4 +248,44 @@ export function getSourceFrameRampOffset(ramp: SourceTimeRamp, frame: number): n
  */
 export function isFrameInsideSourceTimeRamp(ramp: SourceTimeRamp, frame: number): boolean {
   return frame >= ramp.rampStart && frame <= ramp.rampEnd
+}
+
+/**
+ * Resolve the exact source time for a video rendered through an explicit
+ * timeline span. Preview DOM-video synchronization uses the same helper as
+ * the canvas renderer so transition ramps cannot drift between the two paths.
+ */
+export function resolveVideoRenderSourceTimeSeconds(
+  item: VideoItem,
+  renderSpan: RenderTimelineSpan,
+  frame: number,
+  fps: number,
+  sourceFrameOffset = 0,
+): number {
+  const localFrame = frame - renderSpan.from
+  const localTime = localFrame / fps
+  const sourceStart = getRenderTimelineSourceStart(item, renderSpan)
+  const sourceFps = item.sourceFps ?? fps
+  const speed = item.speed ?? 1
+  const sourceFramesNeeded = (item.durationInFrames * speed * sourceFps) / fps
+  const reverseSourceEnd = (item.sourceEnd ?? sourceStart + sourceFramesNeeded) - sourceFrameOffset
+  const adjustedSourceStart = sourceStart + sourceFrameOffset
+  const rampOffsetSourceFrames =
+    renderSpan.sourceTimeRamp && !item.isReversed
+      ? getSourceFrameRampOffset(renderSpan.sourceTimeRamp, frame)
+      : 0
+  const unclampedSourceTime = item.isReversed
+    ? (reverseSourceEnd - localFrame * speed * (sourceFps / fps) - 1) / sourceFps
+    : adjustedSourceStart / sourceFps + localTime * speed + rampOffsetSourceFrames / sourceFps
+  const clampedToStart = Math.max(0, unclampedSourceTime)
+  const rawSourceTime =
+    item.sourceDuration === undefined ||
+    !Number.isFinite(item.sourceDuration) ||
+    item.sourceDuration <= 0
+      ? clampedToStart
+      : Math.min(clampedToStart, (Math.max(0, item.sourceDuration - 1) + 1e-4) / sourceFps)
+  const snappedSourceFrame = Math.round(rawSourceTime * sourceFps)
+  return Math.abs(rawSourceTime * sourceFps - snappedSourceFrame) < 1e-6
+    ? (snappedSourceFrame + 1e-4) / sourceFps
+    : rawSourceTime
 }

--- a/src/features/preview/components/preview-stage.test.tsx
+++ b/src/features/preview/components/preview-stage.test.tsx
@@ -84,6 +84,7 @@ function renderSplitPreviewStage(overrides: Partial<Parameters<typeof PreviewSta
       needsOverflow={false}
       playerSize={{ width: 1280, height: 720 }}
       playerRenderSize={{ width: 1280, height: 720 }}
+      overlayRenderSize={{ width: 1280, height: 720 }}
       totalFrames={120}
       fps={30}
       isResolving={false}
@@ -170,11 +171,7 @@ describe('getPreviewDisplayEdgePadding', () => {
       getPreviewDisplayEdgePadding({ width: 928, height: 522 }, { width: 1920, height: 1080 }, 1),
     ).toBe(5)
     expect(
-      getPreviewDisplayEdgePadding(
-        { width: 1056, height: 594 },
-        { width: 1920, height: 1080 },
-        1,
-      ),
+      getPreviewDisplayEdgePadding({ width: 1056, height: 594 }, { width: 1920, height: 1080 }, 1),
     ).toBe(4)
   })
 
@@ -188,17 +185,13 @@ describe('getPreviewDisplayEdgePadding', () => {
         { width: 1024, height: 576 },
         { width: 1432, height: 805.5 },
       ]) {
-        const padding = getPreviewDisplayEdgePadding(
-          playerSize,
-          renderSize,
-          devicePixelRatio,
-        )
-        expect((padding * playerSize.width * devicePixelRatio) / renderSize.width).toBeGreaterThanOrEqual(
-          2 - 1e-3,
-        )
-        expect((padding * playerSize.height * devicePixelRatio) / renderSize.height).toBeGreaterThanOrEqual(
-          2 - 1e-3,
-        )
+        const padding = getPreviewDisplayEdgePadding(playerSize, renderSize, devicePixelRatio)
+        expect(
+          (padding * playerSize.width * devicePixelRatio) / renderSize.width,
+        ).toBeGreaterThanOrEqual(2 - 1e-3)
+        expect(
+          (padding * playerSize.height * devicePixelRatio) / renderSize.height,
+        ).toBeGreaterThanOrEqual(2 - 1e-3)
       }
     }
   })
@@ -217,6 +210,7 @@ describe('PreviewStage', () => {
         needsOverflow={false}
         playerSize={{ width: 1280, height: 720 }}
         playerRenderSize={{ width: 1280, height: 720 }}
+        overlayRenderSize={{ width: 1280, height: 720 }}
         totalFrames={120}
         fps={30}
         isResolving={false}
@@ -242,6 +236,7 @@ describe('PreviewStage', () => {
         needsOverflow={false}
         playerSize={{ width: 1280, height: 720 }}
         playerRenderSize={{ width: 1280, height: 720 }}
+        overlayRenderSize={{ width: 1280, height: 720 }}
         totalFrames={120}
         fps={30}
         isResolving={false}

--- a/src/features/preview/components/preview-stage.tsx
+++ b/src/features/preview/components/preview-stage.tsx
@@ -36,6 +36,7 @@ interface PreviewStageProps {
   needsOverflow: boolean
   playerSize: { width: number; height: number }
   playerRenderSize: { width: number; height: number }
+  overlayRenderSize: { width: number; height: number }
   totalFrames: number
   fps: number
   /** Frame to start the player clock at on mount (preserves the playhead across remounts). */
@@ -77,6 +78,7 @@ export const PreviewStage = memo(function PreviewStage({
   needsOverflow,
   playerSize,
   playerRenderSize,
+  overlayRenderSize,
   totalFrames,
   fps,
   initialFrame = 0,
@@ -292,7 +294,7 @@ export const PreviewStage = memo(function PreviewStage({
   const splitPosition = Math.max(0.05, Math.min(0.95, colorGradeSplitPosition))
   const splitPercent = splitPosition * 100
   const splitClipPath = `inset(0 ${100 - splitPercent}% 0 0)`
-  const displayCanvasStyle = getPreviewDisplayCanvasStyle(playerSize, playerRenderSize)
+  const displayCanvasStyle = getPreviewDisplayCanvasStyle(playerSize, overlayRenderSize)
 
   const updateSplitPositionFromPointer = useCallback(
     (event: { clientX: number }) => {

--- a/src/features/preview/components/video-preview.sync.test.tsx
+++ b/src/features/preview/components/video-preview.sync.test.tsx
@@ -104,6 +104,9 @@ const rendererMockState = vi.hoisted(() => {
   }
 
   const instances: RendererMock[] = []
+  const getBestDomVideoElementForItem = vi.fn<(itemId: string) => HTMLVideoElement | null>(
+    () => null,
+  )
   const create = vi.fn(async () => {
     const prewarmFrame = vi.fn(async (frame: number) => {
       void frame
@@ -129,6 +132,7 @@ const rendererMockState = vi.hoisted(() => {
 
   return {
     create,
+    getBestDomVideoElementForItem,
     instances,
   }
 })
@@ -297,7 +301,8 @@ vi.mock('../utils/media-resolver', () => ({
   resolveProxyUrl: mockState.resolveProxyUrlMock,
 }))
 
-vi.mock('@/features/preview/deps/export', () => ({
+vi.mock('@/features/preview/deps/export', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/features/preview/deps/export')>()),
   importCompositionRenderer: vi.fn(async () => ({
     createCompositionRenderer: rendererMockState.create,
   })),
@@ -416,7 +421,9 @@ vi.mock('@/features/preview/deps/composition-runtime', () => ({
       </div>
     )
   },
-  getBestDomVideoElementForItem: vi.fn(() => null),
+  getBestDomVideoElementForItem: rendererMockState.getBestDomVideoElementForItem,
+  snapSourceTime: (seconds: number) => seconds,
+  transitionSafePlay: vi.fn(),
   getVideoTargetTimeSeconds: (
     safeTrimBefore: number,
     sourceFps: number,
@@ -908,6 +915,8 @@ describe('VideoPreview sync behavior', () => {
     resolveProxyUrlMock.mockReset()
     resolveProxyUrlMock.mockReturnValue(null)
     createCompositionRendererMock.mockClear()
+    rendererMockState.getBestDomVideoElementForItem.mockReset()
+    rendererMockState.getBestDomVideoElementForItem.mockReturnValue(null)
     rendererMockState.instances.length = 0
     canvasPixelReadbackEnabled = false
     blankCanvasState = new WeakSet<HTMLCanvasElement>()
@@ -3913,6 +3922,109 @@ describe('VideoPreview sync behavior', () => {
     await waitForLatestRendererFrame(47, scrubCanvas, { expectedDisplayedFrame: 47 })
   })
 
+  it('ramp-syncs paused DOM video lanes while skimming an A-A transition', async () => {
+    useItemsStore.getState().setTracks([
+      {
+        id: 'track-video',
+        name: 'Video',
+        height: 60,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 0,
+        items: [],
+      },
+      {
+        id: 'track-text',
+        name: 'Text',
+        height: 60,
+        locked: false,
+        visible: true,
+        muted: false,
+        solo: false,
+        order: 1,
+        items: [],
+      },
+    ])
+    const [leftClip, rightClip] = createTransitionClipPair()
+    useItemsStore.getState().setItems([
+      {
+        ...leftClip,
+        mediaId: 'same-media',
+        src: 'blob:same-media',
+        sourceStart: 0,
+        sourceFps: 30,
+      },
+      {
+        ...rightClip,
+        mediaId: 'same-media',
+        src: 'blob:same-media',
+        sourceStart: 60,
+        sourceFps: 30,
+      },
+      {
+        id: 'parented-title',
+        type: 'text',
+        trackId: 'track-text',
+        from: 0,
+        durationInFrames: 100,
+        label: 'Parented title',
+        text: 'Title',
+        color: '#ffffff',
+        transformParent: {
+          parentItemId: 'clip-left',
+          childLocalReference: { x: 0, y: 0, width: 100, height: 50, rotation: 0 },
+          childWorldReference: { x: 0, y: 0, width: 100, height: 50, rotation: 0 },
+        },
+      },
+    ] as TimelineItem[])
+    useTransitionsStore.getState().setTransitions([createCrossfadeTransition()])
+
+    const createReadyVideo = () => {
+      const element = document.createElement('video')
+      Object.defineProperties(element, {
+        duration: { configurable: true, value: 120 },
+        paused: { configurable: true, get: () => false },
+        readyState: { configurable: true, value: 4 },
+        videoHeight: { configurable: true, value: 1080 },
+        videoWidth: { configurable: true, value: 1920 },
+      })
+      vi.spyOn(element, 'pause').mockImplementation(() => undefined)
+      document.body.appendChild(element)
+      return element
+    }
+    const leftElement = createReadyVideo()
+    const rightElement = createReadyVideo()
+    rendererMockState.getBestDomVideoElementForItem.mockImplementation((itemId) =>
+      itemId === 'clip-left' ? leftElement : itemId === 'clip-right' ? rightElement : null,
+    )
+
+    const { container } = renderDefaultPreview()
+    const scrubCanvas = getScrubCanvas(container)
+    act(() => {
+      usePlaybackStore.getState().setPreviewFrame(50)
+    })
+
+    const renderer = await waitForLatestRendererFrame(50, scrubCanvas, {
+      expectedDisplayedFrame: 50,
+    })
+    await waitFor(() => {
+      expect(leftElement.dataset.transitionHold).toBe('1')
+      expect(rightElement.dataset.transitionHold).toBe('1')
+      expect(leftElement.dataset.transitionSourceRamp).toBe('1')
+      expect(rightElement.dataset.transitionSourceRamp).toBe('1')
+      expect(leftElement.dataset.transitionPrearm).toBeUndefined()
+      expect(rightElement.dataset.transitionPrearm).toBeUndefined()
+    })
+
+    const provider = renderer.setDomVideoElementProvider.mock.calls.at(-1)?.[0]
+    expect(provider?.('clip-left')).toBe(leftElement)
+    expect(provider?.('clip-right')).toBe(rightElement)
+    expect(leftElement.currentTime).not.toBe(0)
+    expect(rightElement.currentTime).not.toBe(0)
+  })
+
   it('keeps backward hover preview frame-accurate for gpu-effect clips', async () => {
     setSingleVideoTrack()
     useItemsStore.getState().setItems([
@@ -4695,6 +4807,30 @@ describe('VideoPreview sync behavior', () => {
     expect(
       playerDimensionsHistory.every((entry) => entry.width === 1920 && entry.height === 1080),
     ).toBe(true)
+  })
+
+  it('renders a 4K composition into a smaller realtime preview backing', async () => {
+    setSingleCompoundItemWithGpuEffectAtFrame(0)
+    render(
+      <VideoPreview
+        project={{ width: 3840, height: 2160, backgroundColor: '#000000' }}
+        containerSize={{ width: 984, height: 554 }}
+      />,
+    )
+
+    const [composition, rendererCanvas] = await waitFor(() => {
+      expect(createCompositionRendererMock).toHaveBeenCalled()
+      return createCompositionRendererMock.mock.calls[0] as unknown as [
+        { width: number; height: number },
+        HTMLCanvasElement,
+      ]
+    })
+
+    expect(composition).toMatchObject({ width: 3840, height: 2160 })
+    expect(rendererCanvas.width).toBeLessThanOrEqual(1920)
+    expect(rendererCanvas.height).toBeLessThanOrEqual(1080)
+    expect(rendererCanvas.width * rendererCanvas.height).toBeLessThan(3840 * 2160)
+    expect(lastPlayerDimensions).toEqual({ width: 3840, height: 2160 })
   })
 
   it('refreshes stale resolved media URLs after blob URL invalidation', async () => {

--- a/src/features/preview/components/video-preview.tsx
+++ b/src/features/preview/components/video-preview.tsx
@@ -1,12 +1,4 @@
-import {
-  useMemo,
-  useCallback,
-  memo,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
+import { useMemo, useCallback, memo, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useRafDeferredValue } from '@/shared/hooks/use-raf-deferred-value'
 import { usePreviewBridgeStore } from '@/shared/state/preview-bridge'
 import { usePlaybackStore } from '@/shared/state/playback'
@@ -189,10 +181,8 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     useProxyMedia: useProxy,
     blobUrlVersion,
   })
-  const {
-    needsOverlay: showGpuEffectsOverlay,
-    shouldWarmRenderer: shouldWarmGpuEffectsRenderer,
-  } = useGpuEffectsOverlay(fps)
+  const { needsOverlay: showGpuEffectsOverlay, shouldWarmRenderer: shouldWarmGpuEffectsRenderer } =
+    useGpuEffectsOverlay(fps)
   const isMaskEditing = useMaskEditorStore((s) => s.isEditing)
   const isCornerPinEditing = useCornerPinStore((s) => s.isEditing)
   const isPowerWindowEditing = usePowerWindowEditorStore((s) => s.isEditing)
@@ -319,6 +309,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
     proxyReadyCount,
     blobUrlVersion,
     project,
+    playerSize,
   })
   const domTextScrubOverlayPlan = useMemo(
     () => buildDomTextScrubOverlayPlan(fastScrubScaledTracks, fastScrubScaledKeyframes),
@@ -382,6 +373,8 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
         fps,
         project.width,
         project.height,
+        renderSize.width,
+        renderSize.height,
         project.backgroundColor ?? '',
         useProxy ? 'proxy' : 'source',
         fastScrubTracksTopologyFingerprint,
@@ -396,6 +389,8 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       project.backgroundColor,
       project.height,
       project.width,
+      renderSize.height,
+      renderSize.width,
       useProxy,
     ],
   )
@@ -429,10 +424,10 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
   useLayoutEffect(() => {
     const canvas = gpuEffectsCanvasRef.current
     if (!canvas) return
-    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, playerRenderSize)
+    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, renderSize)
     if (canvas.width !== backingSize.width) canvas.width = backingSize.width
     if (canvas.height !== backingSize.height) canvas.height = backingSize.height
-  }, [gpuEffectsCanvasRef, playerRenderSize, playerSize])
+  }, [gpuEffectsCanvasRef, playerSize, renderSize])
 
   const ensureSplitAfterRenderer =
     useCallback(async (): Promise<CompositionRendererInstance | null> => {
@@ -607,6 +602,15 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
         forceFastScrubOverlay ||
         isPausedTransitionOverlayActive(playbackState.currentFrame, playbackState)
       if (requiresRenderedPresentation) return false
+      const preservesRenderedPreview =
+        previewFrame !== null && shouldPreserveHighFidelityBackwardPreview(previewFrame)
+      if (preservesRenderedPreview) {
+        // Styled DOM text normally keeps skimming on the Player to preserve
+        // typography. Transition frames are the exception: the Player does
+        // not composite the authored transition, so retain the rendered media
+        // path (and its separate DOM text overlay when that split is safe).
+        return false
+      }
 
       const activeGizmoItemType = useGizmoStore.getState().activeGizmo?.itemType ?? null
       return (
@@ -620,6 +624,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       isPausedTransitionOverlayActive,
       preferPlayerForStyledTextScrubRef,
       previewRuntimeRefs.preferPlayerForDomGizmoRef,
+      shouldPreserveHighFidelityBackwardPreview,
     ],
   )
   const { handleFrameChange, handlePlayStateChange } = usePreviewPlaybackController({
@@ -958,6 +963,7 @@ const VideoPreviewBase = memo(function VideoPreviewBase({
       needsOverflow={needsOverflow}
       playerSize={playerSize}
       playerRenderSize={playerRenderSize}
+      overlayRenderSize={renderSize}
       totalFrames={totalFrames}
       fps={fps}
       initialFrame={initialPlayheadFrameRef.current ?? 0}
@@ -984,11 +990,7 @@ export const VideoPreview = memo(function VideoPreview(props: VideoPreviewProps)
   const { chrome = 'edit', ...previewProps } = props
   const itemsSnapshot = useTransformStableItemsSnapshot()
   return (
-    <DeferredVideoPreview
-      {...previewProps}
-      overlayChrome={chrome}
-      itemsSnapshot={itemsSnapshot}
-    />
+    <DeferredVideoPreview {...previewProps} overlayChrome={chrome} itemsSnapshot={itemsSnapshot} />
   )
 })
 
@@ -1000,12 +1002,7 @@ const DeferredVideoPreview = memo(function DeferredVideoPreview({
   itemsSnapshot: PreviewItemsSnapshot
 }) {
   const deferredItemsSnapshot = useRafDeferredValue(itemsSnapshot)
-  return (
-    <VideoPreviewBase
-      {...props}
-      itemsSnapshot={deferredItemsSnapshot}
-    />
-  )
+  return <VideoPreviewBase {...props} itemsSnapshot={deferredItemsSnapshot} />
 })
 
 export const ColorVideoPreview = memo(function ColorVideoPreview(props: VideoPreviewProps) {

--- a/src/features/preview/deps/export-contract.ts
+++ b/src/features/preview/deps/export-contract.ts
@@ -7,6 +7,12 @@ export {
   SharedVideoExtractorPool,
   type VideoFrameSource,
 } from '@/features/export/utils/shared-video-extractor'
+export {
+  isFrameInsideSourceTimeRamp,
+  resolveAATransitionRamps,
+  resolveTransitionRenderTimelineSpan,
+  resolveVideoRenderSourceTimeSeconds,
+} from '@/features/export/utils/render-span'
 
 export type CreateCompositionRenderer =
   (typeof import('@/features/export/utils/client-render-engine'))['createCompositionRenderer']

--- a/src/features/preview/hooks/use-preview-composition-model.test.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.test.ts
@@ -250,6 +250,24 @@ describe('buildPreviewCompositionData', () => {
     expect(result.renderSize).toEqual({ width: 1280, height: 720 })
   })
 
+  it('keeps project coordinates while using a smaller physical preview target', () => {
+    const result = buildPreviewCompositionData({
+      combinedTracks: [],
+      fps: 30,
+      items: [],
+      keyframes: [],
+      transitions: [],
+      resolvedUrls: new Map(),
+      useProxy: false,
+      blobUrlVersion: 0,
+      project: { width: 3840, height: 2160 },
+      previewRenderSize: { width: 1504, height: 846 },
+    })
+
+    expect(result.fastScrubInputProps).toMatchObject({ width: 3840, height: 2160 })
+    expect(result.renderSize).toEqual({ width: 1504, height: 846 })
+  })
+
   it('uses an already-acquired blob URL before resolvedUrls catches up', () => {
     const track: TimelineTrack = {
       id: 'track-1',

--- a/src/features/preview/hooks/use-preview-composition-model.ts
+++ b/src/features/preview/hooks/use-preview-composition-model.ts
@@ -16,6 +16,7 @@ import { useGizmoStore, type ItemPreview } from '../stores/gizmo-store'
 import { useMaskEditorStore } from '../stores/mask-editor-store'
 import { resolveGizmoWorldPreviewAsLocal } from '../utils/gizmo-world-preview'
 import { resolveProxyUrl } from '../utils/media-resolver'
+import { getRealtimePreviewRenderSize } from '../utils/preview-render-size'
 import {
   getMediaResolveCost,
   toTrackTopologyFingerprint,
@@ -58,6 +59,11 @@ interface PreviewProject {
   backgroundColor?: string
 }
 
+interface PreviewPlayerSize {
+  width: number
+  height: number
+}
+
 interface BuildPreviewCompositionDataParams {
   combinedTracks: TimelineTrack[]
   fps: number
@@ -69,6 +75,7 @@ interface BuildPreviewCompositionDataParams {
   useProxy: boolean
   blobUrlVersion: number
   project: PreviewProject
+  previewRenderSize?: PreviewPlayerSize
   resolveProxyUrlFn?: (mediaId: string) => string | null
   getBlobUrlFn?: (mediaId: string) => string | null
 }
@@ -85,6 +92,7 @@ interface UsePreviewCompositionModelParams {
   proxyReadyCount: number
   blobUrlVersion: number
   project: PreviewProject
+  playerSize: PreviewPlayerSize
 }
 
 interface UsePreviewCompositionBaseModelParams {
@@ -124,9 +132,7 @@ export function mergeLiveItemPresentation(
   if (!liveItem || liveItem.id !== item.id || liveItem.type !== item.type) return item
 
   const itemWithLiveTransform =
-    'transform' in liveItem &&
-    'transform' in item &&
-    liveItem.transform !== item.transform
+    'transform' in liveItem && 'transform' in item && liveItem.transform !== item.transform
       ? ({ ...item, transform: liveItem.transform } as TimelineItem)
       : item
 
@@ -200,7 +206,24 @@ export function usePreviewCompositionModel({
   proxyReadyCount,
   blobUrlVersion,
   project,
+  playerSize,
 }: UsePreviewCompositionModelParams) {
+  const projectWidth = project.width
+  const projectHeight = project.height
+  const playerWidth = playerSize.width
+  const playerHeight = playerSize.height
+  const calculatedPreviewRenderSize = getRealtimePreviewRenderSize(
+    { width: projectWidth, height: projectHeight },
+    { width: playerWidth, height: playerHeight },
+  )
+  const previewRenderWidth = calculatedPreviewRenderSize.width
+  const previewRenderHeight = calculatedPreviewRenderSize.height
+  // Keep renderer identity stable while the layout changes inside the same
+  // physical-size bucket (especially <=1080p projects, which stay full-size).
+  const previewRenderSize = useMemo(
+    () => ({ width: previewRenderWidth, height: previewRenderHeight }),
+    [previewRenderHeight, previewRenderWidth],
+  )
   const {
     playbackVideoSourceSpans,
     scrubVideoSourceSpans,
@@ -228,6 +251,7 @@ export function usePreviewCompositionModel({
       useProxy,
       blobUrlVersion,
       project,
+      previewRenderSize,
     })
   }, [
     blobUrlVersion,
@@ -237,6 +261,7 @@ export function usePreviewCompositionModel({
     items,
     keyframes,
     project,
+    previewRenderSize,
     proxyReadyCount,
     resolvedUrls,
     transitions,
@@ -313,8 +338,7 @@ export function usePreviewCompositionModel({
         canvas: { width: project.width, height: project.height, fps },
         frame: playbackState.previewFrame ?? playbackState.currentFrame,
         getItem: (candidateId) => fastScrubLiveItemsByIdRef.current.get(candidateId),
-        getKeyframes: (candidateId) =>
-          fastScrubKeyframesByItemIdRef.current.get(candidateId),
+        getKeyframes: (candidateId) => fastScrubKeyframesByItemIdRef.current.get(candidateId),
         getLocalPreviewTransform: (candidateId) =>
           useGizmoStore.getState().preview?.[candidateId]?.transform,
       })
@@ -370,6 +394,7 @@ export function buildPreviewCompositionData({
   useProxy,
   blobUrlVersion,
   project,
+  previewRenderSize,
   resolveProxyUrlFn = resolveProxyUrl,
   getBlobUrlFn = (mediaId: string) => blobUrlManager.get(mediaId),
 }: BuildPreviewCompositionDataParams) {
@@ -499,10 +524,7 @@ export function buildPreviewCompositionData({
     width: Math.max(2, project.width),
     height: Math.max(2, project.height),
   }
-  const renderSize = {
-    width: Math.max(2, Math.max(1, Math.round(project.width))),
-    height: Math.max(2, Math.max(1, Math.round(project.height))),
-  }
+  const renderSize = previewRenderSize ?? playerRenderSize
   const fastScrubScaledTracks = fastScrubTracks as CompositionInputProps['tracks']
   const fastScrubScaledKeyframes = keyframes
   const fastScrubInputProps: CompositionInputProps = {

--- a/src/features/preview/hooks/use-preview-render-pump-controller.ts
+++ b/src/features/preview/hooks/use-preview-render-pump-controller.ts
@@ -100,6 +100,7 @@ import {
   type CommittedPreviewSnapshotState,
 } from '../utils/preview-display-canvas'
 import type { TransitionPreviewSessionTrace } from './use-preview-transition-session-controller'
+import { resolveTransitionDomPlaybackState } from '../utils/transition-dom-playback'
 import { createLogger } from '@/shared/logging/logger'
 import { isPreviewTraceEnabled, recordPumpTrace } from '@/shared/logging/preview-trace'
 import {
@@ -111,7 +112,10 @@ import {
   recordPreviewScrubRenderStarted,
   recordPreviewScrubRequest,
 } from '@/shared/logging/preview-scrub-performance'
-import type { CompositionRendererInstance } from '@/features/preview/deps/export'
+import {
+  resolveAATransitionRamps,
+  type CompositionRendererInstance,
+} from '@/features/preview/deps/export'
 
 const logger = createLogger('VideoPreview')
 
@@ -246,7 +250,10 @@ interface UsePreviewRenderPumpParams {
   getPlayingAnyTransitionPrewarmStartFrame: (frame: number) => number | null
   getPausedTransitionPrewarmStartFrame: (frame: number) => number | null
   getPinnedTransitionElementForItem: (itemId: string) => HTMLVideoElement | null
-  pinTransitionPlaybackSession: (window: TransitionWindow | null) => TransitionWindow | null
+  pinTransitionPlaybackSession: (
+    window: TransitionWindow | null,
+    pausedTargetFrame?: number,
+  ) => TransitionWindow | null
   clearTransitionPlaybackSession: () => void
   cacheTransitionSessionFrame: (frame: number) => void
   preparePlaybackTransitionFrame: (frame: number) => Promise<boolean>
@@ -598,6 +605,26 @@ export function usePreviewRenderPump({
         }
         return
       }
+      const playbackState = usePlaybackStore.getState()
+      const transitionWindow = getTransitionWindowByStartFrame(frame)
+      const aaRamps = transitionWindow
+        ? resolveAATransitionRamps(
+            transitionWindow.leftClip,
+            transitionWindow.rightClip,
+            {
+              transitionStart: transitionWindow.startFrame,
+              transitionEnd: transitionWindow.endFrame,
+            },
+            fps,
+          )
+        : null
+      if (aaRamps && playbackState.previewFrame === null && playbackState.currentFrame < frame) {
+        // Continuous-split A-A transitions use synchronized DOM video lanes. Rendering an
+        // eight-frame MediaBunny runway before entry blocks the main thread
+        // without producing frames the live transition will consume.
+        deferredPlaybackTransitionPrepareFrameRef.current = null
+        return
+      }
       deferredPlaybackTransitionPrepareFrameRef.current = frame
       if (!scrubRenderInFlightRef.current) {
         void preparePlaybackTransitionFrame(frame)
@@ -940,6 +967,15 @@ export function usePreviewRenderPump({
                 const prevSession = transitionSessionWindowRef.current
                 const isNewSession =
                   !prevSession || prevSession.transition.id !== windowForFrame.transition.id
+                const aaRamps = resolveAATransitionRamps(
+                  windowForFrame.leftClip,
+                  windowForFrame.rightClip,
+                  {
+                    transitionStart: windowForFrame.startFrame,
+                    transitionEnd: windowForFrame.endFrame,
+                  },
+                  fps,
+                )
                 pinTransitionPlaybackSession(windowForFrame)
                 // Await the prearm prewarm so mediabunny decoders are positioned
                 // at the correct source time before rendering. The prearm fires
@@ -952,7 +988,7 @@ export function usePreviewRenderPump({
                 }
                 // When entering a transition mid-playback (no prearm happened),
                 // await the prewarm synchronously to position decoders.
-                if (isNewSession && 'prewarmItems' in renderer) {
+                if (isNewSession && !aaRamps && 'prewarmItems' in renderer) {
                   await renderer.prewarmItems?.(
                     [windowForFrame.leftClip.id, windowForFrame.rightClip.id],
                     frameToRender,
@@ -975,7 +1011,21 @@ export function usePreviewRenderPump({
               // them here for zero-copy compositing. renderVideoItem still checks
               // freshness (0.2s drift) and falls back to mediabunny on large
               // jumps where the element hasn't caught up.
-              renderer.setDomVideoElementProvider?.(getBestDomVideoElementForItem)
+              const transitionWindow = getTransitionWindowForFrame(frameToRender)
+              const isActiveTransitionFrame =
+                transitionWindow !== null &&
+                frameToRender >= transitionWindow.startFrame &&
+                frameToRender < transitionWindow.endFrame
+              if (transitionWindow && isActiveTransitionFrame) {
+                // A-A transitions use an extended source-time ramp that the
+                // ordinary paused DOM composition does not own. Pin and seek
+                // both browser-video lanes to that ramp before compositing so
+                // hover skims show the real effect without a cold exact decode.
+                pinTransitionPlaybackSession(transitionWindow, frameToRender)
+                renderer.setDomVideoElementProvider?.(getPinnedTransitionElementForItem)
+              } else {
+                renderer.setDomVideoElementProvider?.(getBestDomVideoElementForItem)
+              }
             } else {
               // Reverse media elements retain only one outstanding seek and
               // coalesce every clock update to the newest target. Completed
@@ -1997,7 +2047,7 @@ export function usePreviewRenderPump({
     }
 
     const handleActivePlaybackTransitionMaintenance = (state: PlaybackStoreSnapshot) => {
-      if (!state.isPlaying || !forceFastScrubOverlay) {
+      if (!state.isPlaying) {
         return
       }
 
@@ -2026,12 +2076,33 @@ export function usePreviewRenderPump({
       if (sessionWindow && transitionSessionPinnedElementsRef.current.size > 0) {
         for (const clip of [sessionWindow.leftClip, sessionWindow.rightClip]) {
           if (clip.type !== 'video') continue
-          const el = transitionSessionPinnedElementsRef.current.get(clip.id)
+          const el =
+            transitionSessionPinnedElementsRef.current.get(clip.id) ??
+            getPinnedTransitionElementForItem(clip.id)
           if (!el || el.dataset.transitionHold !== '1') continue
           const clipSpeed = clip.speed ?? 1
-          const mediaPlaybackRate = getBrowserMediaPlaybackRate(clipSpeed, state.playbackRate)
-          const targetTime = getVideoItemSourceTimeSeconds(clip, state.currentFrame, fps)
+          const transitionState = resolveTransitionDomPlaybackState({
+            window: sessionWindow,
+            clip,
+            frame: state.currentFrame,
+            timelineFps: fps,
+            transportRate: state.playbackRate,
+          })
+          const mediaPlaybackRate =
+            transitionState?.playbackRate ??
+            getBrowserMediaPlaybackRate(clipSpeed, state.playbackRate)
+          const targetTime =
+            transitionState?.sourceTime ??
+            getVideoItemSourceTimeSeconds(clip, state.currentFrame, fps)
           if (targetTime === null) continue
+          if (transitionState) {
+            delete el.dataset.transitionPrearm
+          }
+          if (transitionState?.hasActiveSourceRamp) {
+            el.dataset.transitionSourceRamp = '1'
+          } else {
+            delete el.dataset.transitionSourceRamp
+          }
           if (state.playbackRate < 0) {
             el.pause()
             el.playbackRate = 1
@@ -2083,6 +2154,12 @@ export function usePreviewRenderPump({
               Math.min(mediaPlaybackRate + maxAdj, mediaPlaybackRate + correction),
             )
           }
+          if (el.paused && el.readyState >= 2) {
+            el.playbackRate = mediaPlaybackRate
+            el.play().catch(() => {
+              /* best effort */
+            })
+          }
         }
       } else if (transitionSessionStallCountRef.current.size > 0) {
         transitionSessionStallCountRef.current.clear()
@@ -2100,22 +2177,35 @@ export function usePreviewRenderPump({
         if (lastPlayingPrearmTargetRef.current !== prearmStartFrame) {
           lastPlayingPrearmTargetRef.current = prearmStartFrame
           if (transitionWindow) {
-            const renderer = scrubRendererRef.current
-            if (renderer && 'prewarmItems' in renderer) {
-              transitionPrewarmPromiseRef.current = renderer.prewarmItems?.(
-                [transitionWindow.leftClip.id, transitionWindow.rightClip.id],
-                transitionWindow.startFrame,
+            const aaRamps = resolveAATransitionRamps(
+              transitionWindow.leftClip,
+              transitionWindow.rightClip,
+              {
+                transitionStart: transitionWindow.startFrame,
+                transitionEnd: transitionWindow.endFrame,
+              },
+              fps,
+            )
+            transitionPrewarmPromiseRef.current = (async () => {
+              const renderer = await ensureFastScrubRenderer()
+              if (!aaRamps && renderer && 'prewarmItems' in renderer) {
+                await renderer.prewarmItems?.(
+                  [transitionWindow.leftClip.id, transitionWindow.rightClip.id],
+                  transitionWindow.startFrame,
+                )
+              }
+            })()
+            if (!aaRamps) {
+              runBatchPreseek(
+                collectClipVideoSourceTimesBySrcForFrameRange(
+                  [transitionWindow.leftClip, transitionWindow.rightClip],
+                  transitionWindow.startFrame,
+                  Math.min(8, transitionWindow.endFrame - transitionWindow.startFrame),
+                  fps,
+                  { requireExplicitSourceFps: true },
+                ),
               )
             }
-            runBatchPreseek(
-              collectClipVideoSourceTimesBySrcForFrameRange(
-                [transitionWindow.leftClip, transitionWindow.rightClip],
-                transitionWindow.startFrame,
-                Math.min(8, transitionWindow.endFrame - transitionWindow.startFrame),
-                fps,
-                { requireExplicitSourceFps: true },
-              ),
-            )
           }
           pushTransitionTrace('playing_prearm', {
             targetFrame: prearmStartFrame,
@@ -2345,7 +2435,9 @@ export function usePreviewRenderPump({
             playbackTransitionState.hasActiveTransition || playbackTransitionState.shouldHoldOverlay
           )
         ) {
-          if (!playbackTransitionState.shouldPrewarm) {
+          const hasPinnedPrearm =
+            getPlayingAnyTransitionPrewarmStartFrame(state.currentFrame) !== null
+          if (!playbackTransitionState.shouldPrewarm && !hasPinnedPrearm) {
             clearTransitionPlaybackSession()
           }
           hideAllOverlays()
@@ -2950,7 +3042,9 @@ export function usePreviewRenderPump({
           void pumpRenderLoop()
         }
       } else {
-        if (!playbackTransitionState.shouldPrewarm) {
+        const hasPinnedPrearm =
+          getPlayingAnyTransitionPrewarmStartFrame(playbackState.currentFrame) !== null
+        if (!playbackTransitionState.shouldPrewarm && !hasPinnedPrearm) {
           clearTransitionPlaybackSession()
         }
         hideAllOverlays()

--- a/src/features/preview/hooks/use-preview-renderer-controller.ts
+++ b/src/features/preview/hooks/use-preview-renderer-controller.ts
@@ -292,7 +292,7 @@ export function usePreviewRendererController({
   useLayoutEffect(() => {
     const canvas = scrubCanvasRef.current
     if (!canvas) return
-    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, playerRenderSize)
+    const backingSize = getPreviewDisplayCanvasBackingSize(playerSize, renderSize)
     if (canvas.width !== backingSize.width) canvas.width = backingSize.width
     if (canvas.height !== backingSize.height) canvas.height = backingSize.height
     if (!showFastScrubOverlayRef.current && !showPlaybackTransitionOverlayRef.current) return
@@ -329,7 +329,7 @@ export function usePreviewRendererController({
     drawSourceToPreviewDisplayCanvas(ctx, canvas, offscreen)
     setDisplayedFrame(renderedFrame)
   }, [
-    playerRenderSize,
+    renderSize,
     playerSize,
     committedPreviewSnapshotRef,
     scrubCanvasRef,

--- a/src/features/preview/hooks/use-preview-transition-session-controller.ts
+++ b/src/features/preview/hooks/use-preview-transition-session-controller.ts
@@ -1,5 +1,5 @@
-import { useCallback, type MutableRefObject } from 'react'
-import type { TimelineItem } from '@/types/timeline'
+import { useCallback, useRef, type MutableRefObject } from 'react'
+import type { TimelineItem, VideoItem } from '@/types/timeline'
 import type { ResolvedTransitionWindow } from '@/shared/timeline/transitions/transition-planner'
 import { usePlaybackStore } from '@/shared/state/playback'
 import { getBrowserMediaPlaybackRate } from '@/shared/state/playback/shuttle'
@@ -14,6 +14,11 @@ import {
   selectUpcomingTransitionStartFrame,
   shouldUsePausedTransitionOverlay,
 } from '../utils/transition-prewarm-guards'
+import {
+  resolveTransitionDomPlaybackState,
+  synchronizePausedTransitionDomVideo,
+  type TransitionDomPlaybackState,
+} from '../utils/transition-dom-playback'
 
 const logger = createLogger('VideoPreview')
 
@@ -98,6 +103,659 @@ interface UsePreviewTransitionSessionControllerParams {
   transitionTelemetryRef: MutableRefObject<TransitionPreviewTelemetry>
 }
 
+type TransitionWindow = ResolvedTransitionWindow<TimelineItem>
+type TransitionPlaybackSnapshot = ReturnType<typeof usePlaybackStore.getState>
+type TransitionWindowDomProvider = (window: TransitionWindow | null) => boolean
+
+function clearTransitionElementMarkers(element: HTMLVideoElement): void {
+  delete element.dataset.transitionHold
+  delete element.dataset.transitionPrearm
+  delete element.dataset.transitionSourceRamp
+}
+
+function setTransitionSourceRampMarker(
+  element: HTMLVideoElement,
+  state: TransitionDomPlaybackState | null,
+): void {
+  if (state?.hasActiveSourceRamp) {
+    element.dataset.transitionSourceRamp = '1'
+  } else {
+    delete element.dataset.transitionSourceRamp
+  }
+}
+
+function seekTransitionElement(
+  element: HTMLVideoElement,
+  sourceTime: number,
+  toleranceSeconds: number,
+): void {
+  if (element.readyState < 1) return
+  if (Math.abs(element.currentTime - sourceTime) <= toleranceSeconds) return
+  try {
+    element.currentTime = sourceTime
+  } catch {
+    // The pooled element can still be settling; a later maintenance pass retries.
+  }
+}
+
+function completeTransitionSessionTrace(
+  activeTrace: TransitionPreviewSessionTrace | null,
+  telemetry: TransitionPreviewTelemetry,
+  pushTransitionTrace: (phase: string, data?: Record<string, unknown>) => void,
+): void {
+  if (!activeTrace) return
+
+  const finishedAtMs = performance.now()
+  activeTrace.exitedAtMs = finishedAtMs
+  telemetry.lastPrepareMs = activeTrace.lastPrepareMs
+  telemetry.lastEntryMisses = activeTrace.entryMisses
+  telemetry.lastSessionDurationMs = Math.max(0, finishedAtMs - activeTrace.startedAtMs)
+  telemetry.lastReadyLeadMs =
+    activeTrace.enteredAtMs !== null && activeTrace.firstPreparedAtMs !== null
+      ? Math.max(0, activeTrace.enteredAtMs - activeTrace.firstPreparedAtMs)
+      : 0
+  activeTrace.event.success({
+    startFrame: activeTrace.startFrame,
+    endFrame: activeTrace.endFrame,
+    mode: activeTrace.mode,
+    complex: activeTrace.complex,
+    leftClipId: activeTrace.leftClipId,
+    rightClipId: activeTrace.rightClipId,
+    leftSpeed: activeTrace.leftSpeed,
+    rightSpeed: activeTrace.rightSpeed,
+    leftHasEffects: activeTrace.leftHasEffects,
+    rightHasEffects: activeTrace.rightHasEffects,
+    prepareMs: activeTrace.lastPrepareMs,
+    preparedFrame: activeTrace.lastPreparedFrame,
+    bufferedFramesPeak: activeTrace.bufferedFramesPeak,
+    entryMisses: activeTrace.entryMisses,
+    readyLeadMs: telemetry.lastReadyLeadMs,
+    sessionDurationMs: telemetry.lastSessionDurationMs,
+  })
+  pushTransitionTrace('session_end', {
+    opId: activeTrace.opId,
+    mode: activeTrace.mode,
+    complex: activeTrace.complex,
+    startFrame: activeTrace.startFrame,
+    endFrame: activeTrace.endFrame,
+    prepareMs: activeTrace.lastPrepareMs,
+    preparedFrame: activeTrace.lastPreparedFrame,
+    bufferedFramesPeak: activeTrace.bufferedFramesPeak,
+    entryMisses: activeTrace.entryMisses,
+    readyLeadMs: telemetry.lastReadyLeadMs,
+    sessionDurationMs: telemetry.lastSessionDurationMs,
+  })
+}
+
+function restoreTransitionElementTiming({
+  element,
+  targetTime,
+  playbackRate,
+}: {
+  element: HTMLVideoElement
+  targetTime: number
+  playbackRate: number
+}): void {
+  const drift = Math.abs(element.currentTime - targetTime)
+  if (drift > 0.15) {
+    seekTransitionElement(element, targetTime, 0)
+  } else if (drift > 0.016) {
+    element.playbackRate = playbackRate
+  }
+}
+
+function restoreTransitionClipPlaybackPosition({
+  clip,
+  element,
+  currentFrame,
+  timelineFps,
+  transportRate,
+}: {
+  clip: VideoItem
+  element: HTMLVideoElement | null
+  currentFrame: number
+  timelineFps: number
+  transportRate: number
+}): void {
+  if (!element) return
+  const localFrame = currentFrame - clip.from
+  if (localFrame < 0 || localFrame >= clip.durationInFrames) return
+
+  const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0
+  const sourceFps = clip.sourceFps ?? timelineFps
+  const clipSpeed = clip.speed ?? 1
+  const targetTime = snapSourceTime(
+    sourceStart / sourceFps + (localFrame * clipSpeed) / timelineFps,
+    sourceFps,
+  )
+  const videoDuration = element.duration || Infinity
+  const clamped = Math.min(Math.max(0, targetTime), videoDuration - 0.05)
+  restoreTransitionElementTiming({
+    element,
+    targetTime: clamped,
+    playbackRate: getBrowserMediaPlaybackRate(clipSpeed, transportRate),
+  })
+}
+
+function restoreTransitionSessionPlaybackPosition(
+  window: TransitionWindow | null,
+  elements: Map<string, HTMLVideoElement | null>,
+  timelineFps: number,
+): void {
+  if (!window) return
+  const playback = usePlaybackStore.getState()
+  for (const clip of [window.leftClip, window.rightClip]) {
+    if (clip.type !== 'video') continue
+    restoreTransitionClipPlaybackPosition({
+      clip,
+      element: elements.get(clip.id) ?? null,
+      currentFrame: playback.currentFrame,
+      timelineFps,
+      transportRate: playback.playbackRate,
+    })
+  }
+}
+
+function clearPausedTransitionRenderRetries(
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>,
+): void {
+  for (const cleanup of retryCleanupByElement.values()) cleanup()
+  retryCleanupByElement.clear()
+}
+
+function schedulePausedTransitionRenderRetry({
+  element,
+  targetFrame,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  element: HTMLVideoElement
+  targetFrame: number
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): void {
+  retryCleanupByElement.get(element)?.()
+  if (element.readyState >= 2 && !element.seeking) return
+
+  const cleanup = () => {
+    element.removeEventListener('seeked', retryWhenDrawable)
+    element.removeEventListener('loadeddata', retryWhenDrawable)
+    element.removeEventListener('canplay', retryWhenDrawable)
+    retryCleanupByElement.delete(element)
+  }
+  function retryWhenDrawable() {
+    if (element.readyState < 2) return
+    cleanup()
+    requestRender(targetFrame)
+  }
+  element.addEventListener('seeked', retryWhenDrawable)
+  element.addEventListener('loadeddata', retryWhenDrawable)
+  element.addEventListener('canplay', retryWhenDrawable)
+  retryCleanupByElement.set(element, cleanup)
+}
+
+function synchronizePausedTransitionSessionElements({
+  window,
+  pausedTargetFrame,
+  playback,
+  timelineFps,
+  pinnedElements,
+  transitionWindowUsesDomProvider,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  window: TransitionWindow
+  pausedTargetFrame: number | undefined
+  playback: TransitionPlaybackSnapshot
+  timelineFps: number
+  pinnedElements: Map<string, HTMLVideoElement | null>
+  transitionWindowUsesDomProvider: TransitionWindowDomProvider
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): void {
+  if (playback.isPlaying || pausedTargetFrame === undefined) return
+  if (!transitionWindowUsesDomProvider(window)) return
+
+  for (const clip of [window.leftClip, window.rightClip]) {
+    if (clip.type !== 'video') continue
+    const element = pinnedElements.get(clip.id) ?? getBestDomVideoElementForItem(clip.id)
+    pinnedElements.set(clip.id, element)
+    if (!element) continue
+
+    const transitionState = resolveTransitionDomPlaybackState({
+      window,
+      clip,
+      frame: pausedTargetFrame,
+      timelineFps,
+      transportRate: playback.playbackRate,
+    })
+    if (!transitionState) continue
+    synchronizePausedTransitionDomVideo(element, transitionState)
+    schedulePausedTransitionRenderRetry({
+      element,
+      targetFrame: pausedTargetFrame,
+      retryCleanupByElement,
+      requestRender,
+    })
+  }
+}
+
+function startTransitionSessionTrace({
+  window,
+  transitionWindowUsesDomProvider,
+  telemetry,
+  pushTransitionTrace,
+}: {
+  window: TransitionWindow
+  transitionWindowUsesDomProvider: TransitionWindowDomProvider
+  telemetry: TransitionPreviewTelemetry
+  pushTransitionTrace: (phase: string, data?: Record<string, unknown>) => void
+}): TransitionPreviewSessionTrace {
+  const opId = createOperationId()
+  const event = logger.startEvent('preview_transition_session', opId) as TransitionPreviewEvent
+  const leftSpeed = window.leftClip.speed ?? 1
+  const rightSpeed = window.rightClip.speed ?? 1
+  const leftHasEffects = Boolean(window.leftClip.effects?.some((effect) => effect.enabled))
+  const rightHasEffects = Boolean(window.rightClip.effects?.some((effect) => effect.enabled))
+  const mode = transitionWindowUsesDomProvider(window) ? 'dom' : 'render'
+  const complex = mode === 'render'
+  telemetry.sessionCount += 1
+  const trace: TransitionPreviewSessionTrace = {
+    opId,
+    event,
+    startedAtMs: performance.now(),
+    startFrame: window.startFrame,
+    endFrame: window.endFrame,
+    mode,
+    complex,
+    leftClipId: window.leftClip.id,
+    rightClipId: window.rightClip.id,
+    leftSpeed,
+    rightSpeed,
+    leftHasEffects,
+    rightHasEffects,
+    prepareStartedAtMs: null,
+    firstPreparedAtMs: null,
+    enteredAtMs: null,
+    exitedAtMs: null,
+    lastPrepareMs: 0,
+    lastPreparedFrame: -1,
+    bufferedFramesPeak: 0,
+    entryMisses: 0,
+    lastEntryMissFrame: null,
+  }
+  pushTransitionTrace('session_start', {
+    opId,
+    mode,
+    complex,
+    startFrame: window.startFrame,
+    endFrame: window.endFrame,
+    leftClipId: window.leftClip.id,
+    rightClipId: window.rightClip.id,
+    leftSpeed,
+    rightSpeed,
+    leftHasEffects,
+    rightHasEffects,
+  })
+  return trace
+}
+
+function holdTransitionElementAtState(
+  element: HTMLVideoElement,
+  state: TransitionDomPlaybackState,
+  toleranceSeconds: number,
+): void {
+  element.dataset.transitionPrearm = '1'
+  seekTransitionElement(element, state.sourceTime, toleranceSeconds)
+  if (!element.paused) element.pause()
+  element.playbackRate = state.playbackRate
+}
+
+function playTransitionElementWhenReady(
+  element: HTMLVideoElement,
+  playbackRate: number,
+): void {
+  if (element.readyState >= 2) {
+    transitionSafePlay(element, playbackRate)
+    return
+  }
+  const onCanPlay = () => {
+    element.removeEventListener('canplay', onCanPlay)
+    if (element.dataset.transitionHold === '1' && element.paused) {
+      transitionSafePlay(element, playbackRate)
+    }
+  }
+  element.addEventListener('canplay', onCanPlay, { once: true })
+}
+
+type PinnedTransitionInitialization = {
+  shouldSynchronizePausedTarget: boolean
+  shouldPrepositionIncoming: boolean
+  transitionState: TransitionDomPlaybackState | null
+}
+
+function resolvePinnedTransitionInitialization({
+  clip,
+  window,
+  playback,
+  pausedTargetFrame,
+  timelineFps,
+  useDomProvider,
+}: {
+  clip: VideoItem
+  window: TransitionWindow
+  playback: TransitionPlaybackSnapshot
+  pausedTargetFrame: number | undefined
+  timelineFps: number
+  useDomProvider: boolean
+}): PinnedTransitionInitialization | null {
+  const shouldSynchronizePausedTarget =
+    !playback.isPlaying && pausedTargetFrame !== undefined && useDomProvider
+  const shouldPrepositionIncoming =
+    playback.currentFrame < window.startFrame && clip.id === window.rightClip.id
+  const shouldInitialize =
+    playback.isPlaying || shouldPrepositionIncoming || shouldSynchronizePausedTarget
+  if (!shouldInitialize) return null
+
+  const stateFrame = shouldSynchronizePausedTarget
+    ? pausedTargetFrame
+    : shouldPrepositionIncoming
+      ? window.startFrame
+      : playback.currentFrame
+  return {
+    shouldSynchronizePausedTarget,
+    shouldPrepositionIncoming,
+    transitionState: resolveTransitionDomPlaybackState({
+      window,
+      clip,
+      frame: stateFrame,
+      timelineFps,
+      transportRate: playback.playbackRate,
+    }),
+  }
+}
+
+function synchronizePinnedPausedTransitionElement({
+  element,
+  targetFrame,
+  transitionState,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  element: HTMLVideoElement
+  targetFrame: number
+  transitionState: TransitionDomPlaybackState
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): void {
+  synchronizePausedTransitionDomVideo(element, transitionState)
+  schedulePausedTransitionRenderRetry({
+    element,
+    targetFrame,
+    retryCleanupByElement,
+    requestRender,
+  })
+}
+
+function initializePausedPinnedTransitionElement({
+  element,
+  shouldSynchronize,
+  targetFrame,
+  transitionState,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  element: HTMLVideoElement
+  shouldSynchronize: boolean
+  targetFrame: number | undefined
+  transitionState: TransitionDomPlaybackState | null
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): boolean {
+  if (!shouldSynchronize || targetFrame === undefined || !transitionState) return false
+  synchronizePinnedPausedTransitionElement({
+    element,
+    targetFrame,
+    transitionState,
+    retryCleanupByElement,
+    requestRender,
+  })
+  return true
+}
+
+function initializePrepositionedTransitionElement({
+  element,
+  shouldPreposition,
+  transitionState,
+}: {
+  element: HTMLVideoElement
+  shouldPreposition: boolean
+  transitionState: TransitionDomPlaybackState | null
+}): boolean {
+  if (!shouldPreposition || !transitionState) return false
+  const positionAndHold = () => holdTransitionElementAtState(element, transitionState, 0.016)
+  if (element.readyState >= 1) {
+    positionAndHold()
+  } else {
+    element.addEventListener('loadedmetadata', positionAndHold, { once: true })
+  }
+  return true
+}
+
+function initializePinnedTransitionElement({
+  element,
+  clip,
+  window,
+  playback,
+  pausedTargetFrame,
+  timelineFps,
+  useDomProvider,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  element: HTMLVideoElement | null
+  clip: TimelineItem
+  window: TransitionWindow
+  playback: TransitionPlaybackSnapshot
+  pausedTargetFrame: number | undefined
+  timelineFps: number
+  useDomProvider: boolean
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): void {
+  if (!element || clip.type !== 'video') return
+  const initialization = resolvePinnedTransitionInitialization({
+    clip,
+    window,
+    playback,
+    pausedTargetFrame,
+    timelineFps,
+    useDomProvider,
+  })
+  if (!initialization) return
+
+  element.dataset.transitionHold = '1'
+  const { shouldSynchronizePausedTarget, shouldPrepositionIncoming, transitionState } =
+    initialization
+  setTransitionSourceRampMarker(element, transitionState)
+
+  const initializedPausedTarget = initializePausedPinnedTransitionElement({
+    element,
+    shouldSynchronize: shouldSynchronizePausedTarget,
+    targetFrame: pausedTargetFrame,
+    transitionState,
+    retryCleanupByElement,
+    requestRender,
+  })
+  if (initializedPausedTarget) return
+  const initializedPreposition = initializePrepositionedTransitionElement({
+    element,
+    shouldPreposition: shouldPrepositionIncoming,
+    transitionState,
+  })
+  if (initializedPreposition) return
+  const playbackRate =
+    transitionState?.playbackRate ??
+    getBrowserMediaPlaybackRate(clip.speed ?? 1, playback.playbackRate)
+  playTransitionElementWhenReady(element, playbackRate)
+}
+
+function createPinnedTransitionElements({
+  window,
+  playback,
+  pausedTargetFrame,
+  timelineFps,
+  transitionWindowUsesDomProvider,
+  retryCleanupByElement,
+  requestRender,
+}: {
+  window: TransitionWindow
+  playback: TransitionPlaybackSnapshot
+  pausedTargetFrame: number | undefined
+  timelineFps: number
+  transitionWindowUsesDomProvider: TransitionWindowDomProvider
+  retryCleanupByElement: Map<HTMLVideoElement, () => void>
+  requestRender: (targetFrame: number) => void
+}): Map<string, HTMLVideoElement | null> {
+  const pinnedElements = new Map<string, HTMLVideoElement | null>()
+  const useDomProvider = transitionWindowUsesDomProvider(window)
+  for (const clip of [window.leftClip, window.rightClip]) {
+    const element = getBestDomVideoElementForItem(clip.id)
+    pinnedElements.set(clip.id, element)
+    initializePinnedTransitionElement({
+      element,
+      clip,
+      window,
+      playback,
+      pausedTargetFrame,
+      timelineFps,
+      useDomProvider,
+      retryCleanupByElement,
+      requestRender,
+    })
+  }
+  return pinnedElements
+}
+
+function getTransitionSessionClip(
+  window: TransitionWindow | null,
+  itemId: string,
+): TimelineItem | null {
+  if (window?.leftClip.id === itemId) return window.leftClip
+  if (window?.rightClip.id === itemId) return window.rightClip
+  return null
+}
+
+function getNonSessionTransitionElement(
+  itemId: string,
+  exitElements: Map<string, HTMLVideoElement | null>,
+): HTMLVideoElement | null {
+  const registryElement = getBestDomVideoElementForItem(itemId)
+  if (registryElement) {
+    exitElements.delete(itemId)
+    return registryElement
+  }
+  const exitElement = exitElements.get(itemId)
+  if (exitElement?.isConnected && exitElement.readyState >= 2) return exitElement
+  exitElements.delete(itemId)
+  return null
+}
+
+function isReusableTransitionElement(
+  element: HTMLVideoElement | null,
+): element is HTMLVideoElement {
+  return Boolean(
+    element && element.isConnected && element.readyState >= 2 && element.videoWidth > 0,
+  )
+}
+
+function clearReplacedTransitionElement(
+  pinnedElement: HTMLVideoElement | null,
+  nextElement: HTMLVideoElement | null,
+): void {
+  if (pinnedElement && pinnedElement !== nextElement) {
+    clearTransitionElementMarkers(pinnedElement)
+  }
+}
+
+function resolvePlayingTransitionElementState({
+  window,
+  clip,
+  timelineFps,
+  playback,
+}: {
+  window: TransitionWindow | null
+  clip: TimelineItem | null
+  timelineFps: number
+  playback: TransitionPlaybackSnapshot
+}): {
+  shouldPrepositionIncoming: boolean
+  transitionState: TransitionDomPlaybackState | null
+} {
+  const shouldPrepositionIncoming =
+    window !== null &&
+    playback.currentFrame < window.startFrame &&
+    clip?.id === window.rightClip.id
+  const transitionState =
+    window && clip?.type === 'video'
+      ? resolveTransitionDomPlaybackState({
+          window,
+          clip,
+          frame: shouldPrepositionIncoming ? window.startFrame : playback.currentFrame,
+          timelineFps,
+          transportRate: playback.playbackRate,
+        })
+      : null
+  return { shouldPrepositionIncoming, transitionState }
+}
+
+function synchronizePlayingTransitionRamp(
+  element: HTMLVideoElement,
+  transitionState: TransitionDomPlaybackState | null,
+): void {
+  setTransitionSourceRampMarker(element, transitionState)
+  if (transitionState?.hasActiveSourceRamp) {
+    seekTransitionElement(element, transitionState.sourceTime, 0.12)
+  }
+}
+
+function ensureTransitionElementPlaying({
+  element,
+  window,
+  clip,
+  timelineFps,
+  isPlaying,
+}: {
+  element: HTMLVideoElement
+  window: TransitionWindow | null
+  clip: TimelineItem | null
+  timelineFps: number
+  isPlaying: boolean
+}): void {
+  if (!isPlaying) return
+  const playback = usePlaybackStore.getState()
+  const { shouldPrepositionIncoming, transitionState } = resolvePlayingTransitionElementState({
+    window,
+    clip,
+    timelineFps,
+    playback,
+  })
+
+  element.dataset.transitionHold = '1'
+  synchronizePlayingTransitionRamp(element, transitionState)
+  if (shouldPrepositionIncoming && transitionState) {
+    holdTransitionElementAtState(element, transitionState, 0.016)
+    return
+  }
+
+  delete element.dataset.transitionPrearm
+  transitionSafePlay(
+    element,
+    transitionState?.playbackRate ??
+      getBrowserMediaPlaybackRate(clip?.speed ?? 1, playback.playbackRate),
+  )
+}
+
 export function usePreviewTransitionSessionController({
   fps,
   forceFastScrubOverlay,
@@ -129,100 +787,34 @@ export function usePreviewTransitionSessionController({
   transitionSessionTraceRef,
   transitionTelemetryRef,
 }: UsePreviewTransitionSessionControllerParams) {
-  const clearTransitionPlaybackSession = useCallback(() => {
-    const activeTrace = transitionSessionTraceRef.current
-    if (activeTrace) {
-      const finishedAtMs = performance.now()
-      activeTrace.exitedAtMs = finishedAtMs
-      transitionTelemetryRef.current.lastPrepareMs = activeTrace.lastPrepareMs
-      transitionTelemetryRef.current.lastEntryMisses = activeTrace.entryMisses
-      transitionTelemetryRef.current.lastSessionDurationMs = Math.max(
-        0,
-        finishedAtMs - activeTrace.startedAtMs,
-      )
-      transitionTelemetryRef.current.lastReadyLeadMs =
-        activeTrace.enteredAtMs !== null && activeTrace.firstPreparedAtMs !== null
-          ? Math.max(0, activeTrace.enteredAtMs - activeTrace.firstPreparedAtMs)
-          : 0
-      activeTrace.event.success({
-        startFrame: activeTrace.startFrame,
-        endFrame: activeTrace.endFrame,
-        mode: activeTrace.mode,
-        complex: activeTrace.complex,
-        leftClipId: activeTrace.leftClipId,
-        rightClipId: activeTrace.rightClipId,
-        leftSpeed: activeTrace.leftSpeed,
-        rightSpeed: activeTrace.rightSpeed,
-        leftHasEffects: activeTrace.leftHasEffects,
-        rightHasEffects: activeTrace.rightHasEffects,
-        prepareMs: activeTrace.lastPrepareMs,
-        preparedFrame: activeTrace.lastPreparedFrame,
-        bufferedFramesPeak: activeTrace.bufferedFramesPeak,
-        entryMisses: activeTrace.entryMisses,
-        readyLeadMs: transitionTelemetryRef.current.lastReadyLeadMs,
-        sessionDurationMs: transitionTelemetryRef.current.lastSessionDurationMs,
-      })
-      pushTransitionTrace('session_end', {
-        opId: activeTrace.opId,
-        mode: activeTrace.mode,
-        complex: activeTrace.complex,
-        startFrame: activeTrace.startFrame,
-        endFrame: activeTrace.endFrame,
-        prepareMs: activeTrace.lastPrepareMs,
-        preparedFrame: activeTrace.lastPreparedFrame,
-        bufferedFramesPeak: activeTrace.bufferedFramesPeak,
-        entryMisses: activeTrace.entryMisses,
-        readyLeadMs: transitionTelemetryRef.current.lastReadyLeadMs,
-        sessionDurationMs: transitionTelemetryRef.current.lastSessionDurationMs,
-      })
-      transitionSessionTraceRef.current = null
-    }
+  const pausedTransitionRenderRetryCleanupRef = useRef(
+    new Map<HTMLVideoElement, () => void>(),
+  )
 
-    const window = transitionSessionWindowRef.current
-    if (window) {
-      const playback = usePlaybackStore.getState()
-      const currentFrame = playback.currentFrame
-      for (const clip of [window.leftClip, window.rightClip]) {
-        if (clip.type !== 'video') continue
-        const el = transitionSessionPinnedElementsRef.current.get(clip.id)
-        if (!el) continue
-        const localFrame = currentFrame - clip.from
-        if (localFrame < 0) continue
-        if (localFrame >= clip.durationInFrames) continue
-        const sourceStart = clip.sourceStart ?? clip.trimStart ?? 0
-        const sourceFps = clip.sourceFps ?? fps
-        const clipSpeed = clip.speed ?? 1
-        const targetTime = snapSourceTime(
-          sourceStart / sourceFps + (localFrame * clipSpeed) / fps,
-          sourceFps,
-        )
-        const videoDuration = el.duration || Infinity
-        const clamped = Math.min(Math.max(0, targetTime), videoDuration - 0.05)
-        const drift = Math.abs(el.currentTime - clamped)
-        if (drift > 0.15) {
-          try {
-            el.currentTime = clamped
-          } catch {
-            // Element may be settling — ignore transient seek failures.
-          }
-        } else if (drift > 0.016) {
-          el.playbackRate = getBrowserMediaPlaybackRate(
-            clipSpeed,
-            playback.playbackRate,
-          )
-        }
-      }
-    }
+  const clearTransitionPlaybackSession = useCallback(() => {
+    completeTransitionSessionTrace(
+      transitionSessionTraceRef.current,
+      transitionTelemetryRef.current,
+      pushTransitionTrace,
+    )
+    transitionSessionTraceRef.current = null
+
+    restoreTransitionSessionPlaybackPosition(
+      transitionSessionWindowRef.current,
+      transitionSessionPinnedElementsRef.current,
+      fps,
+    )
 
     transitionSessionWindowRef.current = null
-    for (const el of transitionSessionPinnedElementsRef.current.values()) {
-      if (el) delete el.dataset.transitionHold
+    for (const element of transitionSessionPinnedElementsRef.current.values()) {
+      if (element) clearTransitionElementMarkers(element)
     }
     transitionExitElementsRef.current = new Map(transitionSessionPinnedElementsRef.current)
     transitionSessionPinnedElementsRef.current.clear()
     transitionSessionStallCountRef.current.clear()
     transitionSessionBufferedFramesRef.current.clear()
     transitionPrewarmPromiseRef.current = null
+    clearPausedTransitionRenderRetries(pausedTransitionRenderRetryCleanupRef.current)
   }, [
     fps,
     pushTransitionTrace,
@@ -237,10 +829,18 @@ export function usePreviewTransitionSessionController({
   ])
 
   const pinTransitionPlaybackSession = useCallback(
-    (window: ResolvedTransitionWindow<TimelineItem> | null) => {
+    (window: ResolvedTransitionWindow<TimelineItem> | null, pausedTargetFrame?: number) => {
       if (!window) {
         clearTransitionPlaybackSession()
         return null
+      }
+
+      const playback = usePlaybackStore.getState()
+      const requestPausedTransitionRender = (targetFrame: number) => {
+        const latestPlayback = usePlaybackStore.getState()
+        if (latestPlayback.isPlaying || latestPlayback.previewFrame !== targetFrame) return
+        scrubRequestedFrameRef.current = targetFrame
+        resumeScrubLoopRef.current()
       }
 
       const activeWindow = transitionSessionWindowRef.current
@@ -248,86 +848,46 @@ export function usePreviewTransitionSessionController({
         activeWindow?.transition.id === window.transition.id &&
         activeWindow.startFrame === window.startFrame
       ) {
+        synchronizePausedTransitionSessionElements({
+          window: activeWindow,
+          pausedTargetFrame,
+          playback,
+          timelineFps: fps,
+          pinnedElements: transitionSessionPinnedElementsRef.current,
+          transitionWindowUsesDomProvider,
+          retryCleanupByElement: pausedTransitionRenderRetryCleanupRef.current,
+          requestRender: requestPausedTransitionRender,
+        })
         return activeWindow
       }
 
       clearTransitionPlaybackSession()
 
       transitionSessionWindowRef.current = window
-      const opId = createOperationId()
-      const event = logger.startEvent('preview_transition_session', opId) as TransitionPreviewEvent
-      const leftSpeed = window.leftClip.speed ?? 1
-      const rightSpeed = window.rightClip.speed ?? 1
-      const leftHasEffects = Boolean(window.leftClip.effects?.some((effect) => effect.enabled))
-      const rightHasEffects = Boolean(window.rightClip.effects?.some((effect) => effect.enabled))
-      const mode = transitionWindowUsesDomProvider(window) ? 'dom' : 'render'
-      const complex = mode === 'render'
-      transitionTelemetryRef.current.sessionCount += 1
-      transitionSessionTraceRef.current = {
-        opId,
-        event,
-        startedAtMs: performance.now(),
-        startFrame: window.startFrame,
-        endFrame: window.endFrame,
-        mode,
-        complex,
-        leftClipId: window.leftClip.id,
-        rightClipId: window.rightClip.id,
-        leftSpeed,
-        rightSpeed,
-        leftHasEffects,
-        rightHasEffects,
-        prepareStartedAtMs: null,
-        firstPreparedAtMs: null,
-        enteredAtMs: null,
-        exitedAtMs: null,
-        lastPrepareMs: 0,
-        lastPreparedFrame: -1,
-        bufferedFramesPeak: 0,
-        entryMisses: 0,
-        lastEntryMissFrame: null,
-      }
-      pushTransitionTrace('session_start', {
-        opId,
-        mode,
-        complex,
-        startFrame: window.startFrame,
-        endFrame: window.endFrame,
-        leftClipId: window.leftClip.id,
-        rightClipId: window.rightClip.id,
-        leftSpeed,
-        rightSpeed,
-        leftHasEffects,
-        rightHasEffects,
+      transitionSessionTraceRef.current = startTransitionSessionTrace({
+        window,
+        transitionWindowUsesDomProvider,
+        telemetry: transitionTelemetryRef.current,
+        pushTransitionTrace,
       })
-      const isPlaying = usePlaybackStore.getState().isPlaying
-      const pinnedElements = new Map<string, HTMLVideoElement | null>()
-      for (const clip of [window.leftClip, window.rightClip]) {
-        const el = getBestDomVideoElementForItem(clip.id)
-        pinnedElements.set(clip.id, el)
-        if (el && isPlaying) {
-          el.dataset.transitionHold = '1'
-          const clipSpeed = clip.speed ?? 1
-          if (el.readyState >= 2) {
-            transitionSafePlay(el, clipSpeed)
-          } else {
-            const onCanPlay = () => {
-              el.removeEventListener('canplay', onCanPlay)
-              if (el.dataset.transitionHold === '1' && el.paused) {
-                transitionSafePlay(el, clipSpeed)
-              }
-            }
-            el.addEventListener('canplay', onCanPlay, { once: true })
-          }
-        }
-      }
-      transitionSessionPinnedElementsRef.current = pinnedElements
+      transitionSessionPinnedElementsRef.current = createPinnedTransitionElements({
+        window,
+        playback,
+        pausedTargetFrame,
+        timelineFps: fps,
+        transitionWindowUsesDomProvider,
+        retryCleanupByElement: pausedTransitionRenderRetryCleanupRef.current,
+        requestRender: requestPausedTransitionRender,
+      })
       transitionSessionBufferedFramesRef.current.clear()
       return window
     },
     [
       clearTransitionPlaybackSession,
+      fps,
       pushTransitionTrace,
+      resumeScrubLoopRef,
+      scrubRequestedFrameRef,
       transitionSessionBufferedFramesRef,
       transitionSessionPinnedElementsRef,
       transitionSessionTraceRef,
@@ -340,20 +900,9 @@ export function usePreviewTransitionSessionController({
   const getPinnedTransitionElementForItem = useCallback(
     (itemId: string) => {
       const sessionWindow = transitionSessionWindowRef.current
-      const isSessionParticipant =
-        sessionWindow?.leftClip.id === itemId || sessionWindow?.rightClip.id === itemId
-      if (!isSessionParticipant) {
-        const registryEl = getBestDomVideoElementForItem(itemId)
-        if (registryEl) {
-          transitionExitElementsRef.current.delete(itemId)
-          return registryEl
-        }
-        const exitEl = transitionExitElementsRef.current.get(itemId)
-        if (exitEl?.isConnected && exitEl.readyState >= 2) {
-          return exitEl
-        }
-        transitionExitElementsRef.current.delete(itemId)
-        return null
+      const sessionClip = getTransitionSessionClip(sessionWindow, itemId)
+      if (!sessionClip) {
+        return getNonSessionTransitionElement(itemId, transitionExitElementsRef.current)
       }
 
       const isPlaying = usePlaybackStore.getState().isPlaying
@@ -361,30 +910,23 @@ export function usePreviewTransitionSessionController({
         return null
       }
 
-      const clipSpeed =
-        sessionWindow?.leftClip.id === itemId
-          ? (sessionWindow.leftClip.speed ?? 1)
-          : sessionWindow?.rightClip.id === itemId
-            ? (sessionWindow.rightClip.speed ?? 1)
-            : 1
-
-      const ensurePlaying = (el: HTMLVideoElement) => {
-        if (isPlaying) {
-          el.dataset.transitionHold = '1'
-          transitionSafePlay(el, clipSpeed)
-        }
-      }
+      const ensurePlaying = (element: HTMLVideoElement) =>
+        ensureTransitionElementPlaying({
+          element,
+          window: sessionWindow,
+          clip: sessionClip,
+          timelineFps: fps,
+          isPlaying,
+        })
 
       const pinned = transitionSessionPinnedElementsRef.current.get(itemId) ?? null
-      if (pinned && pinned.isConnected && pinned.readyState >= 2 && pinned.videoWidth > 0) {
+      if (isReusableTransitionElement(pinned)) {
         ensurePlaying(pinned)
         return pinned
       }
 
       const next = getBestDomVideoElementForItem(itemId)
-      if (pinned && pinned !== next) {
-        delete pinned.dataset.transitionHold
-      }
+      clearReplacedTransitionElement(pinned, next)
       if (next && next.readyState >= 2) {
         ensurePlaying(next)
       }
@@ -393,6 +935,7 @@ export function usePreviewTransitionSessionController({
     },
     [
       transitionExitElementsRef,
+      fps,
       transitionSessionPinnedElementsRef,
       transitionSessionWindowRef,
       transitionWindowUsesDomProvider,

--- a/src/features/preview/utils/preview-render-size.test.ts
+++ b/src/features/preview/utils/preview-render-size.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { getRealtimePreviewRenderSize } from './preview-render-size'
+
+describe('getRealtimePreviewRenderSize', () => {
+  it('renders a 4K project near the visible device-pixel size', () => {
+    expect(
+      getRealtimePreviewRenderSize({ width: 3840, height: 2160 }, { width: 984, height: 554 }, 1.5),
+    ).toEqual({ width: 1504, height: 846 })
+  })
+
+  it('does not upscale projects that already fit the realtime budget', () => {
+    expect(
+      getRealtimePreviewRenderSize({ width: 1280, height: 720 }, { width: 1600, height: 900 }, 2),
+    ).toEqual({ width: 1280, height: 720 })
+  })
+
+  it('caps a large fullscreen preview to roughly 1080p', () => {
+    const result = getRealtimePreviewRenderSize(
+      { width: 3840, height: 2160 },
+      { width: 3000, height: 1688 },
+      2,
+    )
+    expect(result.width * result.height).toBeLessThanOrEqual(1920 * 1080 * 1.02)
+    expect(result.width / result.height).toBeCloseTo(16 / 9, 2)
+  })
+})

--- a/src/features/preview/utils/preview-render-size.ts
+++ b/src/features/preview/utils/preview-render-size.ts
@@ -1,0 +1,43 @@
+const MAX_REALTIME_PREVIEW_PIXELS = 1920 * 1080
+const PREVIEW_WIDTH_BUCKET_PX = 32
+
+type Size = { width: number; height: number }
+
+function even(value: number): number {
+  const rounded = Math.max(2, Math.round(value))
+  return rounded % 2 === 0 ? rounded : rounded + 1
+}
+
+/**
+ * Resolve a stable preview backing size close to the visible device-pixel size.
+ * Authored project dimensions remain the renderer's logical coordinate space.
+ */
+export function getRealtimePreviewRenderSize(
+  projectSize: Size,
+  playerSize: Size,
+  devicePixelRatio = typeof window === 'undefined' ? 1 : Math.max(1, window.devicePixelRatio || 1),
+): Size {
+  const projectWidth = Math.max(2, Math.round(projectSize.width))
+  const projectHeight = Math.max(2, Math.round(projectSize.height))
+  const projectPixels = projectWidth * projectHeight
+  if (projectPixels <= MAX_REALTIME_PREVIEW_PIXELS) {
+    return { width: projectWidth, height: projectHeight }
+  }
+
+  const visibleWidth = Math.max(2, playerSize.width * devicePixelRatio)
+  const visibleHeight = Math.max(2, playerSize.height * devicePixelRatio)
+  const visibleScale = Math.min(
+    1,
+    Math.max(visibleWidth / projectWidth, visibleHeight / projectHeight),
+  )
+  const pixelBudgetScale = Math.min(1, Math.sqrt(MAX_REALTIME_PREVIEW_PIXELS / projectPixels))
+  const renderScale = Math.min(visibleScale, pixelBudgetScale)
+
+  const bucketedWidth = Math.min(
+    projectWidth,
+    Math.ceil((projectWidth * renderScale) / PREVIEW_WIDTH_BUCKET_PX) * PREVIEW_WIDTH_BUCKET_PX,
+  )
+  const width = even(bucketedWidth)
+  const height = even((width / projectWidth) * projectHeight)
+  return { width, height }
+}

--- a/src/features/preview/utils/transition-dom-playback.test.ts
+++ b/src/features/preview/utils/transition-dom-playback.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+import type { TimelineItem, VideoItem } from '@/types/timeline'
+import type { ResolvedTransitionWindow } from '@/shared/timeline/transitions/transition-planner'
+import {
+  resolveTransitionDomPlaybackState,
+  synchronizePausedTransitionDomVideo,
+} from './transition-dom-playback'
+
+function makeClip(id: string, from: number, sourceStart: number): VideoItem {
+  return {
+    id,
+    type: 'video',
+    trackId: 'video-track',
+    from,
+    durationInFrames: 100,
+    label: id,
+    mediaId: 'same-media',
+    src: 'blob:video',
+    sourceStart,
+    sourceFps: 30,
+    speed: 1,
+  }
+}
+
+describe('transition DOM playback', () => {
+  it('matches the A-A source ramp and playback rate used by the renderer', () => {
+    const leftClip = makeClip('left', 0, 0)
+    const rightClip = makeClip('right', 100, 100)
+    const window = {
+      leftClip,
+      rightClip,
+      startFrame: 80,
+      endFrame: 120,
+    } as ResolvedTransitionWindow<TimelineItem>
+
+    const left = resolveTransitionDomPlaybackState({
+      window,
+      clip: leftClip,
+      frame: 100,
+      timelineFps: 30,
+      transportRate: 1,
+    })
+    const right = resolveTransitionDomPlaybackState({
+      window,
+      clip: rightClip,
+      frame: 100,
+      timelineFps: 30,
+      transportRate: 1,
+    })
+
+    expect(left).toMatchObject({ playbackRate: 1.5, hasActiveSourceRamp: true })
+    expect(right).toMatchObject({ playbackRate: 1.5, hasActiveSourceRamp: true })
+    expect(left!.sourceTime - right!.sourceTime).toBeCloseTo(2 / 3, 4)
+  })
+
+  it('returns null outside the transition window', () => {
+    const leftClip = makeClip('left', 0, 0)
+    const rightClip = makeClip('right', 100, 100)
+    const window = {
+      leftClip,
+      rightClip,
+      startFrame: 80,
+      endFrame: 120,
+    } as ResolvedTransitionWindow<TimelineItem>
+
+    expect(
+      resolveTransitionDomPlaybackState({
+        window,
+        clip: leftClip,
+        frame: 79,
+        timelineFps: 30,
+        transportRate: 1,
+      }),
+    ).toBeNull()
+  })
+
+  it('marks and seeks a paused A-A lane for zero-copy skim composition', () => {
+    const pause = vi.fn()
+    const element = {
+      currentTime: 2,
+      dataset: {
+        transitionPrearm: '1',
+      },
+      pause,
+      paused: false,
+      playbackRate: 1,
+      readyState: 4,
+    } as unknown as HTMLVideoElement
+
+    synchronizePausedTransitionDomVideo(element, {
+      sourceTime: 4.5,
+      playbackRate: 1.5,
+      hasActiveSourceRamp: true,
+    })
+
+    expect(pause).toHaveBeenCalledTimes(1)
+    expect(element.currentTime).toBe(4.5)
+    expect(element.playbackRate).toBe(1.5)
+    expect(element.dataset.transitionHold).toBe('1')
+    expect(element.dataset.transitionSourceRamp).toBe('1')
+    expect(element.dataset.transitionPrearm).toBeUndefined()
+  })
+})

--- a/src/features/preview/utils/transition-dom-playback.ts
+++ b/src/features/preview/utils/transition-dom-playback.ts
@@ -1,0 +1,96 @@
+import type { TimelineItem, VideoItem } from '@/types/timeline'
+import type { ResolvedTransitionWindow } from '@/shared/timeline/transitions/transition-planner'
+import { getBrowserMediaPlaybackRate } from '@/shared/state/playback/shuttle'
+import {
+  isFrameInsideSourceTimeRamp,
+  resolveAATransitionRamps,
+  resolveTransitionRenderTimelineSpan,
+  resolveVideoRenderSourceTimeSeconds,
+} from '@/features/preview/deps/export'
+
+export interface TransitionDomPlaybackState {
+  sourceTime: number
+  playbackRate: number
+  hasActiveSourceRamp: boolean
+}
+
+/**
+ * Position a paused browser-video lane for an exact transition participant.
+ *
+ * A-A transitions use an extended source-time ramp that differs from the DOM
+ * composition's ordinary clip-local seek. Marking the lane as ramp-owned lets
+ * the canvas compositor consume that browser-decoded frame instead of falling
+ * through to a cold random-access decode while the user skims.
+ */
+export function synchronizePausedTransitionDomVideo(
+  element: HTMLVideoElement,
+  state: TransitionDomPlaybackState,
+): void {
+  element.dataset.transitionHold = '1'
+  delete element.dataset.transitionPrearm
+  if (state.hasActiveSourceRamp) {
+    element.dataset.transitionSourceRamp = '1'
+  } else {
+    delete element.dataset.transitionSourceRamp
+  }
+
+  if (!element.paused) element.pause()
+  if (element.readyState >= 1 && Math.abs(element.currentTime - state.sourceTime) > 0.001) {
+    try {
+      element.currentTime = state.sourceTime
+    } catch {
+      // Metadata or the pooled element can still be settling. The transition
+      // session retries the hovered frame on the next drawable media event.
+    }
+  }
+  element.playbackRate = state.playbackRate
+}
+
+/**
+ * Resolve the browser-video state for a transition participant. This mirrors
+ * the canvas renderer's extended span and A-A ramp math, allowing live DOM
+ * frames to remain the exact source while avoiding a random-access decode on
+ * every preview frame.
+ */
+export function resolveTransitionDomPlaybackState({
+  window,
+  clip,
+  frame,
+  timelineFps,
+  transportRate,
+}: {
+  window: ResolvedTransitionWindow<TimelineItem>
+  clip: VideoItem
+  frame: number
+  timelineFps: number
+  transportRate: number
+}): TransitionDomPlaybackState | null {
+  if (frame < window.startFrame || frame >= window.endFrame) return null
+
+  const transitionRange = {
+    transitionStart: window.startFrame,
+    transitionEnd: window.endFrame,
+  }
+  const ramps = resolveAATransitionRamps(
+    window.leftClip,
+    window.rightClip,
+    transitionRange,
+    timelineFps,
+  )
+  const ramp =
+    ramps && clip.id === window.leftClip.id
+      ? ramps.left
+      : ramps && clip.id === window.rightClip.id
+        ? ramps.right
+        : undefined
+  const renderSpan = resolveTransitionRenderTimelineSpan(clip, transitionRange, timelineFps, ramp)
+  const sourceFps = clip.sourceFps ?? timelineFps
+  const hasActiveSourceRamp = Boolean(ramp && isFrameInsideSourceTimeRamp(ramp, frame))
+  const rampRate = hasActiveSourceRamp && ramp ? (ramp.slope * timelineFps) / sourceFps : 0
+
+  return {
+    sourceTime: resolveVideoRenderSourceTimeSeconds(clip, renderSpan, frame, timelineFps),
+    playbackRate: getBrowserMediaPlaybackRate((clip.speed ?? 1) + rampRate, transportRate),
+    hasActiveSourceRamp,
+  }
+}

--- a/src/infrastructure/gpu-transitions/index.test.ts
+++ b/src/infrastructure/gpu-transitions/index.test.ts
@@ -148,6 +148,7 @@ describe('GPU transition registry', () => {
       directions: ['from-left', 'from-right', 'from-top', 'from-bottom'],
       uniformSize: 48,
     })
+    expect(def!.shader).toContain('let base = mix(right, left, reveal);')
   })
 
   it('packs light leak burn uniforms within its declared buffer size', () => {

--- a/src/infrastructure/gpu-transitions/transitions/light-leak-burn.ts
+++ b/src/infrastructure/gpu-transitions/transitions/light-leak-burn.ts
@@ -51,7 +51,10 @@ fn lightLeakBurnFragment(input: VertexOutput) -> @location(0) vec4f {
   let fine = noise2d(uv * vec2f(params.width, params.height) * 0.45 + vec2f(p * 431.0));
   let noisyAxis = axis + (organic - 0.5) * params.spread * 0.28;
   let reveal = smoothstep(p - params.edgeSoftness, p + params.edgeSoftness, noisyAxis);
-  let base = mix(left, right, reveal);
+  // Reveal is 1 ahead of the moving front and 0 behind it. Keep the outgoing
+  // frame ahead of the front so p=0 starts on left, then reveal the incoming
+  // frame behind it until p=1 ends on right.
+  let base = mix(right, left, reveal);
 
   let frontDist = abs(noisyAxis - p);
   let hotCore = exp(-frontDist * frontDist / max(0.0001, params.edgeSoftness * params.edgeSoftness * 0.38));

--- a/src/runtime/composition-runtime/components/stable-video-sequence.tsx
+++ b/src/runtime/composition-runtime/components/stable-video-sequence.tsx
@@ -46,7 +46,7 @@ import { useNestedMediaResolutionMode } from '../contexts/nested-media-resolutio
 import { areGroupPropsEqual } from './stable-video-sequence-comparator'
 
 const warmupLog = createLogger('StableVideoWarmup')
-const SAME_ORIGIN_SHADOW_MOUNT_LOOKAHEAD_FRAMES = 8
+const SAME_ORIGIN_SHADOW_MOUNT_MIN_LOOKAHEAD_FRAMES = 8
 const SHADOW_UNMOUNT_COOLDOWN_FRAMES = 18
 const TRANSITION_SYNC_COOLDOWN_FRAMES = 18
 const TRANSITION_WARMUP_LOOKAHEAD_SECONDS = 1.5
@@ -258,7 +258,10 @@ const GroupRenderer: React.FC<{
   // normal playback keeps using the simple single-clip path until near the cut.
   const overlapKey = useMemo(() => {
     if (isPremounted || activeItemIndex < 0 || group.items.length <= 1) return ''
-    const shadowMountLookaheadFrames = SAME_ORIGIN_SHADOW_MOUNT_LOOKAHEAD_FRAMES
+    const shadowMountLookaheadFrames = Math.max(
+      SAME_ORIGIN_SHADOW_MOUNT_MIN_LOOKAHEAD_FRAMES,
+      Math.ceil(fps * TRANSITION_WARMUP_LOOKAHEAD_SECONDS),
+    )
     const transitionClipIds = collectTransitionParticipantClipIds({
       transitionWindows,
       frame: globalFrame,
@@ -270,7 +273,7 @@ const GroupRenderer: React.FC<{
       activeItemIndex,
       transitionClipIds,
     })
-  }, [isPremounted, activeItemIndex, group.items, transitionWindows, globalFrame])
+  }, [isPremounted, activeItemIndex, fps, group.items, transitionWindows, globalFrame])
 
   // Build adjusted shadow items — only recalculated when overlap composition changes.
   // String comparison is by value, so stable overlapKey prevents rebuilds every frame.

--- a/src/runtime/composition-runtime/components/video-content.tsx
+++ b/src/runtime/composition-runtime/components/video-content.tsx
@@ -675,6 +675,7 @@ const NativePreviewVideo: React.FC<{
     const layoutPlan = planLayoutVideoSync({
       isPremounted: syncContext.isPremounted,
       isTransitionHeld: video.dataset.transitionHold === '1',
+      isTransitionPrearmed: video.dataset.transitionPrearm === '1',
       canSeek: syncContext.canSeek,
       currentTime: video.currentTime,
       targetTime: syncContext.clampedTargetTime,
@@ -820,6 +821,7 @@ const NativePreviewVideo: React.FC<{
     if (syncContext.isPremounted) {
       const premountPlan = planPremountedVideoSync({
         isTransitionHeld: video.dataset.transitionHold === '1',
+        isTransitionPrearmed: video.dataset.transitionPrearm === '1',
         canSeek: syncContext.canSeek,
         currentTime: video.currentTime,
         targetTime: syncContext.clampedTargetTime,

--- a/src/runtime/composition-runtime/hooks/use-transition-participant-sync.test.ts
+++ b/src/runtime/composition-runtime/hooks/use-transition-participant-sync.test.ts
@@ -121,6 +121,35 @@ describe('useTransitionParticipantSync', () => {
     expect(freeVideo.currentTime).toBe(2)
   })
 
+  it('does not overwrite active participants owned by a transition session', () => {
+    clockMock.currentFrame = 40
+    const heldVideo = createVideo({ currentTime: 3.25, paused: false })
+    heldVideo.dataset.transitionHold = '1'
+    heldVideo.playbackRate = 1.5
+    getClipElementMock.mockReturnValue(heldVideo)
+
+    render(
+      React.createElement(SyncHarness, {
+        participants: [
+          {
+            poolClipId: 'held',
+            safeTrimBefore: 0,
+            sourceFps: 30,
+            playbackRate: 1,
+            sequenceFrameOffset: 0,
+            role: 'leader',
+          },
+        ],
+        groupMinFrom: 0,
+        timelineFps: 30,
+      }),
+    )
+
+    expect(heldVideo.currentTime).toBe(3.25)
+    expect(heldVideo.playbackRate).toBe(1.5)
+    expect(heldVideo.play).not.toHaveBeenCalled()
+  })
+
   it('syncs participants against source-native FPS and per-item sequence offsets', () => {
     clockMock.currentFrame = 25
     const leader = createVideo({ currentTime: 0, paused: true })

--- a/src/runtime/composition-runtime/hooks/use-transition-participant-sync.ts
+++ b/src/runtime/composition-runtime/hooks/use-transition-participant-sync.ts
@@ -50,6 +50,10 @@ export function useTransitionParticipantSync(
       for (const participant of participants) {
         const video = pool.getClipElement(participant.poolClipId)
         if (!video) continue
+        // The preview transition session owns held elements, including A-A
+        // source-time ramps. Nominal sequence sync would overwrite its exact
+        // target time and playback rate once per clock frame.
+        if (video.dataset.transitionHold === '1') continue
 
         const relativeFrame = sequenceLocalFrame - participant.sequenceFrameOffset
         const startTime = participant.safeTrimBefore / participant.sourceFps

--- a/src/runtime/composition-runtime/utils/video-sync-plan.ts
+++ b/src/runtime/composition-runtime/utils/video-sync-plan.ts
@@ -82,11 +82,18 @@ export function getVideoSyncTargetContext(input: {
 
 export function planPremountedVideoSync(input: {
   isTransitionHeld: boolean
+  isTransitionPrearmed?: boolean
   canSeek: boolean
   currentTime: number
   targetTime: number
   seekToleranceSeconds: number
 }): VideoSyncAction {
+  if (input.isTransitionPrearmed) {
+    return {
+      shouldPause: true,
+      seekTo: null,
+    }
+  }
   if (input.isTransitionHeld) {
     return {
       shouldPause: false,
@@ -106,6 +113,7 @@ export function planPremountedVideoSync(input: {
 export function planLayoutVideoSync(input: {
   isPremounted: boolean
   isTransitionHeld: boolean
+  isTransitionPrearmed?: boolean
   canSeek: boolean
   currentTime: number
   targetTime: number
@@ -124,6 +132,7 @@ export function planLayoutVideoSync(input: {
     return {
       ...planPremountedVideoSync({
         isTransitionHeld: input.isTransitionHeld,
+        isTransitionPrearmed: input.isTransitionPrearmed,
         canSeek: input.canSeek,
         currentTime: input.currentTime,
         targetTime: input.targetTime,
@@ -273,16 +282,11 @@ export function planVideoFrameCallbackCorrection(input: {
         }
       }
 
-      const correction = Math.min(
-        MAX_LARGE_DRIFT_RATE_CORRECTION,
-        Math.max(0.05, absDrift * 0.2),
-      )
+      const correction = Math.min(MAX_LARGE_DRIFT_RATE_CORRECTION, Math.max(0.05, absDrift * 0.2))
       return {
         kind: 'adjust_rate',
         playbackRate:
-          drift > 0
-            ? input.nominalRate * (1 - correction)
-            : input.nominalRate * (1 + correction),
+          drift > 0 ? input.nominalRate * (1 - correction) : input.nominalRate * (1 + correction),
       }
     }
 


### PR DESCRIPTION
## Summary

- render authored transition effects during timeline skimming instead of falling back to the plain Player path
- synchronize paused A-A transition video lanes to their ramped source times and redraw once media becomes drawable without blocking the scrub loop
- keep subtitles and overlay geometry at the correct preview scale while adapting internal render resolution for smoother realtime playback
- correct the light-leak burn reveal direction

## Root cause

Styled text could force skim presentation through the DOM Player, which does not composite authored canvas transitions. A-A transitions also required source-time ramps that the paused DOM video lanes did not own, causing cold exact decoding, stale frames, or missing transition effects. Preview backing-size mismatches could additionally enlarge subtitle overlays during transition rendering.

## Impact

Timeline hover previews now show the actual transition effect, transition playback remains responsive while decoder seeks settle, and subtitles retain their expected preview size.

## Validation

- localhost visual verification at `/editor/5EuE0hW7` with both ramp-owned lanes ready and the transition canvas visible
- 668 test files / 4,778 tests passed
- `npm run build`
- `npm run check`
- `npm run check:boundaries`
- `npm run check:deps-contracts`
- `npm run check:changed-health`
- `git diff --check`
- `git merge-tree --write-tree origin/staging develop`
