### PR TITLE
fix: improve contrast of drag-over overlay in media library

### DIFF
--- a/src/features/media-library/components/media-library.tsx
+++ b/src/features/media-library/components/media-library.tsx
@@ -1235,7 +1235,7 @@ export const MediaLibrary = memo(function MediaLibrary({ onMediaSelect }: MediaL
 
         {/* Drag overlay — absolute sibling, always covers the visible viewport */}
         {isDragging && (
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-primary/5 border-2 border-dashed border-primary z-50 flex items-center justify-center pointer-events-none">
+          <div className="absolute inset-0 bg-background/95 bg-gradient-to-br from-primary/15 via-transparent to-primary/10 border-2 border-dashed border-primary z-50 flex items-center justify-center pointer-events-none">
             <div className="absolute top-2 left-2 w-6 h-6 border-l-2 border-t-2 border-primary" />
             <div className="absolute top-2 right-2 w-6 h-6 border-r-2 border-t-2 border-primary" />
             <div className="absolute bottom-2 left-2 w-6 h-6 border-l-2 border-b-2 border-primary" />


### PR DESCRIPTION
## Fix
The drag-over overlay in the media library was nearly transparent and hard to read. Added a background layer so it stays legible.

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/04b5b671-f0cb-477e-9ea5-ee6911e8d8ce" width="382" alt="before"> | <img src="https://github.com/user-attachments/assets/4ec77fdb-6c74-4fe5-8359-0c81da0d1102" width="385" alt="after"> |
